### PR TITLE
feat(specref): model EIP-8282 execution requests

### DIFF
--- a/EvmAsm/Stateless/SpecRef/Guest.lean
+++ b/EvmAsm/Stateless/SpecRef/Guest.lean
@@ -91,7 +91,9 @@ def sanityInput : StatelessInput :=
       { executionPayload := sanityPayload
         versionedHashes := []
         parentBeaconBlockRoot := z 32
-        executionRequests := { deposits := [], withdrawals := [], consolidations := [] } }
+        executionRequests := {
+          deposits := [], withdrawals := [], consolidations := [],
+          builderDeposits := [], builderExits := [] } }
     witness := { state := [], codes := [], headers := [sanityHeader] }
     chainConfig := sanityHappyChainConfig
     publicKeys := [] }

--- a/EvmAsm/Stateless/SpecRef/SeamShell.lean
+++ b/EvmAsm/Stateless/SpecRef/SeamShell.lean
@@ -73,10 +73,18 @@ def _encode_withdrawal (w : WithdrawalRequest) : Bytes :=
 def _encode_consolidation (c : ConsolidationRequest) : Bytes :=
   c.sourceAddress ++ c.sourcePubkey ++ c.targetPubkey
 
+/-- `_encode_builder_deposit` (EIP-8282). -/
+def _encode_builder_deposit (b : BuilderDepositRequest) : Bytes :=
+  b.pubkey ++ b.withdrawalCredentials ++ leBytes8 b.amount ++ b.signature
+
+/-- `_encode_builder_exit` (EIP-8282). -/
+def _encode_builder_exit (b : BuilderExitRequest) : Bytes :=
+  b.sourceAddress ++ b.pubkey
+
 /-- `encode_execution_requests(requests)`: each non-empty list becomes
     one `TYPE_BYTE ++ concat(items)` blob, ascending type order
-    (deposit `0x00`, withdrawal `0x01`, consolidation `0x02`); empty
-    lists are omitted. -/
+    (deposit `0x00`, withdrawal `0x01`, consolidation `0x02`, builder
+    deposit `0x03`, builder exit `0x04`); empty lists are omitted. -/
 def encode_execution_requests (requests : ExecutionRequests) : List Bytes :=
   (if requests.deposits.isEmpty then [] else
     [0x00 :: (requests.deposits.flatMap _encode_deposit)])
@@ -84,6 +92,10 @@ def encode_execution_requests (requests : ExecutionRequests) : List Bytes :=
     [0x01 :: (requests.withdrawals.flatMap _encode_withdrawal)])
   ++ (if requests.consolidations.isEmpty then [] else
     [0x02 :: (requests.consolidations.flatMap _encode_consolidation)])
+  ++ (if requests.builderDeposits.isEmpty then [] else
+    [0x03 :: (requests.builderDeposits.flatMap _encode_builder_deposit)])
+  ++ (if requests.builderExits.isEmpty then [] else
+    [0x04 :: (requests.builderExits.flatMap _encode_builder_exit)])
 
 /-! ## `compute_requests_hash` (`requests.py`, function `compute_requests_hash`) -/
 
@@ -428,14 +440,36 @@ def executeSeamShell : ExecutionSeam := fun input => do
 
 -- encode_execution_requests: empty container → no blobs; a single
 -- withdrawal request gets the 0x01 type byte and 76-byte body.
-#guard encode_execution_requests { deposits := [], withdrawals := [], consolidations := [] } == []
+#guard encode_execution_requests {
+  deposits := [], withdrawals := [], consolidations := [], builderDeposits := [], builderExits := []
+} == []
 #guard
   let w : WithdrawalRequest :=
     { sourceAddress := List.replicate 20 0xAA,
       validatorPubkey := List.replicate 48 0xBB, amount := 5 }
-  encode_execution_requests { deposits := [], withdrawals := [w], consolidations := [] }
+  encode_execution_requests {
+    deposits := [], withdrawals := [w], consolidations := [], builderDeposits := [], builderExits := [] }
     == [0x01 :: (List.replicate 20 0xAA ++ List.replicate 48 0xBB
           ++ [0x05, 0, 0, 0, 0, 0, 0, 0])]
