### PR TITLE
refactor: isolate codegen helper imports

### DIFF
--- a/EvmAsm/Codegen/Programs/Account.lean
+++ b/EvmAsm/Codegen/Programs/Account.lean
@@ -25,7 +25,6 @@ import EvmAsm.Codegen.Programs.RlpWalk
 import EvmAsm.Codegen.Programs.Tx
 import EvmAsm.Codegen.Programs.TxExtract
 import EvmAsm.Codegen.Programs.U256
-import EvmAsm.Codegen.Programs.AccountFieldExtract
 import EvmAsm.Codegen.Programs.U256GasPricing
 
 namespace EvmAsm.Codegen

--- a/EvmAsm/Codegen/Programs/AccountApplyStorage.lean
+++ b/EvmAsm/Codegen/Programs/AccountApplyStorage.lean
@@ -31,9 +31,6 @@ import EvmAsm.Codegen.Programs.RlpRead
 import EvmAsm.Codegen.Programs.MptEncode
 import EvmAsm.Codegen.Programs.MptSet
 import EvmAsm.Codegen.Programs.StorageWrite
-import EvmAsm.Codegen.Programs.MptSetAcc
-import EvmAsm.Codegen.Programs.MptInsertAcc
-import EvmAsm.Codegen.Programs.MptDeleteAcc
 
 namespace EvmAsm.Codegen
 

--- a/EvmAsm/Codegen/Programs/BalAccountAccessDescriptors.lean
+++ b/EvmAsm/Codegen/Programs/BalAccountAccessDescriptors.lean
@@ -10,7 +10,6 @@ import EvmAsm.Rv64.Program
 import EvmAsm.Codegen.Emit
 import EvmAsm.Codegen.GuestAddrs
 import EvmAsm.Codegen.AsmReloc
-import EvmAsm.Codegen.Programs.EvmAccessGas
 import EvmAsm.Codegen.Programs.Mpt
 
 namespace EvmAsm.Codegen

--- a/EvmAsm/Codegen/Programs/BalAccountHasStateChange.lean
+++ b/EvmAsm/Codegen/Programs/BalAccountHasStateChange.lean
@@ -8,7 +8,6 @@ import EvmAsm.Rv64.Program
 import EvmAsm.Codegen.Emit
 import EvmAsm.Codegen.GuestAddrs
 import EvmAsm.Codegen.AsmReloc
-import EvmAsm.Codegen.Programs.RlpWalk
 
 namespace EvmAsm.Codegen
 

--- a/EvmAsm/Codegen/Programs/BalModeledSystem.lean
+++ b/EvmAsm/Codegen/Programs/BalModeledSystem.lean
@@ -9,7 +9,6 @@ import EvmAsm.Rv64.Program
 import EvmAsm.Codegen.Emit
 import EvmAsm.Codegen.GuestAddrs
 import EvmAsm.Codegen.AsmReloc
-import EvmAsm.Codegen.Programs.RlpWalk
 
 namespace EvmAsm.Codegen
 

--- a/EvmAsm/Codegen/Programs/BalSlotTupleSequence.lean
+++ b/EvmAsm/Codegen/Programs/BalSlotTupleSequence.lean
@@ -25,7 +25,6 @@
 import EvmAsm.Rv64.Program
 import EvmAsm.Codegen.Layout
 import EvmAsm.Codegen.Programs.RlpWalk
-import EvmAsm.Codegen.Programs.Tx
 import EvmAsm.Codegen.Programs.BlockVerdictParams
 
 namespace EvmAsm.Codegen

--- a/EvmAsm/Codegen/Programs/BalStorageAccessDescriptors.lean
+++ b/EvmAsm/Codegen/Programs/BalStorageAccessDescriptors.lean
@@ -10,7 +10,6 @@ import EvmAsm.Rv64.Program
 import EvmAsm.Codegen.Emit
 import EvmAsm.Codegen.GuestAddrs
 import EvmAsm.Codegen.AsmReloc
-import EvmAsm.Codegen.Programs.EvmStorageAccessGas
 import EvmAsm.Codegen.Programs.Mpt
 
 namespace EvmAsm.Codegen

--- a/EvmAsm/Codegen/Programs/BlockRlpSize.lean
+++ b/EvmAsm/Codegen/Programs/BlockRlpSize.lean
@@ -13,8 +13,6 @@ import EvmAsm.Rv64.Program
 import EvmAsm.Codegen.Emit
 import EvmAsm.Codegen.GuestAddrs
 import EvmAsm.Codegen.AsmReloc
-import EvmAsm.Codegen.Programs.BalGasValid
-import EvmAsm.Codegen.Programs.RlpRead
 import EvmAsm.Codegen.Programs.Withdrawal
 
 namespace EvmAsm.Codegen

--- a/EvmAsm/Codegen/Programs/BlockVerdictContractStage.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictContractStage.lean
@@ -24,7 +24,6 @@
 
 import EvmAsm.Rv64.Program
 import EvmAsm.Codegen.Layout
