### PR TITLE
fix(mpt): compose system changes with withdrawals

### DIFF
--- a/EvmAsm/Codegen/Programs/BlockVerdictStateRoot.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictStateRoot.lean
@@ -269,7 +269,7 @@ def blockStateRootFunction : String :=
   "  beqz t1, .Lbsr_wl_next\n" ++
   "  li t0, " ++ toString bsrMaxWithdrawalChanges ++ "; bgeu s0, t0, .Lbsr_cons_change_cap\n" ++
   "  # Repeated withdrawals to the same recipient accumulate into one state change.\n" ++
-  "  li t6, 2                     # scan recorded withdrawal changes [2, s1)\n" ++
+  "  li t6, 0                     # compose with every earlier committed mutation [0, s1)\n" ++
   ".Lbsr_dup_scan:\n" ++
   "  beq t6, s1, .Lbsr_no_dup\n" ++
   "  slli t0, t6, 5; slli t1, t6, 3; add t0, t0, t1; la t1, bsr_changes; add t0, t1, t0\n" ++


### PR DESCRIPTION
Fixes a state-root false-reject edge case: EIP-4895 withdrawals may target the EIP-2935 or EIP-4788 system account. The existing duplicate-composition path already adds a withdrawal delta to an earlier descriptor; this expands its scan from withdrawal-only descriptors to every earlier committed descriptor, preserving the system account storage-root update before applying the balance credit.

Depends on #10323 (and transitively #10321); merge #10321, then #10323, then this PR. No merge commit.

Validation:
- `lake build codegen`
- `scripts/check-region-map.sh`
- `scripts/check-asm-to-program.sh`
- `scripts/codegen-eest-stateless-check.sh --random --seed 20260715 --limit 100 --backend spike`: 100/100 full/root/success/tail, 0 failures/errors/budget/root-only diffs.