### PR TITLE
fix(codegen): point file-size guard at current imports hub

### DIFF
--- a/EvmAsm/Codegen/Programs/FileSizeGuard.lean
+++ b/EvmAsm/Codegen/Programs/FileSizeGuard.lean
@@ -22,7 +22,7 @@ partial def collectLeanFiles (root : System.FilePath) : IO (Array System.FilePat
       pure acc
 
 def registryHub : System.FilePath :=
-  System.FilePath.mk "EvmAsm/Codegen/Programs.lean"
+  System.FilePath.mk "EvmAsm/Codegen/Programs/Imports.lean"
 
 def programsDir : System.FilePath :=
   System.FilePath.mk "EvmAsm/Codegen/Programs"


### PR DESCRIPTION
## Summary

- repoint `FileSizeGuard.registryHub` from the deleted `EvmAsm/Codegen/Programs.lean` to the current `EvmAsm/Codegen/Programs/Imports.lean` hub
- keep the change standalone to unblock fresh-cache builds

## Verification

- `lake build` (fresh worktree cache): 4706 jobs, green
- `scripts/check-asm-to-program.sh`: CLEAN (386 converted defs across 146 files)
- `scripts/check-region-map.sh`: green; symbol-addresses and ELF layout match

No merge requested.