### PR TITLE
refactor: shorten arithmetic import chains

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith/CLZLemmas.lean
+++ b/EvmAsm/Evm64/EvmWordArith/CLZLemmas.lean
@@ -14,8 +14,11 @@
   Then chain these through the 6 stages.
 -/
 
-import EvmAsm.Evm64.DivMod.LimbSpec.CLZ
 import EvmAsm.Evm64.DivMod.LoopDefs.CLZResult
+import Mathlib.Algebra.Group.Nat.Defs
+import Mathlib.Tactic.NormNum
+import Mathlib.Tactic.Positivity
+import Mathlib.Tactic.Push
 
 namespace EvmAsm.Evm64
 

--- a/EvmAsm/Evm64/EvmWordArith/KnuthTheoremB.lean
+++ b/EvmAsm/Evm64/EvmWordArith/KnuthTheoremB.lean
@@ -74,6 +74,7 @@
 import EvmAsm.Evm64.EvmWordArith.MaxTrialVacuity
 import EvmAsm.Evm64.EvmWordArith.DenormLemmas
 import EvmAsm.Evm64.EvmWordArith.SignExtendLemmas
+import EvmAsm.Rv64.AddrNorm
 
 namespace EvmAsm.Evm64
 

--- a/EvmAsm/Evm64/EvmWordArith/MaxTrialVacuity.lean
+++ b/EvmAsm/Evm64/EvmWordArith/MaxTrialVacuity.lean
@@ -21,7 +21,7 @@
 import EvmAsm.Evm64.EvmWordArith.CLZLemmas
 import EvmAsm.Evm64.EvmWordArith.Common
 import EvmAsm.Evm64.DivMod.TrialPredicatesN4
-import Mathlib.Tactic.Ring
+import EvmAsm.Evm64.EvmWordArith.MultiLimb
 
 namespace EvmAsm.Evm64
 

--- a/EvmAsm/Evm64/SDiv/Compose/SaveRaSignsPost.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/SaveRaSignsPost.lean
@@ -5,6 +5,7 @@
   prefix.
 -/
 
+import EvmAsm.Evm64.SDiv.Program
 import EvmAsm.Evm64.SDiv.Compose.SaveRaSignsPre
 
 namespace EvmAsm.Evm64.SDiv.Compose

--- a/EvmAsm/Evm64/SDiv/Compose/SaveRaSignsPre.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/SaveRaSignsPre.lean
@@ -5,7 +5,7 @@
   prefix.
 -/
 
-import EvmAsm.Evm64.SDiv.Compose.BaseCode
+import EvmAsm.Evm64.SDiv.Program
 
 namespace EvmAsm.Evm64.SDiv.Compose
 


### PR DESCRIPTION
Stacked on #10238.

This pass isolates CLZ arithmetic lemmas from the DivMod machine-spec file, supplies their tactic dependencies directly, and trims SDIV sign-prefix leaves to the program module. KnuthTheoremB now declares its AddrNorm dependency explicitly.

Measured import DAG: max raw depth 91 (down from 93 before this stack).

Validation: lake build; check-unimported; check-layering; check-file-size; check-progress; check-drift; check-axioms; check-no-warnings.