### PR TITLE
feat(sasm): bansf balance-station internals — field init, tuple items, value capture (4ch8f.43.5 slices 4a-4f)

### DIFF
--- a/EvmAsm/Codegen/Programs/BalAccountNonstorageFinalsChainC.lean
+++ b/EvmAsm/Codegen/Programs/BalAccountNonstorageFinalsChainC.lean
@@ -1,0 +1,577 @@
+/-
+  EvmAsm.Codegen.Programs.BalAccountNonstorageFinalsChainC
+
+  Field-window `rlp_walk_init` dispatch for the `bal_account_nonstorage_finals`
+  stations (bead evm-asm-4ch8f.43.5, slice 4a): the span captured by
+  `s3 := a0 - a2 ; s4 := a2` is re-walked as an RLP list; the nine callee
+  arms collapse (as in the outer dispatch) into failure (→ the shared reject
+  epilogue) vs the unified `listHeaderSize`-anchored content cursor.  The
+  side conditions and the inner 9-byte slack discharge from the OUTER region
+  bounds via `rlpItemDecode_spanStart`'s nesting (`fOff + fSpan ≤ aLen`).
+
+  Verified here at the balance-field site (slot 50); the other five field
+  sites (68/97/115/143/161) instantiate by the concrete address table.
+-/
+
+import EvmAsm.Codegen.Programs.BalAccountNonstorageFinalsChainB3
+
+set_option maxRecDepth 8000
+
+namespace EvmAsm.Codegen
+
+open EvmAsm.Rv64 EvmAsm.Rv64.SAsm EvmAsm.Rv64.RLP
+
+namespace BalAccountNonstorageFinalsSpec
+
+private theorem se1c : signExtend12 (1 : BitVec 12) = (1 : Word) := by decide
+
+/-- The pure residue of a successful field-window `rlp_walk_init`: the
+    content cursor offset is `listHeaderSize` of the window's first byte,
+    strictly past the header, within the span. -/
+def FieldInitOk (bytes : List (BitVec 8)) (fOff fSpanN cOff : Nat) : Prop :=
+  ∃ b, bytes[fOff]? = some b ∧ cOff = fOff + listHeaderSize b ∧
+    fOff < cOff ∧ cOff ≤ fOff + fSpanN
+
+/-- The unified continue-state after a field init status check. -/
+def fieldInitPost (aB : Word) (fOff fSpanN : Nat) (acctBytes : List (BitVec 8))
+    (raV : Word) (F : Assertion) : Assertion :=
+  fun h => ∃ cOff : Nat,
+    ((((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 cOff)) **
+      ((.x11 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 (fOff + fSpanN))) **
+      ((.x12 : Reg) ↦ᵣ (0 : Word)) **
+      regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+      regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+      ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x1 : Reg) ↦ᵣ raV) **
+      bytesRegion aB acctBytes ** F) **
+     ⌜FieldInitOk acctBytes fOff fSpanN cOff⌝) h
+
+/-- The reject-side post of a field init failure. -/
+def fieldRej (aB : Word) (acctBytes : List (BitVec 8)) (F : Assertion) :
+    Assertion :=
+  ((.x10 : Reg) ↦ᵣ (1 : Word)) **
+  regOwn .x11 ** regOwn .x12 **
+  regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+  regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+  ((.x0 : Reg) ↦ᵣ (0 : Word)) ** regOwn .x1 **
+  bytesRegion aB acctBytes ** F
+
+/-- Field-window `rlp_walk_init` (slot 50, the balance field) + status
+    check (slot 51): reject on any non-zero status; on success, land at
+    `B + 208` with the unified content cursor.  The window is the span
+    `[fOff, fOff + fSpanN)` with `fSpanW` its length as a word. -/
+theorem bansf_fieldInit50_spec (aB : Word) (aLen fOff : Nat) (fSpanW : Word)
+    (acctBytes : List (BitVec 8))
+    (v5 v6 v7 v12 v28 v29 v30 v31 vRa : Word) (F : Assertion)
+    (hF : F.pcFree)
+    (hsalign : aB.toNat % 8 = 0)
+    (hslack : aLen + 9 ≤ acctBytes.length)
+    (hover : aB.toNat + acctBytes.length < 2 ^ 64)
+    (hvalid : ∀ k, k < acctBytes.length →
+      isValidByteAccess (aB + BitVec.ofNat 64 k) = true)
+    (hfB : fOff + fSpanW.toNat ≤ aLen) :
+    cpsBranchWithin 84 (B + 200) bansfCR
+      (((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 fOff)) **
+       ((.x11 : Reg) ↦ᵣ fSpanW) **
+       ((.x12 : Reg) ↦ᵣ v12) **
+       ((.x5 : Reg) ↦ᵣ v5) ** ((.x6 : Reg) ↦ᵣ v6) ** ((.x7 : Reg) ↦ᵣ v7) **
+       ((.x28 : Reg) ↦ᵣ v28) ** ((.x29 : Reg) ↦ᵣ v29) **
+       ((.x30 : Reg) ↦ᵣ v30) ** ((.x31 : Reg) ↦ᵣ v31) **
+       ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x1 : Reg) ↦ᵣ vRa) **
+       bytesRegion aB acctBytes ** F)
+      (B + 736) (fieldRej aB acctBytes F)
+      (B + 208) (fieldInitPost aB fOff fSpanW.toNat acctBytes (B + 200 + 4) F) := by
+  have hoffb : fOff < acctBytes.length := by omega
+  have hovOff : aB.toNat + fOff < 2 ^ 64 := by omega
+  -- the callee triple at its entry with ra = B + 200 + 4
+  have hwi := rlp_walk_init_spec_within WI aB (B + 200 + 4) fSpanW
+    v12 v5 v6 v7 v28 v29 v30 v31 acctBytes fOff hsalign hoffb hovOff
+    (hvalid fOff hoffb)
+    (fun hf8 => by
+      have hlo : ((acctBytes[fOff]'hoffb).zeroExtend 64 - (0xf7 : Word)).toNat ≤ 8 := by
+        have h2 := not_ult_le hf8
+        have h3 := (acctBytes[fOff]'hoffb).isLt
+        bv_omega
+      omega)
+    (fun hf8 => by
+      have hlo : ((acctBytes[fOff]'hoffb).zeroExtend 64 - (0xf7 : Word)).toNat ≤ 8 := by
+        have h2 := not_ult_le hf8
+        have h3 := (acctBytes[fOff]'hoffb).isLt
+        bv_omega
+      omega)
+    (fun hf8 => by
+      intro k hk
+      have hlo : ((acctBytes[fOff]'hoffb).zeroExtend 64 - (0xf7 : Word)).toNat ≤ 8 := by
+        have h2 := not_ult_le hf8
+        have h3 := (acctBytes[fOff]'hoffb).isLt
+        bv_omega
+      exact hvalid _ (by omega))
+  have hwi' := cpsTripleWithin_weaken
+    (fun h hp => by xperm_hyp hp) (fun _ hq => hq) hwi
+    (P' := ((.x1 : Reg) ↦ᵣ (B + 200 + 4)) **
+      (((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 fOff)) ** ((.x11 : Reg) ↦ᵣ fSpanW) **
+       ((.x12 : Reg) ↦ᵣ v12) **
+       ((.x5 : Reg) ↦ᵣ v5) ** ((.x6 : Reg) ↦ᵣ v6) ** ((.x7 : Reg) ↦ᵣ v7) **
+       ((.x28 : Reg) ↦ᵣ v28) ** ((.x29 : Reg) ↦ᵣ v29) **
+       ((.x30 : Reg) ↦ᵣ v30) ** ((.x31 : Reg) ↦ᵣ v31) **
+       ((.x0 : Reg) ↦ᵣ (0 : Word)) ** bytesRegion aB acctBytes))
+  have hcall := bansf_callSite50_walk_init (n := 81) vRa (by pcf) hwi'
+  rw [show (B + 200) + 4 = B + 204 from by bv_omega] at hcall
+  have hcallF := cpsTripleWithin_frameR F hF hcall
+  set bb : BitVec 8 := acctBytes[fOff]'hoffb with hbb
+  -- the window-end bridge: ptr + span = aB + ofNat (fOff + span.toNat)
+  have hendB : (aB + BitVec.ofNat 64 fOff) + fSpanW
+      = aB + BitVec.ofNat 64 (fOff + fSpanW.toNat) := by
+    bv_omega
+  -- ===== the success continuation (status pinned 0) =====
+  have hsucc : cpsBranchWithin 2 (B + 204) bansfCR
+      (fun h => ∃ cOff : Nat,
+        ((((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 cOff)) **
+          ((.x11 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 (fOff + fSpanW.toNat))) **
+          ((.x12 : Reg) ↦ᵣ (0 : Word)) **
+          regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+          regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+          ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x1 : Reg) ↦ᵣ (B + 200 + 4)) **
+          bytesRegion aB acctBytes ** F) **
+         ⌜FieldInitOk acctBytes fOff fSpanW.toNat cOff⌝) h)
+      (B + 736) (fieldRej aB acctBytes F)
+      (B + 208) (fieldInitPost aB fOff fSpanW.toNat acctBytes (B + 200 + 4) F) := by
+    refine cpsBranchWithin_exists_pre (fun cOff => ?_)
+    refine cpsBranchWithin_pure_pre_right (fun hok => ?_)
+    have hbne := bne_spec_gen_within .x12 .x0 (528 : BitVec 13) (0 : Word) (0 : Word) (B + 204)
+    rw [show (B + 204) + 4 = B + 208 from by bv_omega] at hbne
+    have hbneL := cpsBranchWithin_extend_code (cr' := bansfCR)
+      (fun a i h => CodeReq.union_mono_left a i
+        (CodeReq.ofProg_mem_at B (B + 204) bansfProg 51 (.BNE .x12 .x0 (528 : BitVec 13))
+          (by decide +kernel) (by decide +kernel) (by decide +kernel) (by decide) a i h))
+      hbne
+    have hfall := cpsBranchWithin_ntakenPath hbneL
+      (fun hp hQt => by
+        obtain ⟨_, _, _, _, _, h_pure⟩ := hQt
+        exact absurd rfl (((sepConj_pure_right _).1 h_pure).2))
+    have hfallF := cpsTripleWithin_frameR
+      (((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 cOff)) **
+       ((.x11 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 (fOff + fSpanW.toNat))) **
+       regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+       regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+       ((.x1 : Reg) ↦ᵣ (B + 200 + 4)) **
+       bytesRegion aB acctBytes ** F)
+      (by pcf; exact hF) hfall
+    have hout : cpsTripleWithin 1 (B + 204) (B + 208) bansfCR
+        (((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 cOff)) **
+         ((.x11 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 (fOff + fSpanW.toNat))) **
+         ((.x12 : Reg) ↦ᵣ (0 : Word)) **
+         regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+         regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+         ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x1 : Reg) ↦ᵣ (B + 200 + 4)) **
+         bytesRegion aB acctBytes ** F)
+        (fieldInitPost aB fOff fSpanW.toNat acctBytes (B + 200 + 4) F) := by
+      refine cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp) (fun h hq => ?_) hfallF
+      unfold fieldInitPost
+      refine ⟨cOff, ?_⟩
+      have hq2 : ((((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 cOff)) **
+          ((.x11 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 (fOff + fSpanW.toNat))) **
+          ((.x12 : Reg) ↦ᵣ (0 : Word)) **
+          regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+          regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+          ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x1 : Reg) ↦ᵣ (B + 200 + 4)) **
+          bytesRegion aB acctBytes ** F)) h := by
+        have hq3 := sepConj_mono_left (sepConj_mono_right
+          (fun h' hp' => ((sepConj_pure_right h').1 hp').1)) h hq
+        xperm_hyp hq3
+      exact (sepConj_pure_right h).2 ⟨hq2, hok⟩
+    exact cpsBranchWithin_mono_nSteps (by omega)
+      (cpsTripleWithin_as_cpsBranchWithin_right _ _ hout)
+  -- ===== the failure continuation (status pinned non-zero) =====
+  have hfailc : cpsBranchWithin 2 (B + 204) bansfCR
+      (fun h => ∃ cur endW k : Word,
+        ((((.x10 : Reg) ↦ᵣ cur) ** ((.x11 : Reg) ↦ᵣ endW) **
+          ((.x12 : Reg) ↦ᵣ k) **
+          regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+          regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+          ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x1 : Reg) ↦ᵣ (B + 200 + 4)) **
+          bytesRegion aB acctBytes ** F) **
+         ⌜k ≠ (0 : Word)⌝) h)
+      (B + 736) (fieldRej aB acctBytes F)
+      (B + 208) (fieldInitPost aB fOff fSpanW.toNat acctBytes (B + 200 + 4) F) := by
+    refine cpsBranchWithin_exists_pre (fun cur => ?_)
+    refine cpsBranchWithin_exists_pre (fun endW => ?_)
+    refine cpsBranchWithin_exists_pre (fun k => ?_)
+    refine cpsBranchWithin_pure_pre_right (fun hk => ?_)
+    -- the BNE at slot 51: taken (status ≠ 0) to the reject stub
+    have hbne := bne_spec_gen_within .x12 .x0 (528 : BitVec 13) k (0 : Word) (B + 204)
+    rw [show (B + 204) + signExtend13 (528 : BitVec 13) = B + 732 from by
+          rw [show signExtend13 (528 : BitVec 13) = (528 : Word) from by decide]
+          bv_omega,
+        show (B + 204) + 4 = B + 208 from by bv_omega] at hbne
+    have hbneL := cpsBranchWithin_extend_code (cr' := bansfCR)
+      (fun a i h => CodeReq.union_mono_left a i
+        (CodeReq.ofProg_mem_at B (B + 204) bansfProg 51 (.BNE .x12 .x0 (528 : BitVec 13))
+          (by decide +kernel) (by decide +kernel) (by decide +kernel) (by decide) a i h))
+      hbne
+    have hbneF := cpsBranchWithin_frameR
+      (((.x10 : Reg) ↦ᵣ cur) ** ((.x11 : Reg) ↦ᵣ endW) **
+       regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+       regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+       ((.x1 : Reg) ↦ᵣ (B + 200 + 4)) ** bytesRegion aB acctBytes ** F)
+      (by pcf; exact hF) hbneL
+    have htaken := cpsBranchWithin_takenPath hbneF
+      (fun hp hQf => by
+        obtain ⟨_, _, _, _, ⟨_, _, _, _, _, h_pure⟩, _⟩ := hQf
+        exact hk (((sepConj_pure_right _).1 h_pure).2))
+    have hrej := liftCode (cr' := bansfCR)
+      (bansf_rejectTail_spec B cur (by decide))
+      (fun a i h => CodeReq.union_mono_left a i h)
+    have hrejF := cpsTripleWithin_frameR
+      (((.x12 : Reg) ↦ᵣ k) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+       ((.x11 : Reg) ↦ᵣ endW) **
+       regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+       regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+       ((.x1 : Reg) ↦ᵣ (B + 200 + 4)) ** bytesRegion aB acctBytes ** F)
+      (by pcf; exact hF) hrej
+    have hchain := cpsTripleWithin_seq_perm_same_cr
+      (fun h hp => by
+        have hp2 := sepConj_mono_left (sepConj_mono_right
+          (fun h' hp' => ((sepConj_pure_right h').1 hp').1)) h hp
+        xperm_hyp hp2)
+      htaken hrejF
+    have hout : cpsTripleWithin 2 (B + 204) (B + 736) bansfCR
+        (((.x10 : Reg) ↦ᵣ cur) ** ((.x11 : Reg) ↦ᵣ endW) **
+         ((.x12 : Reg) ↦ᵣ k) **
+         regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+         regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+         ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x1 : Reg) ↦ᵣ (B + 200 + 4)) **
+         bytesRegion aB acctBytes ** F)
+        (fieldRej aB acctBytes F) := by
+      refine cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp) (fun h hq => ?_) hchain
+      unfold fieldRej
+      have hq4 : ((((.x11 : Reg) ↦ᵣ endW) ** ((.x12 : Reg) ↦ᵣ k) **
+          ((.x1 : Reg) ↦ᵣ (B + 200 + 4)) **
+          (((.x10 : Reg) ↦ᵣ (1 : Word)) **
+           regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+           regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+           ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+           bytesRegion aB acctBytes ** F))) h := by
+        xperm_hyp hq
+      have hq5 := sepConj_mono (regIs_implies_regOwn .x11)
+        (sepConj_mono (regIs_implies_regOwn .x12)
+          (sepConj_mono (regIs_implies_regOwn .x1) (fun _ x => x))) h hq4
+      xperm_hyp hq5
+    exact cpsTripleWithin_as_cpsBranchWithin_left _ _ hout
+  -- ===== chain: call ; (success ∨ failure) =====
+  refine cpsBranchWithin_weaken
+    (fun h hp => by xperm_hyp hp) (fun _ x => x) (fun _ x => x)
+    (cpsTripleWithin_seq_branch_same_cr hcallF
+      (cpsBranchWithin_weaken (fun h hp => ?_) (fun _ x => x) (fun _ x => x)
+        (cpsBranchWithin_pre_or hsucc hfailc)))
+  -- pointwise: collapse the nine callee arms into success ∨ failure
+  obtain ⟨h1, h2, hd, hu, ⟨h3, h4, hd2, hu2, hCF, hor⟩, hEx⟩ := hp
+  have rebuild : ∀ (arm : Assertion), arm h4 →
+      ((((regOwn .x5 ** regOwn .x6 ** regOwn .x7 ** regOwn .x28 ** regOwn .x29 **
+          regOwn .x30 ** regOwn .x31 ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+          ((.x1 : Reg) ↦ᵣ (B + 200 + 4)) ** bytesRegion aB acctBytes) ** arm) ** F)) h :=
+    fun arm ha => ⟨h1, h2, hd, hu, ⟨h3, h4, hd2, hu2, hCF, ha⟩, hEx⟩
+  rcases hor with a1 | a2 | a3 | a4 | a5 | a6 | a7 | a8 | a9
+  · -- fail arm: status 2 (empty span)
+    refine Or.inr ⟨aB + BitVec.ofNat 64 fOff, (0 : Word), (2 : Word), ?_⟩
+    obtain ⟨g1, g2, gd1, gu1, hx10, grest⟩ := a1
+    obtain ⟨g3, g4, gd2, gu2, hx11, grest2⟩ := grest
+    obtain ⟨hx12, _⟩ := (sepConj_pure_right g4).1 grest2
+    have hR := rebuild (((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 fOff)) **
+        ((.x11 : Reg) ↦ᵣ (0 : Word)) ** ((.x12 : Reg) ↦ᵣ (2 : Word)))
+      ⟨g1, g2, gd1, gu1, hx10, g3, g4, gd2, gu2, hx11, hx12⟩
+    have hflat : ((((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 fOff)) **
+        ((.x11 : Reg) ↦ᵣ (0 : Word)) **
+        ((.x12 : Reg) ↦ᵣ (2 : Word)) **
+        regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+        regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+        ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x1 : Reg) ↦ᵣ (B + 200 + 4)) **
+        bytesRegion aB acctBytes ** F)) h := by
+      xperm_hyp hR
+    exact (sepConj_pure_right h).2 ⟨hflat, by decide⟩
+  · -- fail arm: status 1 (not a list)
+    refine Or.inr ⟨aB + BitVec.ofNat 64 fOff, (aB + BitVec.ofNat 64 fOff) + fSpanW,
+      (1 : Word), ?_⟩
+    obtain ⟨g1, g2, gd1, gu1, hx10, grest⟩ := a2
+    obtain ⟨g3, g4, gd2, gu2, hx11, grest2⟩ := grest
+    obtain ⟨hx12, _⟩ := (sepConj_pure_right g4).1 grest2
+    have hR := rebuild (((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 fOff)) **
+        ((.x11 : Reg) ↦ᵣ ((aB + BitVec.ofNat 64 fOff) + fSpanW)) **
+        ((.x12 : Reg) ↦ᵣ (1 : Word)))
+      ⟨g1, g2, gd1, gu1, hx10, g3, g4, gd2, gu2, hx11, hx12⟩
+    have hflat : ((((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 fOff)) **
+        ((.x11 : Reg) ↦ᵣ ((aB + BitVec.ofNat 64 fOff) + fSpanW)) **
+        ((.x12 : Reg) ↦ᵣ (1 : Word)) **
+        regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+        regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+        ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x1 : Reg) ↦ᵣ (B + 200 + 4)) **
+        bytesRegion aB acctBytes ** F)) h := by
+      xperm_hyp hR
+    exact (sepConj_pure_right h).2 ⟨hflat, by decide⟩
+  · -- short-list success (status 0)
+    refine Or.inl ⟨fOff + 1, ?_⟩
+    obtain ⟨g1, g2, gd1, gu1, hx10, grest⟩ := a3
+    obtain ⟨g3, g4, gd2, gu2, hx11, grest2⟩ := grest
+    obtain ⟨hx12, hfacts⟩ := (sepConj_pure_right g4).1 grest2
+    obtain ⟨hne0, hge0c, hf8, hcons⟩ := hfacts
+    have hx10' : ((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 (fOff + 1))) g1 := by
+      rwa [show (aB + BitVec.ofNat 64 fOff) + signExtend12 (1 : BitVec 12)
+          = aB + BitVec.ofNat 64 (fOff + 1) from by
+        rw [se1c]
+        bv_omega] at hx10
+    have hx11' : ((.x11 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 (fOff + fSpanW.toNat))) g3 := by
+      rwa [hendB] at hx11
+    have hR := rebuild (((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 (fOff + 1))) **
+        ((.x11 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 (fOff + fSpanW.toNat))) **
+        ((.x12 : Reg) ↦ᵣ (0 : Word)))
+      ⟨g1, g2, gd1, gu1, hx10', g3, g4, gd2, gu2, hx11', hx12⟩
+    have hflat : ((((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 (fOff + 1))) **
+        ((.x11 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 (fOff + fSpanW.toNat))) **
+        ((.x12 : Reg) ↦ᵣ (0 : Word)) **
+        regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+        regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+        ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x1 : Reg) ↦ᵣ (B + 200 + 4)) **
+        bytesRegion aB acctBytes ** F)) h := by
+      xperm_hyp hR
+    refine (sepConj_pure_right h).2 ⟨hflat,
+      ⟨bb, List.getElem?_eq_getElem hoffb, ?_, by omega, ?_⟩⟩
+    · -- listHeaderSize bb = 1: short-form prefix
+      have hlt := ult_lt hf8
+      have hzb : (bb.zeroExtend 64).toNat = bb.toNat := by bv_omega
+      unfold listHeaderSize
+      rw [if_pos (by
+        rw [show ((0xf8 : Word)).toNat = 0xf8 from rfl] at hlt
+        omega)]
+    · -- 1 ≤ span: the consistency equation forces a non-trivial span
+      have hlen1 : ((bb.zeroExtend 64 - (0xc0 : Word)) + signExtend12 (1 : BitVec 12))
+          = fSpanW := by
+        have := hcons
+        bv_omega
+      have h1 : 1 ≤ fSpanW.toNat := by
+        have hgec := not_ult_le hge0c
+        rw [← hlen1, se1c]
+        bv_omega
+      omega
+  · -- fail arm: status 3 (short mismatch)
+    refine Or.inr ⟨aB + BitVec.ofNat 64 fOff, (aB + BitVec.ofNat 64 fOff) + fSpanW,
+      (3 : Word), ?_⟩
+    obtain ⟨g1, g2, gd1, gu1, hx10, grest⟩ := a4
+    obtain ⟨g3, g4, gd2, gu2, hx11, grest2⟩ := grest
+    obtain ⟨hx12, _⟩ := (sepConj_pure_right g4).1 grest2
+    have hR := rebuild (((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 fOff)) **
+        ((.x11 : Reg) ↦ᵣ ((aB + BitVec.ofNat 64 fOff) + fSpanW)) **
+        ((.x12 : Reg) ↦ᵣ (3 : Word)))
+      ⟨g1, g2, gd1, gu1, hx10, g3, g4, gd2, gu2, hx11, hx12⟩
+    have hflat : ((((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 fOff)) **
+        ((.x11 : Reg) ↦ᵣ ((aB + BitVec.ofNat 64 fOff) + fSpanW)) **
+        ((.x12 : Reg) ↦ᵣ (3 : Word)) **
+        regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+        regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+        ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x1 : Reg) ↦ᵣ (B + 200 + 4)) **
+        bytesRegion aB acctBytes ** F)) h := by
+      xperm_hyp hR
+    exact (sepConj_pure_right h).2 ⟨hflat, by decide⟩
+  · -- fail arm: status 4 (long truncated)
+    refine Or.inr ⟨aB + BitVec.ofNat 64 fOff, (aB + BitVec.ofNat 64 fOff) + fSpanW,
+      (4 : Word), ?_⟩
+    obtain ⟨g1, g2, gd1, gu1, hx10, grest⟩ := a5
+    obtain ⟨g3, g4, gd2, gu2, hx11, grest2⟩ := grest
+    obtain ⟨hx12, _⟩ := (sepConj_pure_right g4).1 grest2
+    have hR := rebuild (((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 fOff)) **
+        ((.x11 : Reg) ↦ᵣ ((aB + BitVec.ofNat 64 fOff) + fSpanW)) **
+        ((.x12 : Reg) ↦ᵣ (4 : Word)))
+      ⟨g1, g2, gd1, gu1, hx10, g3, g4, gd2, gu2, hx11, hx12⟩
+    have hflat : ((((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 fOff)) **
+        ((.x11 : Reg) ↦ᵣ ((aB + BitVec.ofNat 64 fOff) + fSpanW)) **
+        ((.x12 : Reg) ↦ᵣ (4 : Word)) **
+        regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+        regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+        ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x1 : Reg) ↦ᵣ (B + 200 + 4)) **
+        bytesRegion aB acctBytes ** F)) h := by
+      xperm_hyp hR
+    exact (sepConj_pure_right h).2 ⟨hflat, by decide⟩
+  · -- fail arm: status 5 (long leading zero)
+    refine Or.inr ⟨aB + BitVec.ofNat 64 fOff, (aB + BitVec.ofNat 64 fOff) + fSpanW,
+      (5 : Word), ?_⟩
+    obtain ⟨g1, g2, gd1, gu1, hx10, grest⟩ := a6
+    obtain ⟨g3, g4, gd2, gu2, hx11, grest2⟩ := grest
+    obtain ⟨hx12, _⟩ := (sepConj_pure_right g4).1 grest2
+    have hR := rebuild (((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 fOff)) **
+        ((.x11 : Reg) ↦ᵣ ((aB + BitVec.ofNat 64 fOff) + fSpanW)) **
+        ((.x12 : Reg) ↦ᵣ (5 : Word)))
+      ⟨g1, g2, gd1, gu1, hx10, g3, g4, gd2, gu2, hx11, hx12⟩
+    have hflat : ((((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 fOff)) **
+        ((.x11 : Reg) ↦ᵣ ((aB + BitVec.ofNat 64 fOff) + fSpanW)) **
+        ((.x12 : Reg) ↦ᵣ (5 : Word)) **
+        regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+        regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+        ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x1 : Reg) ↦ᵣ (B + 200 + 4)) **
+        bytesRegion aB acctBytes ** F)) h := by
+      xperm_hyp hR
+    exact (sepConj_pure_right h).2 ⟨hflat, by decide⟩
+  · -- fail arm: status 6 (long non-minimal)
+    refine Or.inr ⟨aB + BitVec.ofNat 64 fOff, (aB + BitVec.ofNat 64 fOff) + fSpanW,
+      (6 : Word), ?_⟩
+    obtain ⟨g1, g2, gd1, gu1, hx10, grest⟩ := a7
+    obtain ⟨g3, g4, gd2, gu2, hx11, grest2⟩ := grest
+    obtain ⟨hx12, _⟩ := (sepConj_pure_right g4).1 grest2
+    have hR := rebuild (((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 fOff)) **
+        ((.x11 : Reg) ↦ᵣ ((aB + BitVec.ofNat 64 fOff) + fSpanW)) **
+        ((.x12 : Reg) ↦ᵣ (6 : Word)))
+      ⟨g1, g2, gd1, gu1, hx10, g3, g4, gd2, gu2, hx11, hx12⟩
+    have hflat : ((((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 fOff)) **
+        ((.x11 : Reg) ↦ᵣ ((aB + BitVec.ofNat 64 fOff) + fSpanW)) **
+        ((.x12 : Reg) ↦ᵣ (6 : Word)) **
+        regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+        regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+        ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x1 : Reg) ↦ᵣ (B + 200 + 4)) **
+        bytesRegion aB acctBytes ** F)) h := by
+      xperm_hyp hR
+    exact (sepConj_pure_right h).2 ⟨hflat, by decide⟩
+  · -- fail arm: status 7 (long mismatch)
+    refine Or.inr ⟨aB + BitVec.ofNat 64 fOff, (aB + BitVec.ofNat 64 fOff) + fSpanW,
+      (7 : Word), ?_⟩
+    obtain ⟨g1, g2, gd1, gu1, hx10, grest⟩ := a8
+    obtain ⟨g3, g4, gd2, gu2, hx11, grest2⟩ := grest
+    obtain ⟨hx12, _⟩ := (sepConj_pure_right g4).1 grest2
+    have hR := rebuild (((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 fOff)) **
+        ((.x11 : Reg) ↦ᵣ ((aB + BitVec.ofNat 64 fOff) + fSpanW)) **
+        ((.x12 : Reg) ↦ᵣ (7 : Word)))
+      ⟨g1, g2, gd1, gu1, hx10, g3, g4, gd2, gu2, hx11, hx12⟩
+    have hflat : ((((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 fOff)) **
+        ((.x11 : Reg) ↦ᵣ ((aB + BitVec.ofNat 64 fOff) + fSpanW)) **
+        ((.x12 : Reg) ↦ᵣ (7 : Word)) **
+        regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+        regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+        ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x1 : Reg) ↦ᵣ (B + 200 + 4)) **
+        bytesRegion aB acctBytes ** F)) h := by
+      xperm_hyp hR
+    exact (sepConj_pure_right h).2 ⟨hflat, by decide⟩
+  · -- long-list success (status 0)
+    refine Or.inl ⟨fOff + ((bb.zeroExtend 64 - (0xf7 : Word)) +
+      signExtend12 (1 : BitVec 12)).toNat, ?_⟩
+    obtain ⟨g1, g2, gd1, gu1, hx10, grest⟩ := a9
+    obtain ⟨g3, g4, gd2, gu2, hx11, grest2⟩ := grest
+    obtain ⟨hx12, hfacts⟩ := (sepConj_pure_right g4).1 grest2
+    obtain ⟨hne0, hnc0, hnf8, hfit, hmin5, hsum6⟩ := hfacts
+    clear hmin5 hsum6 hnc0
+    have hgef8 := not_ult_le hnf8
+    rw [show ((0xf8 : Word)).toNat = 0xf8 from rfl] at hgef8
+    have hzb : (bb.zeroExtend 64).toNat = bb.toNat := by bv_omega
+    have hhdrN : ((bb.zeroExtend 64 - (0xf7 : Word)) + signExtend12 (1 : BitVec 12)).toNat
+        = 1 + (bb.toNat - 0xf7) := by
+      rw [show signExtend12 (1 : BitVec 12) = (1 : Word) from by decide]
+      have hb := bb.isLt
+      bv_omega
+    have hx10' : ((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64
+        (fOff + ((bb.zeroExtend 64 - (0xf7 : Word)) +
+          signExtend12 (1 : BitVec 12)).toNat))) g1 := by
+      rwa [show (aB + BitVec.ofNat 64 fOff) +
+          ((bb.zeroExtend 64 - (0xf7 : Word)) + signExtend12 (1 : BitVec 12))
+          = aB + BitVec.ofNat 64
+            (fOff + ((bb.zeroExtend 64 - (0xf7 : Word)) +
+              signExtend12 (1 : BitVec 12)).toNat) from by
+        bv_omega] at hx10
+    have hx11' : ((.x11 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 (fOff + fSpanW.toNat))) g3 := by
+      rwa [hendB] at hx11
+    have hR := rebuild (((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64
+        (fOff + ((bb.zeroExtend 64 - (0xf7 : Word)) +
+          signExtend12 (1 : BitVec 12)).toNat))) **
+        ((.x11 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 (fOff + fSpanW.toNat))) **
+        ((.x12 : Reg) ↦ᵣ (0 : Word)))
+      ⟨g1, g2, gd1, gu1, hx10', g3, g4, gd2, gu2, hx11', hx12⟩
+    have hflat : ((((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64
+        (fOff + ((bb.zeroExtend 64 - (0xf7 : Word)) +
+          signExtend12 (1 : BitVec 12)).toNat))) **
+        ((.x11 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 (fOff + fSpanW.toNat))) **
+        ((.x12 : Reg) ↦ᵣ (0 : Word)) **
+        regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+        regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+        ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x1 : Reg) ↦ᵣ (B + 200 + 4)) **
+        bytesRegion aB acctBytes ** F)) h := by
+      xperm_hyp hR
+    refine (sepConj_pure_right h).2 ⟨hflat,
+      ⟨bb, List.getElem?_eq_getElem hoffb, ?_, ?_, ?_⟩⟩
+    · -- listHeaderSize bb = 1 + (bb - 0xf7): long-form prefix
+      unfold listHeaderSize
+      rw [if_neg (by omega), hhdrN]
+    · -- strictly past the header
+      rw [hhdrN]
+      omega
+    · -- header fits inside the window
+      rw [hhdrN]
+      have hfit' := not_ult_le hfit
+      rw [show signExtend12 (1 : BitVec 12) = (1 : Word) from by decide] at hfit'
+      have hb := bb.isLt
+      bv_omega
+
+
+/-! ## §2  Span capture (slots 46–49): `s3/s4 := (a0 - a2, a2)`, args -/
+
+/-- Slots 46–49 (`B + 184 → B + 200`): capture the field span into `s3`/`s4`
+    and set up the `rlp_walk_init` arguments. -/
+theorem bansf_spanCapture46_spec (n3 l3 v19 v20 : Word) :
+    cpsTripleWithin 4 (B + 184) (B + 200) bansfCode
+      (((.x10 : Reg) ↦ᵣ n3) ** ((.x12 : Reg) ↦ᵣ l3) **
+       ((.x19 : Reg) ↦ᵣ v19) ** ((.x20 : Reg) ↦ᵣ v20) **
+       ((.x11 : Reg) ↦ᵣ (0 : Word)))
+      (((.x10 : Reg) ↦ᵣ (n3 - l3)) ** ((.x12 : Reg) ↦ᵣ l3) **
+       ((.x19 : Reg) ↦ᵣ (n3 - l3)) ** ((.x20 : Reg) ↦ᵣ l3) **
+       ((.x11 : Reg) ↦ᵣ l3)) := by
+  have s1 := sub_spec_gen_within .x19 .x10 .x12 n3 l3 v19 (B + 184) (by decide)
+  have s2 := mv_spec_gen_within .x20 .x12 l3 v20 (B + 188) (by decide)
+  have s3 := mv_spec_gen_within .x10 .x19 (n3 - l3) n3 (B + 192) (by decide)
+  have s4 := mv_spec_gen_within .x11 .x20 l3 (0 : Word) (B + 196) (by decide)
+  runBlock s1 s2 s3 s4
+
+#print axioms bansf_spanCapture46_spec
+
+/-! ## §3  The empty-list split (slot 52) -/
+
+/-- The station post at the nonce-station boundary (`B + 352`) for the
+    balance field: either the field list was EMPTY (out block untouched,
+    `FieldFinal … none`), or the found path completed (has_balance set,
+    the 32-byte right-aligned BE image in place, `FieldFinal … (some …)`
+    with the value canonicality facts). -/
+def balStationPost (aB newSp oB : Word) (aLen fOff fSpanN : Nat)
+    (n3 : Word) (acctBytes : List (BitVec 8)) (F : Assertion) : Assertion :=
+  fun h =>
+    -- EMPTY arm
+    (((oB ↦ₘ (0 : Word)) **
+      ((oB + 8) ↦ₘ (0 : Word)) ** ((oB + 16) ↦ₘ (0 : Word)) **
+      ((oB + 24) ↦ₘ (0 : Word)) ** ((oB + 32) ↦ₘ (0 : Word)) **
+      ((newSp + 48) ↦ₘ n3) **
+      ((newSp + 56) ↦ₘ (aB + BitVec.ofNat 64 aLen)) **
+      memOwn (newSp + 64) ** memOwn (newSp + 72) **
+      ((.x2 : Reg) ↦ᵣ newSp) **
+      ((.x8 : Reg) ↦ᵣ aB) ** ((.x9 : Reg) ↦ᵣ BitVec.ofNat 64 aLen) **
+      ((.x18 : Reg) ↦ᵣ oB) **
+      regOwn .x10 ** regOwn .x11 ** regOwn .x12 **
+      regOwn .x19 ** regOwn .x20 **
+      regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+      regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+      ((.x0 : Reg) ↦ᵣ (0 : Word)) ** regOwn .x1 **
+      bytesRegion aB acctBytes ** F) **
+     ⌜FieldFinal acctBytes aB fOff fSpanN none⌝) h ∨
+    -- FOUND arm
+    (∃ vNext vLen : Word,
+      (((oB ↦ₘ (1 : Word)) **
+        bytesRegion (oB + 8) (copyN (List.replicate 32 (0 : BitVec 8)) acctBytes
+          (32 - vLen.toNat) ((vNext - vLen - aB).toNat) vLen.toNat) **
+        ((newSp + 48) ↦ₘ n3) **
+        ((newSp + 56) ↦ₘ (aB + BitVec.ofNat 64 aLen)) **
+        memOwn (newSp + 64) ** memOwn (newSp + 72) **
+        ((.x2 : Reg) ↦ᵣ newSp) **
+        ((.x8 : Reg) ↦ᵣ aB) ** ((.x9 : Reg) ↦ᵣ BitVec.ofNat 64 aLen) **
+        ((.x18 : Reg) ↦ᵣ oB) **
+        regOwn .x10 ** regOwn .x11 ** regOwn .x12 **
+        regOwn .x19 ** regOwn .x20 **
+        regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+        regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+        ((.x0 : Reg) ↦ᵣ (0 : Word)) ** regOwn .x1 **
+        bytesRegion aB acctBytes ** F) **
+       ⌜FieldFinal acctBytes aB fOff fSpanN (some (vNext, vLen)) ∧
+        vLen.toNat ≤ 32⌝) h)
+
+
+end BalAccountNonstorageFinalsSpec
+end EvmAsm.Codegen