-import EvmAsm.Codegen.Programs.BlockVerdictSimpleTransfer
 
 namespace EvmAsm.Codegen
 

--- a/EvmAsm/Codegen/Programs/BlockVerdictCreationStage.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictCreationStage.lean
@@ -6,7 +6,6 @@
 
 import EvmAsm.Rv64.Program
 import EvmAsm.Codegen.Layout
-import EvmAsm.Codegen.Programs.NonstorageEffectLog
 
 namespace EvmAsm.Codegen
 

--- a/EvmAsm/Codegen/Programs/ChildFrameCreateTail.lean
+++ b/EvmAsm/Codegen/Programs/ChildFrameCreateTail.lean
@@ -8,10 +8,8 @@
 
 import EvmAsm.Codegen.Programs.EvmAccessGas
 import EvmAsm.Codegen.Programs.EvmMemoryGas
-import EvmAsm.Codegen.Programs.Modexp
 import EvmAsm.Codegen.Programs.CreateRuntime
 import EvmAsm.Codegen.Programs.CreateSameTxCollision
-import EvmAsm.Codegen.Programs.PrecompileRuntime
 import EvmAsm.Codegen.Programs.AmsterdamSystemTx
 import EvmAsm.Rv64.Program
 namespace EvmAsm.Codegen

--- a/EvmAsm/Codegen/Programs/ChildFrameHandlerTails.lean
+++ b/EvmAsm/Codegen/Programs/ChildFrameHandlerTails.lean
@@ -11,11 +11,8 @@ import EvmAsm.Codegen.Programs.EvmAccessGas
 import EvmAsm.Codegen.Programs.EvmMemoryGas
 import EvmAsm.Codegen.Programs.EvmStorageAccessGas
 import EvmAsm.Codegen.Programs.Modexp
-import EvmAsm.Codegen.Programs.CreateRuntime
-import EvmAsm.Codegen.Programs.CreateSameTxCollision
 import EvmAsm.Codegen.Programs.PrecompileRuntime
 import EvmAsm.Codegen.Programs.AmsterdamSystemTx
-import EvmAsm.Codegen.Programs.ChildFrameCreateTail
 import EvmAsm.Rv64.Program
 namespace EvmAsm.Codegen
 open EvmAsm.Rv64

--- a/EvmAsm/Codegen/Programs/ChildFrameHandlers.lean
+++ b/EvmAsm/Codegen/Programs/ChildFrameHandlers.lean
@@ -30,6 +30,7 @@ import EvmAsm.Codegen.Programs.PrecompileRuntime
 import EvmAsm.Codegen.Programs.StaticContext
 import EvmAsm.Rv64.Program
 import EvmAsm.Codegen.Programs.ChildFrameHandlerTails
+import EvmAsm.Codegen.Programs.ChildFrameCreateTail
 
 namespace EvmAsm.Codegen
 

--- a/EvmAsm/Codegen/Programs/CommittedStorageBlockVerdictProbe.lean
+++ b/EvmAsm/Codegen/Programs/CommittedStorageBlockVerdictProbe.lean
@@ -12,6 +12,7 @@ import EvmAsm.Rv64.Program
 import EvmAsm.Codegen.Layout
 import EvmAsm.Codegen.Programs.CommittedStorageLookup
 import EvmAsm.Codegen.Programs.CommittedStorageSnapshot
+import EvmAsm.Codegen.Programs.BlockVerdictParams
 
 namespace EvmAsm.Codegen
 

--- a/EvmAsm/Codegen/Programs/CommittedStorageLookup.lean
+++ b/EvmAsm/Codegen/Programs/CommittedStorageLookup.lean
@@ -12,7 +12,6 @@ import EvmAsm.Codegen.Layout
 import EvmAsm.Codegen.Emit
 import EvmAsm.Codegen.GuestAddrs
 import EvmAsm.Codegen.AsmReloc
-import EvmAsm.Codegen.Programs.BlockVerdictParams
 import EvmAsm.Codegen.Programs.ExecLogLatestValue
 
 namespace EvmAsm.Codegen

--- a/EvmAsm/Codegen/Programs/CommittedStorageSnapshot.lean
+++ b/EvmAsm/Codegen/Programs/CommittedStorageSnapshot.lean
@@ -10,7 +10,6 @@
 import EvmAsm.Rv64.Program
 import EvmAsm.Codegen.Layout
 import EvmAsm.Codegen.Emit
-import EvmAsm.Codegen.Programs.BlockVerdictParams
 
 namespace EvmAsm.Codegen
 

--- a/EvmAsm/Codegen/Programs/Eip7702NonceReuseGuard.lean
+++ b/EvmAsm/Codegen/Programs/Eip7702NonceReuseGuard.lean
@@ -5,13 +5,9 @@
 -/
 
 import EvmAsm.Rv64.Program
