### PR TITLE
refactor: split transaction import closures

### DIFF
--- a/EvmAsm/Codegen/Programs/AccountBalance.lean
+++ b/EvmAsm/Codegen/Programs/AccountBalance.lean
@@ -31,6 +31,7 @@ import EvmAsm.Codegen.AsmReloc
 import EvmAsm.Codegen.Programs.RlpRead
 import EvmAsm.Codegen.Programs.MptSet
 import EvmAsm.Codegen.Programs.AccountFieldExtract
+import EvmAsm.Codegen.Programs.Tx
 
 namespace EvmAsm.Codegen
 

--- a/EvmAsm/Codegen/Programs/AccountFieldExtract.lean
+++ b/EvmAsm/Codegen/Programs/AccountFieldExtract.lean
@@ -19,9 +19,7 @@ import EvmAsm.Codegen.Layout
 import EvmAsm.Codegen.Emit
 import EvmAsm.Codegen.GuestAddrs
 import EvmAsm.Codegen.AsmReloc
-import EvmAsm.Codegen.Programs.RlpRead
 import EvmAsm.Codegen.Programs.RlpWalk
-import EvmAsm.Codegen.Programs.Tx
 
 namespace EvmAsm.Codegen
 

--- a/EvmAsm/Codegen/Programs/EvmArithUnits.lean
+++ b/EvmAsm/Codegen/Programs/EvmArithUnits.lean
@@ -6,7 +6,8 @@
   SDIV / SMOD baked-data and from-input `BuildUnit` definitions.
 -/
 
-import EvmAsm.Codegen.Programs.Evm
+import EvmAsm.Codegen.Programs.EvmBasic
+import EvmAsm.Codegen.Programs.EvmDivModWrappers
 
 namespace EvmAsm.Codegen
 

--- a/EvmAsm/Codegen/Programs/EvmCodes.lean
+++ b/EvmAsm/Codegen/Programs/EvmCodes.lean
@@ -6,7 +6,7 @@
   `StateCompose` so it can reference the string-constant helpers
   defined there.
 -/
-import EvmAsm.Codegen.Programs.StateCompose
+import EvmAsm.Codegen.Programs.State
 import EvmAsm.Codegen.Emit
 import EvmAsm.Codegen.GuestAddrs
 import EvmAsm.Codegen.AsmReloc

--- a/EvmAsm/Codegen/Programs/EvmDispatchUnits.lean
+++ b/EvmAsm/Codegen/Programs/EvmDispatchUnits.lean
@@ -5,7 +5,8 @@
   satisfy the 1500-line file-size cap.
 -/
 
-import EvmAsm.Codegen.Programs.Evm
+import EvmAsm.Codegen.Programs.EvmTinyInterp
+import EvmAsm.Codegen.Programs.EvmRegistry
 import EvmAsm.Codegen.Programs.SystemCallStaging
 import EvmAsm.Codegen.Programs.AssembleExecutionRequests
 import EvmAsm.Codegen.Programs.TxPubkey

--- a/EvmAsm/Codegen/Programs/EvmOpcodes.lean
+++ b/EvmAsm/Codegen/Programs/EvmOpcodes.lean
@@ -28,7 +28,6 @@ import EvmAsm.Codegen.Programs.Mpt
 import EvmAsm.Codegen.Programs.HashBridge
 import EvmAsm.Codegen.Programs.HeaderFields
 import EvmAsm.Codegen.Programs.State
-import EvmAsm.Codegen.Programs.EvmNonce
 
 namespace EvmAsm.Codegen
 

--- a/EvmAsm/Codegen/Programs/ExpProperty.lean
+++ b/EvmAsm/Codegen/Programs/ExpProperty.lean
@@ -18,7 +18,7 @@
   `(base, exponent)` pairs against Python's `pow(base, exp, 2**256)`.
 -/
 
-import EvmAsm.Codegen.Programs.Evm
+import EvmAsm.Codegen.Programs.EvmBasic
 import EvmAsm.Evm64.Exp.Program
 import EvmAsm.Evm64.Multiply.Callable
 

--- a/EvmAsm/Codegen/Programs/HeaderDecode.lean
+++ b/EvmAsm/Codegen/Programs/HeaderDecode.lean
@@ -20,7 +20,6 @@ import EvmAsm.Codegen.GuestAddrs
 import EvmAsm.Codegen.AsmReloc
 import EvmAsm.Codegen.Programs.RlpRead
 import EvmAsm.Codegen.Programs.RlpWalk
-import EvmAsm.Codegen.Programs.Tx
 
 namespace EvmAsm.Codegen
 

--- a/EvmAsm/Codegen/Programs/RuntimeSameBlockCode.lean
+++ b/EvmAsm/Codegen/Programs/RuntimeSameBlockCode.lean
@@ -9,7 +9,6 @@
 -/
 
 import EvmAsm.Rv64.Program
-import EvmAsm.Codegen.Programs.RlpRead
 import EvmAsm.Codegen.Emit
 import EvmAsm.Codegen.GuestAddrs
 import EvmAsm.Codegen.AsmReloc