+
+#guard
+  let b : BuilderDepositRequest :=
+    { pubkey := List.replicate 48 0x11,
+      withdrawalCredentials := List.replicate 32 0x22,
+      amount := 0x0102030405060708,
+      signature := List.replicate 96 0x33 }
+  encode_execution_requests {
+    deposits := [], withdrawals := [], consolidations := [], builderDeposits := [b], builderExits := [] }
+    == [0x03 :: (List.replicate 48 0x11 ++ List.replicate 32 0x22
+      ++ [0x08, 0x07, 0x06, 0x05, 0x04, 0x03, 0x02, 0x01]
+      ++ List.replicate 96 0x33)]
+
+#guard
+  let b : BuilderExitRequest :=
+    { sourceAddress := List.replicate 20 0x44, pubkey := List.replicate 48 0x55 }
+  encode_execution_requests {
+    deposits := [], withdrawals := [], consolidations := [], builderDeposits := [], builderExits := [b] }
+    == [0x04 :: (List.replicate 20 0x44 ++ List.replicate 48 0x55)]
 
 -- check_gas_limit boundaries.
 -- max_adjustment_delta = 30000000/1024 = 29296: strict bounds both sides.

--- a/EvmAsm/Stateless/SpecRef/Ssz.lean
+++ b/EvmAsm/Stateless/SpecRef/Ssz.lean
@@ -30,6 +30,8 @@ def MAX_BLOB_COMMITMENTS_PER_BLOCK : Nat := 4096
 def MAX_DEPOSIT_REQUESTS_PER_PAYLOAD : Nat := 2 ^ 13
 def MAX_WITHDRAWAL_REQUESTS_PER_PAYLOAD : Nat := 2 ^ 4
 def MAX_CONSOLIDATION_REQUESTS_PER_PAYLOAD : Nat := 2 ^ 1
+def MAX_BUILDER_DEPOSIT_REQUESTS_PER_PAYLOAD : Nat := 2 ^ 6
+def MAX_BUILDER_EXIT_REQUESTS_PER_PAYLOAD : Nat := 2 ^ 4
 def MAX_BLOCK_ACCESS_LIST_BYTES : Nat := MAX_BYTES_PER_TRANSACTION
 def MAX_WITNESS_NODES : Nat := 2 ^ 22
 def MAX_WITNESS_CODES : Nat := 2 ^ 18
@@ -93,11 +95,21 @@ def sszWithdrawalRequestType : SszType :=
 def sszConsolidationRequestType : SszType :=
   .container [.byteVector 20, .byteVector 48, .byteVector 48]
 
+/-- `SszBuilderDepositRequest` (`stateless_ssz.py:141`). -/
+def sszBuilderDepositRequestType : SszType :=
+  .container [.byteVector 48, bytes32Type, u64Type, .byteVector 96]
+
+/-- `SszBuilderExitRequest` (`stateless_ssz.py:150`). -/
+def sszBuilderExitRequestType : SszType :=
+  .container [.byteVector 20, .byteVector 48]
+
 /-- `SszExecutionRequests` (`stateless_ssz.py:141`). -/
 def sszExecutionRequestsType : SszType :=
   .container [.list sszDepositRequestType MAX_DEPOSIT_REQUESTS_PER_PAYLOAD,
     .list sszWithdrawalRequestType MAX_WITHDRAWAL_REQUESTS_PER_PAYLOAD,
-    .list sszConsolidationRequestType MAX_CONSOLIDATION_REQUESTS_PER_PAYLOAD]
+    .list sszConsolidationRequestType MAX_CONSOLIDATION_REQUESTS_PER_PAYLOAD,
+    .list sszBuilderDepositRequestType MAX_BUILDER_DEPOSIT_REQUESTS_PER_PAYLOAD,
+    .list sszBuilderExitRequestType MAX_BUILDER_EXIT_REQUESTS_PER_PAYLOAD]
 
 /-- `SszNewPayloadRequest` (`stateless_ssz.py:153`). -/
 def sszNewPayloadRequestType : SszType :=
@@ -256,6 +268,27 @@ def sszToConsolidationRequest (sv : SszValue) : Except SpecError ConsolidationRe
   let targetPubkey ← asBytesV (← getField fs 2)
   pure { sourceAddress, sourcePubkey, targetPubkey }
 