--- a/EvmAsm/Codegen/Programs/BalAccountNonstorageFinalsChainC.lean
+++ b/EvmAsm/Codegen/Programs/BalAccountNonstorageFinalsChainC.lean
@@ -505,6 +505,8 @@ theorem bansf_fieldInit50_spec (aB : Word) (aLen fOff : Nat) (fSpanW : Word)
       bv_omega
 
 
+#print axioms bansf_fieldInit50_spec
+
 /-! ## §2  Span capture (slots 46–49): `s3/s4 := (a0 - a2, a2)`, args -/
 
 /-- Slots 46–49 (`B + 184 → B + 200`): capture the field span into `s3`/`s4`
@@ -696,6 +698,460 @@ theorem bansf_loopEntry53_spec (aB newSp : Word) (cOff fEnd : Nat) :
 #print axioms bansf_balEmptyTaken_spec
 #print axioms bansf_balEmptyFall_spec
 #print axioms bansf_loopEntry53_spec
+
+/-! ## §5  The tuple-window init (slot 68) -/
+
+/-- Field-window `rlp_walk_init` (slot 68) + status
+    check (slot 51): reject on any non-zero status; on success, land at
+    `B + 280` with the unified content cursor.  The window is the span
+    `[fOff, fOff + fSpanN)` with `fSpanW` its length as a word. -/
+theorem bansf_fieldInit68_spec (aB : Word) (aLen fOff : Nat) (fSpanW : Word)
+    (acctBytes : List (BitVec 8))
+    (v5 v6 v7 v12 v28 v29 v30 v31 vRa : Word) (F : Assertion)
+    (hF : F.pcFree)
+    (hsalign : aB.toNat % 8 = 0)
+    (hslack : aLen + 9 ≤ acctBytes.length)
+    (hover : aB.toNat + acctBytes.length < 2 ^ 64)
+    (hvalid : ∀ k, k < acctBytes.length →
+      isValidByteAccess (aB + BitVec.ofNat 64 k) = true)
+    (hfB : fOff + fSpanW.toNat ≤ aLen) :
+    cpsBranchWithin 84 (B + 272) bansfCR
+      (((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 fOff)) **
+       ((.x11 : Reg) ↦ᵣ fSpanW) **
+       ((.x12 : Reg) ↦ᵣ v12) **
+       ((.x5 : Reg) ↦ᵣ v5) ** ((.x6 : Reg) ↦ᵣ v6) ** ((.x7 : Reg) ↦ᵣ v7) **
+       ((.x28 : Reg) ↦ᵣ v28) ** ((.x29 : Reg) ↦ᵣ v29) **
+       ((.x30 : Reg) ↦ᵣ v30) ** ((.x31 : Reg) ↦ᵣ v31) **
+       ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x1 : Reg) ↦ᵣ vRa) **
+       bytesRegion aB acctBytes ** F)
+      (B + 736) (fieldRej aB acctBytes F)
+      (B + 280) (fieldInitPost aB fOff fSpanW.toNat acctBytes (B + 272 + 4) F) := by
+  have hoffb : fOff < acctBytes.length := by omega
+  have hovOff : aB.toNat + fOff < 2 ^ 64 := by omega
+  -- the callee triple at its entry with ra = B + 272 + 4
+  have hwi := rlp_walk_init_spec_within WI aB (B + 272 + 4) fSpanW
+    v12 v5 v6 v7 v28 v29 v30 v31 acctBytes fOff hsalign hoffb hovOff
+    (hvalid fOff hoffb)
+    (fun hf8 => by
+      have hlo : ((acctBytes[fOff]'hoffb).zeroExtend 64 - (0xf7 : Word)).toNat ≤ 8 := by
+        have h2 := not_ult_le hf8
+        have h3 := (acctBytes[fOff]'hoffb).isLt
+        bv_omega
+      omega)
+    (fun hf8 => by
+      have hlo : ((acctBytes[fOff]'hoffb).zeroExtend 64 - (0xf7 : Word)).toNat ≤ 8 := by
+        have h2 := not_ult_le hf8
+        have h3 := (acctBytes[fOff]'hoffb).isLt
+        bv_omega
+      omega)
+    (fun hf8 => by
+      intro k hk
+      have hlo : ((acctBytes[fOff]'hoffb).zeroExtend 64 - (0xf7 : Word)).toNat ≤ 8 := by
+        have h2 := not_ult_le hf8
+        have h3 := (acctBytes[fOff]'hoffb).isLt
+        bv_omega
+      exact hvalid _ (by omega))
+  have hwi' := cpsTripleWithin_weaken
+    (fun h hp => by xperm_hyp hp) (fun _ hq => hq) hwi
+    (P' := ((.x1 : Reg) ↦ᵣ (B + 272 + 4)) **
+      (((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 fOff)) ** ((.x11 : Reg) ↦ᵣ fSpanW) **
+       ((.x12 : Reg) ↦ᵣ v12) **
+       ((.x5 : Reg) ↦ᵣ v5) ** ((.x6 : Reg) ↦ᵣ v6) ** ((.x7 : Reg) ↦ᵣ v7) **
+       ((.x28 : Reg) ↦ᵣ v28) ** ((.x29 : Reg) ↦ᵣ v29) **
+       ((.x30 : Reg) ↦ᵣ v30) ** ((.x31 : Reg) ↦ᵣ v31) **
+       ((.x0 : Reg) ↦ᵣ (0 : Word)) ** bytesRegion aB acctBytes))
+  have hcall := bansf_callSite68_walk_init (n := 81) vRa (by pcf) hwi'
+  rw [show (B + 272) + 4 = B + 276 from by bv_omega] at hcall
+  have hcallF := cpsTripleWithin_frameR F hF hcall
+  set bb : BitVec 8 := acctBytes[fOff]'hoffb with hbb
+  -- the window-end bridge: ptr + span = aB + ofNat (fOff + span.toNat)
+  have hendB : (aB + BitVec.ofNat 64 fOff) + fSpanW
+      = aB + BitVec.ofNat 64 (fOff + fSpanW.toNat) := by
+    bv_omega
+  -- ===== the success continuation (status pinned 0) =====
+  have hsucc : cpsBranchWithin 2 (B + 276) bansfCR
+      (fun h => ∃ cOff : Nat,
+        ((((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 cOff)) **
+          ((.x11 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 (fOff + fSpanW.toNat))) **
+          ((.x12 : Reg) ↦ᵣ (0 : Word)) **
+          regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+          regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+          ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x1 : Reg) ↦ᵣ (B + 272 + 4)) **
+          bytesRegion aB acctBytes ** F) **
+         ⌜FieldInitOk acctBytes fOff fSpanW.toNat cOff⌝) h)
+      (B + 736) (fieldRej aB acctBytes F)
+      (B + 280) (fieldInitPost aB fOff fSpanW.toNat acctBytes (B + 272 + 4) F) := by
+    refine cpsBranchWithin_exists_pre (fun cOff => ?_)
+    refine cpsBranchWithin_pure_pre_right (fun hok => ?_)
+    have hbne := bne_spec_gen_within .x12 .x0 (456 : BitVec 13) (0 : Word) (0 : Word) (B + 276)
+    rw [show (B + 276) + 4 = B + 280 from by bv_omega] at hbne
+    have hbneL := cpsBranchWithin_extend_code (cr' := bansfCR)
+      (fun a i h => CodeReq.union_mono_left a i
+        (CodeReq.ofProg_mem_at B (B + 276) bansfProg 69 (.BNE .x12 .x0 (456 : BitVec 13))
+          (by decide +kernel) (by decide +kernel) (by decide +kernel) (by decide) a i h))
+      hbne
+    have hfall := cpsBranchWithin_ntakenPath hbneL
+      (fun hp hQt => by
+        obtain ⟨_, _, _, _, _, h_pure⟩ := hQt
+        exact absurd rfl (((sepConj_pure_right _).1 h_pure).2))
+    have hfallF := cpsTripleWithin_frameR
+      (((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 cOff)) **
+       ((.x11 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 (fOff + fSpanW.toNat))) **
+       regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+       regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+       ((.x1 : Reg) ↦ᵣ (B + 272 + 4)) **
+       bytesRegion aB acctBytes ** F)
+      (by pcf; exact hF) hfall
+    have hout : cpsTripleWithin 1 (B + 276) (B + 280) bansfCR
+        (((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 cOff)) **
+         ((.x11 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 (fOff + fSpanW.toNat))) **
+         ((.x12 : Reg) ↦ᵣ (0 : Word)) **
+         regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+         regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+         ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x1 : Reg) ↦ᵣ (B + 272 + 4)) **
+         bytesRegion aB acctBytes ** F)
+        (fieldInitPost aB fOff fSpanW.toNat acctBytes (B + 272 + 4) F) := by
+      refine cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp) (fun h hq => ?_) hfallF
+      unfold fieldInitPost
+      refine ⟨cOff, ?_⟩
+      have hq2 : ((((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 cOff)) **
+          ((.x11 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 (fOff + fSpanW.toNat))) **
+          ((.x12 : Reg) ↦ᵣ (0 : Word)) **
+          regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+          regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+          ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x1 : Reg) ↦ᵣ (B + 272 + 4)) **
+          bytesRegion aB acctBytes ** F)) h := by
+        have hq3 := sepConj_mono_left (sepConj_mono_right
+          (fun h' hp' => ((sepConj_pure_right h').1 hp').1)) h hq
+        xperm_hyp hq3
+      exact (sepConj_pure_right h).2 ⟨hq2, hok⟩
+    exact cpsBranchWithin_mono_nSteps (by omega)
+      (cpsTripleWithin_as_cpsBranchWithin_right _ _ hout)
+  -- ===== the failure continuation (status pinned non-zero) =====
+  have hfailc : cpsBranchWithin 2 (B + 276) bansfCR
+      (fun h => ∃ cur endW k : Word,
+        ((((.x10 : Reg) ↦ᵣ cur) ** ((.x11 : Reg) ↦ᵣ endW) **
+          ((.x12 : Reg) ↦ᵣ k) **
+          regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+          regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+          ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x1 : Reg) ↦ᵣ (B + 272 + 4)) **
+          bytesRegion aB acctBytes ** F) **
+         ⌜k ≠ (0 : Word)⌝) h)
+      (B + 736) (fieldRej aB acctBytes F)
+      (B + 280) (fieldInitPost aB fOff fSpanW.toNat acctBytes (B + 272 + 4) F) := by
+    refine cpsBranchWithin_exists_pre (fun cur => ?_)
+    refine cpsBranchWithin_exists_pre (fun endW => ?_)
+    refine cpsBranchWithin_exists_pre (fun k => ?_)
+    refine cpsBranchWithin_pure_pre_right (fun hk => ?_)
+    -- the BNE at slot 51: taken (status ≠ 0) to the reject stub
+    have hbne := bne_spec_gen_within .x12 .x0 (456 : BitVec 13) k (0 : Word) (B + 276)
+    rw [show (B + 276) + signExtend13 (456 : BitVec 13) = B + 732 from by
+          rw [show signExtend13 (456 : BitVec 13) = (456 : Word) from by decide]
+          bv_omega,
+        show (B + 276) + 4 = B + 280 from by bv_omega] at hbne
+    have hbneL := cpsBranchWithin_extend_code (cr' := bansfCR)
+      (fun a i h => CodeReq.union_mono_left a i
+        (CodeReq.ofProg_mem_at B (B + 276) bansfProg 69 (.BNE .x12 .x0 (456 : BitVec 13))
+          (by decide +kernel) (by decide +kernel) (by decide +kernel) (by decide) a i h))
+      hbne
+    have hbneF := cpsBranchWithin_frameR
+      (((.x10 : Reg) ↦ᵣ cur) ** ((.x11 : Reg) ↦ᵣ endW) **
+       regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+       regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+       ((.x1 : Reg) ↦ᵣ (B + 272 + 4)) ** bytesRegion aB acctBytes ** F)
+      (by pcf; exact hF) hbneL
+    have htaken := cpsBranchWithin_takenPath hbneF
+      (fun hp hQf => by
+        obtain ⟨_, _, _, _, ⟨_, _, _, _, _, h_pure⟩, _⟩ := hQf
+        exact hk (((sepConj_pure_right _).1 h_pure).2))
+    have hrej := liftCode (cr' := bansfCR)
+      (bansf_rejectTail_spec B cur (by decide))
+      (fun a i h => CodeReq.union_mono_left a i h)
+    have hrejF := cpsTripleWithin_frameR
+      (((.x12 : Reg) ↦ᵣ k) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+       ((.x11 : Reg) ↦ᵣ endW) **
+       regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+       regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+       ((.x1 : Reg) ↦ᵣ (B + 272 + 4)) ** bytesRegion aB acctBytes ** F)
+      (by pcf; exact hF) hrej
+    have hchain := cpsTripleWithin_seq_perm_same_cr
+      (fun h hp => by
+        have hp2 := sepConj_mono_left (sepConj_mono_right
+          (fun h' hp' => ((sepConj_pure_right h').1 hp').1)) h hp
+        xperm_hyp hp2)
+      htaken hrejF
+    have hout : cpsTripleWithin 2 (B + 276) (B + 736) bansfCR
+        (((.x10 : Reg) ↦ᵣ cur) ** ((.x11 : Reg) ↦ᵣ endW) **
+         ((.x12 : Reg) ↦ᵣ k) **
+         regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+         regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+         ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x1 : Reg) ↦ᵣ (B + 272 + 4)) **
+         bytesRegion aB acctBytes ** F)
+        (fieldRej aB acctBytes F) := by
+      refine cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp) (fun h hq => ?_) hchain
+      unfold fieldRej
+      have hq4 : ((((.x11 : Reg) ↦ᵣ endW) ** ((.x12 : Reg) ↦ᵣ k) **
+          ((.x1 : Reg) ↦ᵣ (B + 272 + 4)) **
+          (((.x10 : Reg) ↦ᵣ (1 : Word)) **
+           regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+           regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+           ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+           bytesRegion aB acctBytes ** F))) h := by
+        xperm_hyp hq
+      have hq5 := sepConj_mono (regIs_implies_regOwn .x11)
+        (sepConj_mono (regIs_implies_regOwn .x12)
+          (sepConj_mono (regIs_implies_regOwn .x1) (fun _ x => x))) h hq4
+      xperm_hyp hq5
+    exact cpsTripleWithin_as_cpsBranchWithin_left _ _ hout
+  -- ===== chain: call ; (success ∨ failure) =====
+  refine cpsBranchWithin_weaken
+    (fun h hp => by xperm_hyp hp) (fun _ x => x) (fun _ x => x)
+    (cpsTripleWithin_seq_branch_same_cr hcallF
+      (cpsBranchWithin_weaken (fun h hp => ?_) (fun _ x => x) (fun _ x => x)
+        (cpsBranchWithin_pre_or hsucc hfailc)))
+  -- pointwise: collapse the nine callee arms into success ∨ failure
+  obtain ⟨h1, h2, hd, hu, ⟨h3, h4, hd2, hu2, hCF, hor⟩, hEx⟩ := hp
+  have rebuild : ∀ (arm : Assertion), arm h4 →
+      ((((regOwn .x5 ** regOwn .x6 ** regOwn .x7 ** regOwn .x28 ** regOwn .x29 **
+          regOwn .x30 ** regOwn .x31 ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+          ((.x1 : Reg) ↦ᵣ (B + 272 + 4)) ** bytesRegion aB acctBytes) ** arm) ** F)) h :=
+    fun arm ha => ⟨h1, h2, hd, hu, ⟨h3, h4, hd2, hu2, hCF, ha⟩, hEx⟩
+  rcases hor with a1 | a2 | a3 | a4 | a5 | a6 | a7 | a8 | a9
+  · -- fail arm: status 2 (empty span)
+    refine Or.inr ⟨aB + BitVec.ofNat 64 fOff, (0 : Word), (2 : Word), ?_⟩
+    obtain ⟨g1, g2, gd1, gu1, hx10, grest⟩ := a1
+    obtain ⟨g3, g4, gd2, gu2, hx11, grest2⟩ := grest
+    obtain ⟨hx12, _⟩ := (sepConj_pure_right g4).1 grest2
+    have hR := rebuild (((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 fOff)) **
+        ((.x11 : Reg) ↦ᵣ (0 : Word)) ** ((.x12 : Reg) ↦ᵣ (2 : Word)))
+      ⟨g1, g2, gd1, gu1, hx10, g3, g4, gd2, gu2, hx11, hx12⟩
+    have hflat : ((((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 fOff)) **
+        ((.x11 : Reg) ↦ᵣ (0 : Word)) **
+        ((.x12 : Reg) ↦ᵣ (2 : Word)) **
+        regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+        regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+        ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x1 : Reg) ↦ᵣ (B + 272 + 4)) **
+        bytesRegion aB acctBytes ** F)) h := by
+      xperm_hyp hR
+    exact (sepConj_pure_right h).2 ⟨hflat, by decide⟩
+  · -- fail arm: status 1 (not a list)
+    refine Or.inr ⟨aB + BitVec.ofNat 64 fOff, (aB + BitVec.ofNat 64 fOff) + fSpanW,
+      (1 : Word), ?_⟩
+    obtain ⟨g1, g2, gd1, gu1, hx10, grest⟩ := a2
+    obtain ⟨g3, g4, gd2, gu2, hx11, grest2⟩ := grest
+    obtain ⟨hx12, _⟩ := (sepConj_pure_right g4).1 grest2
+    have hR := rebuild (((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 fOff)) **
+        ((.x11 : Reg) ↦ᵣ ((aB + BitVec.ofNat 64 fOff) + fSpanW)) **
+        ((.x12 : Reg) ↦ᵣ (1 : Word)))
+      ⟨g1, g2, gd1, gu1, hx10, g3, g4, gd2, gu2, hx11, hx12⟩
+    have hflat : ((((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 fOff)) **
+        ((.x11 : Reg) ↦ᵣ ((aB + BitVec.ofNat 64 fOff) + fSpanW)) **
+        ((.x12 : Reg) ↦ᵣ (1 : Word)) **
+        regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+        regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+        ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x1 : Reg) ↦ᵣ (B + 272 + 4)) **
+        bytesRegion aB acctBytes ** F)) h := by
+      xperm_hyp hR
+    exact (sepConj_pure_right h).2 ⟨hflat, by decide⟩
+  · -- short-list success (status 0)
+    refine Or.inl ⟨fOff + 1, ?_⟩
+    obtain ⟨g1, g2, gd1, gu1, hx10, grest⟩ := a3
+    obtain ⟨g3, g4, gd2, gu2, hx11, grest2⟩ := grest
+    obtain ⟨hx12, hfacts⟩ := (sepConj_pure_right g4).1 grest2
+    obtain ⟨hne0, hge0c, hf8, hcons⟩ := hfacts
+    have hx10' : ((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 (fOff + 1))) g1 := by
+      rwa [show (aB + BitVec.ofNat 64 fOff) + signExtend12 (1 : BitVec 12)
+          = aB + BitVec.ofNat 64 (fOff + 1) from by
+        rw [se1c]
+        bv_omega] at hx10
+    have hx11' : ((.x11 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 (fOff + fSpanW.toNat))) g3 := by
+      rwa [hendB] at hx11
+    have hR := rebuild (((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 (fOff + 1))) **
+        ((.x11 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 (fOff + fSpanW.toNat))) **
+        ((.x12 : Reg) ↦ᵣ (0 : Word)))
+      ⟨g1, g2, gd1, gu1, hx10', g3, g4, gd2, gu2, hx11', hx12⟩
+    have hflat : ((((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 (fOff + 1))) **
+        ((.x11 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 (fOff + fSpanW.toNat))) **
+        ((.x12 : Reg) ↦ᵣ (0 : Word)) **
+        regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+        regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+        ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x1 : Reg) ↦ᵣ (B + 272 + 4)) **
+        bytesRegion aB acctBytes ** F)) h := by
+      xperm_hyp hR
+    refine (sepConj_pure_right h).2 ⟨hflat,
+      ⟨bb, List.getElem?_eq_getElem hoffb, ?_, by omega, ?_⟩⟩
+    · -- listHeaderSize bb = 1: short-form prefix
+      have hlt := ult_lt hf8
+      have hzb : (bb.zeroExtend 64).toNat = bb.toNat := by bv_omega
+      unfold listHeaderSize
+      rw [if_pos (by
+        rw [show ((0xf8 : Word)).toNat = 0xf8 from rfl] at hlt
+        omega)]
+    · -- 1 ≤ span: the consistency equation forces a non-trivial span
+      have hlen1 : ((bb.zeroExtend 64 - (0xc0 : Word)) + signExtend12 (1 : BitVec 12))
+          = fSpanW := by
+        have := hcons
+        bv_omega
+      have h1 : 1 ≤ fSpanW.toNat := by
+        have hgec := not_ult_le hge0c
+        rw [← hlen1, se1c]
+        bv_omega
+      omega
+  · -- fail arm: status 3 (short mismatch)
+    refine Or.inr ⟨aB + BitVec.ofNat 64 fOff, (aB + BitVec.ofNat 64 fOff) + fSpanW,
+      (3 : Word), ?_⟩
+    obtain ⟨g1, g2, gd1, gu1, hx10, grest⟩ := a4
+    obtain ⟨g3, g4, gd2, gu2, hx11, grest2⟩ := grest
+    obtain ⟨hx12, _⟩ := (sepConj_pure_right g4).1 grest2
+    have hR := rebuild (((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 fOff)) **
+        ((.x11 : Reg) ↦ᵣ ((aB + BitVec.ofNat 64 fOff) + fSpanW)) **
+        ((.x12 : Reg) ↦ᵣ (3 : Word)))
+      ⟨g1, g2, gd1, gu1, hx10, g3, g4, gd2, gu2, hx11, hx12⟩
+    have hflat : ((((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 fOff)) **
+        ((.x11 : Reg) ↦ᵣ ((aB + BitVec.ofNat 64 fOff) + fSpanW)) **
+        ((.x12 : Reg) ↦ᵣ (3 : Word)) **
+        regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+        regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+        ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x1 : Reg) ↦ᵣ (B + 272 + 4)) **
+        bytesRegion aB acctBytes ** F)) h := by
+      xperm_hyp hR
+    exact (sepConj_pure_right h).2 ⟨hflat, by decide⟩
+  · -- fail arm: status 4 (long truncated)
+    refine Or.inr ⟨aB + BitVec.ofNat 64 fOff, (aB + BitVec.ofNat 64 fOff) + fSpanW,
+      (4 : Word), ?_⟩
+    obtain ⟨g1, g2, gd1, gu1, hx10, grest⟩ := a5
+    obtain ⟨g3, g4, gd2, gu2, hx11, grest2⟩ := grest
+    obtain ⟨hx12, _⟩ := (sepConj_pure_right g4).1 grest2
+    have hR := rebuild (((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 fOff)) **
+        ((.x11 : Reg) ↦ᵣ ((aB + BitVec.ofNat 64 fOff) + fSpanW)) **
+        ((.x12 : Reg) ↦ᵣ (4 : Word)))
+      ⟨g1, g2, gd1, gu1, hx10, g3, g4, gd2, gu2, hx11, hx12⟩
+    have hflat : ((((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 fOff)) **
+        ((.x11 : Reg) ↦ᵣ ((aB + BitVec.ofNat 64 fOff) + fSpanW)) **
+        ((.x12 : Reg) ↦ᵣ (4 : Word)) **
+        regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+        regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+        ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x1 : Reg) ↦ᵣ (B + 272 + 4)) **
+        bytesRegion aB acctBytes ** F)) h := by
+      xperm_hyp hR
+    exact (sepConj_pure_right h).2 ⟨hflat, by decide⟩
+  · -- fail arm: status 5 (long leading zero)
+    refine Or.inr ⟨aB + BitVec.ofNat 64 fOff, (aB + BitVec.ofNat 64 fOff) + fSpanW,
+      (5 : Word), ?_⟩
+    obtain ⟨g1, g2, gd1, gu1, hx10, grest⟩ := a6
+    obtain ⟨g3, g4, gd2, gu2, hx11, grest2⟩ := grest
+    obtain ⟨hx12, _⟩ := (sepConj_pure_right g4).1 grest2
+    have hR := rebuild (((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 fOff)) **
+        ((.x11 : Reg) ↦ᵣ ((aB + BitVec.ofNat 64 fOff) + fSpanW)) **
+        ((.x12 : Reg) ↦ᵣ (5 : Word)))
+      ⟨g1, g2, gd1, gu1, hx10, g3, g4, gd2, gu2, hx11, hx12⟩
+    have hflat : ((((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 fOff)) **
+        ((.x11 : Reg) ↦ᵣ ((aB + BitVec.ofNat 64 fOff) + fSpanW)) **
+        ((.x12 : Reg) ↦ᵣ (5 : Word)) **
+        regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+        regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+        ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x1 : Reg) ↦ᵣ (B + 272 + 4)) **
+        bytesRegion aB acctBytes ** F)) h := by
+      xperm_hyp hR
+    exact (sepConj_pure_right h).2 ⟨hflat, by decide⟩
+  · -- fail arm: status 6 (long non-minimal)
+    refine Or.inr ⟨aB + BitVec.ofNat 64 fOff, (aB + BitVec.ofNat 64 fOff) + fSpanW,
+      (6 : Word), ?_⟩
+    obtain ⟨g1, g2, gd1, gu1, hx10, grest⟩ := a7
+    obtain ⟨g3, g4, gd2, gu2, hx11, grest2⟩ := grest
+    obtain ⟨hx12, _⟩ := (sepConj_pure_right g4).1 grest2
+    have hR := rebuild (((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 fOff)) **
+        ((.x11 : Reg) ↦ᵣ ((aB + BitVec.ofNat 64 fOff) + fSpanW)) **
+        ((.x12 : Reg) ↦ᵣ (6 : Word)))
+      ⟨g1, g2, gd1, gu1, hx10, g3, g4, gd2, gu2, hx11, hx12⟩
+    have hflat : ((((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 fOff)) **
+        ((.x11 : Reg) ↦ᵣ ((aB + BitVec.ofNat 64 fOff) + fSpanW)) **
+        ((.x12 : Reg) ↦ᵣ (6 : Word)) **
+        regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+        regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+        ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x1 : Reg) ↦ᵣ (B + 272 + 4)) **
+        bytesRegion aB acctBytes ** F)) h := by
+      xperm_hyp hR
+    exact (sepConj_pure_right h).2 ⟨hflat, by decide⟩
+  · -- fail arm: status 7 (long mismatch)
+    refine Or.inr ⟨aB + BitVec.ofNat 64 fOff, (aB + BitVec.ofNat 64 fOff) + fSpanW,
+      (7 : Word), ?_⟩
+    obtain ⟨g1, g2, gd1, gu1, hx10, grest⟩ := a8
+    obtain ⟨g3, g4, gd2, gu2, hx11, grest2⟩ := grest
+    obtain ⟨hx12, _⟩ := (sepConj_pure_right g4).1 grest2
+    have hR := rebuild (((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 fOff)) **
+        ((.x11 : Reg) ↦ᵣ ((aB + BitVec.ofNat 64 fOff) + fSpanW)) **
+        ((.x12 : Reg) ↦ᵣ (7 : Word)))
+      ⟨g1, g2, gd1, gu1, hx10, g3, g4, gd2, gu2, hx11, hx12⟩
+    have hflat : ((((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 fOff)) **
+        ((.x11 : Reg) ↦ᵣ ((aB + BitVec.ofNat 64 fOff) + fSpanW)) **
+        ((.x12 : Reg) ↦ᵣ (7 : Word)) **
+        regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+        regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+        ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x1 : Reg) ↦ᵣ (B + 272 + 4)) **
+        bytesRegion aB acctBytes ** F)) h := by
+      xperm_hyp hR
+    exact (sepConj_pure_right h).2 ⟨hflat, by decide⟩
+  · -- long-list success (status 0)
+    refine Or.inl ⟨fOff + ((bb.zeroExtend 64 - (0xf7 : Word)) +
+      signExtend12 (1 : BitVec 12)).toNat, ?_⟩
+    obtain ⟨g1, g2, gd1, gu1, hx10, grest⟩ := a9
+    obtain ⟨g3, g4, gd2, gu2, hx11, grest2⟩ := grest
+    obtain ⟨hx12, hfacts⟩ := (sepConj_pure_right g4).1 grest2
+    obtain ⟨hne0, hnc0, hnf8, hfit, hmin5, hsum6⟩ := hfacts
+    clear hmin5 hsum6 hnc0
+    have hgef8 := not_ult_le hnf8
+    rw [show ((0xf8 : Word)).toNat = 0xf8 from rfl] at hgef8
+    have hzb : (bb.zeroExtend 64).toNat = bb.toNat := by bv_omega
+    have hhdrN : ((bb.zeroExtend 64 - (0xf7 : Word)) + signExtend12 (1 : BitVec 12)).toNat
+        = 1 + (bb.toNat - 0xf7) := by
+      rw [show signExtend12 (1 : BitVec 12) = (1 : Word) from by decide]
+      have hb := bb.isLt
+      bv_omega
+    have hx10' : ((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64
+        (fOff + ((bb.zeroExtend 64 - (0xf7 : Word)) +
+          signExtend12 (1 : BitVec 12)).toNat))) g1 := by
+      rwa [show (aB + BitVec.ofNat 64 fOff) +
+          ((bb.zeroExtend 64 - (0xf7 : Word)) + signExtend12 (1 : BitVec 12))
+          = aB + BitVec.ofNat 64
+            (fOff + ((bb.zeroExtend 64 - (0xf7 : Word)) +
+              signExtend12 (1 : BitVec 12)).toNat) from by
+        bv_omega] at hx10
+    have hx11' : ((.x11 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 (fOff + fSpanW.toNat))) g3 := by
+      rwa [hendB] at hx11
+    have hR := rebuild (((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64
+        (fOff + ((bb.zeroExtend 64 - (0xf7 : Word)) +
+          signExtend12 (1 : BitVec 12)).toNat))) **
+        ((.x11 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 (fOff + fSpanW.toNat))) **
+        ((.x12 : Reg) ↦ᵣ (0 : Word)))
+      ⟨g1, g2, gd1, gu1, hx10', g3, g4, gd2, gu2, hx11', hx12⟩
+    have hflat : ((((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64
+        (fOff + ((bb.zeroExtend 64 - (0xf7 : Word)) +
+          signExtend12 (1 : BitVec 12)).toNat))) **
+        ((.x11 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 (fOff + fSpanW.toNat))) **
+        ((.x12 : Reg) ↦ᵣ (0 : Word)) **
+        regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+        regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+        ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x1 : Reg) ↦ᵣ (B + 272 + 4)) **
+        bytesRegion aB acctBytes ** F)) h := by
+      xperm_hyp hR
+    refine (sepConj_pure_right h).2 ⟨hflat,
+      ⟨bb, List.getElem?_eq_getElem hoffb, ?_, ?_, ?_⟩⟩
+    · -- listHeaderSize bb = 1 + (bb - 0xf7): long-form prefix
+      unfold listHeaderSize
+      rw [if_neg (by omega), hhdrN]
+    · -- strictly past the header
+      rw [hhdrN]
+      omega
+    · -- header fits inside the window
+      rw [hhdrN]
+      have hfit' := not_ult_le hfit
+      rw [show signExtend12 (1 : BitVec 12) = (1 : Word) from by decide] at hfit'
+      have hb := bb.isLt
+      bv_omega
+
+
+#print axioms bansf_fieldInit68_spec
 
 end BalAccountNonstorageFinalsSpec
 end EvmAsm.Codegen

