### PR TITLE
docs(guest): document the memory-affordability gas invariant (evm-asm-274cr)

### DIFF
--- a/EvmAsm/Codegen/Programs/EvmMemoryGas.lean
+++ b/EvmAsm/Codegen/Programs/EvmMemoryGas.lean
@@ -20,13 +20,59 @@ namespace EvmAsm.Codegen
     `mcopyActiveMemorySizeOff` in `EvmMcopyGas.lean`.) -/
 def activeMemorySizeOff : Nat := 488
 
+/-!
+### Memory-affordability invariant (which gas limit bounds EVM memory?)
+
+This was under-documented and is easy to get wrong, because v0.6.0 has THREE
+distinct "gas limits" and only ONE of them bounds EVM memory:
+
+* **Per-tx REGULAR gas ≤ `TX_MAX_GAS_LIMIT = 16_777_216 = 2^24`.** The spec
+  caps a transaction's regular-gas dimension at this value
+  (`execution-specs amsterdam/transactions.py:63` + the `intrinsic.regular >
+  TX_MAX_GAS_LIMIT` reject at `:624`; the guest enforces the same bound in
+  `BlockVerdictGasGate` — `li …, 16777216`). Memory-expansion gas
+  (`calculate_memory_gas_cost`, `3·w + w²/512` words) is charged against the
+  REGULAR dimension, so **this is the only limit that bounds EVM memory.**
+* **Per-tx STATE gas** (EIP-7778/8037): a separate dimension; does NOT pay for
+  memory.
+* **Block gas limit** (`header.gas_limit`, ~200M–500M in the SSZ sizing notes
+  `stateless_ssz.py:57-81`): the TOTAL block budget (all txs, both dimensions)
+  used for BAL / tx-count array sizing. It does **not** bound a single frame's
+  memory — do not size memory arenas against it.
+
+Consequences (numbers from `3·w + w²/512 ≤ 2^24`):
+* Max affordable memory in ONE frame ≈ **92_681 words ≈ 2.90 MiB** — a memory
+  offset whose expansion needs more than that is **legitimately OOG**, NOT a
+  false-reject. So `rootRuntimeMemoryArenaLimitBytes = 4 MiB` genuinely covers
+  every affordable depth-0 expansion, and anything past it is correctly
+  rejected.
+* Because CALL forwards ≤ 63/64 of remaining gas per descent, the affordable
+  memory PER FRAME decays with depth; the affordable memory summed over ALL
+  live frames on the call stack is bounded by `sum(wᵢ²/512) ≤ 2^24 ⇒`
+  **≈ 90 MiB total-live** (k = 1024).
+
+Design impact (see `docs/memory-arena-gas-bound.md`): a nested frame can
+legitimately afford up to ~2.90 MiB, but `runtimeMemoryArenaLimitBytes` below
+is only 128 KiB, and the sparse word store is only 4096 words = 128 KiB — so
+BOTH under-serve the affordable bound (a nested frame using 256 KiB … 2.90 MiB
+of memory is a false-reject today). Fully closing the beyond-dense window
+false-reject class (`evm-asm-274cr`) therefore requires provisioning up to
+~2.90 MiB/frame (≈90 MiB total-live); the options + trade-offs are in the docs
+note. -/
+
 /-- Runtime EVM memory arena size for nested call/create frames. This remains
-    tied to the preallocated call-frame layout. -/
+    tied to the preallocated call-frame layout. NOTE (evm-asm-274cr): 128 KiB
+    under-serves the ~2.90 MiB a nested frame can legitimately afford under the
+    `TX_MAX_GAS_LIMIT = 2^24` regular-gas cap — see the invariant note above and
+    `docs/memory-arena-gas-bound.md`. -/
 def runtimeMemoryArenaLimitBytes : Nat := 0x20000
 
 /-- Runtime EVM memory arena size for the depth-0 frame. Four MiB covers every