-import EvmAsm.Codegen.Layout
 import EvmAsm.Codegen.Emit
 import EvmAsm.Codegen.GuestAddrs
 import EvmAsm.Codegen.AsmReloc
-import EvmAsm.Codegen.Programs.RlpRead
-import EvmAsm.Codegen.Programs.TxExtract
-import EvmAsm.Codegen.Programs.Address
 
 namespace EvmAsm.Codegen
 

--- a/EvmAsm/Codegen/Programs/EvmCodes.lean
+++ b/EvmAsm/Codegen/Programs/EvmCodes.lean
@@ -7,6 +7,7 @@
   defined there.
 -/
 import EvmAsm.Codegen.Programs.State
+import EvmAsm.Codegen.Programs.HeaderFields
 import EvmAsm.Codegen.Emit
 import EvmAsm.Codegen.GuestAddrs
 import EvmAsm.Codegen.AsmReloc

--- a/EvmAsm/Codegen/Programs/Header.lean
+++ b/EvmAsm/Codegen/Programs/Header.lean
@@ -42,7 +42,6 @@ import EvmAsm.Codegen.AsmReloc
 import EvmAsm.Codegen.Programs.HashBridge
 import EvmAsm.Codegen.Programs.RlpRead
 import EvmAsm.Codegen.Programs.Tx
-import EvmAsm.Codegen.Programs.HeaderFields
 
 namespace EvmAsm.Codegen
 

--- a/EvmAsm/Codegen/Programs/MptInsertWalk.lean
+++ b/EvmAsm/Codegen/Programs/MptInsertWalk.lean
@@ -41,7 +41,6 @@
 import EvmAsm.Rv64.Program
 import EvmAsm.Codegen.Layout
 import EvmAsm.Codegen.Programs.Mpt
-import EvmAsm.Codegen.Programs.MptSet
 
 namespace EvmAsm.Codegen
 

--- a/EvmAsm/Codegen/Programs/State.lean
+++ b/EvmAsm/Codegen/Programs/State.lean
@@ -29,7 +29,6 @@ import EvmAsm.Codegen.AsmReloc
 import EvmAsm.Codegen.Programs.RlpRead
 import EvmAsm.Codegen.Programs.Mpt
 import EvmAsm.Codegen.Programs.HashBridge
-import EvmAsm.Codegen.Programs.HeaderFields
 
 namespace EvmAsm.Codegen
 

--- a/EvmAsm/Codegen/Programs/StateCompose.lean
+++ b/EvmAsm/Codegen/Programs/StateCompose.lean
@@ -10,6 +10,7 @@ import EvmAsm.Codegen.Emit
 import EvmAsm.Codegen.GuestAddrs
 import EvmAsm.Codegen.AsmReloc
 import EvmAsm.Codegen.Programs.WitnessCodeLookup
+import EvmAsm.Codegen.Programs.HeaderFields
 
 namespace EvmAsm.Codegen
 

--- a/EvmAsm/Codegen/Programs/SystemCallStoragePreload.lean
+++ b/EvmAsm/Codegen/Programs/SystemCallStoragePreload.lean
@@ -25,6 +25,7 @@ import EvmAsm.Codegen.Programs.StateCompose
 import EvmAsm.Codegen.Programs.BlockVerdictContractStorage
 import EvmAsm.Codegen.Programs.BlockVerdictParams
 import EvmAsm.Codegen.Programs.BalSlotTupleSequence
+import EvmAsm.Codegen.Programs.Tx
 
 namespace EvmAsm.Codegen
 

--- a/EvmAsm/Codegen/Programs/SystemWrites.lean
+++ b/EvmAsm/Codegen/Programs/SystemWrites.lean
@@ -35,7 +35,6 @@ import EvmAsm.Codegen.Layout
 import EvmAsm.Codegen.Emit
 import EvmAsm.Codegen.GuestAddrs
 import EvmAsm.Codegen.AsmReloc
-import EvmAsm.Codegen.Programs.AmsterdamSystemTx
 
 namespace EvmAsm.Codegen
 


### PR DESCRIPTION
## Summary

Stacked on #10236, this follow-up removes another set of unused Codegen imports and makes the few cross-module consumers explicit:

- narrow state/header ownership and transaction-probe helper closures;
- remove unused MPT, BAL, storage, and system-transaction imports from focused programs;
- split CREATE tail imports so `ChildFrameHandlers` owns the CREATE-tail dependency;
- keep the block-verdict committed-storage probe’s parameter import explicit.

No emitted symbols or bytecode changed.

## Validation

- `lake build`
- `scripts/check-no-warnings.sh`
- `scripts/check-unimported.sh`
- `scripts/check-layering.sh`
- `scripts/check-file-size.sh`
- `scripts/check-progress.sh`
- `scripts/check-drift.sh`
- `scripts/check-axioms.sh`

The reachable graph is 3,000 modules / 12,235 internal edges, with raw maximum import depth 93.
