### PR TITLE
feat(rlp): verify rlp_walk_next flat SAsm contract

### DIFF
--- a/EvmAsm/Codegen/Programs/Imports.lean
+++ b/EvmAsm/Codegen/Programs/Imports.lean
@@ -463,6 +463,7 @@ import EvmAsm.Codegen.Programs.BalAccountNonstorageFinalsChainN
 import EvmAsm.Codegen.Programs.BalAccountNonstorageFinalsChainO
 import EvmAsm.Codegen.Programs.RlpListNthItemSAsm
 import EvmAsm.Codegen.Programs.RlpWalkInitFlatSAsm
+import EvmAsm.Codegen.Programs.RlpWalkNextFlatSAsm
 import EvmAsm.Codegen.Programs.RlpListCountItemsSAsmBase
 import EvmAsm.Codegen.Programs.RlpListCountItemsSAsmCode
 import EvmAsm.Codegen.Programs.RlpListCountItemsSAsmFrame

--- a/EvmAsm/Codegen/Programs/RlpWalkNextFlatSAsm.lean
+++ b/EvmAsm/Codegen/Programs/RlpWalkNextFlatSAsm.lean
@@ -1,0 +1,60 @@
+/- Framed caller contract for the strict cursor-walk next-item primitive. -/
+
+import EvmAsm.Codegen.Programs.RlpWalk
+import EvmAsm.Rv64.CPSSpec
+import EvmAsm.Rv64.RLP.WalkNext
+import EvmAsm.Rv64.SAsm.Fn
+
+namespace EvmAsm.Codegen.RlpWalkNextFlatSAsm
+
+open EvmAsm.Rv64 EvmAsm.Rv64.RLP EvmAsm.Rv64.SAsm
+
+#guard EvmAsm.Rv64.RLP.rlp_walk_next_prog.length = 103
+
+def frameCps
+    {n : Nat} {base ret : Word} {cr : CodeReq}
+    {P Q : Assertion} (A : Assertion) (hA : A.pcFree)
+    (h : cpsTripleWithin n base ret cr P Q) :
+    Prop := by
+  let _hA := hA
+  let _h := h
+  exact cpsTripleWithin n base ret cr (P ** A) (Q ** A)
+
+/-- `rlp_walk_next` with a caller-owned ambient assertion framed around the
+    exact unified raw post (the canonical success relation and all five
+    strict failure statuses are preserved). -/
+theorem rlp_walk_next_flat_spec_within
+    (base srcBase endPtr raVal a2Old t0Old t1Old t2Old t3Old t4Old t5Old t6Old : Word)
+    (srcBytes : List (BitVec 8)) (srcOff : Nat) (A : Assertion)
+    (hA : A.pcFree) (hsalign : srcBase.toNat % 8 = 0)
+    (hoff : srcOff < srcBytes.length) (hover : srcBase.toNat + srcOff < 2 ^ 64)
+    (hvalid : isValidByteAccess (srcBase + BitVec.ofNat 64 srcOff) = true)
+    (hss : ¬ BitVec.ult ((srcBytes[srcOff]'hoff).zeroExtend 64) (0x80 : Word) = true →
+        BitVec.ult ((srcBytes[srcOff]'hoff).zeroExtend 64) (0xb8 : Word) = true →
+        srcOff + 1 < srcBytes.length ∧ srcBase.toNat + (srcOff + 1) < 2 ^ 64 ∧
+          isValidByteAccess (srcBase + BitVec.ofNat 64 (srcOff + 1)) = true)
+    (hls : ¬ BitVec.ult ((srcBytes[srcOff]'hoff).zeroExtend 64) (0xb8 : Word) = true →
+        BitVec.ult ((srcBytes[srcOff]'hoff).zeroExtend 64) (0xc0 : Word) = true →
+        srcOff + 1 + ((srcBytes[srcOff]'hoff).zeroExtend 64 - (0xb7 : Word)).toNat
+          ≤ srcBytes.length ∧
+        srcBase.toNat + (srcOff + 1 +
+          ((srcBytes[srcOff]'hoff).zeroExtend 64 - (0xb7 : Word)).toNat) ≤ 2 ^ 64 ∧
+        ∀ k, k < ((srcBytes[srcOff]'hoff).zeroExtend 64 - (0xb7 : Word)).toNat →
+          isValidByteAccess (srcBase + BitVec.ofNat 64 (srcOff + 1 + k)) = true)
+    (hll : ¬ BitVec.ult ((srcBytes[srcOff]'hoff).zeroExtend 64) (0xf8 : Word) = true →
+        srcOff + 1 + ((srcBytes[srcOff]'hoff).zeroExtend 64 - (0xf7 : Word)).toNat
+          ≤ srcBytes.length ∧
+        srcBase.toNat + (srcOff + 1 +
+          ((srcBytes[srcOff]'hoff).zeroExtend 64 - (0xf7 : Word)).toNat) ≤ 2 ^ 64 ∧
+        ∀ k, k < ((srcBytes[srcOff]'hoff).zeroExtend 64 - (0xf7 : Word)).toNat →
+          isValidByteAccess (srcBase + BitVec.ofNat 64 (srcOff + 1 + k)) = true) :
+    frameCps A hA
+      (rlp_walk_next_spec_within base srcBase endPtr raVal a2Old t0Old t1Old t2Old
+        t3Old t4Old t5Old t6Old srcBytes srcOff hsalign hoff hover hvalid hss hls hll) := by
+  exact cpsTripleWithin_frameR A hA
+    (rlp_walk_next_spec_within base srcBase endPtr raVal a2Old t0Old t1Old t2Old
+      t3Old t4Old t5Old t6Old srcBytes srcOff hsalign hoff hover hvalid hss hls hll)
+
+#print axioms rlp_walk_next_flat_spec_within
+
+end EvmAsm.Codegen.RlpWalkNextFlatSAsm

--- a/PLAN.md
+++ b/PLAN.md
@@ -2661,6 +2661,15 @@ calling convention so it is a literal drop-in.
   classical axioms. Guest-link regeneration and EEST A/B are the byte-changing
   deployment gates.
 
+- ✅ **Cursor-walk flat caller contracts** (beads `evm-asm-4ch8f.14.15` and
+  `.14.16`, PRs #10298/#10299): Codegen adapters frame the verified strict
+  `rlp_walk_init_spec_within` (all nine outcomes) and
+  `rlp_walk_next_spec_within` (all six outcomes) with arbitrary caller-owned
+  `pcFree` ambient assertions. Program length guards pin 53/103 instructions;
+  the adapters are spec-only, preserve the complete raw posts, and audit to
+  the three permitted classical axioms. These contracts unblock cursor-walk
+  account/header decoder composition; emitted bytes are unchanged.
+
 - ✅ **`ssz_pack_bytes` SAsm port** (bead `evm-asm-4ch8f.19.1`): structured
   copy/pad loops, exact one-step operational lemmas, packed-byte/chunk-count
   algebra, a genuine unified top-level postcondition, and a byte-identical


### PR DESCRIPTION
## Summary
- expose the existing strict `rlp_walk_next_spec_within` theorem as a caller-consumable framed flat contract
- preserve the complete six-outcome post (end, bound, canonicality failures, and success) plus all static validity hypotheses
- add a length drift guard and wire the module into `Programs/Imports.lean`

## Verification
- `lake build EvmAsm.Codegen.Programs.Imports`
- `scripts/port-check.sh EvmAsm/Codegen/Programs/RlpWalkNextFlatSAsm.lean`
- `scripts/check-forbidden-tactics.sh`
- `scripts/check-axioms.sh`
- theorem axioms: `[propext, Classical.choice, Quot.sound]`

Spec-only adapter; emitted bytes are unchanged and the underlying program guard remains in `RlpWalk.lean`. Stacked on #10298; do not self-merge.