-    memory expansion affordable under Amsterdam's 16,777,216 regular-gas cap:
-    the quadratic term alone exceeds the cap above roughly 2.9 MiB. Keeping a
+    memory expansion affordable under the `TX_MAX_GAS_LIMIT = 16_777_216 = 2^24`
+    per-tx REGULAR-gas cap (spec `transactions.py:63,624`): the quadratic term
+    `w²/512` alone exceeds `2^24` above ≈ 2.90 MiB, so a larger depth-0 offset is
+    legitimately OOG (not a false-reject). Memory is bounded by this regular-gas
+    cap, NOT by the block gas limit — see the invariant note above. Keeping a
     rounded margin avoids rejecting valid high-memory RETURN/CALL programs while
     leaving nested frame slots at their fixed 128 KiB capacity. -/
 def rootRuntimeMemoryArenaLimitBytes : Nat := 0x400000

--- a/docs/memory-arena-gas-bound.md
+++ b/docs/memory-arena-gas-bound.md
@@ -1,0 +1,84 @@
+# Which gas limit bounds EVM memory? (and what it means for the frame arenas)
+
+*Status: reference note. Resolves a recurring ambiguity and frames the open
+arena-sizing decision for `evm-asm-274cr` (the beyond-dense memory-window
+false-reject class). Fork = amsterdam, execution-specs pin `40f956fab`.*
+
+## TL;DR
+
+EVM memory is bounded by the **per-transaction REGULAR gas cap
+`TX_MAX_GAS_LIMIT = 16_777_216 = 2^24`**, not by the block gas limit. A single
+frame can legitimately expand memory to **≈ 2.90 MiB**; beyond that is a
+**correct OOG**, not a false-reject. The affordable memory summed over all live
+frames on the call stack is **≈ 90 MiB**. Size memory arenas against these
+numbers — never against the 200M–500M block gas limit.
+
+## The three gas limits (only one bounds memory)
+
+| limit | value | dimension | bounds memory? |
+|---|---|---|---|
+| `TX_MAX_GAS_LIMIT` | `16_777_216 = 2^24` | per-tx **regular** | **YES** — memory-expansion gas is charged here |
+| per-tx **state** gas (EIP-7778/8037) | separate | per-tx state | no (does not pay for memory) |
+| block gas limit (`header.gas_limit`) | ~200M–500M | total block, both dims, all txs | no (BAL / tx-array SSZ sizing only) |
+
+Spec anchors (amsterdam):
+
+- `transactions.py:63` — `TX_MAX_GAS_LIMIT = Uint(16_777_216)`.
+- `transactions.py:624` — `if intrinsic.regular > TX_MAX_GAS_LIMIT: raise …`.
+- `vm/gas.py::calculate_memory_gas_cost` — memory cost `3·w + ⌊w²/512⌋` (words),
+  charged against the **regular** dimension (`gas_left`).
+- `stateless_ssz.py:57-81` — the 200M/500M figures are the **block** gas limit
+  ("At 500M gas … BAL permits block_gas_limit // 2_000 items"), used to size
+  the BAL and tx arrays — unrelated to per-frame memory.
+
+Guest: the `2^24` regular cap is already enforced in `BlockVerdictGasGate`
+(`li …, 16777216`, the EIP-8037 `min(TX_MAX_GAS_LIMIT, tx.gas)` inclusion).
+
+## The numbers (from `3·w + w²/512 ≤ 2^24`, `w` = 32-byte words)
+
+- **Max affordable memory, one frame:** `w ≈ 92_681` words ≈ **2.90 MiB**.
+  Any offset needing more expansion gas than `2^24` is a legitimate OOG.
+- **Per-depth decay:** CALL forwards ≤ 63/64 of remaining gas, so a depth-`d`
+  frame's affordable memory ≈ `2.90 MiB · (63/64)^(d/2)`.
+- **Total-live bound (all frames on the stack at once):** `Σ wᵢ²/512 ≤ 2^24`
+  ⇒ `Σ wᵢ ≤ √(k · 512 · 2^24)` ≈ **90 MiB** at `k = 1024`.
+
+## Why this matters: the current arenas under-serve the affordable bound
+
+- `rootRuntimeMemoryArenaLimitBytes = 4 MiB` (depth 0): **correct** — covers the
+  full 2.90 MiB affordable, rejects beyond it legitimately.
+- `runtimeMemoryArenaLimitBytes = 128 KiB` (nested): **too small** — a nested
+  frame can afford up to 2.90 MiB.
+- Sparse word store = `4096 words = 128 KiB` (shared): **too small** — a frame
+  can afford ~92_681 beyond-dense words; entries 4097+ hit the capacity bail →
+  OOG. So the sparse approach, at today's capacity, *also* false-rejects a frame
+  using 256 KiB … 2.90 MiB of memory.
+
+Net: every path caps effective nested-frame memory at ~256 KiB, while the spec
+allows ~2.90 MiB — a false-reject band of 256 KiB … 2.90 MiB per nested frame.
+
+## Arena-sizing options to fully close the class (open decision)
+
+All must provision up to ~2.90 MiB/frame and ~90 MiB total-live. Following
+execution-specs (flat growable `bytearray`, every window op via
+`memory_read_bytes`/`memory_write`), three shapes fit within the RAM window
+(`.data` ≈ 473 MiB budget; current frame arena = `0x39000 × 1025` ≈ 228 MiB):
+
+1. **Grow the shared sparse store toward the total-live bound (~90 MiB / ~3M
+   words)** + per-opcode sparse-awareness (the `evm-asm-274cr` families).
+   One shared region; per-opcode glue; store scans stay O(entries).
+2. **Per-depth-decaying static dense arenas (~360 MiB).** Frame `d`'s arena =
+   its `(63/64)^d`-affordable max; all window ops work raw, no sparse, class
+   closed structurally. Cost: non-uniform frame stride (prefix-sum offsets
+   instead of `d · 0x39000`) — a change to the byte-tied `frame_base`
+   arithmetic and its proofs; ~360 MiB footprint is tight vs the RAM window.
+3. **Dynamic per-frame memory pool (~90 MiB shared).** Bump-allocate a frame's
+   arena on descend, free on return; flat per-frame memory, no sparse, tightest
+   footprint; pool exhaustion = legitimate OOG. Cost: a runtime allocator +
+   save/restore discipline across the call stack.
+
+Trade-off summary: (1) is the least structural change but keeps per-opcode
+sparse glue and needs the store grown; (2)/(3) close the class structurally
+(no per-opcode work, spec-faithful flat memory) at the cost of a frame-layout /
+allocator change. The `evm-asm-274cr` umbrella currently assumes (1); (2)/(3)
+would supersede its per-family plan. Decision pending.