--- a/EvmAsm/Codegen/Programs/BalAccountNonstorageFinalsChainC.lean
+++ b/EvmAsm/Codegen/Programs/BalAccountNonstorageFinalsChainC.lean
@@ -573,5 +573,129 @@ def balStationPost (aB newSp oB : Word) (aLen fOff fSpanN : Nat)
         vLen.toNat ≤ 32⌝) h)
 
 
+/-! ## §4  The empty-list split (slot 52) and loop entry (slots 53–54) -/
+
+/-- The last decode of a `LastItemAt` derivation, extracted with its
+    in-window position (for `rlpItemDecode_spanStart` at the tuple window). -/
+theorem LastItemAt_decode {bytes : List (BitVec 8)} {base : Word}
+    {off0 endOff : Nat} {n l : Word}
+    (h : LastItemAt bytes base (base + BitVec.ofNat 64 endOff) off0 n l)
+    (hoff0 : off0 ≤ endOff)
+    (hover : base.toNat + endOff + 9 < 2 ^ 64) :
+    ∃ off : Nat, off ≤ endOff ∧
+      rlpItemDecode bytes off (base + BitVec.ofNat 64 off)
+        (base + BitVec.ofNat 64 endOff) n l := by
+  induction h with
+  | last o nn ll hi _ => exact ⟨o, hoff0, hi⟩
+  | step o nn ll n' l' hi _ _ ih =>
+      have hadv := rlpItemDecode_advance hi hoff0 hover
+      exact ih hadv.2.2
+
+/-- Empty-field exit (slot 52 taken, `B + 208 → B + 352`): the content
+    cursor equals the window end, so the field list is EMPTY. -/
+theorem bansf_balEmptyTaken_spec (aB : Word) (cOff fEnd : Nat)
+    (heq : cOff = fEnd) :
+    cpsTripleWithin 1 (B + 208) (B + 352) bansfCode
+      (((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 cOff)) **
+       ((.x11 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 fEnd)))
+      (((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 cOff)) **
+       ((.x11 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 fEnd))) := by
+  subst heq
+  have hbeq := beq_spec_gen_within .x10 .x11 (144 : BitVec 13)
+    (aB + BitVec.ofNat 64 cOff) (aB + BitVec.ofNat 64 cOff) (B + 208)
+  rw [show (B + 208) + signExtend13 (144 : BitVec 13) = B + 352 from by
+        rw [show signExtend13 (144 : BitVec 13) = (144 : Word) from by decide]
+        bv_omega] at hbeq
+  have hbeqL := cpsBranchWithin_extend_code (cr' := bansfCode)
+    (fun a i h => CodeReq.ofProg_mem_at B (B + 208) bansfProg 52
+      (.BEQ .x10 .x11 (144 : BitVec 13))
+      (by decide +kernel) (by decide +kernel) (by decide +kernel) (by decide) a i h)
+    hbeq
+  have h := cpsBranchWithin_takenPath hbeqL
+    (fun hp hQf => by
+      obtain ⟨_, _, _, _, _, h_pure⟩ := hQf
+      exact absurd rfl (((sepConj_pure_right _).1 h_pure).2))
+  exact cpsTripleWithin_weaken (fun _ hp => hp)
+    (fun h hq => by
+      exact sepConj_mono_right
+        (fun h' hp' => ((sepConj_pure_right h').1 hp').1) h hq) h
+
+/-- Non-empty fall-through (slot 52 not taken, `B + 208 → B + 212`). -/
+theorem bansf_balEmptyFall_spec (aB : Word) (aLen cOff fEnd : Nat)
+    (hne : cOff ≠ fEnd) (hcle : cOff ≤ aLen) (hfle : fEnd ≤ aLen)
+    (hover9 : aB.toNat + aLen + 9 < 2 ^ 64) :
+    cpsTripleWithin 1 (B + 208) (B + 212) bansfCode
+      (((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 cOff)) **
+       ((.x11 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 fEnd)))
+      (((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 cOff)) **
+       ((.x11 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 fEnd))) := by
+  have hwne : aB + BitVec.ofNat 64 cOff ≠ aB + BitVec.ofNat 64 fEnd := by
+    intro hc
+    apply hne
+    have := congrArg BitVec.toNat hc
+    rw [BitVec.toNat_add, BitVec.toNat_add, BitVec.toNat_ofNat,
+      BitVec.toNat_ofNat] at this
+    omega
+  have hbeq := beq_spec_gen_within .x10 .x11 (144 : BitVec 13)
+    (aB + BitVec.ofNat 64 cOff) (aB + BitVec.ofNat 64 fEnd) (B + 208)
+  rw [show (B + 208) + 4 = B + 212 from by bv_omega] at hbeq
+  have hbeqL := cpsBranchWithin_extend_code (cr' := bansfCode)
+    (fun a i h => CodeReq.ofProg_mem_at B (B + 208) bansfProg 52
+      (.BEQ .x10 .x11 (144 : BitVec 13))
+      (by decide +kernel) (by decide +kernel) (by decide +kernel) (by decide) a i h)
+    hbeq
+  have h := cpsBranchWithin_ntakenPath hbeqL
+    (fun hp hQt => by
+      obtain ⟨_, _, _, _, _, h_pure⟩ := hQt
+      exact absurd (((sepConj_pure_right _).1 h_pure).2) hwne)
+  exact cpsTripleWithin_weaken (fun _ hp => hp)
+    (fun h hq => by
+      exact sepConj_mono_right
+        (fun h' hp' => ((sepConj_pure_right h').1 hp').1) h hq) h
+
+/-- Loop-entry spills (slots 53–54): store the tuple-walk cursor and end. -/
+theorem bansf_loopEntry53_spec (aB newSp : Word) (cOff fEnd : Nat) :
+    cpsTripleWithin 2 (B + 212) (B + 220) bansfCR
+      (((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 cOff)) **
+       ((.x11 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 fEnd)) **
+       ((.x2 : Reg) ↦ᵣ newSp) **
+       memOwn (newSp + 64) ** memOwn (newSp + 72))
+      (((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 cOff)) **
+       ((.x11 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 fEnd)) **
+       ((.x2 : Reg) ↦ᵣ newSp) **
+       ((newSp + 64) ↦ₘ (aB + BitVec.ofNat 64 cOff)) **
+       ((newSp + 72) ↦ₘ (aB + BitVec.ofNat 64 fEnd))) := by
+  have hsd1 := sd_spec_gen_own_within .x2 .x10 newSp (aB + BitVec.ofNat 64 cOff)
+    (64 : BitVec 12) (B + 212)
+  rw [show signExtend12 (64 : BitVec 12) = (64 : Word) from by decide,
+      show (B + 212) + 4 = B + 216 from by bv_omega] at hsd1
+  have hsd1L := liftCode (cr' := bansfCR) hsd1
+    (fun a i h => CodeReq.union_mono_left a i
+      (CodeReq.ofProg_mem_at B (B + 212) bansfProg 53 (.SD .x2 .x10 (64 : BitVec 12))
+        (by decide +kernel) (by decide +kernel) (by decide +kernel) (by decide) a i h))
+  have hsd2 := sd_spec_gen_own_within .x2 .x11 newSp (aB + BitVec.ofNat 64 fEnd)
+    (72 : BitVec 12) (B + 216)
+  rw [show signExtend12 (72 : BitVec 12) = (72 : Word) from by decide,
+      show (B + 216) + 4 = B + 220 from by bv_omega] at hsd2
+  have hsd2L := liftCode (cr' := bansfCR) hsd2
+    (fun a i h => CodeReq.union_mono_left a i
+      (CodeReq.ofProg_mem_at B (B + 216) bansfProg 54 (.SD .x2 .x11 (72 : BitVec 12))
+        (by decide +kernel) (by decide +kernel) (by decide +kernel) (by decide) a i h))
+  have hsd1F := cpsTripleWithin_frameR
+    (((.x11 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 fEnd)) ** memOwn (newSp + 72))
+    (by pcf) hsd1L
+  have hsd2F := cpsTripleWithin_frameR
+    (((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 cOff)) **
+     ((newSp + 64) ↦ₘ (aB + BitVec.ofNat 64 cOff)))
+    (by pcf) hsd2L
+  have hchain := cpsTripleWithin_seq_perm_same_cr (fun h hp => by xperm_hyp hp)
+    hsd1F hsd2F
+  exact cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp)
+    (fun h hq => by xperm_hyp hq) hchain
+
+#print axioms bansf_balEmptyTaken_spec
+#print axioms bansf_balEmptyFall_spec
+#print axioms bansf_loopEntry53_spec
+
 end BalAccountNonstorageFinalsSpec
 end EvmAsm.Codegen

--- a/EvmAsm/Codegen/Programs/BalAccountNonstorageFinalsChainC2.lean
+++ b/EvmAsm/Codegen/Programs/BalAccountNonstorageFinalsChainC2.lean
@@ -1,0 +1,914 @@
+/-
+  EvmAsm.Codegen.Programs.BalAccountNonstorageFinalsChainC2
+
+  Tuple item units for the `bal_account_nonstorage_finals` balance station
+  (bead evm-asm-4ch8f.43.5, slice 4d): the `[block_access_index, value]`
+  tuple's index and value items, walked at the `64/72(sp)` spill pair,
+  generated from the SEG-B outer item template by the address table.
+-/
+
+import EvmAsm.Codegen.Programs.BalAccountNonstorageFinalsChainC
+
+set_option maxRecDepth 8000
+
+namespace EvmAsm.Codegen
+
+open EvmAsm.Rv64 EvmAsm.Rv64.SAsm EvmAsm.Rv64.RLP
+
+namespace BalAccountNonstorageFinalsSpec
+
+private theorem se64t : signExtend12 (64 : BitVec 12) = (64 : Word) := by decide
+private theorem se72t : signExtend12 (72 : BitVec 12) = (72 : Word) := by decide
+
+/-- The unit reject shape (everything the unit touches, weakened). -/
+def tupleRej (aB newSp : Word) (acctBytes : List (BitVec 8)) (F : Assertion) :
+    Assertion :=
+  ((.x10 : Reg) ↦ᵣ (1 : Word)) ** ((.x2 : Reg) ↦ᵣ newSp) **
+  memOwn (newSp + 64) ** memOwn (newSp + 72) **
+  regOwn .x11 ** regOwn .x12 **
+  regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+  regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+  ((.x0 : Reg) ↦ᵣ (0 : Word)) ** regOwn .x1 **
+  bytesRegion aB acctBytes ** F
+
+/-- The unit success shape at its exit: the advanced cursor is spilled and
+    pinned in `a0`, `a2` reports the decoded length, and the pure decode
+    fact is recorded. -/
+def tupleOk (aB newSp : Word) (aLen off : Nat) (acctBytes : List (BitVec 8))
+    (F : Assertion) : Assertion :=
+  fun h => ∃ next len : Word,
+    ((((.x10 : Reg) ↦ᵣ next) ** ((.x11 : Reg) ↦ᵣ (0 : Word)) **
+      ((.x12 : Reg) ↦ᵣ len) **
+      ((.x2 : Reg) ↦ᵣ newSp) **
+      ((newSp + 64) ↦ₘ next) **
+      ((newSp + 72) ↦ₘ (aB + BitVec.ofNat 64 aLen)) **
+      regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+      regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+      ((.x0 : Reg) ↦ᵣ (0 : Word)) ** regOwn .x1 **
+      bytesRegion aB acctBytes ** F) **
+     ⌜rlpItemDecode acctBytes off (aB + BitVec.ofNat 64 off)
+       (aB + BitVec.ofNat 64 aLen) next len⌝) h
+
+/-- Tuple item unit 0 — the [index, value] tuple's INDEX item\n    (slots 72–76, `B + 288 → B + 308`); spills at `64/72(sp)`. -/
+theorem bansf_tupleItem0_spec (aB newSp : Word) (aLen off : Nat)
+    (acctBytes : List (BitVec 8))
+    (v5 v6 v7 v10 v11 v12 v28 v29 v30 v31 vRa : Word) (F : Assertion)
+    (hF : F.pcFree)
+    (hsalign : aB.toNat % 8 = 0)
+    (hslack : aLen + 9 ≤ acctBytes.length)
+    (hover : aB.toNat + acctBytes.length < 2 ^ 64)
+    (hvalid : ∀ k, k < acctBytes.length →
+      isValidByteAccess (aB + BitVec.ofNat 64 k) = true)
+    (hoffle : off ≤ aLen) :
+    cpsBranchWithin 93 (B + 288) bansfCR
+      (((newSp + 64) ↦ₘ (aB + BitVec.ofNat 64 off)) **
+       ((newSp + 72) ↦ₘ (aB + BitVec.ofNat 64 aLen)) **
+       ((.x2 : Reg) ↦ᵣ newSp) **
+       ((.x10 : Reg) ↦ᵣ v10) ** ((.x11 : Reg) ↦ᵣ v11) ** ((.x12 : Reg) ↦ᵣ v12) **
+       ((.x5 : Reg) ↦ᵣ v5) ** ((.x6 : Reg) ↦ᵣ v6) ** ((.x7 : Reg) ↦ᵣ v7) **
+       ((.x28 : Reg) ↦ᵣ v28) ** ((.x29 : Reg) ↦ᵣ v29) **
+       ((.x30 : Reg) ↦ᵣ v30) ** ((.x31 : Reg) ↦ᵣ v31) **
+       ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x1 : Reg) ↦ᵣ vRa) **
+       bytesRegion aB acctBytes ** F)
+      (B + 736) (tupleRej aB newSp acctBytes F)
+      (B + 308) (tupleOk aB newSp aLen off acctBytes F) := by
+  have hoffb : off < acctBytes.length := by omega
+  -- LD a0, 48(sp) ; LD a1, 56(sp)  (B+104, B+108)
+  have hld1 := ld_spec_gen_within .x10 .x2 newSp v10 (aB + BitVec.ofNat 64 off)
+    (64 : BitVec 12) (B + 288) (by decide)
+  rw [se64t, show (B + 288) + 4 = B + 292 from by bv_omega] at hld1
+  have hld1L := liftCode (cr' := bansfCR) hld1
+    (fun a i h => CodeReq.union_mono_left a i
+      (CodeReq.ofProg_mem_at B (B + 288) bansfProg 72 (.LD .x10 .x2 (64 : BitVec 12))
+        (by decide +kernel) (by decide +kernel) (by decide +kernel) (by decide) a i h))
+  have hld2 := ld_spec_gen_within .x11 .x2 newSp v11 (aB + BitVec.ofNat 64 aLen)
+    (72 : BitVec 12) (B + 292) (by decide)
+  rw [se72t, show (B + 292) + 4 = B + 296 from by bv_omega] at hld2
+  have hld2L := liftCode (cr' := bansfCR) hld2
+    (fun a i h => CodeReq.union_mono_left a i
+      (CodeReq.ofProg_mem_at B (B + 292) bansfProg 73 (.LD .x11 .x2 (72 : BitVec 12))
+        (by decide +kernel) (by decide +kernel) (by decide +kernel) (by decide) a i h))
+  have hld1F := cpsTripleWithin_frameR
+    (((newSp + 72) ↦ₘ (aB + BitVec.ofNat 64 aLen)) ** ((.x11 : Reg) ↦ᵣ v11))
+    (by pcf) hld1L
+  have hld2F := cpsTripleWithin_frameR
+    (((newSp + 64) ↦ₘ (aB + BitVec.ofNat 64 off)) **
+     ((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 off)))
+    (by pcf) hld2L
+  have hlds := cpsTripleWithin_seq_perm_same_cr (fun h hp => by xperm_hyp hp) hld1F hld2F
+  have hldsF := cpsTripleWithin_frameR
+    (((.x12 : Reg) ↦ᵣ v12) **
+     ((.x5 : Reg) ↦ᵣ v5) ** ((.x6 : Reg) ↦ᵣ v6) ** ((.x7 : Reg) ↦ᵣ v7) **
+     ((.x28 : Reg) ↦ᵣ v28) ** ((.x29 : Reg) ↦ᵣ v29) **
+     ((.x30 : Reg) ↦ᵣ v30) ** ((.x31 : Reg) ↦ᵣ v31) **
+     ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x1 : Reg) ↦ᵣ vRa) **
+     bytesRegion aB acctBytes ** F)
+    (by pcf; exact hF) hlds
+  -- the callee triple with ra = B + 296 + 4
+  have hwn := rlp_walk_next_spec_within WN aB (aB + BitVec.ofNat 64 aLen)
+    (B + 296 + 4) v12 v5 v6 v7 v28 v29 v30 v31 acctBytes off hsalign hoffb (by omega)
+    (hvalid off hoffb)
+    (fun h80 hb8 => ⟨by omega, by omega, hvalid _ (by omega)⟩)
+    (fun hb8 hc0 => by
+      have hlo : ((acctBytes[off]'hoffb).zeroExtend 64 - (0xb7 : Word)).toNat ≤ 8 := by
+        have h1 := ult_lt hc0
+        have h2 := not_ult_le hb8
+        bv_omega
+      exact ⟨by omega, by omega, fun k hk => hvalid _ (by omega)⟩)
+    (fun hf8 => by
+      have hlo : ((acctBytes[off]'hoffb).zeroExtend 64 - (0xf7 : Word)).toNat ≤ 8 := by
+        have h2 := not_ult_le hf8
+        have h3 := (acctBytes[off]'hoffb).isLt
+        bv_omega
+      exact ⟨by omega, by omega, fun k hk => hvalid _ (by omega)⟩)
+  have hwn' := cpsTripleWithin_weaken
+    (fun h hp => by xperm_hyp hp) (fun _ hq => hq) hwn
+    (P' := ((.x1 : Reg) ↦ᵣ (B + 296 + 4)) **
+      (((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 off)) **
+       ((.x11 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 aLen)) ** ((.x12 : Reg) ↦ᵣ v12) **
+       ((.x5 : Reg) ↦ᵣ v5) ** ((.x6 : Reg) ↦ᵣ v6) ** ((.x7 : Reg) ↦ᵣ v7) **
+       ((.x28 : Reg) ↦ᵣ v28) ** ((.x29 : Reg) ↦ᵣ v29) **
+       ((.x30 : Reg) ↦ᵣ v30) ** ((.x31 : Reg) ↦ᵣ v31) **
+       ((.x0 : Reg) ↦ᵣ (0 : Word)) ** bytesRegion aB acctBytes))
+  have hcall := bansf_callSite74_walk_next (n := 87) vRa (by pcf) hwn'
+  rw [show (B + 296) + 4 = B + 300 from by bv_omega] at hcall
+  have hcallF := cpsTripleWithin_frameR
+    (((.x2 : Reg) ↦ᵣ newSp) **
+     ((newSp + 64) ↦ₘ (aB + BitVec.ofNat 64 off)) **
+     ((newSp + 72) ↦ₘ (aB + BitVec.ofNat 64 aLen)) ** F)
+    (by pcf; exact hF) hcall
+  have hpre := cpsTripleWithin_seq_perm_same_cr (fun h hp => by xperm_hyp hp)
+    hldsF hcallF
+  -- ===== ok continuation: BNE falls through, SD spills the cursor =====
+  have hokc : cpsBranchWithin 2 (B + 300) bansfCR
+      (fun h => ∃ next len : Word,
+        ((((.x10 : Reg) ↦ᵣ next) ** ((.x11 : Reg) ↦ᵣ (0 : Word)) **
+          ((.x12 : Reg) ↦ᵣ len) **
+          ((.x2 : Reg) ↦ᵣ newSp) **
+          ((newSp + 64) ↦ₘ (aB + BitVec.ofNat 64 off)) **
+          ((newSp + 72) ↦ₘ (aB + BitVec.ofNat 64 aLen)) **
+          regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+          regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+          ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x1 : Reg) ↦ᵣ (B + 296 + 4)) **
+          bytesRegion aB acctBytes ** F) **
+         ⌜rlpItemDecode acctBytes off (aB + BitVec.ofNat 64 off)
+           (aB + BitVec.ofNat 64 aLen) next len⌝) h)
+      (B + 736) (tupleRej aB newSp acctBytes F)
+      (B + 308) (tupleOk aB newSp aLen off acctBytes F) := by
+    refine cpsBranchWithin_exists_pre (fun next => ?_)
+    refine cpsBranchWithin_exists_pre (fun len => ?_)
+    refine cpsBranchWithin_pure_pre_right (fun hdec => ?_)
+    have hbne := bne_spec_gen_within .x11 .x0 (432 : BitVec 13) (0 : Word) (0 : Word) (B + 300)
+    rw [show (B + 300) + 4 = B + 304 from by bv_omega] at hbne
+    have hbneL := cpsBranchWithin_extend_code (cr' := bansfCR)
+      (fun a i h => CodeReq.union_mono_left a i
+        (CodeReq.ofProg_mem_at B (B + 300) bansfProg 75 (.BNE .x11 .x0 (432 : BitVec 13))
+          (by decide +kernel) (by decide +kernel) (by decide +kernel) (by decide) a i h))
+      hbne
+    have hfall := cpsBranchWithin_ntakenPath hbneL
+      (fun hp hQt => by
+        obtain ⟨_, _, _, _, _, h_pure⟩ := hQt
+        exact absurd rfl (((sepConj_pure_right _).1 h_pure).2))
+    -- SD a0, 48(sp) at B+120
+    have hsd := sd_spec_gen_within .x2 .x10 newSp next (aB + BitVec.ofNat 64 off)
+      (64 : BitVec 12) (B + 304)
+    rw [se64t, show (B + 304) + 4 = B + 308 from by bv_omega] at hsd
+    have hsdL := liftCode (cr' := bansfCR) hsd
+      (fun a i h => CodeReq.union_mono_left a i
+        (CodeReq.ofProg_mem_at B (B + 304) bansfProg 76 (.SD .x2 .x10 (64 : BitVec 12))
+          (by decide +kernel) (by decide +kernel) (by decide +kernel) (by decide) a i h))
+    have hfallF := cpsTripleWithin_frameR
+      (((.x10 : Reg) ↦ᵣ next) ** ((.x12 : Reg) ↦ᵣ len) **
+       ((.x2 : Reg) ↦ᵣ newSp) **
+       ((newSp + 64) ↦ₘ (aB + BitVec.ofNat 64 off)) **
+       ((newSp + 72) ↦ₘ (aB + BitVec.ofNat 64 aLen)) **
+       regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+       regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+       ((.x1 : Reg) ↦ᵣ (B + 296 + 4)) **
+       bytesRegion aB acctBytes ** F)
+      (by pcf; exact hF) hfall
+    have hsdF := cpsTripleWithin_frameR
+      (((.x11 : Reg) ↦ᵣ (0 : Word)) ** ((.x12 : Reg) ↦ᵣ len) **
+       ((newSp + 72) ↦ₘ (aB + BitVec.ofNat 64 aLen)) **
+       regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+       regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+       ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x1 : Reg) ↦ᵣ (B + 296 + 4)) **
+       bytesRegion aB acctBytes ** F)
+      (by pcf; exact hF) hsdL
+    have hout : cpsTripleWithin 2 (B + 300) (B + 308) bansfCR
+        (((.x10 : Reg) ↦ᵣ next) ** ((.x11 : Reg) ↦ᵣ (0 : Word)) **
+         ((.x12 : Reg) ↦ᵣ len) **
+         ((.x2 : Reg) ↦ᵣ newSp) **
+         ((newSp + 64) ↦ₘ (aB + BitVec.ofNat 64 off)) **
+         ((newSp + 72) ↦ₘ (aB + BitVec.ofNat 64 aLen)) **
+         regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+         regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+         ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x1 : Reg) ↦ᵣ (B + 296 + 4)) **
+         bytesRegion aB acctBytes ** F)
+        (tupleOk aB newSp aLen off acctBytes F) := by
+      have hchain := cpsTripleWithin_seq_perm_same_cr
+        (fun h hp => by
+          have hp2 := sepConj_mono_left (sepConj_mono_right
+            (fun h' hp' => ((sepConj_pure_right h').1 hp').1)) h hp
+          xperm_hyp hp2)
+        hfallF hsdF
+      refine cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp) (fun h hq => ?_) hchain
+      unfold tupleOk
+      refine ⟨next, len, ?_⟩
+      have hq2 : ((((.x10 : Reg) ↦ᵣ next) ** ((.x11 : Reg) ↦ᵣ (0 : Word)) **
+          ((.x12 : Reg) ↦ᵣ len) **
+          ((.x2 : Reg) ↦ᵣ newSp) **
+          ((newSp + 64) ↦ₘ next) **
+          ((newSp + 72) ↦ₘ (aB + BitVec.ofNat 64 aLen)) **
+          regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+          regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+          ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x1 : Reg) ↦ᵣ (B + 296 + 4)) **
+          bytesRegion aB acctBytes ** F)) h := by
+        xperm_hyp hq
+      have hq3 : ((((.x10 : Reg) ↦ᵣ next) ** ((.x11 : Reg) ↦ᵣ (0 : Word)) **
+          ((.x12 : Reg) ↦ᵣ len) **
+          ((.x2 : Reg) ↦ᵣ newSp) **
+          ((newSp + 64) ↦ₘ next) **
+          ((newSp + 72) ↦ₘ (aB + BitVec.ofNat 64 aLen)) **
+          regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+          regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+          ((.x0 : Reg) ↦ᵣ (0 : Word)) ** regOwn .x1 **
+          bytesRegion aB acctBytes ** F)) h := by
+        have hq4 : ((((.x1 : Reg) ↦ᵣ (B + 296 + 4)) **
+            (((.x10 : Reg) ↦ᵣ next) ** ((.x11 : Reg) ↦ᵣ (0 : Word)) **
+             ((.x12 : Reg) ↦ᵣ len) **
+             ((.x2 : Reg) ↦ᵣ newSp) **
+             ((newSp + 64) ↦ₘ next) **
+             ((newSp + 72) ↦ₘ (aB + BitVec.ofNat 64 aLen)) **
+             regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+             regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+             ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+             bytesRegion aB acctBytes ** F))) h := by
+          xperm_hyp hq2
+        have hq5 := sepConj_mono (regIs_implies_regOwn .x1) (fun _ x => x) h hq4
+        xperm_hyp hq5
+      exact (sepConj_pure_right h).2 ⟨hq3, hdec⟩
+    exact cpsBranchWithin_mono_nSteps (by omega)
+      (cpsTripleWithin_as_cpsBranchWithin_right _ _ hout)
+  -- ===== fail continuation =====
+  have hfailc : cpsBranchWithin 2 (B + 300) bansfCR
+      (fun h => ∃ cur k : Word,
+        ((((.x10 : Reg) ↦ᵣ cur) ** ((.x11 : Reg) ↦ᵣ k) **
+          ((.x12 : Reg) ↦ᵣ (0 : Word)) **
+          ((.x2 : Reg) ↦ᵣ newSp) **
+          ((newSp + 64) ↦ₘ (aB + BitVec.ofNat 64 off)) **
+          ((newSp + 72) ↦ₘ (aB + BitVec.ofNat 64 aLen)) **
+          regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+          regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+          ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x1 : Reg) ↦ᵣ (B + 296 + 4)) **
+          bytesRegion aB acctBytes ** F) **
+         ⌜k ≠ (0 : Word)⌝) h)
+      (B + 736) (tupleRej aB newSp acctBytes F)
+      (B + 308) (tupleOk aB newSp aLen off acctBytes F) := by
+    refine cpsBranchWithin_exists_pre (fun cur => ?_)
+    refine cpsBranchWithin_exists_pre (fun k => ?_)
+    refine cpsBranchWithin_pure_pre_right (fun hk => ?_)
+    have hbne := bne_spec_gen_within .x11 .x0 (432 : BitVec 13) k (0 : Word) (B + 300)
+    rw [show (B + 300) + signExtend13 (432 : BitVec 13) = B + 732 from by
+          rw [show signExtend13 (432 : BitVec 13) = (432 : Word) from by decide]
+          bv_omega,
+        show (B + 300) + 4 = B + 304 from by bv_omega] at hbne
+    have hbneL := cpsBranchWithin_extend_code (cr' := bansfCR)
+      (fun a i h => CodeReq.union_mono_left a i
+        (CodeReq.ofProg_mem_at B (B + 300) bansfProg 75 (.BNE .x11 .x0 (432 : BitVec 13))
+          (by decide +kernel) (by decide +kernel) (by decide +kernel) (by decide) a i h))
+      hbne
+    have hbneF := cpsBranchWithin_frameR
+      (((.x10 : Reg) ↦ᵣ cur) ** ((.x12 : Reg) ↦ᵣ (0 : Word)) **
+       ((.x2 : Reg) ↦ᵣ newSp) **
+       ((newSp + 64) ↦ₘ (aB + BitVec.ofNat 64 off)) **
+       ((newSp + 72) ↦ₘ (aB + BitVec.ofNat 64 aLen)) **
+       regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+       regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+       ((.x1 : Reg) ↦ᵣ (B + 296 + 4)) **
+       bytesRegion aB acctBytes ** F)
+      (by pcf; exact hF) hbneL
+    have htaken := cpsBranchWithin_takenPath hbneF
+      (fun hp hQf => by
+        obtain ⟨_, _, _, _, ⟨_, _, _, _, _, h_pure⟩, _⟩ := hQf
+        exact hk (((sepConj_pure_right _).1 h_pure).2))
+    have hrej := liftCode (cr' := bansfCR)
+      (bansf_rejectTail_spec B cur (by decide))
+      (fun a i h => CodeReq.union_mono_left a i h)
+    have hrejF := cpsTripleWithin_frameR
+      (((.x11 : Reg) ↦ᵣ k) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+       ((.x12 : Reg) ↦ᵣ (0 : Word)) **
+       ((.x2 : Reg) ↦ᵣ newSp) **
+       ((newSp + 64) ↦ₘ (aB + BitVec.ofNat 64 off)) **
+       ((newSp + 72) ↦ₘ (aB + BitVec.ofNat 64 aLen)) **
+       regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+       regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+       ((.x1 : Reg) ↦ᵣ (B + 296 + 4)) **
+       bytesRegion aB acctBytes ** F)
+      (by pcf; exact hF) hrej
+    have hchain := cpsTripleWithin_seq_perm_same_cr
+      (fun h hp => by
+        have hp2 := sepConj_mono_left (sepConj_mono_right
+          (fun h' hp' => ((sepConj_pure_right h').1 hp').1)) h hp
+        xperm_hyp hp2)
+      htaken hrejF
+    have hout : cpsTripleWithin 2 (B + 300) (B + 736) bansfCR
+        (((.x10 : Reg) ↦ᵣ cur) ** ((.x11 : Reg) ↦ᵣ k) **
+         ((.x12 : Reg) ↦ᵣ (0 : Word)) **
+         ((.x2 : Reg) ↦ᵣ newSp) **
+         ((newSp + 64) ↦ₘ (aB + BitVec.ofNat 64 off)) **
+         ((newSp + 72) ↦ₘ (aB + BitVec.ofNat 64 aLen)) **
+         regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+         regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+         ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x1 : Reg) ↦ᵣ (B + 296 + 4)) **
+         bytesRegion aB acctBytes ** F)
+        (tupleRej aB newSp acctBytes F) := by
+      refine cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp) (fun h hq => ?_) hchain
+      unfold tupleRej
+      have hq4 : ((((.x11 : Reg) ↦ᵣ k) ** ((.x12 : Reg) ↦ᵣ (0 : Word)) **
+          ((.x1 : Reg) ↦ᵣ (B + 296 + 4)) **
+          ((newSp + 64) ↦ₘ (aB + BitVec.ofNat 64 off)) **
+          ((newSp + 72) ↦ₘ (aB + BitVec.ofNat 64 aLen)) **
+          (((.x10 : Reg) ↦ᵣ (1 : Word)) ** ((.x2 : Reg) ↦ᵣ newSp) **
+           regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+           regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+           ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+           bytesRegion aB acctBytes ** F))) h := by
+        xperm_hyp hq
+      have hq5 := sepConj_mono (regIs_implies_regOwn .x11)
+        (sepConj_mono (regIs_implies_regOwn .x12)
+          (sepConj_mono (regIs_implies_regOwn .x1)
+            (sepConj_mono memIs_implies_memOwn
+              (sepConj_mono memIs_implies_memOwn (fun _ x => x))))) h hq4
+      xperm_hyp hq5
+    exact cpsTripleWithin_as_cpsBranchWithin_left _ _ hout
+  -- ===== chain: loads ; call ; (ok ∨ fail) =====
+  refine cpsBranchWithin_weaken
+    (fun h hp => by xperm_hyp hp) (fun _ x => x) (fun _ x => x)
+    (cpsBranchWithin_mono_nSteps (by omega)
+      (cpsTripleWithin_seq_branch_same_cr hpre
+        (cpsBranchWithin_weaken (fun h hp => ?_) (fun _ x => x) (fun _ x => x)
+          (cpsBranchWithin_pre_or hokc hfailc))))
+  -- pointwise: collapse the six callee arms into ok ∨ fail
+  obtain ⟨h1, h2, hd, hu, ⟨h3, h4, hd2, hu2, hCF, hor⟩, hEx⟩ := hp
+  have rebuild : ∀ (arm : Assertion), arm h4 →
+      ((((regOwn .x5 ** regOwn .x6 ** regOwn .x7 ** regOwn .x28 ** regOwn .x29 **
+          regOwn .x30 ** regOwn .x31 ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+          ((.x1 : Reg) ↦ᵣ (B + 296 + 4)) ** bytesRegion aB acctBytes) ** arm) **
+        (((.x2 : Reg) ↦ᵣ newSp) **
+         ((newSp + 64) ↦ₘ (aB + BitVec.ofNat 64 off)) **
+         ((newSp + 72) ↦ₘ (aB + BitVec.ofNat 64 aLen)) ** F))) h :=
+    fun arm ha => ⟨h1, h2, hd, hu, ⟨h3, h4, hd2, hu2, hCF, ha⟩, hEx⟩
+  rcases hor with a1 | a2 | a3 | a4 | a5 | a6
+  · -- ok arm: rlpWalkNextOk
+    obtain ⟨next, len, hpins⟩ := a1
+    refine Or.inl ⟨next, len, ?_⟩
+    obtain ⟨g1, g2, gd1, gu1, hx10, grest⟩ := hpins
+    obtain ⟨g3, g4, gd2, gu2, hx11, grest2⟩ := grest
+    obtain ⟨hx12, hdec⟩ := (sepConj_pure_right g4).1 grest2
+    have hR := rebuild (((.x10 : Reg) ↦ᵣ next) ** ((.x11 : Reg) ↦ᵣ (0 : Word)) **
+        ((.x12 : Reg) ↦ᵣ len))
+      ⟨g1, g2, gd1, gu1, hx10, g3, g4, gd2, gu2, hx11, hx12⟩
+    have hflat : ((((.x10 : Reg) ↦ᵣ next) ** ((.x11 : Reg) ↦ᵣ (0 : Word)) **
+        ((.x12 : Reg) ↦ᵣ len) **
+        ((.x2 : Reg) ↦ᵣ newSp) **
+        ((newSp + 64) ↦ₘ (aB + BitVec.ofNat 64 off)) **
+        ((newSp + 72) ↦ₘ (aB + BitVec.ofNat 64 aLen)) **
+        regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+        regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+        ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x1 : Reg) ↦ᵣ (B + 296 + 4)) **
+        bytesRegion aB acctBytes ** F)) h := by
+      xperm_hyp hR
+    exact (sepConj_pure_right h).2 ⟨hflat, hdec⟩
+  · -- fail arm: status 2
+    refine Or.inr ⟨aB + BitVec.ofNat 64 off, (2 : Word), ?_⟩
+    obtain ⟨g1, g2, gd1, gu1, hx10, grest⟩ := a2
+    obtain ⟨g3, g4, gd2, gu2, hx11, grest2⟩ := grest
+    obtain ⟨hx12, _⟩ := (sepConj_pure_right g4).1 grest2
+    have hR := rebuild (((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 off)) **
+        ((.x11 : Reg) ↦ᵣ (2 : Word)) ** ((.x12 : Reg) ↦ᵣ (0 : Word)))
+      ⟨g1, g2, gd1, gu1, hx10, g3, g4, gd2, gu2, hx11, hx12⟩
+    have hflat : ((((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 off)) **
+        ((.x11 : Reg) ↦ᵣ (2 : Word)) **
+        ((.x12 : Reg) ↦ᵣ (0 : Word)) **
+        ((.x2 : Reg) ↦ᵣ newSp) **
+        ((newSp + 64) ↦ₘ (aB + BitVec.ofNat 64 off)) **
+        ((newSp + 72) ↦ₘ (aB + BitVec.ofNat 64 aLen)) **
+        regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+        regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+        ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x1 : Reg) ↦ᵣ (B + 296 + 4)) **
+        bytesRegion aB acctBytes ** F)) h := by
+      xperm_hyp hR
+    exact (sepConj_pure_right h).2 ⟨hflat, by decide⟩
+  · -- fail arm: status 3
+    refine Or.inr ⟨aB + BitVec.ofNat 64 off, (3 : Word), ?_⟩
+    obtain ⟨g1, g2, gd1, gu1, hx10, grest⟩ := a3
+    obtain ⟨g3, g4, gd2, gu2, hx11, grest2⟩ := grest
+    obtain ⟨hx12, _⟩ := (sepConj_pure_right g4).1 grest2
+    have hR := rebuild (((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 off)) **
+        ((.x11 : Reg) ↦ᵣ (3 : Word)) ** ((.x12 : Reg) ↦ᵣ (0 : Word)))
+      ⟨g1, g2, gd1, gu1, hx10, g3, g4, gd2, gu2, hx11, hx12⟩
+    have hflat : ((((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 off)) **
+        ((.x11 : Reg) ↦ᵣ (3 : Word)) **
+        ((.x12 : Reg) ↦ᵣ (0 : Word)) **
+        ((.x2 : Reg) ↦ᵣ newSp) **
+        ((newSp + 64) ↦ₘ (aB + BitVec.ofNat 64 off)) **
+        ((newSp + 72) ↦ₘ (aB + BitVec.ofNat 64 aLen)) **
+        regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+        regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+        ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x1 : Reg) ↦ᵣ (B + 296 + 4)) **
+        bytesRegion aB acctBytes ** F)) h := by
+      xperm_hyp hR
+    exact (sepConj_pure_right h).2 ⟨hflat, by decide⟩
+  · -- fail arm: status 4
+    refine Or.inr ⟨aB + BitVec.ofNat 64 off, (4 : Word), ?_⟩
+    obtain ⟨g1, g2, gd1, gu1, hx10, grest⟩ := a4
+    obtain ⟨g3, g4, gd2, gu2, hx11, grest2⟩ := grest
+    obtain ⟨hx12, _⟩ := (sepConj_pure_right g4).1 grest2
+    have hR := rebuild (((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 off)) **
+        ((.x11 : Reg) ↦ᵣ (4 : Word)) ** ((.x12 : Reg) ↦ᵣ (0 : Word)))
+      ⟨g1, g2, gd1, gu1, hx10, g3, g4, gd2, gu2, hx11, hx12⟩
+    have hflat : ((((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 off)) **
+        ((.x11 : Reg) ↦ᵣ (4 : Word)) **
+        ((.x12 : Reg) ↦ᵣ (0 : Word)) **
+        ((.x2 : Reg) ↦ᵣ newSp) **
+        ((newSp + 64) ↦ₘ (aB + BitVec.ofNat 64 off)) **
+        ((newSp + 72) ↦ₘ (aB + BitVec.ofNat 64 aLen)) **
+        regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+        regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+        ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x1 : Reg) ↦ᵣ (B + 296 + 4)) **
+        bytesRegion aB acctBytes ** F)) h := by
+      xperm_hyp hR
+    exact (sepConj_pure_right h).2 ⟨hflat, by decide⟩
+  · -- fail arm: status 5
+    refine Or.inr ⟨aB + BitVec.ofNat 64 off, (5 : Word), ?_⟩
+    obtain ⟨g1, g2, gd1, gu1, hx10, grest⟩ := a5
+    obtain ⟨g3, g4, gd2, gu2, hx11, grest2⟩ := grest
+    obtain ⟨hx12, _⟩ := (sepConj_pure_right g4).1 grest2
+    have hR := rebuild (((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 off)) **
+        ((.x11 : Reg) ↦ᵣ (5 : Word)) ** ((.x12 : Reg) ↦ᵣ (0 : Word)))
+      ⟨g1, g2, gd1, gu1, hx10, g3, g4, gd2, gu2, hx11, hx12⟩
+    have hflat : ((((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 off)) **
+        ((.x11 : Reg) ↦ᵣ (5 : Word)) **
+        ((.x12 : Reg) ↦ᵣ (0 : Word)) **
+        ((.x2 : Reg) ↦ᵣ newSp) **
+        ((newSp + 64) ↦ₘ (aB + BitVec.ofNat 64 off)) **
+        ((newSp + 72) ↦ₘ (aB + BitVec.ofNat 64 aLen)) **
+        regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+        regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+        ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x1 : Reg) ↦ᵣ (B + 296 + 4)) **
+        bytesRegion aB acctBytes ** F)) h := by
+      xperm_hyp hR
+    exact (sepConj_pure_right h).2 ⟨hflat, by decide⟩
+  · -- fail arm: status 6
+    refine Or.inr ⟨aB + BitVec.ofNat 64 off, (6 : Word), ?_⟩
+    obtain ⟨g1, g2, gd1, gu1, hx10, grest⟩ := a6
+    obtain ⟨g3, g4, gd2, gu2, hx11, grest2⟩ := grest
+    obtain ⟨hx12, _⟩ := (sepConj_pure_right g4).1 grest2
+    have hR := rebuild (((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 off)) **
+        ((.x11 : Reg) ↦ᵣ (6 : Word)) ** ((.x12 : Reg) ↦ᵣ (0 : Word)))
+      ⟨g1, g2, gd1, gu1, hx10, g3, g4, gd2, gu2, hx11, hx12⟩
+    have hflat : ((((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 off)) **
+        ((.x11 : Reg) ↦ᵣ (6 : Word)) **
+        ((.x12 : Reg) ↦ᵣ (0 : Word)) **
+        ((.x2 : Reg) ↦ᵣ newSp) **
+        ((newSp + 64) ↦ₘ (aB + BitVec.ofNat 64 off)) **
+        ((newSp + 72) ↦ₘ (aB + BitVec.ofNat 64 aLen)) **
+        regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+        regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+        ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x1 : Reg) ↦ᵣ (B + 296 + 4)) **
+        bytesRegion aB acctBytes ** F)) h := by
+      xperm_hyp hR
+    exact (sepConj_pure_right h).2 ⟨hflat, by decide⟩
+
+#print axioms bansf_tupleItem0_spec
+
+/-- The value-unit success shape at `B + 324`: the value item's advanced
+    cursor and length pinned in `a0`/`a2` with the decode fact; the spill
+    pair is left owned (dead after this point). -/
+def tupleValOk (aB newSp : Word) (tEnd off : Nat) (acctBytes : List (BitVec 8))
+    (F : Assertion) : Assertion :=
+  fun h => ∃ next len : Word,
+    ((((.x10 : Reg) ↦ᵣ next) ** ((.x11 : Reg) ↦ᵣ (0 : Word)) **
+      ((.x12 : Reg) ↦ᵣ len) **
+      ((.x2 : Reg) ↦ᵣ newSp) **
+      memOwn (newSp + 64) ** memOwn (newSp + 72) **
+      regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+      regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+      ((.x0 : Reg) ↦ᵣ (0 : Word)) ** regOwn .x1 **
+      bytesRegion aB acctBytes ** F) **
+     ⌜rlpItemDecode acctBytes off (aB + BitVec.ofNat 64 off)
+       (aB + BitVec.ofNat 64 tEnd) next len⌝) h
+
+/-- Tuple item unit 1 — the VALUE item (slots 77–80, `B + 308 → B + 324`);
+    no trailing spill store: the ok arm falls straight into the capture
+    block. -/
+theorem bansf_tupleItem1_spec (aB newSp : Word) (aLen tEnd off : Nat)
+    (acctBytes : List (BitVec 8))
+    (v5 v6 v7 v10 v11 v12 v28 v29 v30 v31 vRa : Word) (F : Assertion)
+    (hF : F.pcFree)
+    (hsalign : aB.toNat % 8 = 0)
+    (hslack : aLen + 9 ≤ acctBytes.length)
+    (hover : aB.toNat + acctBytes.length < 2 ^ 64)
+    (hvalid : ∀ k, k < acctBytes.length →
+      isValidByteAccess (aB + BitVec.ofNat 64 k) = true)
+    (htEnd : tEnd ≤ aLen)
+    (hoffle : off ≤ tEnd) :
+    cpsBranchWithin 92 (B + 308) bansfCR
+      (((newSp + 64) ↦ₘ (aB + BitVec.ofNat 64 off)) **
+       ((newSp + 72) ↦ₘ (aB + BitVec.ofNat 64 tEnd)) **
+       ((.x2 : Reg) ↦ᵣ newSp) **
+       ((.x10 : Reg) ↦ᵣ v10) ** ((.x11 : Reg) ↦ᵣ v11) ** ((.x12 : Reg) ↦ᵣ v12) **
+       ((.x5 : Reg) ↦ᵣ v5) ** ((.x6 : Reg) ↦ᵣ v6) ** ((.x7 : Reg) ↦ᵣ v7) **
+       ((.x28 : Reg) ↦ᵣ v28) ** ((.x29 : Reg) ↦ᵣ v29) **
+       ((.x30 : Reg) ↦ᵣ v30) ** ((.x31 : Reg) ↦ᵣ v31) **
+       ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x1 : Reg) ↦ᵣ vRa) **
+       bytesRegion aB acctBytes ** F)
+      (B + 736) (tupleRej aB newSp acctBytes F)
+      (B + 324) (tupleValOk aB newSp tEnd off acctBytes F) := by
+  have hoffb : off < acctBytes.length := by omega
+  -- LD a0, 64(sp) ; LD a1, 72(sp)  (B+308, B+312)
+  have hld1 := ld_spec_gen_within .x10 .x2 newSp v10 (aB + BitVec.ofNat 64 off)
+    (64 : BitVec 12) (B + 308) (by decide)
+  rw [se64t, show (B + 308) + 4 = B + 312 from by bv_omega] at hld1
+  have hld1L := liftCode (cr' := bansfCR) hld1
+    (fun a i h => CodeReq.union_mono_left a i
+      (CodeReq.ofProg_mem_at B (B + 308) bansfProg 77 (.LD .x10 .x2 (64 : BitVec 12))
+        (by decide +kernel) (by decide +kernel) (by decide +kernel) (by decide) a i h))
+  have hld2 := ld_spec_gen_within .x11 .x2 newSp v11 (aB + BitVec.ofNat 64 tEnd)
+    (72 : BitVec 12) (B + 312) (by decide)
+  rw [se72t, show (B + 312) + 4 = B + 316 from by bv_omega] at hld2
+  have hld2L := liftCode (cr' := bansfCR) hld2
+    (fun a i h => CodeReq.union_mono_left a i
+      (CodeReq.ofProg_mem_at B (B + 312) bansfProg 78 (.LD .x11 .x2 (72 : BitVec 12))
+        (by decide +kernel) (by decide +kernel) (by decide +kernel) (by decide) a i h))
+  have hld1F := cpsTripleWithin_frameR
+    (((newSp + 72) ↦ₘ (aB + BitVec.ofNat 64 tEnd)) ** ((.x11 : Reg) ↦ᵣ v11))
+    (by pcf) hld1L
+  have hld2F := cpsTripleWithin_frameR
+    (((newSp + 64) ↦ₘ (aB + BitVec.ofNat 64 off)) **
+     ((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 off)))
+    (by pcf) hld2L
+  have hlds := cpsTripleWithin_seq_perm_same_cr (fun h hp => by xperm_hyp hp) hld1F hld2F
+  have hldsF := cpsTripleWithin_frameR
+    (((.x12 : Reg) ↦ᵣ v12) **
+     ((.x5 : Reg) ↦ᵣ v5) ** ((.x6 : Reg) ↦ᵣ v6) ** ((.x7 : Reg) ↦ᵣ v7) **
+     ((.x28 : Reg) ↦ᵣ v28) ** ((.x29 : Reg) ↦ᵣ v29) **
+     ((.x30 : Reg) ↦ᵣ v30) ** ((.x31 : Reg) ↦ᵣ v31) **
+     ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x1 : Reg) ↦ᵣ vRa) **
+     bytesRegion aB acctBytes ** F)
+    (by pcf; exact hF) hlds
+  -- the callee triple with ra = B + 316 + 4
+  have hwn := rlp_walk_next_spec_within WN aB (aB + BitVec.ofNat 64 tEnd)
+    (B + 316 + 4) v12 v5 v6 v7 v28 v29 v30 v31 acctBytes off hsalign hoffb (by omega)
+    (hvalid off hoffb)
+    (fun h80 hb8 => ⟨by omega, by omega, hvalid _ (by omega)⟩)
+    (fun hb8 hc0 => by
+      have hlo : ((acctBytes[off]'hoffb).zeroExtend 64 - (0xb7 : Word)).toNat ≤ 8 := by
+        have h1 := ult_lt hc0
+        have h2 := not_ult_le hb8
+        bv_omega
+      exact ⟨by omega, by omega, fun k hk => hvalid _ (by omega)⟩)
+    (fun hf8 => by
+      have hlo : ((acctBytes[off]'hoffb).zeroExtend 64 - (0xf7 : Word)).toNat ≤ 8 := by
+        have h2 := not_ult_le hf8
+        have h3 := (acctBytes[off]'hoffb).isLt
+        bv_omega
+      exact ⟨by omega, by omega, fun k hk => hvalid _ (by omega)⟩)
+  have hwn' := cpsTripleWithin_weaken
+    (fun h hp => by xperm_hyp hp) (fun _ hq => hq) hwn
+    (P' := ((.x1 : Reg) ↦ᵣ (B + 316 + 4)) **
+      (((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 off)) **
+       ((.x11 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 tEnd)) ** ((.x12 : Reg) ↦ᵣ v12) **
+       ((.x5 : Reg) ↦ᵣ v5) ** ((.x6 : Reg) ↦ᵣ v6) ** ((.x7 : Reg) ↦ᵣ v7) **
+       ((.x28 : Reg) ↦ᵣ v28) ** ((.x29 : Reg) ↦ᵣ v29) **
+       ((.x30 : Reg) ↦ᵣ v30) ** ((.x31 : Reg) ↦ᵣ v31) **
+       ((.x0 : Reg) ↦ᵣ (0 : Word)) ** bytesRegion aB acctBytes))
+  have hcall := bansf_callSite79_walk_next (n := 87) vRa (by pcf) hwn'
+  rw [show (B + 316) + 4 = B + 320 from by bv_omega] at hcall
+  have hcallF := cpsTripleWithin_frameR
+    (((.x2 : Reg) ↦ᵣ newSp) **
+     ((newSp + 64) ↦ₘ (aB + BitVec.ofNat 64 off)) **
+     ((newSp + 72) ↦ₘ (aB + BitVec.ofNat 64 tEnd)) ** F)
+    (by pcf; exact hF) hcall
+  have hpre := cpsTripleWithin_seq_perm_same_cr (fun h hp => by xperm_hyp hp)
+    hldsF hcallF
+  -- ===== ok continuation: BNE falls through only =====
+  have hokc : cpsBranchWithin 1 (B + 320) bansfCR
+      (fun h => ∃ next len : Word,
+        ((((.x10 : Reg) ↦ᵣ next) ** ((.x11 : Reg) ↦ᵣ (0 : Word)) **
+          ((.x12 : Reg) ↦ᵣ len) **
+          ((.x2 : Reg) ↦ᵣ newSp) **
+          ((newSp + 64) ↦ₘ (aB + BitVec.ofNat 64 off)) **
+          ((newSp + 72) ↦ₘ (aB + BitVec.ofNat 64 tEnd)) **
+          regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+          regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+          ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x1 : Reg) ↦ᵣ (B + 316 + 4)) **
+          bytesRegion aB acctBytes ** F) **
+         ⌜rlpItemDecode acctBytes off (aB + BitVec.ofNat 64 off)
+           (aB + BitVec.ofNat 64 tEnd) next len⌝) h)
+      (B + 736) (tupleRej aB newSp acctBytes F)
+      (B + 324) (tupleValOk aB newSp tEnd off acctBytes F) := by
+    refine cpsBranchWithin_exists_pre (fun next => ?_)
+    refine cpsBranchWithin_exists_pre (fun len => ?_)
+    refine cpsBranchWithin_pure_pre_right (fun hdec => ?_)
+    have hbne := bne_spec_gen_within .x11 .x0 (412 : BitVec 13) (0 : Word) (0 : Word) (B + 320)
+    rw [show (B + 320) + 4 = B + 324 from by bv_omega] at hbne
+    have hbneL := cpsBranchWithin_extend_code (cr' := bansfCR)
+      (fun a i h => CodeReq.union_mono_left a i
+        (CodeReq.ofProg_mem_at B (B + 320) bansfProg 80 (.BNE .x11 .x0 (412 : BitVec 13))
+          (by decide +kernel) (by decide +kernel) (by decide +kernel) (by decide) a i h))
+      hbne
+    have hfall := cpsBranchWithin_ntakenPath hbneL
+      (fun hp hQt => by
+        obtain ⟨_, _, _, _, _, h_pure⟩ := hQt
+        exact absurd rfl (((sepConj_pure_right _).1 h_pure).2))
+    have hfallF := cpsTripleWithin_frameR
+      (((.x10 : Reg) ↦ᵣ next) ** ((.x12 : Reg) ↦ᵣ len) **
+       ((.x2 : Reg) ↦ᵣ newSp) **
+       ((newSp + 64) ↦ₘ (aB + BitVec.ofNat 64 off)) **
+       ((newSp + 72) ↦ₘ (aB + BitVec.ofNat 64 tEnd)) **
+       regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+       regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+       ((.x1 : Reg) ↦ᵣ (B + 316 + 4)) **
+       bytesRegion aB acctBytes ** F)
+      (by pcf; exact hF) hfall
+    have hout : cpsTripleWithin 1 (B + 320) (B + 324) bansfCR
+        (((.x10 : Reg) ↦ᵣ next) ** ((.x11 : Reg) ↦ᵣ (0 : Word)) **
+         ((.x12 : Reg) ↦ᵣ len) **
+         ((.x2 : Reg) ↦ᵣ newSp) **
+         ((newSp + 64) ↦ₘ (aB + BitVec.ofNat 64 off)) **
+         ((newSp + 72) ↦ₘ (aB + BitVec.ofNat 64 tEnd)) **
+         regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+         regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+         ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x1 : Reg) ↦ᵣ (B + 316 + 4)) **
+         bytesRegion aB acctBytes ** F)
+        (tupleValOk aB newSp tEnd off acctBytes F) := by
+      refine cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp) (fun h hq => ?_) hfallF
+      unfold tupleValOk
+      refine ⟨next, len, ?_⟩
+      have hq1 := sepConj_mono_left (sepConj_mono_right
+        (fun h' hp' => ((sepConj_pure_right h').1 hp').1)) h hq
+      have hq2 : ((((.x1 : Reg) ↦ᵣ (B + 316 + 4)) **
+          (((.x10 : Reg) ↦ᵣ next) ** ((.x11 : Reg) ↦ᵣ (0 : Word)) **
+           ((.x12 : Reg) ↦ᵣ len) **
+           ((.x2 : Reg) ↦ᵣ newSp) **
+           ((newSp + 64) ↦ₘ (aB + BitVec.ofNat 64 off)) **
+           ((newSp + 72) ↦ₘ (aB + BitVec.ofNat 64 tEnd)) **
+           regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+           regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+           ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+           bytesRegion aB acctBytes ** F))) h := by
+        xperm_hyp hq1
+      have hq3 := sepConj_mono (regIs_implies_regOwn .x1) (fun _ x => x) h hq2
+      have hq4 : ((((.x10 : Reg) ↦ᵣ next) ** ((.x11 : Reg) ↦ᵣ (0 : Word)) **
+          ((.x12 : Reg) ↦ᵣ len) **
+          ((.x2 : Reg) ↦ᵣ newSp) **
+          (((newSp + 64) ↦ₘ (aB + BitVec.ofNat 64 off)) **
+           ((newSp + 72) ↦ₘ (aB + BitVec.ofNat 64 tEnd))) **
+          regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+          regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+          ((.x0 : Reg) ↦ᵣ (0 : Word)) ** regOwn .x1 **
+          bytesRegion aB acctBytes ** F)) h := by
+        xperm_hyp hq3
+      have hq5 := sepConj_mono (fun _ x => x)
+        (sepConj_mono (fun _ x => x) (sepConj_mono (fun _ x => x)
+          (sepConj_mono (fun _ x => x)
+            (sepConj_mono (sepConj_mono memIs_implies_memOwn memIs_implies_memOwn)
+              (fun _ x => x))))) h hq4
+      exact (sepConj_pure_right h).2 ⟨by xperm_hyp hq5, hdec⟩
+    exact cpsTripleWithin_as_cpsBranchWithin_right _ _ hout
+  -- ===== fail continuation =====
+  have hfailc : cpsBranchWithin 2 (B + 320) bansfCR
+      (fun h => ∃ cur k : Word,
+        ((((.x10 : Reg) ↦ᵣ cur) ** ((.x11 : Reg) ↦ᵣ k) **
+          ((.x12 : Reg) ↦ᵣ (0 : Word)) **
+          ((.x2 : Reg) ↦ᵣ newSp) **
+          ((newSp + 64) ↦ₘ (aB + BitVec.ofNat 64 off)) **
+          ((newSp + 72) ↦ₘ (aB + BitVec.ofNat 64 tEnd)) **
+          regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+          regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+          ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x1 : Reg) ↦ᵣ (B + 316 + 4)) **
+          bytesRegion aB acctBytes ** F) **
+         ⌜k ≠ (0 : Word)⌝) h)
+      (B + 736) (tupleRej aB newSp acctBytes F)
+      (B + 324) (tupleValOk aB newSp tEnd off acctBytes F) := by
+    refine cpsBranchWithin_exists_pre (fun cur => ?_)
+    refine cpsBranchWithin_exists_pre (fun k => ?_)
+    refine cpsBranchWithin_pure_pre_right (fun hk => ?_)
+    have hbne := bne_spec_gen_within .x11 .x0 (412 : BitVec 13) k (0 : Word) (B + 320)
+    rw [show (B + 320) + signExtend13 (412 : BitVec 13) = B + 732 from by
+          rw [show signExtend13 (412 : BitVec 13) = (412 : Word) from by decide]
+          bv_omega,
+        show (B + 320) + 4 = B + 324 from by bv_omega] at hbne
+    have hbneL := cpsBranchWithin_extend_code (cr' := bansfCR)
+      (fun a i h => CodeReq.union_mono_left a i
+        (CodeReq.ofProg_mem_at B (B + 320) bansfProg 80 (.BNE .x11 .x0 (412 : BitVec 13))
+          (by decide +kernel) (by decide +kernel) (by decide +kernel) (by decide) a i h))
+      hbne
+    have hbneF := cpsBranchWithin_frameR
+      (((.x10 : Reg) ↦ᵣ cur) ** ((.x12 : Reg) ↦ᵣ (0 : Word)) **
+       ((.x2 : Reg) ↦ᵣ newSp) **
+       ((newSp + 64) ↦ₘ (aB + BitVec.ofNat 64 off)) **
+       ((newSp + 72) ↦ₘ (aB + BitVec.ofNat 64 tEnd)) **
+       regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+       regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+       ((.x1 : Reg) ↦ᵣ (B + 316 + 4)) **
+       bytesRegion aB acctBytes ** F)
+      (by pcf; exact hF) hbneL
+    have htaken := cpsBranchWithin_takenPath hbneF
+      (fun hp hQf => by
+        obtain ⟨_, _, _, _, ⟨_, _, _, _, _, h_pure⟩, _⟩ := hQf
+        exact hk (((sepConj_pure_right _).1 h_pure).2))
+    have hrej := liftCode (cr' := bansfCR)
+      (bansf_rejectTail_spec B cur (by decide))
+      (fun a i h => CodeReq.union_mono_left a i h)
+    have hrejF := cpsTripleWithin_frameR
+      (((.x11 : Reg) ↦ᵣ k) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+       ((.x12 : Reg) ↦ᵣ (0 : Word)) **
+       ((.x2 : Reg) ↦ᵣ newSp) **
+       ((newSp + 64) ↦ₘ (aB + BitVec.ofNat 64 off)) **
+       ((newSp + 72) ↦ₘ (aB + BitVec.ofNat 64 tEnd)) **
+       regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+       regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+       ((.x1 : Reg) ↦ᵣ (B + 316 + 4)) **
+       bytesRegion aB acctBytes ** F)
+      (by pcf; exact hF) hrej
+    have hchain := cpsTripleWithin_seq_perm_same_cr
+      (fun h hp => by
+        have hp2 := sepConj_mono_left (sepConj_mono_right
+          (fun h' hp' => ((sepConj_pure_right h').1 hp').1)) h hp
+        xperm_hyp hp2)
+      htaken hrejF
+    have hout : cpsTripleWithin 2 (B + 320) (B + 736) bansfCR
+        (((.x10 : Reg) ↦ᵣ cur) ** ((.x11 : Reg) ↦ᵣ k) **
+         ((.x12 : Reg) ↦ᵣ (0 : Word)) **
+         ((.x2 : Reg) ↦ᵣ newSp) **
+         ((newSp + 64) ↦ₘ (aB + BitVec.ofNat 64 off)) **
+         ((newSp + 72) ↦ₘ (aB + BitVec.ofNat 64 tEnd)) **
+         regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+         regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+         ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x1 : Reg) ↦ᵣ (B + 316 + 4)) **
+         bytesRegion aB acctBytes ** F)
+        (tupleRej aB newSp acctBytes F) := by
+      refine cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp) (fun h hq => ?_) hchain
+      unfold tupleRej
+      have hq4 : ((((.x11 : Reg) ↦ᵣ k) ** ((.x12 : Reg) ↦ᵣ (0 : Word)) **
+          ((.x1 : Reg) ↦ᵣ (B + 316 + 4)) **
+          ((newSp + 64) ↦ₘ (aB + BitVec.ofNat 64 off)) **
+          ((newSp + 72) ↦ₘ (aB + BitVec.ofNat 64 tEnd)) **
+          (((.x10 : Reg) ↦ᵣ (1 : Word)) ** ((.x2 : Reg) ↦ᵣ newSp) **
+           regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+           regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+           ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+           bytesRegion aB acctBytes ** F))) h := by
+        xperm_hyp hq
+      have hq5 := sepConj_mono (regIs_implies_regOwn .x11)
+        (sepConj_mono (regIs_implies_regOwn .x12)
+          (sepConj_mono (regIs_implies_regOwn .x1)
+            (sepConj_mono memIs_implies_memOwn
+              (sepConj_mono memIs_implies_memOwn (fun _ x => x))))) h hq4
+      xperm_hyp hq5
+    exact cpsTripleWithin_as_cpsBranchWithin_left _ _ hout
+  -- ===== chain: loads ; call ; (ok ∨ fail) =====
+  refine cpsBranchWithin_weaken
+    (fun h hp => by xperm_hyp hp) (fun _ x => x) (fun _ x => x)
+    (cpsBranchWithin_mono_nSteps (by omega)
+      (cpsTripleWithin_seq_branch_same_cr hpre
+        (cpsBranchWithin_weaken (fun h hp => ?_) (fun _ x => x) (fun _ x => x)
+          (cpsBranchWithin_pre_or
+            (cpsBranchWithin_mono_nSteps (by omega) hokc) hfailc))))
+  obtain ⟨h1, h2, hd, hu, ⟨h3, h4, hd2, hu2, hCF, hor⟩, hEx⟩ := hp
+  have rebuild : ∀ (arm : Assertion), arm h4 →
+      ((((regOwn .x5 ** regOwn .x6 ** regOwn .x7 ** regOwn .x28 ** regOwn .x29 **
+          regOwn .x30 ** regOwn .x31 ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+          ((.x1 : Reg) ↦ᵣ (B + 316 + 4)) ** bytesRegion aB acctBytes) ** arm) **
+        (((.x2 : Reg) ↦ᵣ newSp) **
+         ((newSp + 64) ↦ₘ (aB + BitVec.ofNat 64 off)) **
+         ((newSp + 72) ↦ₘ (aB + BitVec.ofNat 64 tEnd)) ** F))) h :=
+    fun arm ha => ⟨h1, h2, hd, hu, ⟨h3, h4, hd2, hu2, hCF, ha⟩, hEx⟩
+  rcases hor with a1 | a2 | a3 | a4 | a5 | a6
+  · obtain ⟨next, len, hpins⟩ := a1
+    refine Or.inl ⟨next, len, ?_⟩
+    obtain ⟨g1, g2, gd1, gu1, hx10, grest⟩ := hpins
+    obtain ⟨g3, g4, gd2, gu2, hx11, grest2⟩ := grest
+    obtain ⟨hx12, hdec⟩ := (sepConj_pure_right g4).1 grest2
+    have hR := rebuild (((.x10 : Reg) ↦ᵣ next) ** ((.x11 : Reg) ↦ᵣ (0 : Word)) **
+        ((.x12 : Reg) ↦ᵣ len))
+      ⟨g1, g2, gd1, gu1, hx10, g3, g4, gd2, gu2, hx11, hx12⟩
+    have hflat : ((((.x10 : Reg) ↦ᵣ next) ** ((.x11 : Reg) ↦ᵣ (0 : Word)) **
+        ((.x12 : Reg) ↦ᵣ len) **
+        ((.x2 : Reg) ↦ᵣ newSp) **
+        ((newSp + 64) ↦ₘ (aB + BitVec.ofNat 64 off)) **
+        ((newSp + 72) ↦ₘ (aB + BitVec.ofNat 64 tEnd)) **
+        regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+        regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+        ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x1 : Reg) ↦ᵣ (B + 316 + 4)) **
+        bytesRegion aB acctBytes ** F)) h := by
+      xperm_hyp hR
+    exact (sepConj_pure_right h).2 ⟨hflat, hdec⟩
+  · -- fail arm: status 2
+    refine Or.inr ⟨aB + BitVec.ofNat 64 off, (2 : Word), ?_⟩
+    obtain ⟨g1, g2, gd1, gu1, hx10, grest⟩ := a2
+    obtain ⟨g3, g4, gd2, gu2, hx11, grest2⟩ := grest
+    obtain ⟨hx12, _⟩ := (sepConj_pure_right g4).1 grest2
+    have hR := rebuild (((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 off)) **
+        ((.x11 : Reg) ↦ᵣ (2 : Word)) ** ((.x12 : Reg) ↦ᵣ (0 : Word)))
+      ⟨g1, g2, gd1, gu1, hx10, g3, g4, gd2, gu2, hx11, hx12⟩
+    have hflat : ((((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 off)) **
+        ((.x11 : Reg) ↦ᵣ (2 : Word)) **
+        ((.x12 : Reg) ↦ᵣ (0 : Word)) **
+        ((.x2 : Reg) ↦ᵣ newSp) **
+        ((newSp + 64) ↦ₘ (aB + BitVec.ofNat 64 off)) **
+        ((newSp + 72) ↦ₘ (aB + BitVec.ofNat 64 tEnd)) **
+        regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+        regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+        ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x1 : Reg) ↦ᵣ (B + 316 + 4)) **
+        bytesRegion aB acctBytes ** F)) h := by
+      xperm_hyp hR
+    exact (sepConj_pure_right h).2 ⟨hflat, by decide⟩
+  · -- fail arm: status 3
+    refine Or.inr ⟨aB + BitVec.ofNat 64 off, (3 : Word), ?_⟩
+    obtain ⟨g1, g2, gd1, gu1, hx10, grest⟩ := a3
+    obtain ⟨g3, g4, gd2, gu2, hx11, grest2⟩ := grest
+    obtain ⟨hx12, _⟩ := (sepConj_pure_right g4).1 grest2
+    have hR := rebuild (((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 off)) **
+        ((.x11 : Reg) ↦ᵣ (3 : Word)) ** ((.x12 : Reg) ↦ᵣ (0 : Word)))
+      ⟨g1, g2, gd1, gu1, hx10, g3, g4, gd2, gu2, hx11, hx12⟩
+    have hflat : ((((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 off)) **
+        ((.x11 : Reg) ↦ᵣ (3 : Word)) **
+        ((.x12 : Reg) ↦ᵣ (0 : Word)) **
+        ((.x2 : Reg) ↦ᵣ newSp) **
+        ((newSp + 64) ↦ₘ (aB + BitVec.ofNat 64 off)) **
+        ((newSp + 72) ↦ₘ (aB + BitVec.ofNat 64 tEnd)) **
+        regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+        regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+        ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x1 : Reg) ↦ᵣ (B + 316 + 4)) **
+        bytesRegion aB acctBytes ** F)) h := by
+      xperm_hyp hR
+    exact (sepConj_pure_right h).2 ⟨hflat, by decide⟩
+  · -- fail arm: status 4
+    refine Or.inr ⟨aB + BitVec.ofNat 64 off, (4 : Word), ?_⟩
+    obtain ⟨g1, g2, gd1, gu1, hx10, grest⟩ := a4
+    obtain ⟨g3, g4, gd2, gu2, hx11, grest2⟩ := grest
+    obtain ⟨hx12, _⟩ := (sepConj_pure_right g4).1 grest2
+    have hR := rebuild (((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 off)) **
+        ((.x11 : Reg) ↦ᵣ (4 : Word)) ** ((.x12 : Reg) ↦ᵣ (0 : Word)))
+      ⟨g1, g2, gd1, gu1, hx10, g3, g4, gd2, gu2, hx11, hx12⟩
+    have hflat : ((((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 off)) **
+        ((.x11 : Reg) ↦ᵣ (4 : Word)) **
+        ((.x12 : Reg) ↦ᵣ (0 : Word)) **
+        ((.x2 : Reg) ↦ᵣ newSp) **
+        ((newSp + 64) ↦ₘ (aB + BitVec.ofNat 64 off)) **
+        ((newSp + 72) ↦ₘ (aB + BitVec.ofNat 64 tEnd)) **
+        regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+        regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+        ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x1 : Reg) ↦ᵣ (B + 316 + 4)) **
+        bytesRegion aB acctBytes ** F)) h := by
+      xperm_hyp hR
+    exact (sepConj_pure_right h).2 ⟨hflat, by decide⟩
+  · -- fail arm: status 5
+    refine Or.inr ⟨aB + BitVec.ofNat 64 off, (5 : Word), ?_⟩
+    obtain ⟨g1, g2, gd1, gu1, hx10, grest⟩ := a5
+    obtain ⟨g3, g4, gd2, gu2, hx11, grest2⟩ := grest
+    obtain ⟨hx12, _⟩ := (sepConj_pure_right g4).1 grest2
+    have hR := rebuild (((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 off)) **
+        ((.x11 : Reg) ↦ᵣ (5 : Word)) ** ((.x12 : Reg) ↦ᵣ (0 : Word)))
+      ⟨g1, g2, gd1, gu1, hx10, g3, g4, gd2, gu2, hx11, hx12⟩
+    have hflat : ((((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 off)) **
+        ((.x11 : Reg) ↦ᵣ (5 : Word)) **
+        ((.x12 : Reg) ↦ᵣ (0 : Word)) **
+        ((.x2 : Reg) ↦ᵣ newSp) **
+        ((newSp + 64) ↦ₘ (aB + BitVec.ofNat 64 off)) **
+        ((newSp + 72) ↦ₘ (aB + BitVec.ofNat 64 tEnd)) **
+        regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+        regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+        ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x1 : Reg) ↦ᵣ (B + 316 + 4)) **
+        bytesRegion aB acctBytes ** F)) h := by
+      xperm_hyp hR
+    exact (sepConj_pure_right h).2 ⟨hflat, by decide⟩
+  · -- fail arm: status 6
+    refine Or.inr ⟨aB + BitVec.ofNat 64 off, (6 : Word), ?_⟩
+    obtain ⟨g1, g2, gd1, gu1, hx10, grest⟩ := a6
+    obtain ⟨g3, g4, gd2, gu2, hx11, grest2⟩ := grest
+    obtain ⟨hx12, _⟩ := (sepConj_pure_right g4).1 grest2
+    have hR := rebuild (((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 off)) **
+        ((.x11 : Reg) ↦ᵣ (6 : Word)) ** ((.x12 : Reg) ↦ᵣ (0 : Word)))
+      ⟨g1, g2, gd1, gu1, hx10, g3, g4, gd2, gu2, hx11, hx12⟩
+    have hflat : ((((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 off)) **
+        ((.x11 : Reg) ↦ᵣ (6 : Word)) **
+        ((.x12 : Reg) ↦ᵣ (0 : Word)) **
+        ((.x2 : Reg) ↦ᵣ newSp) **
+        ((newSp + 64) ↦ₘ (aB + BitVec.ofNat 64 off)) **
+        ((newSp + 72) ↦ₘ (aB + BitVec.ofNat 64 tEnd)) **
+        regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+        regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+        ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x1 : Reg) ↦ᵣ (B + 316 + 4)) **
+        bytesRegion aB acctBytes ** F)) h := by
+      xperm_hyp hR
+    exact (sepConj_pure_right h).2 ⟨hflat, by decide⟩
+
+#print axioms bansf_tupleItem1_spec
+
+end BalAccountNonstorageFinalsSpec
+end EvmAsm.Codegen

