### PR TITLE
refactor: narrow addmod composition imports

### DIFF
--- a/EvmAsm/Evm64/AddMod/Compose/CarryBlockSpecs.lean
+++ b/EvmAsm/Evm64/AddMod/Compose/CarryBlockSpecs.lean
@@ -24,7 +24,10 @@
   in `Compose/CondSubSpec.lean`.
 -/
 
-import EvmAsm.Evm64.AddMod.LimbSpec
+import EvmAsm.Rv64.CPSSpec
+import EvmAsm.Rv64.SyscallSpecs
+import EvmAsm.Rv64.Tactics.RunBlock
+import EvmAsm.Evm64.AddMod.Program
 
 namespace EvmAsm.Evm64.AddMod.Compose
 

--- a/EvmAsm/Evm64/AddMod/Compose/CarryCompose.lean
+++ b/EvmAsm/Evm64/AddMod/Compose/CarryCompose.lean
@@ -21,6 +21,8 @@
 -/
 
 import EvmAsm.Evm64.AddMod.Compose.CarryLc
+import EvmAsm.Evm64.AddMod.Compose.CarryLb
+import EvmAsm.Evm64.EvmWordArith.AddMod
 
 namespace EvmAsm.Evm64.AddMod.Compose
 

--- a/EvmAsm/Evm64/AddMod/Compose/CarryLb.lean
+++ b/EvmAsm/Evm64/AddMod/Compose/CarryLb.lean
@@ -20,6 +20,7 @@
 
 import EvmAsm.Evm64.AddMod.Compose.CarryLa
 import EvmAsm.Evm64.AddMod.Compose.CarryBranch
+import EvmAsm.Evm64.EvmWordArith.Arithmetic
 
 namespace EvmAsm.Evm64.AddMod.Compose
 

--- a/EvmAsm/Evm64/AddMod/Compose/CarryLd.lean
+++ b/EvmAsm/Evm64/AddMod/Compose/CarryLd.lean
@@ -16,6 +16,7 @@
   top (x12 = F+32), exposing the add carry-out in x5.
 -/
 
+import EvmAsm.Evm64.AddMod.Compose.CarryPipeline
 import EvmAsm.Evm64.AddMod.Compose.CondSubWrapper
 import EvmAsm.Evm64.AddMod.Compose.CarryCompose
 import EvmAsm.Evm64.AddMod.Compose.CarryLdCondSub

--- a/EvmAsm/Evm64/AddMod/Compose/CarryLdCondSub.lean
+++ b/EvmAsm/Evm64/AddMod/Compose/CarryLdCondSub.lean
@@ -15,8 +15,8 @@
   same technique `TotalBase` uses for the whole blocks. No disjointness needed.
 -/
 
-import EvmAsm.Evm64.AddMod.Compose.CondSubWrapper
 import EvmAsm.Evm64.AddMod.Compose.TotalBase
+import EvmAsm.Evm64.AddMod.Compose.CondSubWrapper
 
 namespace EvmAsm.Evm64.AddMod.Compose
 

--- a/EvmAsm/Evm64/AddMod/Compose/CarryPipeline.lean
+++ b/EvmAsm/Evm64/AddMod/Compose/CarryPipeline.lean
@@ -13,6 +13,7 @@
 -/
 
 import EvmAsm.Evm64.AddMod.Compose.CallAdapter
+import EvmAsm.Evm64.AddMod.Compose.CarryBlockSpecs
 import EvmAsm.Evm64.AddMod.Compose.TotalBase
 
 namespace EvmAsm.Evm64.AddMod.Compose

--- a/EvmAsm/Evm64/AddMod/Compose/CondSubSpec.lean
+++ b/EvmAsm/Evm64/AddMod/Compose/CondSubSpec.lean
@@ -19,7 +19,10 @@
   The value-level `EvmWord.modAdd` bridge is the next milestone's job.
 -/
 
-import EvmAsm.Evm64.AddMod.Compose.CarryBlockSpecs
+import EvmAsm.Rv64.CPSSpec
+import EvmAsm.Rv64.SyscallSpecs
+import EvmAsm.Rv64.Tactics.RunBlock
+import EvmAsm.Evm64.AddMod.Program
 
 namespace EvmAsm.Evm64.AddMod.Compose
 