### PR DESCRIPTION
## Summary

Documentation only — resolves a recurring ambiguity about **which gas limit bounds EVM memory**, and records the design consequences for the frame memory arenas.

EVM memory is bounded by the **per-tx REGULAR gas cap `TX_MAX_GAS_LIMIT = 16_777_216 = 2²⁴`** (spec `amsterdam/transactions.py:63` + the `intrinsic.regular > TX_MAX_GAS_LIMIT` reject at `:624`; the guest already enforces it in `BlockVerdictGasGate`). It is **not** bounded by the block gas limit (~200M–500M `header.gas_limit`, which is the total-block / BAL-sizing budget, `stateless_ssz.py:57-81`). Memory-expansion gas is charged against the regular dimension, so:

- one frame can afford ≈ **2.90 MiB** (`3w + w²/512 ≤ 2²⁴`); a larger offset is a **legitimate OOG, not a false-reject** — so the 4 MiB depth-0 arena is correct and large offsets *are* rejectable;
- affordable memory decays per depth (63/64 forwarding); the total-live memory across the call stack is bounded ≈ **90 MiB**.

The note also records a finding: the current nested arena (128 KiB) and the sparse word store (4096 words = 128 KiB) **both under-serve** the ~2.90 MiB a nested frame can legitimately afford — a 256 KiB…2.90 MiB nested-memory false-reject band (tracked under `evm-asm-274cr`) — and lays out the arena-sizing options to fully close that class (grow the shared sparse store, per-depth-decaying static arenas, or a dynamic per-frame pool).

## Changes

- `docs/memory-arena-gas-bound.md` — new reference note (the three gas limits, the numbers, the design options).
- `EvmAsm/Codegen/Programs/EvmMemoryGas.lean` — authoritative invariant note at the arena constants, with the spec citation.

**Doc-only: no emitted-code change**, so no regen / byte-tie needed; based on `main`.

Refs `evm-asm-274cr`, GH #10207.

🤖 Generated with [Claude Code](https://claude.com/claude-code)