--- a/EvmAsm/Codegen/Programs/BalAccountNonstorageFinalsChainC3.lean
+++ b/EvmAsm/Codegen/Programs/BalAccountNonstorageFinalsChainC3.lean
@@ -1,0 +1,611 @@
+/-
+  EvmAsm.Codegen.Programs.BalAccountNonstorageFinalsChainC3
+
+  The balance-value capture block of `bal_account_nonstorage_finals`
+  (bead evm-asm-4ch8f.43.5, slice 4e): slots 81–87 —
+
+    81  sub a0, a0, a2         (value content pointer = next - len)
+    82  mv  a1, a2             (value content length)
+    83  addi a2, s2, 8         (the out block's post_balance slot)
+    84  jal rlp_content_to_u256_be
+    85  bnez a0 → reject       (too-long / non-canonical value)
+    86  li  t0, 1
+    87  sd  t0, 0(s2)          (has_balance := 1)
+
+  The callee is dispatched from its four PUBLIC per-case sub-specs with the
+  case split done at the LEMMA level (the length and lead byte are
+  quantified parameters here), so the success exit carries the
+  `vLen.toNat ≤ 32` bound the `FinalsDerivation` balance image requires —
+  the packaged four-way dispatch post cannot supply it.
+-/
+
+import EvmAsm.Codegen.Programs.BalAccountNonstorageFinalsChainC2
+
+set_option maxRecDepth 8000
+
+namespace EvmAsm.Codegen
+
+open EvmAsm.Rv64 EvmAsm.Rv64.SAsm EvmAsm.Rv64.RLP
+
+namespace BalAccountNonstorageFinalsSpec
+
+/-- The capture-success state at the nonce boundary (`B + 352`):
+    `has_balance = 1` and the 32-byte right-aligned big-endian image of the
+    value content in the `post_balance` slot. -/
+def balCaptureOk (aB newSp oB : Word) (srcOff lenN : Nat)
+    (acctBytes : List (BitVec 8)) (F : Assertion) : Assertion :=
+  ((oB ↦ₘ (1 : Word)) **
+   bytesRegion (oB + 8) (copyN (List.replicate 32 (0 : BitVec 8)) acctBytes
+     (32 - lenN) srcOff lenN) **
+   ((.x18 : Reg) ↦ᵣ oB) ** ((.x2 : Reg) ↦ᵣ newSp) **
+   regOwn .x10 ** regOwn .x11 ** regOwn .x12 **
+   regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+   regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+   ((.x0 : Reg) ↦ᵣ (0 : Word)) ** regOwn .x1 **
+   bytesRegion aB acctBytes ** F) **
+  ⌜lenN ≤ 32⌝
+
+/-- The capture reject: `has_balance` still 0, the balance area released. -/
+def balCaptureRej (aB newSp oB : Word) (acctBytes : List (BitVec 8))
+    (F : Assertion) : Assertion :=
+  ((.x10 : Reg) ↦ᵣ (1 : Word)) **
+  (oB ↦ₘ (0 : Word)) ** memOwnU256 (oB + 8) **
+  ((.x18 : Reg) ↦ᵣ oB) ** ((.x2 : Reg) ↦ᵣ newSp) **
+  regOwn .x11 ** regOwn .x12 **
+  regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+  regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+  ((.x0 : Reg) ↦ᵣ (0 : Word)) ** regOwn .x1 **
+  bytesRegion aB acctBytes ** F
+
+/-- Slots 81–87: capture the balance value into the out block.  The value
+    window `(vNext, vLen)` decodes at `off` inside the tuple window
+    `[·, tEnd]`; the length/canonicality cases are split here so each
+    per-case sub-spec applies with its exact hypotheses. -/
+theorem bansf_balCapture_spec (aB newSp oB : Word) (aLen tEnd off : Nat)
+    (vNext vLen : Word) (acctBytes : List (BitVec 8))
+    (v5 v6 v7 v28 v29 v30 v31 vRa : Word) (F : Assertion)
+    (hF : F.pcFree)
+    (hsalign : aB.toNat % 8 = 0)
+    (hoalign : oB.toNat % 8 = 0)
+    (hslack : aLen + 9 ≤ acctBytes.length)
+    (hover : aB.toNat + acctBytes.length < 2 ^ 64)
+    (hvalid : ∀ k, k < acctBytes.length →
+      isValidByteAccess (aB + BitVec.ofNat 64 k) = true)
+    (hovout : oB.toNat + 80 ≤ 2 ^ 64)
+    (hovalid : ∀ k, k < 80 → isValidByteAccess (oB + BitVec.ofNat 64 k) = true)
+    (htEnd : tEnd ≤ aLen) (hoffle : off ≤ tEnd)
+    (hdec : rlpItemDecode acctBytes off (aB + BitVec.ofNat 64 off)
+      (aB + BitVec.ofNat 64 tEnd) vNext vLen) :
+    cpsBranchWithin 260 (B + 324) bansfCR
+      (((.x10 : Reg) ↦ᵣ vNext) ** ((.x11 : Reg) ↦ᵣ (0 : Word)) **
+       ((.x12 : Reg) ↦ᵣ vLen) **
+       ((.x18 : Reg) ↦ᵣ oB) ** ((.x2 : Reg) ↦ᵣ newSp) **
+       (oB ↦ₘ (0 : Word)) **
+       ((oB + 8) ↦ₘ (0 : Word)) ** ((oB + 16) ↦ₘ (0 : Word)) **
+       ((oB + 24) ↦ₘ (0 : Word)) ** ((oB + 32) ↦ₘ (0 : Word)) **
+       ((.x5 : Reg) ↦ᵣ v5) ** ((.x6 : Reg) ↦ᵣ v6) ** ((.x7 : Reg) ↦ᵣ v7) **
+       ((.x28 : Reg) ↦ᵣ v28) ** ((.x29 : Reg) ↦ᵣ v29) **
+       ((.x30 : Reg) ↦ᵣ v30) ** ((.x31 : Reg) ↦ᵣ v31) **
+       ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x1 : Reg) ↦ᵣ vRa) **
+       bytesRegion aB acctBytes ** F)
+      (B + 736) (balCaptureRej aB newSp oB acctBytes F)
+      (B + 352) (balCaptureOk aB newSp oB ((vNext - vLen - aB).toNat) vLen.toNat
+        acctBytes F) := by
+  have hover9 : aB.toNat + aLen + 9 < 2 ^ 64 := by omega
+  obtain ⟨hrepS, hsple, hspb⟩ := rlpItemDecode_spanStart hdec hoffle (by omega)
+  have hsoffb : (vNext - vLen - aB).toNat < acctBytes.length := by omega
+  have hlenrep : vLen = BitVec.ofNat 64 (vLen.toNat) := by
+    rw [BitVec.ofNat_toNat, BitVec.setWidth_eq]
+  have hoalign8 : (oB + 8).toNat % 8 = 0 := by bv_omega
+  have hoover8 : (oB + 8).toNat + 32 ≤ 2 ^ 64 := by bv_omega
+  have hdval : ∀ k, k < 32 →
+      isValidByteAccess ((oB + 8) + BitVec.ofNat 64 k) = true := by
+    intro k hk
+    have h := hovalid (8 + k) (by omega)
+    rwa [show oB + BitVec.ofNat 64 (8 + k) = (oB + 8) + BitVec.ofNat 64 k from by
+      bv_omega] at h
+  -- ===== the three argument-setup instructions (81–83) =====
+  have h81 := sub_spec_gen_rd_eq_rs1_within .x10 .x12 vNext vLen (B + 324) (by decide)
+  rw [hrepS, show (B + 324) + 4 = B + 328 from by bv_omega] at h81
+  have h81L := liftCode (cr' := bansfCR) h81
+    (fun a i h => CodeReq.union_mono_left a i
+      (CodeReq.ofProg_mem_at B (B + 324) bansfProg 81 (.SUB .x10 .x10 .x12)
+        (by decide +kernel) (by decide +kernel) (by decide +kernel) (by decide) a i h))
+  have h82 := mv_spec_gen_within .x11 .x12 vLen (0 : Word) (B + 328) (by decide)
+  rw [show (B + 328) + 4 = B + 332 from by bv_omega] at h82
+  have h82L := liftCode (cr' := bansfCR) h82
+    (fun a i h => CodeReq.union_mono_left a i
+      (CodeReq.ofProg_mem_at B (B + 328) bansfProg 82 (.MV .x11 .x12)
+        (by decide +kernel) (by decide +kernel) (by decide +kernel) (by decide) a i h))
+  have h83 := addi_spec_gen_within .x12 .x18 vLen oB (8 : BitVec 12) (B + 332) (by decide)
+  rw [show signExtend12 (8 : BitVec 12) = (8 : Word) from by decide,
+      show (B + 332) + 4 = B + 336 from by bv_omega] at h83
+  have h83L := liftCode (cr' := bansfCR) h83
+    (fun a i h => CodeReq.union_mono_left a i
+      (CodeReq.ofProg_mem_at B (B + 332) bansfProg 83 (.ADDI .x12 .x18 (8 : BitVec 12))
+        (by decide +kernel) (by decide +kernel) (by decide +kernel) (by decide) a i h))
+  have h81F := cpsTripleWithin_frameR
+    (((.x11 : Reg) ↦ᵣ (0 : Word)) **
+     ((.x18 : Reg) ↦ᵣ oB) ** ((.x2 : Reg) ↦ᵣ newSp) **
+     (oB ↦ₘ (0 : Word)) **
+     ((oB + 8) ↦ₘ (0 : Word)) ** ((oB + 16) ↦ₘ (0 : Word)) **
+     ((oB + 24) ↦ₘ (0 : Word)) ** ((oB + 32) ↦ₘ (0 : Word)) **
+     ((.x5 : Reg) ↦ᵣ v5) ** ((.x6 : Reg) ↦ᵣ v6) ** ((.x7 : Reg) ↦ᵣ v7) **
+     ((.x28 : Reg) ↦ᵣ v28) ** ((.x29 : Reg) ↦ᵣ v29) **
+     ((.x30 : Reg) ↦ᵣ v30) ** ((.x31 : Reg) ↦ᵣ v31) **
+     ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x1 : Reg) ↦ᵣ vRa) **
+     bytesRegion aB acctBytes ** F)
+    (by pcf; exact hF) h81L
+  have h82F := cpsTripleWithin_frameR
+    (((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 ((vNext - vLen - aB).toNat))) **
+     ((.x18 : Reg) ↦ᵣ oB) ** ((.x2 : Reg) ↦ᵣ newSp) **
+     (oB ↦ₘ (0 : Word)) **
+     ((oB + 8) ↦ₘ (0 : Word)) ** ((oB + 16) ↦ₘ (0 : Word)) **
+     ((oB + 24) ↦ₘ (0 : Word)) ** ((oB + 32) ↦ₘ (0 : Word)) **
+     ((.x5 : Reg) ↦ᵣ v5) ** ((.x6 : Reg) ↦ᵣ v6) ** ((.x7 : Reg) ↦ᵣ v7) **
+     ((.x28 : Reg) ↦ᵣ v28) ** ((.x29 : Reg) ↦ᵣ v29) **
+     ((.x30 : Reg) ↦ᵣ v30) ** ((.x31 : Reg) ↦ᵣ v31) **
+     ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x1 : Reg) ↦ᵣ vRa) **
+     bytesRegion aB acctBytes ** F)
+    (by pcf; exact hF) h82L
+  have h83F := cpsTripleWithin_frameR
+    (((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 ((vNext - vLen - aB).toNat))) **
+     ((.x11 : Reg) ↦ᵣ vLen) **
+     ((.x2 : Reg) ↦ᵣ newSp) **
+     (oB ↦ₘ (0 : Word)) **
+     ((oB + 8) ↦ₘ (0 : Word)) ** ((oB + 16) ↦ₘ (0 : Word)) **
+     ((oB + 24) ↦ₘ (0 : Word)) ** ((oB + 32) ↦ₘ (0 : Word)) **
+     ((.x5 : Reg) ↦ᵣ v5) ** ((.x6 : Reg) ↦ᵣ v6) ** ((.x7 : Reg) ↦ᵣ v7) **
+     ((.x28 : Reg) ↦ᵣ v28) ** ((.x29 : Reg) ↦ᵣ v29) **
+     ((.x30 : Reg) ↦ᵣ v30) ** ((.x31 : Reg) ↦ᵣ v31) **
+     ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x1 : Reg) ↦ᵣ vRa) **
+     bytesRegion aB acctBytes ** F)
+    (by pcf; exact hF) h83L
+  have hsetup0 := cpsTripleWithin_seq_perm_same_cr (fun h hp => by xperm_hyp hp) h81F h82F
+  have hsetup := cpsTripleWithin_seq_perm_same_cr (fun h hp => by xperm_hyp hp) hsetup0 h83F
+  -- ===== the shared success tail: BNE fall, LI, SD (85–87) =====
+  have htail : ∀ (img : List (BitVec 8)),
+      cpsTripleWithin 3 (B + 340) (B + 352) bansfCR
+        (((.x10 : Reg) ↦ᵣ (0 : Word)) **
+         (oB ↦ₘ (0 : Word)) ** bytesRegion (oB + 8) img **
+         ((.x18 : Reg) ↦ᵣ oB) ** regOwn .x5 **
+         ((.x0 : Reg) ↦ᵣ (0 : Word)))
+        (((.x10 : Reg) ↦ᵣ (0 : Word)) **
+         (oB ↦ₘ (1 : Word)) ** bytesRegion (oB + 8) img **
+         ((.x18 : Reg) ↦ᵣ oB) ** ((.x5 : Reg) ↦ᵣ (1 : Word)) **
+         ((.x0 : Reg) ↦ᵣ (0 : Word))) := by
+    intro img
+    -- BNE not taken (status 0)
+    have hbne := bne_spec_gen_within .x10 .x0 (392 : BitVec 13) (0 : Word) (0 : Word) (B + 340)
+    rw [show (B + 340) + 4 = B + 344 from by bv_omega] at hbne
+    have hbneL := cpsBranchWithin_extend_code (cr' := bansfCR)
+      (fun a i h => CodeReq.union_mono_left a i
+        (CodeReq.ofProg_mem_at B (B + 340) bansfProg 85 (.BNE .x10 .x0 (392 : BitVec 13))
+          (by decide +kernel) (by decide +kernel) (by decide +kernel) (by decide) a i h))
+      hbne
+    have hfall := cpsBranchWithin_ntakenPath hbneL
+      (fun hp hQt => by
+        obtain ⟨_, _, _, _, _, h_pure⟩ := hQt
+        exact absurd rfl (((sepConj_pure_right _).1 h_pure).2))
+    -- LI t0, 1 at B+344 (from an owned x5)
+    have hli : cpsTripleWithin 1 (B + 344) (B + 348) bansfCR
+        (regOwn .x5) ((.x5 : Reg) ↦ᵣ (1 : Word)) := by
+      refine cpsTripleWithin_of_forall_regIs_to_regOwn_single (fun vOld => ?_)
+      have h := li_spec_gen_within .x5 vOld (1 : Word) (B + 344) (by decide)
+      rw [show (B + 344) + 4 = B + 348 from by bv_omega] at h
+      exact liftCode (cr' := bansfCR) h
+        (fun a i hh => CodeReq.union_mono_left a i
+          (CodeReq.ofProg_mem_at B (B + 344) bansfProg 86 (.LI .x5 (1 : Word))
+            (by decide +kernel) (by decide +kernel) (by decide +kernel) (by decide) a i hh))
+    -- SD t0, 0(s2) at B+348
+    have hsd := sd_spec_gen_within .x18 .x5 oB (1 : Word) (0 : Word) (0 : BitVec 12) (B + 348)
+    rw [show signExtend12 (0 : BitVec 12) = (0 : Word) from by decide,
+        show oB + (0 : Word) = oB from by bv_omega,
+        show (B + 348) + 4 = B + 352 from by bv_omega] at hsd
+    have hsdL := liftCode (cr' := bansfCR) hsd
+      (fun a i h => CodeReq.union_mono_left a i
+        (CodeReq.ofProg_mem_at B (B + 348) bansfProg 87 (.SD .x18 .x5 (0 : BitVec 12))
+          (by decide +kernel) (by decide +kernel) (by decide +kernel) (by decide) a i h))
+    have hfallF := cpsTripleWithin_frameR
+      ((oB ↦ₘ (0 : Word)) ** bytesRegion (oB + 8) img **
+       ((.x18 : Reg) ↦ᵣ oB) ** regOwn .x5)
+      (by pcf) hfall
+    have hliF := cpsTripleWithin_frameR
+      (((.x10 : Reg) ↦ᵣ (0 : Word)) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+       (oB ↦ₘ (0 : Word)) ** bytesRegion (oB + 8) img **
+       ((.x18 : Reg) ↦ᵣ oB))
+      (by pcf) hli
+    have hsdF := cpsTripleWithin_frameR
+      (((.x10 : Reg) ↦ᵣ (0 : Word)) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+       bytesRegion (oB + 8) img)
+      (by pcf) hsdL
+    have c1 := cpsTripleWithin_seq_perm_same_cr
+      (fun h hp => by
+        have hp2 := sepConj_mono_left (sepConj_mono_right
+          (fun h' hp' => ((sepConj_pure_right h').1 hp').1)) h hp
+        xperm_hyp hp2)
+      hfallF hliF
+    have c2 := cpsTripleWithin_seq_perm_same_cr (fun h hp => by xperm_hyp hp) c1 hsdF
+    exact cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp)
+      (fun h hq => by xperm_hyp hq) c2
+  -- ===== reject-route helper at the status check (B + 340) =====
+  have hrejRoute : ∀ (st : Word), st ≠ (0 : Word) →
+      cpsTripleWithin 2 (B + 340) (B + 736) bansfCR
+        (((.x10 : Reg) ↦ᵣ st) ** ((.x11 : Reg) ↦ᵣ vLen) **
+         ((.x12 : Reg) ↦ᵣ (oB + 8)) **
+         regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+         regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+         ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x1 : Reg) ↦ᵣ (B + 336 + 4)) **
+         bytesRegion aB acctBytes ** memOwnU256 (oB + 8) **
+         ((.x18 : Reg) ↦ᵣ oB) ** ((.x2 : Reg) ↦ᵣ newSp) **
+         (oB ↦ₘ (0 : Word)) ** F)
+        (balCaptureRej aB newSp oB acctBytes F) := by
+    intro st hst
+    have hbne := bne_spec_gen_within .x10 .x0 (392 : BitVec 13) st (0 : Word) (B + 340)
+    rw [show (B + 340) + signExtend13 (392 : BitVec 13) = B + 732 from by
+          rw [show signExtend13 (392 : BitVec 13) = (392 : Word) from by decide]
+          bv_omega,
+        show (B + 340) + 4 = B + 344 from by bv_omega] at hbne
+    have hbneL := cpsBranchWithin_extend_code (cr' := bansfCR)
+      (fun a i h => CodeReq.union_mono_left a i
+        (CodeReq.ofProg_mem_at B (B + 340) bansfProg 85 (.BNE .x10 .x0 (392 : BitVec 13))
+          (by decide +kernel) (by decide +kernel) (by decide +kernel) (by decide) a i h))
+      hbne
+    have hbneF := cpsBranchWithin_frameR
+      (((.x11 : Reg) ↦ᵣ vLen) ** ((.x12 : Reg) ↦ᵣ (oB + 8)) **
+       regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+       regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+       ((.x1 : Reg) ↦ᵣ (B + 336 + 4)) **
+       bytesRegion aB acctBytes ** memOwnU256 (oB + 8) **
+       ((.x18 : Reg) ↦ᵣ oB) ** ((.x2 : Reg) ↦ᵣ newSp) **
+       (oB ↦ₘ (0 : Word)) ** F)
+      (by pcf; exact hF) hbneL
+    have htaken := cpsBranchWithin_takenPath hbneF
+      (fun hp hQf => by
+        obtain ⟨_, _, _, _, ⟨_, _, _, _, _, h_pure⟩, _⟩ := hQf
+        exact hst (((sepConj_pure_right _).1 h_pure).2))
+    have hrej := liftCode (cr' := bansfCR)
+      (bansf_rejectTail_spec B st (by decide))
+      (fun a i h => CodeReq.union_mono_left a i h)
+    have hrejF := cpsTripleWithin_frameR
+      (((.x0 : Reg) ↦ᵣ (0 : Word)) **
+       ((.x11 : Reg) ↦ᵣ vLen) ** ((.x12 : Reg) ↦ᵣ (oB + 8)) **
+       regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+       regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+       ((.x1 : Reg) ↦ᵣ (B + 336 + 4)) **
+       bytesRegion aB acctBytes ** memOwnU256 (oB + 8) **
+       ((.x18 : Reg) ↦ᵣ oB) ** ((.x2 : Reg) ↦ᵣ newSp) **
+       (oB ↦ₘ (0 : Word)) ** F)
+      (by pcf; exact hF) hrej
+    have hchain := cpsTripleWithin_seq_perm_same_cr
+      (fun h hp => by
+        have hp2 := sepConj_mono_left (sepConj_mono_right
+          (fun h' hp' => ((sepConj_pure_right h').1 hp').1)) h hp
+        xperm_hyp hp2)
+      htaken hrejF
+    refine cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp) (fun h hq => ?_) hchain
+    unfold balCaptureRej
+    have hq4 : ((((.x11 : Reg) ↦ᵣ vLen) ** ((.x12 : Reg) ↦ᵣ (oB + 8)) **
+        ((.x1 : Reg) ↦ᵣ (B + 336 + 4)) **
+        (((.x10 : Reg) ↦ᵣ (1 : Word)) **
+         (oB ↦ₘ (0 : Word)) ** memOwnU256 (oB + 8) **
+         ((.x18 : Reg) ↦ᵣ oB) ** ((.x2 : Reg) ↦ᵣ newSp) **
+         regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+         regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+         ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+         bytesRegion aB acctBytes ** F))) h := by
+      xperm_hyp hq
+    have hq5 := sepConj_mono (regIs_implies_regOwn .x11)
+      (sepConj_mono (regIs_implies_regOwn .x12)
+        (sepConj_mono (regIs_implies_regOwn .x1) (fun _ x => x))) h hq4
+    xperm_hyp hq5
+  -- the four out cells assemble into the callee's owned output token
+  have hmemU : ∀ h, ((((oB + 8) ↦ₘ (0 : Word)) ** ((oB + 16) ↦ₘ (0 : Word)) **
+      ((oB + 24) ↦ₘ (0 : Word)) ** ((oB + 32) ↦ₘ (0 : Word))) h) →
+      memOwnU256 (oB + 8) h := by
+    intro h hp
+    rw [show oB + 16 = (oB + 8) + 8 from by bv_omega,
+        show oB + 24 = (oB + 8) + 16 from by bv_omega,
+        show oB + 32 = (oB + 8) + 24 from by bv_omega] at hp
+    exact sepConj_mono memIs_implies_memOwn
+      (sepConj_mono memIs_implies_memOwn
+        (sepConj_mono memIs_implies_memOwn memIs_implies_memOwn)) h hp
+  -- ===== the four value cases =====
+  by_cases hlen32 : 32 < vLen.toNat
+  · -- too-long value: callee returns status 2 → reject
+    have hcs := rlp_content_to_u256_be_too_long_spec_within CB
+      (aB + BitVec.ofNat 64 ((vNext - vLen - aB).toNat)) vLen (oB + 8) v5 (B + 336 + 4)
+      (by
+        simp only [BitVec.ult, decide_eq_true_eq]
+        have h32 : (32 : Word).toNat = 32 := by decide
+        omega)
+    have hcs' := cpsTripleWithin_weaken
+      (fun h hp => by xperm_hyp hp) (fun _ hq => hq) hcs
+      (P' := ((.x1 : Reg) ↦ᵣ (B + 336 + 4)) **
+        (((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 ((vNext - vLen - aB).toNat))) **
+         ((.x11 : Reg) ↦ᵣ vLen) ** ((.x12 : Reg) ↦ᵣ (oB + 8)) **
+         ((.x5 : Reg) ↦ᵣ v5) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+         memOwnU256 (oB + 8)))
+    have hcall := bansf_callSite84_content_to_u256_be (n := 8) vRa (by pcf) hcs'
+    have hcallF := cpsTripleWithin_frameR
+      (((.x6 : Reg) ↦ᵣ v6) ** ((.x7 : Reg) ↦ᵣ v7) **
+       ((.x28 : Reg) ↦ᵣ v28) ** ((.x29 : Reg) ↦ᵣ v29) **
+       ((.x30 : Reg) ↦ᵣ v30) ** ((.x31 : Reg) ↦ᵣ v31) **
+       bytesRegion aB acctBytes **
+       ((.x18 : Reg) ↦ᵣ oB) ** ((.x2 : Reg) ↦ᵣ newSp) **
+       (oB ↦ₘ (0 : Word)) ** F)
+      (by pcf; exact hF) hcall
+    have hfull1 := cpsTripleWithin_seq_perm_same_cr
+      (fun h hp => by
+        have hp2 : (((((oB + 8) ↦ₘ (0 : Word)) ** ((oB + 16) ↦ₘ (0 : Word)) **
+            ((oB + 24) ↦ₘ (0 : Word)) ** ((oB + 32) ↦ₘ (0 : Word))) **
+           (((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 ((vNext - vLen - aB).toNat))) **
+            ((.x11 : Reg) ↦ᵣ vLen) ** ((.x12 : Reg) ↦ᵣ (oB + 8)) **
+            ((.x5 : Reg) ↦ᵣ v5) ** ((.x6 : Reg) ↦ᵣ v6) ** ((.x7 : Reg) ↦ᵣ v7) **
+            ((.x28 : Reg) ↦ᵣ v28) ** ((.x29 : Reg) ↦ᵣ v29) **
+            ((.x30 : Reg) ↦ᵣ v30) ** ((.x31 : Reg) ↦ᵣ v31) **
+            ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x1 : Reg) ↦ᵣ vRa) **
+            ((.x18 : Reg) ↦ᵣ oB) ** ((.x2 : Reg) ↦ᵣ newSp) **
+            (oB ↦ₘ (0 : Word)) ** bytesRegion aB acctBytes ** F))) h := by
+          xperm_hyp hp
+        have hp3 := sepConj_mono hmemU (fun _ x => x) h hp2
+        xperm_hyp hp3)
+      hsetup hcallF
+    have hroute := hrejRoute (2 : Word) (by decide)
+    rw [show B + 340 = B + 336 + 4 from by bv_omega] at hroute
+    have hfull2 := cpsTripleWithin_seq_perm_same_cr
+      (fun h hp => by
+        have hp2 : ((((.x5 : Reg) ↦ᵣ (32 : Word)) ** ((.x6 : Reg) ↦ᵣ v6) **
+            ((.x7 : Reg) ↦ᵣ v7) ** ((.x28 : Reg) ↦ᵣ v28) ** ((.x29 : Reg) ↦ᵣ v29) **
+            ((.x30 : Reg) ↦ᵣ v30) ** ((.x31 : Reg) ↦ᵣ v31)) **
+           (((.x10 : Reg) ↦ᵣ (2 : Word)) ** ((.x11 : Reg) ↦ᵣ vLen) **
+            ((.x12 : Reg) ↦ᵣ (oB + 8)) **
+            ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x1 : Reg) ↦ᵣ (B + 336 + 4)) **
+            bytesRegion aB acctBytes ** memOwnU256 (oB + 8) **
+            ((.x18 : Reg) ↦ᵣ oB) ** ((.x2 : Reg) ↦ᵣ newSp) **
+            (oB ↦ₘ (0 : Word)) ** F)) h := by
+          xperm_hyp hp
+        have hp3 := sepConj_mono
+          (sepConj_mono (regIs_implies_regOwn .x5)
+            (sepConj_mono (regIs_implies_regOwn .x6)
+              (sepConj_mono (regIs_implies_regOwn .x7)
+                (sepConj_mono (regIs_implies_regOwn .x28)
+                  (sepConj_mono (regIs_implies_regOwn .x29)
+                    (sepConj_mono (regIs_implies_regOwn .x30)
+                      (regIs_implies_regOwn .x31)))))))
+          (fun _ x => x) h hp2
+        xperm_hyp hp3)
+      hfull1 hroute
+    exact cpsBranchWithin_weaken (fun h hp => by xperm_hyp hp) (fun _ x => x) (fun _ x => x)
+      (cpsBranchWithin_mono_nSteps (by omega)
+        (cpsTripleWithin_as_cpsBranchWithin_left (B + 352)
+          (balCaptureOk aB newSp oB ((vNext - vLen - aB).toNat) vLen.toNat acctBytes F)
+          hfull2))
+  by_cases hlen0 : vLen.toNat = 0
+  · -- empty value: zero image, success
+    have hvz : vLen = (0 : Word) := by bv_omega
+    have hcs := rlp_content_to_u256_be_empty_spec_within CB aB (oB + 8)
+      (B + 336 + 4) v5 v6 v7 v28 v29 ((vNext - vLen - aB).toNat)
+    have hcs' := cpsTripleWithin_weaken
+      (fun h hp => by xperm_hyp hp) (fun _ hq => hq) hcs
+      (P' := ((.x1 : Reg) ↦ᵣ (B + 336 + 4)) **
+        (((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 ((vNext - vLen - aB).toNat))) **
+         ((.x11 : Reg) ↦ᵣ (0 : Word)) ** ((.x12 : Reg) ↦ᵣ (oB + 8)) **
+         ((.x5 : Reg) ↦ᵣ v5) ** ((.x6 : Reg) ↦ᵣ v6) ** ((.x7 : Reg) ↦ᵣ v7) **
+         ((.x28 : Reg) ↦ᵣ v28) ** ((.x29 : Reg) ↦ᵣ v29) **
+         ((.x0 : Reg) ↦ᵣ (0 : Word)) ** memOwnU256 (oB + 8)))
+    have hcall := bansf_callSite84_content_to_u256_be (n := 9) vRa (by pcf) hcs'
+    have hcallF := cpsTripleWithin_frameR
+      (((.x30 : Reg) ↦ᵣ v30) ** ((.x31 : Reg) ↦ᵣ v31) **
+       bytesRegion aB acctBytes **
+       ((.x18 : Reg) ↦ᵣ oB) ** ((.x2 : Reg) ↦ᵣ newSp) **
+       (oB ↦ₘ (0 : Word)) ** F)
+      (by pcf; exact hF) hcall
+    have hfull1 := cpsTripleWithin_seq_perm_same_cr
+      (fun h hp => by
+        have hp2 : (((((oB + 8) ↦ₘ (0 : Word)) ** ((oB + 16) ↦ₘ (0 : Word)) **
+            ((oB + 24) ↦ₘ (0 : Word)) ** ((oB + 32) ↦ₘ (0 : Word))) **
+           (((.x11 : Reg) ↦ᵣ vLen) **
+            (((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 ((vNext - vLen - aB).toNat))) **
+             ((.x12 : Reg) ↦ᵣ (oB + 8)) **
+             ((.x5 : Reg) ↦ᵣ v5) ** ((.x6 : Reg) ↦ᵣ v6) ** ((.x7 : Reg) ↦ᵣ v7) **
+             ((.x28 : Reg) ↦ᵣ v28) ** ((.x29 : Reg) ↦ᵣ v29) **
+             ((.x30 : Reg) ↦ᵣ v30) ** ((.x31 : Reg) ↦ᵣ v31) **
+             ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x1 : Reg) ↦ᵣ vRa) **
+             ((.x18 : Reg) ↦ᵣ oB) ** ((.x2 : Reg) ↦ᵣ newSp) **
+             (oB ↦ₘ (0 : Word)) ** bytesRegion aB acctBytes ** F)))) h := by
+          xperm_hyp hp
+        have hp3 := sepConj_mono hmemU
+          (sepConj_mono (fun h' hx => hvz ▸ hx) (fun _ x => x)) h hp2
+        xperm_hyp hp3)
+      hsetup hcallF
+    have ht := htail (List.replicate 32 (0 : BitVec 8))
+    rw [show B + 340 = B + 336 + 4 from by bv_omega] at ht
+    have htF := cpsTripleWithin_frameR
+      (((.x11 : Reg) ↦ᵣ (0 : Word)) ** ((.x12 : Reg) ↦ᵣ (oB + 8)) **
+       regOwn .x6 ** regOwn .x7 ** regOwn .x28 ** regOwn .x29 **
+       ((.x30 : Reg) ↦ᵣ v30) ** ((.x31 : Reg) ↦ᵣ v31) **
+       ((.x1 : Reg) ↦ᵣ (B + 336 + 4)) **
+       ((.x2 : Reg) ↦ᵣ newSp) **
+       bytesRegion aB acctBytes ** F)
+      (by pcf; exact hF) ht
+    have hfull2 := cpsTripleWithin_seq_perm_same_cr
+      (fun h hp => by xperm_hyp hp) hfull1 htF
+    refine cpsBranchWithin_weaken (fun h hp => by xperm_hyp hp) (fun _ x => x)
+      (fun h hq => ?_)
+      (cpsBranchWithin_mono_nSteps (by omega)
+        (cpsTripleWithin_as_cpsBranchWithin_right (B + 736)
+          (balCaptureRej aB newSp oB acctBytes F) hfull2))
+    unfold balCaptureOk
+    rw [hlen0, copyN_zero]
+    have hq4 : ((((.x10 : Reg) ↦ᵣ (0 : Word)) ** ((.x11 : Reg) ↦ᵣ (0 : Word)) **
+        ((.x12 : Reg) ↦ᵣ (oB + 8)) ** ((.x5 : Reg) ↦ᵣ (1 : Word)) **
+        ((.x30 : Reg) ↦ᵣ v30) ** ((.x31 : Reg) ↦ᵣ v31) **
+        ((.x1 : Reg) ↦ᵣ (B + 336 + 4)) **
+        ((oB ↦ₘ (1 : Word)) **
+         bytesRegion (oB + 8) (List.replicate 32 (0 : BitVec 8)) **
+         ((.x18 : Reg) ↦ᵣ oB) ** ((.x2 : Reg) ↦ᵣ newSp) **
+         regOwn .x6 ** regOwn .x7 ** regOwn .x28 ** regOwn .x29 **
+         ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+         bytesRegion aB acctBytes ** F))) h := by
+      xperm_hyp hq
+    have hq5 := sepConj_mono (regIs_implies_regOwn .x10)
+      (sepConj_mono (regIs_implies_regOwn .x11)
+        (sepConj_mono (regIs_implies_regOwn .x12)
+          (sepConj_mono (regIs_implies_regOwn .x5)
+            (sepConj_mono (regIs_implies_regOwn .x30)
+              (sepConj_mono (regIs_implies_regOwn .x31)
+                (sepConj_mono (regIs_implies_regOwn .x1) (fun _ x => x))))))) h hq4
+    refine (sepConj_pure_right h).2 ⟨?_, by omega⟩
+    xperm_hyp hq5
+  by_cases hcz : acctBytes[(vNext - vLen - aB).toNat]'hsoffb = (0 : BitVec 8)
+  · -- non-canonical value (leading zero byte): status 3 → reject
+    have hcs := rlp_content_to_u256_be_noncanonical_spec_within CB aB (oB + 8)
+      (B + 336 + 4) v5 v6 acctBytes ((vNext - vLen - aB).toNat) vLen.toNat
+      (by omega) (by omega) hsalign hsoffb (by omega) (hvalid _ hsoffb) hcz
+    rw [← hlenrep] at hcs
+    have hcs' := cpsTripleWithin_weaken
+      (fun h hp => by xperm_hyp hp) (fun _ hq => hq) hcs
+      (P' := ((.x1 : Reg) ↦ᵣ (B + 336 + 4)) **
+        (((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 ((vNext - vLen - aB).toNat))) **
+         ((.x11 : Reg) ↦ᵣ vLen) ** ((.x12 : Reg) ↦ᵣ (oB + 8)) **
+         ((.x5 : Reg) ↦ᵣ v5) ** ((.x6 : Reg) ↦ᵣ v6) **
+         ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+         bytesRegion aB acctBytes ** memOwnU256 (oB + 8)))
+    have hcall := bansf_callSite84_content_to_u256_be (n := 11) vRa (by pcf) hcs'
+    have hcallF := cpsTripleWithin_frameR
+      (((.x7 : Reg) ↦ᵣ v7) **
+       ((.x28 : Reg) ↦ᵣ v28) ** ((.x29 : Reg) ↦ᵣ v29) **
+       ((.x30 : Reg) ↦ᵣ v30) ** ((.x31 : Reg) ↦ᵣ v31) **
+       ((.x18 : Reg) ↦ᵣ oB) ** ((.x2 : Reg) ↦ᵣ newSp) **
+       (oB ↦ₘ (0 : Word)) ** F)
+      (by pcf; exact hF) hcall
+    have hfull1 := cpsTripleWithin_seq_perm_same_cr
+      (fun h hp => by
+        have hp2 : (((((oB + 8) ↦ₘ (0 : Word)) ** ((oB + 16) ↦ₘ (0 : Word)) **
+            ((oB + 24) ↦ₘ (0 : Word)) ** ((oB + 32) ↦ₘ (0 : Word))) **
+           (((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 ((vNext - vLen - aB).toNat))) **
+            ((.x11 : Reg) ↦ᵣ vLen) ** ((.x12 : Reg) ↦ᵣ (oB + 8)) **
+            ((.x5 : Reg) ↦ᵣ v5) ** ((.x6 : Reg) ↦ᵣ v6) ** ((.x7 : Reg) ↦ᵣ v7) **
+            ((.x28 : Reg) ↦ᵣ v28) ** ((.x29 : Reg) ↦ᵣ v29) **
+            ((.x30 : Reg) ↦ᵣ v30) ** ((.x31 : Reg) ↦ᵣ v31) **
+            ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x1 : Reg) ↦ᵣ vRa) **
+            ((.x18 : Reg) ↦ᵣ oB) ** ((.x2 : Reg) ↦ᵣ newSp) **
+            (oB ↦ₘ (0 : Word)) ** bytesRegion aB acctBytes ** F))) h := by
+          xperm_hyp hp
+        have hp3 := sepConj_mono hmemU (fun _ x => x) h hp2
+        xperm_hyp hp3)
+      hsetup hcallF
+    have hroute := hrejRoute (3 : Word) (by decide)
+    rw [show B + 340 = B + 336 + 4 from by bv_omega] at hroute
+    have hfull2 := cpsTripleWithin_seq_perm_same_cr
+      (fun h hp => by
+        have hp2 : ((((.x7 : Reg) ↦ᵣ v7) ** ((.x28 : Reg) ↦ᵣ v28) **
+            ((.x29 : Reg) ↦ᵣ v29) **
+            ((.x30 : Reg) ↦ᵣ v30) ** ((.x31 : Reg) ↦ᵣ v31)) **
+           (((.x10 : Reg) ↦ᵣ (3 : Word)) ** ((.x11 : Reg) ↦ᵣ vLen) **
+            ((.x12 : Reg) ↦ᵣ (oB + 8)) **
+            regOwn .x5 ** regOwn .x6 **
+            ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x1 : Reg) ↦ᵣ (B + 336 + 4)) **
+            bytesRegion aB acctBytes ** memOwnU256 (oB + 8) **
+            ((.x18 : Reg) ↦ᵣ oB) ** ((.x2 : Reg) ↦ᵣ newSp) **
+            (oB ↦ₘ (0 : Word)) ** F)) h := by
+          xperm_hyp hp
+        have hp3 := sepConj_mono
+          (sepConj_mono (regIs_implies_regOwn .x7)
+            (sepConj_mono (regIs_implies_regOwn .x28)
+              (sepConj_mono (regIs_implies_regOwn .x29)
+                (sepConj_mono (regIs_implies_regOwn .x30)
+                  (regIs_implies_regOwn .x31)))))
+          (fun _ x => x) h hp2
+        xperm_hyp hp3)
+      hfull1 hroute
+    exact cpsBranchWithin_weaken (fun h hp => by xperm_hyp hp) (fun _ x => x) (fun _ x => x)
+      (cpsBranchWithin_mono_nSteps (by omega)
+        (cpsTripleWithin_as_cpsBranchWithin_left (B + 352)
+          (balCaptureOk aB newSp oB ((vNext - vLen - aB).toNat) vLen.toNat acctBytes F)
+          hfull2))
+  · -- canonical non-empty value: right-aligned copy, success
+    have hcs := rlp_content_to_u256_be_success_spec_within CB aB (oB + 8)
+      (B + 336 + 4) v5 v6 v7 v28 v29 acctBytes ((vNext - vLen - aB).toNat) vLen.toNat
+      (by omega) (by omega) hsalign hoalign8 hsoffb hcz
+      (by omega) (by omega) hoover8
+      (fun k hk => hvalid _ (by omega))
+      (fun k hk => hdval _ (by omega))
+    rw [← hlenrep] at hcs
+    have hcs' := cpsTripleWithin_weaken
+      (fun h hp => by xperm_hyp hp) (fun _ hq => hq) hcs
+      (P' := ((.x1 : Reg) ↦ᵣ (B + 336 + 4)) **
+        (((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 ((vNext - vLen - aB).toNat))) **
+         ((.x11 : Reg) ↦ᵣ vLen) ** ((.x12 : Reg) ↦ᵣ (oB + 8)) **
+         ((.x5 : Reg) ↦ᵣ v5) ** ((.x6 : Reg) ↦ᵣ v6) ** ((.x7 : Reg) ↦ᵣ v7) **
+         ((.x28 : Reg) ↦ᵣ v28) ** ((.x29 : Reg) ↦ᵣ v29) **
+         ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+         bytesRegion aB acctBytes ** memOwnU256 (oB + 8)))
+    have hcall := bansf_callSite84_content_to_u256_be
+      (n := 7 * vLen.toNat + 16) vRa (by pcf) hcs'
+    have hcallF := cpsTripleWithin_frameR
+      (((.x30 : Reg) ↦ᵣ v30) ** ((.x31 : Reg) ↦ᵣ v31) **
+       ((.x18 : Reg) ↦ᵣ oB) ** ((.x2 : Reg) ↦ᵣ newSp) **
+       (oB ↦ₘ (0 : Word)) ** F)
+      (by pcf; exact hF) hcall
+    have hfull1 := cpsTripleWithin_seq_perm_same_cr
+      (fun h hp => by
+        have hp2 : (((((oB + 8) ↦ₘ (0 : Word)) ** ((oB + 16) ↦ₘ (0 : Word)) **
+            ((oB + 24) ↦ₘ (0 : Word)) ** ((oB + 32) ↦ₘ (0 : Word))) **
+           (((.x10 : Reg) ↦ᵣ (aB + BitVec.ofNat 64 ((vNext - vLen - aB).toNat))) **
+            ((.x11 : Reg) ↦ᵣ vLen) ** ((.x12 : Reg) ↦ᵣ (oB + 8)) **
+            ((.x5 : Reg) ↦ᵣ v5) ** ((.x6 : Reg) ↦ᵣ v6) ** ((.x7 : Reg) ↦ᵣ v7) **
+            ((.x28 : Reg) ↦ᵣ v28) ** ((.x29 : Reg) ↦ᵣ v29) **
+            ((.x30 : Reg) ↦ᵣ v30) ** ((.x31 : Reg) ↦ᵣ v31) **
+            ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x1 : Reg) ↦ᵣ vRa) **
+            ((.x18 : Reg) ↦ᵣ oB) ** ((.x2 : Reg) ↦ᵣ newSp) **
+            (oB ↦ₘ (0 : Word)) ** bytesRegion aB acctBytes ** F))) h := by
+          xperm_hyp hp
+        have hp3 := sepConj_mono hmemU (fun _ x => x) h hp2
+        xperm_hyp hp3)
+      hsetup hcallF
+    have ht := htail (copyN (List.replicate 32 (0 : BitVec 8)) acctBytes
+      (32 - vLen.toNat) ((vNext - vLen - aB).toNat) vLen.toNat)
+    rw [show B + 340 = B + 336 + 4 from by bv_omega] at ht
+    have htF := cpsTripleWithin_frameR
+      (((.x11 : Reg) ↦ᵣ vLen) ** ((.x12 : Reg) ↦ᵣ (oB + 8)) **
+       regOwn .x6 ** regOwn .x7 ** regOwn .x28 ** regOwn .x29 **
+       ((.x30 : Reg) ↦ᵣ v30) ** ((.x31 : Reg) ↦ᵣ v31) **
+       ((.x1 : Reg) ↦ᵣ (B + 336 + 4)) **
+       ((.x2 : Reg) ↦ᵣ newSp) **
+       bytesRegion aB acctBytes ** F)
+      (by pcf; exact hF) ht
+    have hfull2 := cpsTripleWithin_seq_perm_same_cr
+      (fun h hp => by xperm_hyp hp) hfull1 htF
+    refine cpsBranchWithin_weaken (fun h hp => by xperm_hyp hp) (fun _ x => x)
+      (fun h hq => ?_)
+      (cpsBranchWithin_mono_nSteps (by omega)
+        (cpsTripleWithin_as_cpsBranchWithin_right (B + 736)
+          (balCaptureRej aB newSp oB acctBytes F) hfull2))
+    unfold balCaptureOk
+    have hq4 : ((((.x10 : Reg) ↦ᵣ (0 : Word)) ** ((.x11 : Reg) ↦ᵣ vLen) **
+        ((.x12 : Reg) ↦ᵣ (oB + 8)) ** ((.x5 : Reg) ↦ᵣ (1 : Word)) **
+        ((.x30 : Reg) ↦ᵣ v30) ** ((.x31 : Reg) ↦ᵣ v31) **
+        ((.x1 : Reg) ↦ᵣ (B + 336 + 4)) **
+        ((oB ↦ₘ (1 : Word)) **
+         bytesRegion (oB + 8) (copyN (List.replicate 32 (0 : BitVec 8)) acctBytes
+           (32 - vLen.toNat) ((vNext - vLen - aB).toNat) vLen.toNat) **
+         ((.x18 : Reg) ↦ᵣ oB) ** ((.x2 : Reg) ↦ᵣ newSp) **
+         regOwn .x6 ** regOwn .x7 ** regOwn .x28 ** regOwn .x29 **
+         ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+         bytesRegion aB acctBytes ** F))) h := by
+      xperm_hyp hq
+    have hq5 := sepConj_mono (regIs_implies_regOwn .x10)
+      (sepConj_mono (regIs_implies_regOwn .x11)
+        (sepConj_mono (regIs_implies_regOwn .x12)
+          (sepConj_mono (regIs_implies_regOwn .x5)
+            (sepConj_mono (regIs_implies_regOwn .x30)
+              (sepConj_mono (regIs_implies_regOwn .x31)
+                (sepConj_mono (regIs_implies_regOwn .x1) (fun _ x => x))))))) h hq4
+    refine (sepConj_pure_right h).2 ⟨?_, by omega⟩
+    xperm_hyp hq5
+#print axioms bansf_balCapture_spec
+
+end BalAccountNonstorageFinalsSpec
+end EvmAsm.Codegen