--- a/EvmAsm/Codegen/Programs/SimpleTransferRecipient.lean
+++ b/EvmAsm/Codegen/Programs/SimpleTransferRecipient.lean
@@ -10,6 +10,7 @@ import EvmAsm.Codegen.Programs.AccountFieldExtract
 import EvmAsm.Codegen.Programs.BalAccountPostFields
 import EvmAsm.Codegen.Programs.RlpRead
 import EvmAsm.Codegen.Programs.U256
+import EvmAsm.Codegen.Programs.Tx
 
 namespace EvmAsm.Codegen
 

--- a/EvmAsm/Codegen/Programs/Tx.lean
+++ b/EvmAsm/Codegen/Programs/Tx.lean
@@ -39,7 +39,6 @@ import EvmAsm.Codegen.Layout
 import EvmAsm.Codegen.Emit
 import EvmAsm.Codegen.GuestAddrs
 import EvmAsm.Codegen.AsmReloc
-import EvmAsm.Codegen.Programs.HashBridge
 import EvmAsm.Codegen.Programs.RlpRead
 import EvmAsm.Codegen.Programs.RlpWalk
 import EvmAsm.Codegen.Programs.U256

--- a/EvmAsm/Codegen/Programs/TxDecode1559.lean
+++ b/EvmAsm/Codegen/Programs/TxDecode1559.lean
@@ -19,9 +19,7 @@ import EvmAsm.Codegen.Layout
 import EvmAsm.Codegen.Emit
 import EvmAsm.Codegen.GuestAddrs
 import EvmAsm.Codegen.AsmReloc
-import EvmAsm.Codegen.Programs.RlpRead
 import EvmAsm.Codegen.Programs.RlpWalk
-import EvmAsm.Codegen.Programs.Tx
 
 namespace EvmAsm.Codegen
 

--- a/EvmAsm/Codegen/Programs/TxDecode2930.lean
+++ b/EvmAsm/Codegen/Programs/TxDecode2930.lean
@@ -19,9 +19,7 @@ import EvmAsm.Codegen.Layout
 import EvmAsm.Codegen.Emit
 import EvmAsm.Codegen.GuestAddrs
 import EvmAsm.Codegen.AsmReloc
-import EvmAsm.Codegen.Programs.RlpRead
 import EvmAsm.Codegen.Programs.RlpWalk
-import EvmAsm.Codegen.Programs.Tx
 
 namespace EvmAsm.Codegen
 

--- a/EvmAsm/Codegen/Programs/TxDecode4844.lean
+++ b/EvmAsm/Codegen/Programs/TxDecode4844.lean
@@ -19,9 +19,7 @@ import EvmAsm.Codegen.Layout
 import EvmAsm.Codegen.Emit
 import EvmAsm.Codegen.GuestAddrs
 import EvmAsm.Codegen.AsmReloc
-import EvmAsm.Codegen.Programs.RlpRead
 import EvmAsm.Codegen.Programs.RlpWalk
-import EvmAsm.Codegen.Programs.Tx
 
 namespace EvmAsm.Codegen
 

--- a/EvmAsm/Codegen/Programs/TxDecode7702.lean
+++ b/EvmAsm/Codegen/Programs/TxDecode7702.lean
@@ -19,9 +19,7 @@ import EvmAsm.Codegen.Layout
 import EvmAsm.Codegen.Emit
 import EvmAsm.Codegen.GuestAddrs
 import EvmAsm.Codegen.AsmReloc
-import EvmAsm.Codegen.Programs.RlpRead
 import EvmAsm.Codegen.Programs.RlpWalk
-import EvmAsm.Codegen.Programs.Tx
 
 namespace EvmAsm.Codegen
 

--- a/EvmAsm/Codegen/Programs/TxSignature.lean
+++ b/EvmAsm/Codegen/Programs/TxSignature.lean
@@ -23,7 +23,6 @@
 import EvmAsm.Rv64.Program
 import EvmAsm.Codegen.Layout
 import EvmAsm.Codegen.Programs.RlpWalk
-import EvmAsm.Codegen.Programs.Tx
 
 namespace EvmAsm.Codegen
 


### PR DESCRIPTION
## Summary

Stacked on #10235, this follow-up trims the transaction/codegen import hubs:

- typed transaction decoders now use the cursor walker directly instead of the legacy `RlpRead`/`Tx` slabs;
- signature, header, and runtime-code consumers drop unused `Tx`/`RlpRead` imports;
- `AccountFieldExtract` is kept as a narrow walker leaf, with its few legacy field-helper users importing `Tx` explicitly;
- arithmetic/dispatch units use focused EVM registries rather than the full `Evm` umbrella;
- opcode/state consumers use their direct state modules.

No emitted symbols or bytecode changed.

## Validation

- `lake build`
- `scripts/check-no-warnings.sh`
- `scripts/check-unimported.sh`
- `scripts/check-layering.sh`
- `scripts/check-file-size.sh`
- `scripts/check-progress.sh`
- `scripts/check-drift.sh`
- `scripts/check-axioms.sh`

The reachable graph is 3,000 modules / 12,258 internal edges, with raw maximum import depth 93.
