### PR TITLE
refactor: isolate n2 arithmetic proof imports

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec/N2V5ThreeStep.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N2V5ThreeStep.lean
@@ -16,7 +16,9 @@
   `fullDivN2MulSubEqV5`.  Bead `evm-asm-wbc4i.9.2`.
 -/
 
-import EvmAsm.Evm64.DivMod.Spec.N2V5R10Conservation
+import Mathlib.Algebra.Group.Nat.Defs
+import Mathlib.Tactic.Linarith
+import EvmAsm.Evm64.Basic
 
 namespace EvmAsm.Evm64
 


### PR DESCRIPTION
Stacked on #10239.

The n=2 three-step conservation lemma is a pure Nat arithmetic proof, but it previously imported the full R10 conservation/spec chain. It now imports only the EVM basic namespace and the nlinarith support it actually uses.

Validation: lake build; check-unimported; check-layering; check-file-size; check-progress; check-drift; check-axioms; check-no-warnings.