--- a/EvmAsm/Codegen/Programs/BalAccountNonstorageFinalsChainD.lean
+++ b/EvmAsm/Codegen/Programs/BalAccountNonstorageFinalsChainD.lean
@@ -92,6 +92,18 @@ def balStationRej (aB newSp oB : Word) (aLen : Nat)
   ((.x0 : Reg) ↦ᵣ (0 : Word)) ** regOwn .x1 **
   bytesRegion aB acctBytes ** F
 
+/-- Swap the two exits of a branch (the find-last loop reports its clean
+    exit FIRST; the station convention keeps the reject exit first). -/
+theorem cpsBranchWithin_swap {n : Nat} {entry : Word} {cr : CodeReq}
+    {P : Assertion} {e1 : Word} {Q1 : Assertion} {e2 : Word} {Q2 : Assertion}
+    (h : cpsBranchWithin n entry cr P e1 Q1 e2 Q2) :
+    cpsBranchWithin n entry cr P e2 Q2 e1 Q1 := by
+  intro R hR s hcr hPR hpc
+  obtain ⟨k, hk, s', hstep, hcase⟩ := h R hR s hcr hPR hpc
+  exact ⟨k, hk, s', hstep, hcase.symm⟩
+
+#print axioms cpsBranchWithin_swap
+
 /-!
 ## Balance-station assembly plan (slice 4g, `bansf_balStation_spec`)
 