--- a/EvmAsm/Evm64/AddMod/Compose/TotalBase.lean
+++ b/EvmAsm/Evm64/AddMod/Compose/TotalBase.lean
@@ -37,8 +37,9 @@
     end                  : idx 216  byte 864
 -/
 
-import EvmAsm.Evm64.AddMod.LimbSpec
-import EvmAsm.Evm64.AddMod.AddrNorm
+import EvmAsm.Rv64.SepLogic
+import EvmAsm.Rv64.Tactics.RunBlock
+import EvmAsm.Evm64.AddMod.Program
 
 namespace EvmAsm.Evm64.AddMod.Compose
 
@@ -394,7 +395,7 @@ theorem evm_addmod_total_program_code_epilogue_sub
     evm_addmod_epilogue 215
     (by bv_omega) ?_ ?_ ?_
   · evm_addmod_total_slice_rfl
-  · rw [evm_addmod_total_length, evm_addmod_epilogue_length]
+  · rw [evm_addmod_total_length, evm_addmod_epilogue_length]; decide
   · rw [evm_addmod_total_length]; decide
 
 end EvmAsm.Evm64.AddMod.Compose

--- a/EvmAsm/Evm64/AddMod/Compose/ZeroNoCarryArms.lean
+++ b/EvmAsm/Evm64/AddMod/Compose/ZeroNoCarryArms.lean
@@ -17,6 +17,7 @@
 -/
 
 import EvmAsm.Evm64.AddMod.Compose.CarryLdChain
+import EvmAsm.Evm64.AddMod.LimbSpec
 
 namespace EvmAsm.Evm64.AddMod.Compose
 

--- a/EvmAsm/Evm64/AddMod/Program.lean
+++ b/EvmAsm/Evm64/AddMod/Program.lean
@@ -27,7 +27,6 @@
 
 import EvmAsm.Rv64.Program
 import EvmAsm.Evm64.Add.Program
-import EvmAsm.Evm64.EvmWordArith.AddMod
 
 namespace EvmAsm.Evm64
 
@@ -370,18 +369,6 @@ theorem evm_addmod_pow256_mod_n_length (modOff : BitVec 21) :
 theorem evm_addmod_pow256_mod_n_byte_length (modOff : BitVec 21) :
     4 * (evm_addmod_pow256_mod_n modOff).length = 172 := by
   rw [evm_addmod_pow256_mod_n_length]
-
--- Concrete pure-oracle checks for the value these runtime blocks materialize.
-
-example : (EvmWord.pow256ModN (0 : EvmWord)).toNat = 0 := by decide
-
-example : (EvmWord.pow256ModN (1 : EvmWord)).toNat = 0 := by decide
-
-example : (EvmWord.pow256ModN (7 : EvmWord)).toNat = 2 := by decide
-
-example :
-    (EvmWord.pow256ModN (BitVec.ofNat 256 (2 ^ 128 + 1))).toNat = 1 := by
-  decide
 
 /-- Phase 2 — zero-store path (taken when `N = 0`).
 

--- a/EvmAsm/Evm64/AddMod/ProgramTest.lean
+++ b/EvmAsm/Evm64/AddMod/ProgramTest.lean
@@ -11,6 +11,7 @@
 -/
 
 import EvmAsm.Evm64.AddMod.Program
+import EvmAsm.Evm64.EvmWordArith.AddMod
 import EvmAsm.Evm64.DivMod.Callable
 import EvmAsm.Rv64.Execution
 


### PR DESCRIPTION
Stacked on #10237.

This pass removes the broad EvmWord arithmetic import from AddMod.Program (including non-emitted oracle examples), then adds only the concrete RV64/spec leaves needed by each AddMod composition stage and its test module. This shortens import closures while preserving the verified/emitted boundaries.

Validation: lake build; check-unimported; check-layering; check-file-size; check-progress; check-drift; check-axioms; check-no-warnings.