+def builderDepositRequestToSsz (b : BuilderDepositRequest) : SszValue :=
+  .container [.byteVector b.pubkey, .byteVector b.withdrawalCredentials,
+    .uint 8 b.amount, .byteVector b.signature]
+
+def sszToBuilderDepositRequest (sv : SszValue) : Except SpecError BuilderDepositRequest := do
+  let fs ← asContainerV sv
+  let pubkey ← asBytesV (← getField fs 0)
+  let withdrawalCredentials ← asBytesV (← getField fs 1)
+  let amount ← asUintV (← getField fs 2)
+  let signature ← asBytesV (← getField fs 3)
+  pure { pubkey, withdrawalCredentials, amount, signature }
+
+def builderExitRequestToSsz (b : BuilderExitRequest) : SszValue :=
+  .container [.byteVector b.sourceAddress, .byteVector b.pubkey]
+
+def sszToBuilderExitRequest (sv : SszValue) : Except SpecError BuilderExitRequest := do
+  let fs ← asContainerV sv
+  let sourceAddress ← asBytesV (← getField fs 0)
+  let pubkey ← asBytesV (← getField fs 1)
+  pure { sourceAddress, pubkey }
+
 /-! ## `_execution_requests_to_ssz` / `_ssz_to_execution_requests` (`:392`, `:409`) -/
 
 def executionRequestsToSsz (er : ExecutionRequests) : SszValue :=
@@ -263,14 +296,20 @@ def executionRequestsToSsz (er : ExecutionRequests) : SszValue :=
     .list MAX_DEPOSIT_REQUESTS_PER_PAYLOAD none (er.deposits.map depositRequestToSsz),
     .list MAX_WITHDRAWAL_REQUESTS_PER_PAYLOAD none (er.withdrawals.map withdrawalRequestToSsz),
     .list MAX_CONSOLIDATION_REQUESTS_PER_PAYLOAD none
-      (er.consolidations.map consolidationRequestToSsz)]
+      (er.consolidations.map consolidationRequestToSsz),
+    .list MAX_BUILDER_DEPOSIT_REQUESTS_PER_PAYLOAD none
+      (er.builderDeposits.map builderDepositRequestToSsz),
+    .list MAX_BUILDER_EXIT_REQUESTS_PER_PAYLOAD none
+      (er.builderExits.map builderExitRequestToSsz)]
 
 def sszToExecutionRequests (sv : SszValue) : Except SpecError ExecutionRequests := do
   let fs ← asContainerV sv
   let deposits ← (← asListV (← getField fs 0)).mapM sszToDepositRequest
   let withdrawals ← (← asListV (← getField fs 1)).mapM sszToWithdrawalRequest
   let consolidations ← (← asListV (← getField fs 2)).mapM sszToConsolidationRequest
-  pure { deposits, withdrawals, consolidations }
+  let builderDeposits ← (← asListV (← getField fs 3)).mapM sszToBuilderDepositRequest
+  let builderExits ← (← asListV (← getField fs 4)).mapM sszToBuilderExitRequest
+  pure { deposits, withdrawals, consolidations, builderDeposits, builderExits }
 
 /-! ## `_new_payload_request_to_ssz` / `_ssz_to_new_payload_request` (`:424`, `:438`) -/
 

--- a/EvmAsm/Stateless/SpecRef/Types.lean
+++ b/EvmAsm/Stateless/SpecRef/Types.lean
@@ -213,11 +213,27 @@ structure ConsolidationRequest where
   targetPubkey : Bytes
   deriving Repr, BEq, DecidableEq
 
+/-- `BuilderDepositRequest` (`execution_engine/requests.py:67`). -/
+structure BuilderDepositRequest where
+  pubkey : Bytes
+  withdrawalCredentials : Bytes
+  amount : U64
+  signature : Bytes
+  deriving Repr, BEq, DecidableEq
+
+/-- `BuilderExitRequest` (`execution_engine/requests.py:78`). -/
+structure BuilderExitRequest where
+  sourceAddress : Address
+  pubkey : Bytes
+  deriving Repr, BEq, DecidableEq
+
 /-- `ExecutionRequests` (`execution_engine/requests.py:67`). -/
 structure ExecutionRequests where
   deposits : List DepositRequest
   withdrawals : List WithdrawalRequest
   consolidations : List ConsolidationRequest
+  builderDeposits : List BuilderDepositRequest
+  builderExits : List BuilderExitRequest
   deriving Repr, BEq, DecidableEq
 
 /-- `NewPayloadRequest` (`execution_engine/types.py:63`). -/


### PR DESCRIPTION
Extends the reference model for tests-zkevm@v0.6.2 / EIP-8282:

- adds BuilderDepositRequest and BuilderExitRequest domain types;
- adds SSZ containers, limits (2^6 / 2^4), and conversions;
- emits request wire types 0x03 and 0x04 with exact 184/68-byte layouts;
- updates the empty-request constructor and executable guards.

This is spec-only and byte-neutral: no guest assembly or linked GuestAddrs/TSV symbols change, so no EEST A/B gate is needed.

Validation: lake build EvmAsm.Stateless.SpecRef.Guest (40 jobs green).
Bead: evm-asm-5uapm.2