--- a/EvmAsm/Codegen/Programs/BalAccountNonstorageFinalsChainD.lean
+++ b/EvmAsm/Codegen/Programs/BalAccountNonstorageFinalsChainD.lean
@@ -92,5 +92,74 @@ def balStationRej (aB newSp oB : Word) (aLen : Nat)
   ((.x0 : Reg) ↦ᵣ (0 : Word)) ** regOwn .x1 **
   bytesRegion aB acctBytes ** F
 
+/-!
+## Balance-station assembly plan (slice 4g, `bansf_balStation_spec`)
+
+Goal shape:
+```
+theorem bansf_balStation_spec (aB newSp oB : Word) (aLen off3 : Nat)
+    (n3 l3 v19 v20 : Word) (acctBytes) (F) (hF hsalign hoalign hslack hover
+    hvalid hovout hovalid) (hoff3 : off3 ≤ aLen)
+    (hdec3 : rlpItemDecode acctBytes off3 (aB+ofNat off3) (aB+ofNat aLen) n3 l3) :
+  cpsBranchWithin (98 * (aLen + 1) + 700) (B + 184) bansfCR
+    (x10↦n3 ** x11↦0 ** x12↦l3 ** x19↦v19 ** x20↦v20 **
+     (newSp+48)↦ₘn3 ** (newSp+56)↦ₘ(aB+ofNat aLen) ** memOwn (newSp+64/72) **
+     x2↦newSp ** x8↦aB ** x9↦ofNat aLen ** x18↦oB **
+     oB↦ₘ0 ** (oB+8/16/24/32)↦ₘ0 ** x0↦0 ** bytesRegion aB acctBytes ** F **
+     regOwn x5 x6 x7 x28 x29 x30 x31 x1)          -- owns LAST for regOwn8 intro
+    (B+736) (balStationRej aB newSp oB aLen acctBytes F)
+    (B+352) (balStationPost aB newSp oB aLen ((n3-l3-aB).toNat) l3.toNat n3 acctBytes F)
+```
+Proof skeleton:
+1. `cpsBranchWithin_of_forall_regIs_to_regOwn8` (after a weaken-perm) intros
+   v5 v6 v7 v28 v29 v30 v31 vRa.
+2. `rlpItemDecode_spanStart hdec3 hoff3` ⇒ hrepS (n3−l3 = aB+ofNat fOff),
+   hsple, hspb (fOff + l3.toNat ≤ aLen — discharges fieldInit50's hfB).
+3. spanCapture46 (liftCode bansfCode→bansfCR via union_mono_left, frameR rest,
+   rw [hrepS]) ; seq_branch with fieldInit50 (fOff := (n3−l3−aB).toNat,
+   fSpanW := l3, vRa-old := vRa).  Reject arm: fieldRej ** frame ⇒
+   balStationRej (memIs→memOwn on 48/56/64/72 + oB cells → memOwn oB +
+   hmemU-style memOwnU256 (oB+8), regIs→regOwn x19 x20 x11? note fieldRej
+   owns x11/x12 already).
+4. At B+208: continuation branch with pre `fun h => ∃ cOff, ((fieldInitPost
+   atoms ** frame) ** ⌜FieldInitOk acctBytes fOff l3.toNat cOff⌝) h` connected
+   by a pointwise rebuild lambda (ChainC2-collapse style).  exists_pre +
+   pure_pre_right, then `by_cases hce : cOff = fOff + l3.toNat`:
+   - EMPTY: balEmptyTaken (lift, frame all) ⇒ B+352; weaken to balStationPost
+     EMPTY arm (FieldFinal.empty b hb (hok.2.1 ▸ hce); regIs→regOwn
+     x10 x11 x12 x19 x20).  `cpsTripleWithin_as_cpsBranchWithin_right`.
+   - NONEMPTY: balEmptyFall (hne := hce, hcle/hfle by omega from FieldInitOk
+     + hspb) ; loopEntry53 ; findLastLoop1 (off0 := cOff, endOff := fOff +
+     l3.toNat, j := endOff − cOff; hoff0 : cOff < endOff from hok ≤ + hce;
+     flInv entry: ⟨cOff, v19', v20', …, Or.inl rfl⟩; v19'/v20' are the
+     spanCapture-written x19=n3−l3, x20=l3).  Loop exits are (B+264 flExit |
+     B+736 flRej) — FIRST exit continues ⇒ need the swap variant (write
+     `cpsBranchWithin_swap` inline: intro/rcases/Or-swap) before chain_snd.
+     flRej ⇒ balStationRej (oB cells from frame).
+5. At B+264 (flExit): exists_pre n l + pure (LastItemAt).  loopExitMove66
+   (lift, frame) ; `LastItemAt_decode hlast (by omega) (by omega)` ⇒
+   ∃ offT ≤ endOff, decode of the last tuple; `rlpItemDecode_spanStart` on it
+   ⇒ hrepT (n−l = aB+ofNat tOff), tOff + l.toNat ≤ endOff ≤ aLen (fieldInit68
+   hfB ✓).  rw [hrepT]; fieldInit68 (fOff := (n−l−aB).toNat, fSpanW := l).
+6. At B+280: same ∃cOff2/FieldInitOk unpack; tupleSpill70 ; tupleItem0
+   (aLen-param := tOff2 + l.toNat, off := cOff2, hoffle from FieldInitOk;
+   hslack' : tOff2 + l.toNat + 9 ≤ length by omega).  tupleRej ⇒
+   balStationRej.
+7. At B+308 (tupleOk): ∃ next len + idx-decode pure; `rlpItemDecode_advance`
+   ⇒ next = aB+ofNat nOff, cOff2 < nOff ≤ tEnd2.  rw; tupleItem1 (off := nOff).
+8. At B+324 (tupleValOk): ∃ vNext vLen + val-decode; balCapture (tEnd :=
+   tEnd2, off := nOff, hdec := val-decode; hovout/hovalid/hoalign from
+   station hyps).  balCaptureRej ⇒ balStationRej.
+9. At B+352 (balCaptureOk): weaken to balStationPost FOUND arm:
+   FieldFinal.last b n l vNext vLen with hb (field FieldInitOk), hne (hok ▸
+   hce), hlast (flExit pure, off0 rewritten to fOff + listHeaderSize b),
+   hval : TupleValueWindow = ⟨b2, hb2, next, len, idx-decode (cOff2 → tOff2 +
+   listHeaderSize b2), val-decode with cursor rewritten aB+ofNat nOff → next⟩;
+   vLen.toNat ≤ 32 from balCaptureOk's pure; regIs→regOwn x19 x20 (+ x10 etc.
+   already own in balCaptureOk); spills 48/56 & memOwn 64/72 from frame.
+Step budget per path: empty 4+84+1 = 89; found 4+84+1+2+98*(j+1)+2+84+2+93+
+92+260 ≤ 98*(aLen+1)+624.  `cpsBranchWithin_mono_nSteps (by omega)` at the end.
+-/
+
 end BalAccountNonstorageFinalsSpec
 end EvmAsm.Codegen

--- a/EvmAsm/Codegen/Programs/BalAccountNonstorageFinalsChainD.lean
+++ b/EvmAsm/Codegen/Programs/BalAccountNonstorageFinalsChainD.lean
@@ -1,0 +1,96 @@
+/-
+  EvmAsm.Codegen.Programs.BalAccountNonstorageFinalsChainD
+
+  Balance-station glue (bead evm-asm-4ch8f.43.5, slice 4f):
+
+    66  mv a0, s3              (loop exit → tuple span start)
+    67  mv a1, s4              (tuple span length)
+    70  sd a0, 64(sp)          (tuple-walk cursor spill)
+    71  sd a1, 72(sp)          (tuple-walk end spill)
+
+  plus the station-level reject shape shared by every failure path of the
+  balance station (field init, find-last loop, tuple items, value capture).
+-/
+
+import EvmAsm.Codegen.Programs.BalAccountNonstorageFinalsChainC3
+
+set_option maxRecDepth 8000
+
+namespace EvmAsm.Codegen
+
+open EvmAsm.Rv64 EvmAsm.Rv64.SAsm EvmAsm.Rv64.RLP
+
+namespace BalAccountNonstorageFinalsSpec
+
+/-- Slots 66–67 (`B + 264 → B + 272`): move the last tuple's span
+    `(s3, s4)` into the `rlp_walk_init` argument registers. -/
+theorem bansf_loopExitMove66_spec (v19 v20 v10 v11 : Word) :
+    cpsTripleWithin 2 (B + 264) (B + 272) bansfCode
+      (((.x19 : Reg) ↦ᵣ v19) ** ((.x20 : Reg) ↦ᵣ v20) **
+       ((.x10 : Reg) ↦ᵣ v10) ** ((.x11 : Reg) ↦ᵣ v11))
+      (((.x19 : Reg) ↦ᵣ v19) ** ((.x20 : Reg) ↦ᵣ v20) **
+       ((.x10 : Reg) ↦ᵣ v19) ** ((.x11 : Reg) ↦ᵣ v20)) := by
+  have s1 := mv_spec_gen_within .x10 .x19 v19 v10 (B + 264) (by decide)
+  have s2 := mv_spec_gen_within .x11 .x20 v20 v11 (B + 268) (by decide)
+  runBlock s1 s2
+
+#print axioms bansf_loopExitMove66_spec
+
+/-- Slots 70–71 (`B + 280 → B + 288`): spill the tuple-walk cursor and
+    window end for the item units. -/
+theorem bansf_tupleSpill70_spec (newSp v10 v11 : Word) :
+    cpsTripleWithin 2 (B + 280) (B + 288) bansfCR
+      (((.x10 : Reg) ↦ᵣ v10) ** ((.x11 : Reg) ↦ᵣ v11) **
+       ((.x2 : Reg) ↦ᵣ newSp) **
+       memOwn (newSp + 64) ** memOwn (newSp + 72))
+      (((.x10 : Reg) ↦ᵣ v10) ** ((.x11 : Reg) ↦ᵣ v11) **
+       ((.x2 : Reg) ↦ᵣ newSp) **
+       ((newSp + 64) ↦ₘ v10) ** ((newSp + 72) ↦ₘ v11)) := by
+  have hsd1 := sd_spec_gen_own_within .x2 .x10 newSp v10 (64 : BitVec 12) (B + 280)
+  rw [show signExtend12 (64 : BitVec 12) = (64 : Word) from by decide,
+      show (B + 280) + 4 = B + 284 from by bv_omega] at hsd1
+  have hsd1L := liftCode (cr' := bansfCR) hsd1
+    (fun a i h => CodeReq.union_mono_left a i
+      (CodeReq.ofProg_mem_at B (B + 280) bansfProg 70 (.SD .x2 .x10 (64 : BitVec 12))
+        (by decide +kernel) (by decide +kernel) (by decide +kernel) (by decide) a i h))
+  have hsd2 := sd_spec_gen_own_within .x2 .x11 newSp v11 (72 : BitVec 12) (B + 284)
+  rw [show signExtend12 (72 : BitVec 12) = (72 : Word) from by decide,
+      show (B + 284) + 4 = B + 288 from by bv_omega] at hsd2
+  have hsd2L := liftCode (cr' := bansfCR) hsd2
+    (fun a i h => CodeReq.union_mono_left a i
+      (CodeReq.ofProg_mem_at B (B + 284) bansfProg 71 (.SD .x2 .x11 (72 : BitVec 12))
+        (by decide +kernel) (by decide +kernel) (by decide +kernel) (by decide) a i h))
+  have hsd1F := cpsTripleWithin_frameR
+    (((.x11 : Reg) ↦ᵣ v11) ** memOwn (newSp + 72))
+    (by pcf) hsd1L
+  have hsd2F := cpsTripleWithin_frameR
+    (((.x10 : Reg) ↦ᵣ v10) ** ((newSp + 64) ↦ₘ v10))
+    (by pcf) hsd2L
+  have hchain := cpsTripleWithin_seq_perm_same_cr (fun h hp => by xperm_hyp hp)
+    hsd1F hsd2F
+  exact cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp)
+    (fun h hq => by xperm_hyp hq) hchain
+
+#print axioms bansf_tupleSpill70_spec
+
+/-- The station-level reject shape at the epilogue entry (`B + 736`):
+    every failure path of the balance station (field init, find-last loop,
+    tuple items, value capture) weakens into this.  All station-scratch
+    state is released to ownership; the callee-saved anchors survive. -/
+def balStationRej (aB newSp oB : Word) (aLen : Nat)
+    (acctBytes : List (BitVec 8)) (F : Assertion) : Assertion :=
+  ((.x10 : Reg) ↦ᵣ (1 : Word)) ** ((.x2 : Reg) ↦ᵣ newSp) **
+  memOwn (newSp + 48) ** memOwn (newSp + 56) **
+  memOwn (newSp + 64) ** memOwn (newSp + 72) **
+  ((.x8 : Reg) ↦ᵣ aB) ** ((.x9 : Reg) ↦ᵣ BitVec.ofNat 64 aLen) **
+  ((.x18 : Reg) ↦ᵣ oB) **
+  memOwn oB ** memOwnU256 (oB + 8) **
+  regOwn .x19 ** regOwn .x20 **
+  regOwn .x11 ** regOwn .x12 **
+  regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+  regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+  ((.x0 : Reg) ↦ᵣ (0 : Word)) ** regOwn .x1 **
+  bytesRegion aB acctBytes ** F
+
+end BalAccountNonstorageFinalsSpec
+end EvmAsm.Codegen

--- a/EvmAsm/Codegen/Programs/Imports.lean
+++ b/EvmAsm/Codegen/Programs/Imports.lean
@@ -448,3 +448,4 @@ import EvmAsm.Codegen.Programs.BalAccountNonstorageFinalsChainB3
 import EvmAsm.Codegen.Programs.BalAccountNonstorageFinalsChainC
 import EvmAsm.Codegen.Programs.BalAccountNonstorageFinalsChainC2
 import EvmAsm.Codegen.Programs.BalAccountNonstorageFinalsChainC3
+import EvmAsm.Codegen.Programs.BalAccountNonstorageFinalsChainD

--- a/EvmAsm/Codegen/Programs/Imports.lean
+++ b/EvmAsm/Codegen/Programs/Imports.lean
@@ -447,3 +447,4 @@ import EvmAsm.Codegen.Programs.BalAccountNonstorageFinalsChainB2
 import EvmAsm.Codegen.Programs.BalAccountNonstorageFinalsChainB3
 import EvmAsm.Codegen.Programs.BalAccountNonstorageFinalsChainC
 import EvmAsm.Codegen.Programs.BalAccountNonstorageFinalsChainC2
+import EvmAsm.Codegen.Programs.BalAccountNonstorageFinalsChainC3

--- a/EvmAsm/Codegen/Programs/Imports.lean
+++ b/EvmAsm/Codegen/Programs/Imports.lean
@@ -446,3 +446,4 @@ import EvmAsm.Codegen.Programs.BalAccountNonstorageFinalsChainB
 import EvmAsm.Codegen.Programs.BalAccountNonstorageFinalsChainB2
 import EvmAsm.Codegen.Programs.BalAccountNonstorageFinalsChainB3
 import EvmAsm.Codegen.Programs.BalAccountNonstorageFinalsChainC
+import EvmAsm.Codegen.Programs.BalAccountNonstorageFinalsChainC2

--- a/EvmAsm/Codegen/Programs/Imports.lean
+++ b/EvmAsm/Codegen/Programs/Imports.lean
@@ -445,3 +445,4 @@ import EvmAsm.Codegen.Programs.BalAccountNonstorageFinalsLoop3
 import EvmAsm.Codegen.Programs.BalAccountNonstorageFinalsChainB
 import EvmAsm.Codegen.Programs.BalAccountNonstorageFinalsChainB2
 import EvmAsm.Codegen.Programs.BalAccountNonstorageFinalsChainB3
+import EvmAsm.Codegen.Programs.BalAccountNonstorageFinalsChainC


### PR DESCRIPTION
## Summary

Intermediate slice PR for bead `evm-asm-4ch8f.43.5` (the `bal_account_nonstorage_finals` top theorem), covering the **balance-station internals** — everything between the SEG-B item chain (`B+184`) and the nonce-station boundary (`B+352`) except the final station assembly:

- **ChainC (4a–4b)**: `bansf_spanCapture46_spec` (slots 46–49), `bansf_fieldInit50_spec` — the field-window `rlp_walk_init` nine-arm dispatch with the window side conditions + 9-byte slack discharged from the **outer account-region bounds via `rlpItemDecode_spanStart`** (the `hfB : fOff + fSpanW.toNat ≤ aLen` hypothesis is the nesting fact, not an unexplained top-level assumption); `balStationPost` (the station's empty/found post at `B+352`); the slot-52 empty split (`bansf_balEmptyTaken_spec`/`bansf_balEmptyFall_spec`, lemma-level case split on `cOff = fEnd`); `bansf_loopEntry53_spec`; `LastItemAt_decode`.
- **ChainC (4c)**: `bansf_fieldInit68_spec` — the tuple-window init dispatch at site 68.
- **ChainC2 (4d)**: `tupleRej`/`tupleOk`/`tupleValOk` and the two tuple item units `bansf_tupleItem0_spec` (slots 72–76) / `bansf_tupleItem1_spec` (slots 77–80, ok arm falls into the capture block).
- **ChainC3 (4e)**: `bansf_balCapture_spec` (slots 81–87) — the balance-value capture as a two-exit branch `B+324 → B+736 | B+352`. The four value cases (too-long / empty / non-canonical / canonical success) are split at the **lemma level** against the four public `rlp_content_to_u256_be` sub-specs, so the success exit carries the `copyN` right-aligned 32-byte BE image **and** the `vLen.toNat ≤ 32` bound the `FinalsDerivation` balance field requires (the packaged four-way dispatch post cannot supply it).
- **ChainD (4f + 4g prep)**: `bansf_loopExitMove66_spec` (slots 66–67), `bansf_tupleSpill70_spec` (slots 70–71), `balStationRej` (the common reject shape every station failure path weakens into), `cpsBranchWithin_swap`, and the slice-4g station-assembly plan as a doc comment.

## Discipline

- Byte-transparent: pure proof over the existing `balAccountNonstorageFinals_prog`; no emit/regen. Symbolic `GuestAddrs.*`, no value pins.
- Additive only; `Imports.lean` changes are import-line appends.
- `#print axioms` on every theorem: `[propext, Classical.choice, Quot.sound]`. No `sorry`/`native_decide`/`bv_decide`/`maxHeartbeats` (`maxRecDepth 8000` only).
- `lake build` green (4968 jobs); `check-forbidden-tactics` clean.

## Next (same bead, follow-up slices)

`bansf_balStation_spec` (4g, plan in ChainD), the nonce/code stations, then the top assembly `abiFrame_spec_own ⇒ bansf_spec_within` + the non-absent success witness — that final PR keeps the `feat(sasm): … top theorem` title.

🤖 Generated with [Claude Code](https://claude.com/claude-code)