### PR TITLE
proof(chain-validate): chainValidateGasUsedUnderLimit caller Fn.Spec (batch sibling 3)

### DIFF
--- a/EvmAsm/Codegen/Programs/ChainValidateGasUsedUnderLimitLoop.lean
+++ b/EvmAsm/Codegen/Programs/ChainValidateGasUsedUnderLimitLoop.lean
@@ -566,4 +566,208 @@ theorem cvgulCall2 (hbi lenBase spC iW : Word) (Li : Nat)
 
 #print axioms cvgulCall2
 
+/-! ## Normalizing K34's `flatPost` into a single Result-carrying assertion
+
+    Generic in the output `cell` and the return-site `linkRA`.  Both arms of
+    `flatPost` collapse to `dispNorm`, exposing `x10 = status` (for the `bne`)
+    and `cell ↦ value` (for the reload) while owning the callee-perturbed
+    remainder. -/
+def dispNorm (spC calleeNewSp hbi validPtr firstBadPtr nN lenBase iW linkRA cell value status : Word)
+    (bytes : List (BitVec 8)) : Assertion :=
+  (.x2 ↦ᵣ spC) ** (.x8 ↦ᵣ nN) ** (.x9 ↦ᵣ lenBase) **
+  (.x18 ↦ᵣ hbi) ** (.x19 ↦ᵣ validPtr) ** (.x20 ↦ᵣ firstBadPtr) ** (.x21 ↦ᵣ iW) **
+  (.x10 ↦ᵣ status) ** (.x0 ↦ᵣ (0 : Word)) ** (cell ↦ₘ value) **
+  regOwn .x5 ** regOwn .x6 ** regOwn .x7 ** regOwn .x11 ** regOwn .x12 ** regOwn .x13 **
+  regOwn .x14 ** regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+  memOwn RfuOff ** memOwn RfuLen ** stackFree calleeNewSp 8 **
+  bytesRegion hbi bytes **
+  EvmAsm.Codegen.RlpFieldToU64SAsm.savedFrame calleeNewSp ⟨linkRA, nN, lenBase⟩
+
+set_option maxRecDepth 8000 in
+theorem flatPost_normalize (spC hbi validPtr firstBadPtr nN lenBase iW linkRA cell
+    oldOff oldLen : Word) (bytes : List (BitVec 8)) (Li index : Nat) : ∀ h,
+    (EvmAsm.Codegen.RlpFieldToU64SAsm.flatPost spC (spC + signExtend12 (-32 : BitVec 12)) hbi
+      oldOff oldLen (⟨linkRA, nN, lenBase⟩ : EvmAsm.Codegen.RlpFieldToU64SAsm.Saved)
+      (⟨EvmAsm.Codegen.RlpFieldToU64SAsm.B + 48, hbi, cell, hbi, validPtr, firstBadPtr, iW⟩ : Saved)
+      bytes Li index) h →
+    (∃ status value,
+      (dispNorm spC (spC + signExtend12 (-32 : BitVec 12)) hbi validPtr firstBadPtr nN lenBase iW
+          linkRA cell value status bytes **
+        ⌜EvmAsm.Codegen.RlpFieldToU64SAsm.Result bytes hbi Li index status value⌝) h) := by
+  intro h hp
+  unfold EvmAsm.Codegen.RlpFieldToU64SAsm.flatPost at hp
+  rcases hp with hs | hf
+  · unfold EvmAsm.Codegen.RlpFieldToU64SAsm.flatSuccessReturned at hs
+    obtain ⟨offset, len, v12, x5v, scalarStatus, wrapperStatus, outputValue, hs⟩ := hs
+    unfold EvmAsm.Codegen.RlpFieldToU64SAsm.successPayload at hs
+    refine ⟨wrapperStatus, outputValue, ?_⟩
+    obtain ⟨h1, h2, hd, hu, hO, hP⟩ := hs
+    obtain ⟨hBig, hRes⟩ := (sepConj_pure_right _).1 hP
+    refine (sepConj_pure_right _).2 ⟨?_, hRes⟩
+    have hOB : (_ ** _) h := ⟨h1, h2, hd, hu, hO, hBig⟩
+    unfold dispNorm
+    have hp1 : ((RfuOff ↦ₘ offset) ** (RfuLen ↦ₘ len) ** (.x5 ↦ᵣ x5v) **
+        (.x11 ↦ᵣ scalarStatus) ** (.x12 ↦ᵣ v12) **
+        ((.x2 ↦ᵣ spC) ** (.x8 ↦ᵣ nN) ** (.x9 ↦ᵣ lenBase) ** (.x18 ↦ᵣ hbi) **
+          (.x19 ↦ᵣ validPtr) ** (.x20 ↦ᵣ firstBadPtr) ** (.x21 ↦ᵣ iW) **
+          (.x10 ↦ᵣ wrapperStatus) ** (.x0 ↦ᵣ (0 : Word)) ** (cell ↦ₘ outputValue) **
+          regOwn .x6 ** regOwn .x7 ** regOwn .x13 ** regOwn .x14 ** regOwn .x28 **
+          regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+          stackFree (spC + signExtend12 (-32 : BitVec 12)) 8 ** bytesRegion hbi bytes **
+          EvmAsm.Codegen.RlpFieldToU64SAsm.savedFrame (spC + signExtend12 (-32 : BitVec 12))
+            ⟨linkRA, nN, lenBase⟩)) h := by xperm_hyp hOB
+    have hp2 := sepConj_mono memIs_implies_memOwn (sepConj_mono memIs_implies_memOwn
+      (sepConj_mono (regIs_implies_regOwn .x5) (sepConj_mono (regIs_implies_regOwn .x11)
+        (sepConj_mono (regIs_implies_regOwn .x12) (fun _ x => x))))) h hp1
+    xperm_hyp hp2
+  · unfold EvmAsm.Codegen.RlpFieldToU64SAsm.flatFailureReturned at hf
+    obtain ⟨v11, v12, hf⟩ := hf
+    unfold EvmAsm.Codegen.RlpFieldToU64SAsm.failurePayload at hf
+    refine ⟨(1 : Word), (0 : Word), ?_⟩
+    obtain ⟨h1, h2, hd, hu, hO, hP⟩ := hf
+    obtain ⟨hBig, hRes⟩ := (sepConj_pure_right _).1 hP
+    refine (sepConj_pure_right _).2 ⟨?_, hRes⟩
+    have hOB : (_ ** _) h := ⟨h1, h2, hd, hu, hO, hBig⟩
+    unfold dispNorm
+    have hp1 : ((RfuOff ↦ₘ oldOff) ** (RfuLen ↦ₘ oldLen) ** (.x11 ↦ᵣ v11) **
+        (.x12 ↦ᵣ v12) **
+        ((.x2 ↦ᵣ spC) ** (.x8 ↦ᵣ nN) ** (.x9 ↦ᵣ lenBase) ** (.x18 ↦ᵣ hbi) **
+          (.x19 ↦ᵣ validPtr) ** (.x20 ↦ᵣ firstBadPtr) ** (.x21 ↦ᵣ iW) **
+          (.x10 ↦ᵣ (1 : Word)) ** (.x0 ↦ᵣ (0 : Word)) ** (cell ↦ₘ (0 : Word)) **
+          regOwn .x5 ** regOwn .x6 ** regOwn .x7 ** regOwn .x13 ** regOwn .x14 **
+          regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+          stackFree (spC + signExtend12 (-32 : BitVec 12)) 8 ** bytesRegion hbi bytes **
+          EvmAsm.Codegen.RlpFieldToU64SAsm.savedFrame (spC + signExtend12 (-32 : BitVec 12))
+            ⟨linkRA, nN, lenBase⟩)) h := by xperm_hyp hOB
+    have hp2 := sepConj_mono memIs_implies_memOwn (sepConj_mono memIs_implies_memOwn
+      (sepConj_mono (regIs_implies_regOwn .x11) (sepConj_mono (regIs_implies_regOwn .x12)
+        (fun _ x => x)))) h hp1
+    xperm_hyp hp2
+
+#print axioms flatPost_normalize
+
+/-- K34's 3-slot saved frame, once restored, weakens to the merely-owned frame
+    slots the loop invariant carries. -/
+theorem k34SavedFrame_implies_frameSlotsOwn (newSp : Word)
+    (saved : EvmAsm.Codegen.RlpFieldToU64SAsm.Saved) : ∀ h,
+    EvmAsm.Codegen.RlpFieldToU64SAsm.savedFrame newSp saved h →
+    frameSlotsOwn EvmAsm.Codegen.RlpFieldToU64SAsm.frame newSp h := by
+  intro h hp
+  rw [← EvmAsm.Codegen.RlpFieldToU64SAsm.frameSlotsSaved_frame] at hp
+  exact EvmAsm.Codegen.ChainValidateExtraDataLengthSpec.frameSlotsSaved_implies_frameSlotsOwn
+    EvmAsm.Codegen.RlpFieldToU64SAsm.frame newSp
+    (EvmAsm.Codegen.RlpFieldToU64SAsm.savedVals saved) h hp
+
+/-- pcFree discharger covering the assertion atoms used in the dispatch. -/
+local macro "pcfx" : tactic =>
+  `(tactic| repeat' first
+      | apply pcFree_sepConj | exact pcFree_regIs | exact pcFree_regOwn
+      | exact pcFree_memIs | exact pcFree_memOwn | exact pcFree_emp | exact pcFree_pure
+      | exact bytesRegion_pcFree _ _ | exact pcFree_frameSlotsOwn _ _
+      | exact pcFree_stackFree _ _
+      | exact pcFree_wordArrayFrom _ _ _ | unfold savedFrame
+      | unfold EvmAsm.Codegen.RlpFieldToU64SAsm.savedFrame)
+
+/-! ## Entry half of one iteration: guard → call 1 → K34 flatPost
+
+    From the loop guard (`D+68`, `i < N`) through the first `jal` to K34's
+    return (`D+128`), with the header slice handed to K34 for field 10 and the
+    untouched `wordArray`/`bytesRegion` prefixes and the `GasLimit` cell framed. -/
+
+set_option maxRecDepth 8000 in
+theorem cvgulIterEntry (spC hdrBase lenBase validPtr firstBadPtr : Word)
+    (csaved : Saved) (bigBytes : List (BitVec 8)) (lengths : List Nat) (i : Nat)
+    (oldOut oldLimit oldOff oldLen : Word)
+    (hi : i < lengths.length)
+    (hN : lengths.length < 2 ^ 64)
+    (hsalign : (hdrBaseAt hdrBase lengths i).toNat % 8 = 0)
+    (hslack : lengths[i]! + 9 ≤ (bigBytes.drop (hdrOff lengths i)).length)
+    (hover : (hdrBaseAt hdrBase lengths i).toNat +
+      (bigBytes.drop (hdrOff lengths i)).length < 2 ^ 64)
+    (hvalid : ∀ k, k < (bigBytes.drop (hdrOff lengths i)).length →
+      isValidByteAccess (hdrBaseAt hdrBase lengths i + BitVec.ofNat 64 k) = true) :
+    cpsTripleWithin (1 + (13 + 1 + nCall 10)) (D + 68) (D + 128) fullCode
+      ((.x2 ↦ᵣ spC) ** (.x8 ↦ᵣ BitVec.ofNat 64 lengths.length) ** (.x9 ↦ᵣ lenBase) **
+        (.x18 ↦ᵣ hdrBaseAt hdrBase lengths i) ** (.x19 ↦ᵣ validPtr) **
+        (.x20 ↦ᵣ firstBadPtr) ** (.x21 ↦ᵣ BitVec.ofNat 64 i) ** savedFrame spC csaved **
+        (validPtr ↦ₘ (1 : Word)) ** (firstBadPtr ↦ₘ (0 : Word)) **
+        wordArrayFrom lenBase 0 (lengths.take i) **
+        ((lenBase + BitVec.ofNat 64 (8 * i)) ↦ₘ BitVec.ofNat 64 lengths[i]!) **
+        wordArrayFrom lenBase (i + 1) (lengths.drop (i + 1)) **
+        bytesRegion hdrBase (bigBytes.take (hdrOff lengths i)) **
+        bytesRegion (hdrBaseAt hdrBase lengths i) (bigBytes.drop (hdrOff lengths i)) **
+        (GasUsed ↦ₘ oldOut) ** (GasLimit ↦ₘ oldLimit) **
+        (RfuOff ↦ₘ oldOff) ** (RfuLen ↦ₘ oldLen) **
+        memOwn IterPtr ** memOwn IterI **
+        regOwn .x1 ** regOwn .x5 ** regOwn .x6 ** regOwn .x7 ** regOwn .x10 **
+        regOwn .x11 ** regOwn .x12 ** regOwn .x13 ** regOwn .x14 ** regOwn .x28 **
+        regOwn .x29 ** regOwn .x30 ** regOwn .x31 ** (.x0 ↦ᵣ (0 : Word)) **
+        frameSlotsOwn EvmAsm.Codegen.RlpFieldToU64SAsm.frame (spC + signExtend12 (-32 : BitVec 12)) **
+        stackFree (spC + signExtend12 (-32 : BitVec 12)) 8)
+      ((.x1 ↦ᵣ LinkRA1) **
+        EvmAsm.Codegen.RlpFieldToU64SAsm.flatPost spC (spC + signExtend12 (-32 : BitVec 12))
+          (hdrBaseAt hdrBase lengths i) oldOff oldLen
+          (⟨LinkRA1, BitVec.ofNat 64 lengths.length, lenBase⟩ :
+            EvmAsm.Codegen.RlpFieldToU64SAsm.Saved)
+          (⟨EvmAsm.Codegen.RlpFieldToU64SAsm.B + 48, hdrBaseAt hdrBase lengths i, GasUsed,
+            hdrBaseAt hdrBase lengths i, validPtr, firstBadPtr, BitVec.ofNat 64 i⟩ : Saved)
+          (bigBytes.drop (hdrOff lengths i)) lengths[i]! 10 **
+        (IterPtr ↦ₘ hdrBaseAt hdrBase lengths i) ** (IterI ↦ₘ BitVec.ofNat 64 i) **
+        ((lenBase + BitVec.ofNat 64 (8 * i)) ↦ₘ BitVec.ofNat 64 lengths[i]!) **
+        wordArrayFrom lenBase 0 (lengths.take i) **
+        wordArrayFrom lenBase (i + 1) (lengths.drop (i + 1)) **
+        bytesRegion hdrBase (bigBytes.take (hdrOff lengths i)) **
+        (GasLimit ↦ₘ oldLimit) ** (validPtr ↦ₘ (1 : Word)) ** (firstBadPtr ↦ₘ (0 : Word)) **
+        savedFrame spC csaved) := by
+  have hbeq := beq_spec_gen_within .x21 .x8 (224 : BitVec 13) (BitVec.ofNat 64 i)
+    (BitVec.ofNat 64 lengths.length) (D + 68)
+  have hbeqC := cpsBranchWithin_extend_code cvgul_mono
+    (cpsBranchWithin_extend_code (cr' := cvgulCode)
+      (CodeReq.ofProg_mem_at D (D + 68) cvgulProg 17 (.BEQ .x21 .x8 (224 : BitVec 13))
+        (by bv_omega) (by rw [cvgul_length]; decide) rfl (by rw [cvgul_length]; decide)) hbeq)
+  have hguard0 := cpsBranchWithin_ntakenStripPure2 hbeqC (fun hp hq => by
+    obtain ⟨_, _, _, _, _, hrest⟩ := hq
+    exact ofNat_ne_of_lt i lengths.length hi hN ((sepConj_pure_right _).1 hrest).2)
+  rw [show (D + 68 + 4 : Word) = D + 72 from by bv_omega] at hguard0
+  have hguardF := cpsTripleWithin_frameR
+    ((.x2 ↦ᵣ spC) ** (.x9 ↦ᵣ lenBase) ** (.x18 ↦ᵣ hdrBaseAt hdrBase lengths i) **
+      (.x19 ↦ᵣ validPtr) ** (.x20 ↦ᵣ firstBadPtr) ** savedFrame spC csaved **
+      (validPtr ↦ₘ (1 : Word)) ** (firstBadPtr ↦ₘ (0 : Word)) **
+      wordArrayFrom lenBase 0 (lengths.take i) **
+      ((lenBase + BitVec.ofNat 64 (8 * i)) ↦ₘ BitVec.ofNat 64 lengths[i]!) **
+      wordArrayFrom lenBase (i + 1) (lengths.drop (i + 1)) **
+      bytesRegion hdrBase (bigBytes.take (hdrOff lengths i)) **
+      bytesRegion (hdrBaseAt hdrBase lengths i) (bigBytes.drop (hdrOff lengths i)) **
+      (GasUsed ↦ₘ oldOut) ** (GasLimit ↦ₘ oldLimit) **
+      (RfuOff ↦ₘ oldOff) ** (RfuLen ↦ₘ oldLen) **
+      memOwn IterPtr ** memOwn IterI **
+      regOwn .x1 ** regOwn .x5 ** regOwn .x6 ** regOwn .x7 ** regOwn .x10 **
+      regOwn .x11 ** regOwn .x12 ** regOwn .x13 ** regOwn .x14 ** regOwn .x28 **
+      regOwn .x29 ** regOwn .x30 ** regOwn .x31 ** (.x0 ↦ᵣ (0 : Word)) **
+      frameSlotsOwn EvmAsm.Codegen.RlpFieldToU64SAsm.frame (spC + signExtend12 (-32 : BitVec 12)) **
+      stackFree (spC + signExtend12 (-32 : BitVec 12)) 8)
+    (by repeat' first | apply pcFree_sepConj | exact pcFree_regIs | exact pcFree_regOwn
+                      | exact pcFree_memIs | exact pcFree_memOwn
+                      | exact pcFree_frameSlotsOwn _ _ | exact pcFree_stackFree _ _
+                      | exact bytesRegion_pcFree _ _
+                      | exact pcFree_wordArrayFrom _ _ _) hguard0
+  have hcall := cvgulCall1Owned (hdrBaseAt hdrBase lengths i) lenBase spC (BitVec.ofNat 64 i)
+    lengths[i]! (BitVec.ofNat 64 lengths.length) validPtr firstBadPtr oldOut oldOff oldLen
+    (bigBytes.drop (hdrOff lengths i)) csaved hsalign hslack hover hvalid
+  have hcallF := cpsTripleWithin_frameR
+    (wordArrayFrom lenBase 0 (lengths.take i) **
+      wordArrayFrom lenBase (i + 1) (lengths.drop (i + 1)) **
+      bytesRegion hdrBase (bigBytes.take (hdrOff lengths i)) **
+      (GasLimit ↦ₘ oldLimit) ** (validPtr ↦ₘ (1 : Word)) ** (firstBadPtr ↦ₘ (0 : Word)))
+    (by repeat' first | apply pcFree_sepConj | exact pcFree_wordArrayFrom _ _ _
+                      | exact bytesRegion_pcFree _ _ | exact pcFree_memIs) hcall
+  refine cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp) (fun h hq => by
+      rw [show (BitVec.ofNat 64 i) <<< 3 = BitVec.ofNat 64 (8 * i) from shiftLeft3_ofNat i] at hq
+      xperm_hyp hq)
+    (cpsTripleWithin_seq_perm_same_cr (fun h hp => by
+      rw [show (BitVec.ofNat 64 i) <<< 3 = BitVec.ofNat 64 (8 * i) from shiftLeft3_ofNat i]
+      xperm_hyp hp) hguardF hcallF)
+
+#print axioms cvgulIterEntry
+
 end EvmAsm.Codegen.ChainValidateGasUsedUnderLimitSpec

--- a/EvmAsm/Codegen/Programs/ChainValidateGasUsedUnderLimitLoop.lean
+++ b/EvmAsm/Codegen/Programs/ChainValidateGasUsedUnderLimitLoop.lean
@@ -244,4 +244,194 @@ theorem cvgulAdvance (hbi lenBase iW : Word) (Li : Nat) (o28 o29 : Word) :
 
 #print axioms cvgulAdvance
 
+/-! ## Call block 1 (instructions 18--31 + K34): setup1 ;; jal ;; rlp_field_to_u64
+
+    From the loop-guard fall-through (`D+72`) to the first return site (`D+128`),
+    producing K34's `flatPost` for header `hbi` field 10 (gas_used → `GasUsed`),
+    with the spill cells, the array cell, and the chain frame carried through. -/
+
+set_option maxRecDepth 8000 in
+theorem cvgulCall1 (hbi lenBase spC iW : Word) (Li : Nat)
+    (nN s3 s4 oldOut oldOff oldLen old14 oldX1 old5 o10 o11 o12 o13 o28 : Word)
+    (bytes : List (BitVec 8)) (csaved : Saved)
+    (hsalign : hbi.toNat % 8 = 0)
+    (hslack : Li + 9 ≤ bytes.length)
+    (hover : hbi.toNat + bytes.length < 2 ^ 64)
+    (hvalid : ∀ k, k < bytes.length →
+      isValidByteAccess (hbi + BitVec.ofNat 64 k) = true) :
+    cpsTripleWithin (13 + 1 + nCall 10) (D + 72) (D + 128) fullCode
+      ((.x2 ↦ᵣ spC) ** (.x9 ↦ᵣ lenBase) ** (.x18 ↦ᵣ hbi) ** (.x21 ↦ᵣ iW) **
+        (.x5 ↦ᵣ old5) ** (.x10 ↦ᵣ o10) ** (.x11 ↦ᵣ o11) ** (.x12 ↦ᵣ o12) **
+        (.x13 ↦ᵣ o13) ** (.x28 ↦ᵣ o28) **
+        memOwn IterPtr ** memOwn IterI **
+        ((lenBase + (iW <<< 3)) ↦ₘ BitVec.ofNat 64 Li) **
+        (.x1 ↦ᵣ oldX1) ** (.x8 ↦ᵣ nN) ** (.x19 ↦ᵣ s3) ** (.x20 ↦ᵣ s4) **
+        (.x14 ↦ᵣ old14) ** regOwn .x6 ** regOwn .x7 ** regOwn .x29 ** regOwn .x30 **
+        regOwn .x31 ** (.x0 ↦ᵣ (0 : Word)) **
+        frameSlotsOwn EvmAsm.Codegen.RlpFieldToU64SAsm.frame (spC + signExtend12 (-32 : BitVec 12)) **
+        stackFree (spC + signExtend12 (-32 : BitVec 12)) 8 **
+        (GasUsed ↦ₘ oldOut) ** (RfuOff ↦ₘ oldOff) ** (RfuLen ↦ₘ oldLen) **
+        bytesRegion hbi bytes ** savedFrame spC csaved)
+      ((.x1 ↦ᵣ LinkRA1) **
+        EvmAsm.Codegen.RlpFieldToU64SAsm.flatPost spC (spC + signExtend12 (-32 : BitVec 12)) hbi
+          oldOff oldLen (⟨LinkRA1, nN, lenBase⟩ : EvmAsm.Codegen.RlpFieldToU64SAsm.Saved)
+          (⟨EvmAsm.Codegen.RlpFieldToU64SAsm.B + 48, hbi, GasUsed, hbi, s3, s4, iW⟩ : Saved)
+          bytes Li 10 **
+        (IterPtr ↦ₘ hbi) ** (IterI ↦ₘ iW) **
+        ((lenBase + (iW <<< 3)) ↦ₘ BitVec.ofNat 64 Li) ** savedFrame spC csaved) := by
+  set calleeNewSp : Word := spC + signExtend12 (-32 : BitVec 12) with hcalleeNewSp
+  have hsetup := cpsTripleWithin_extend_code cvgul_mono
+    (cvgulSetup1 hbi lenBase spC iW Li old5 o10 o11 o12 o13 o28)
+  have hsetupF := cpsTripleWithin_frameR
+    ((.x1 ↦ᵣ oldX1) ** (.x8 ↦ᵣ nN) ** (.x19 ↦ᵣ s3) ** (.x20 ↦ᵣ s4) **
+      (.x14 ↦ᵣ old14) ** regOwn .x6 ** regOwn .x7 ** regOwn .x29 ** regOwn .x30 **
+      regOwn .x31 ** (.x0 ↦ᵣ (0 : Word)) **
+      frameSlotsOwn EvmAsm.Codegen.RlpFieldToU64SAsm.frame calleeNewSp **
+      stackFree calleeNewSp 8 **
+      (GasUsed ↦ₘ oldOut) ** (RfuOff ↦ₘ oldOff) ** (RfuLen ↦ₘ oldLen) **
+      bytesRegion hbi bytes ** savedFrame spC csaved)
+    (by repeat' first | apply pcFree_sepConj | exact pcFree_regIs | exact pcFree_regOwn
+                      | exact pcFree_memIs | exact pcFree_memOwn
+                      | exact pcFree_frameSlotsOwn _ _ | exact pcFree_stackFree _ _
+                      | exact bytesRegion_pcFree _ _) hsetup
+  have hjal := jal_link_spec_within
+    (EvmAsm.Codegen.jalOff GuestAddrs.rlp_field_to_u64
+      (GuestAddrs.chain_validate_gas_used_under_limit + 124)) (D + 124) oldX1
+  rw [show (D + 124) + signExtend21 (EvmAsm.Codegen.jalOff GuestAddrs.rlp_field_to_u64
+      (GuestAddrs.chain_validate_gas_used_under_limit + 124))
+      = EvmAsm.Codegen.RlpFieldToU64SAsm.B from by decide,
+    show (D + 124 + 4 : Word) = LinkRA1 from by
+      change (D + 124 + 4 : Word) = D + 128; bv_omega] at hjal
+  have hjalC := cpsTripleWithin_extend_code cvgul_mono
+    (cpsTripleWithin_extend_code (cr' := cvgulCode)
+      (CodeReq.ofProg_mem_at D (D + 124) cvgulProg 31
+        (.JAL .x1 (EvmAsm.Codegen.jalOff GuestAddrs.rlp_field_to_u64
+          (GuestAddrs.chain_validate_gas_used_under_limit + 124))) (by bv_omega)
+        (by rw [cvgul_length]; decide) rfl (by rw [cvgul_length]; decide)) hjal)
+  have hjalF := cpsTripleWithin_frameR
+    ((.x2 ↦ᵣ spC) ** (.x9 ↦ᵣ lenBase) ** (.x18 ↦ᵣ hbi) ** (.x21 ↦ᵣ iW) **
+      (.x5 ↦ᵣ IterI) ** (.x10 ↦ᵣ hbi) ** (.x11 ↦ᵣ BitVec.ofNat 64 Li) **
+      (.x12 ↦ᵣ (10 : Word)) ** (.x13 ↦ᵣ GasUsed) **
+      (.x28 ↦ᵣ (lenBase + (iW <<< 3))) ** (IterPtr ↦ₘ hbi) ** (IterI ↦ₘ iW) **
+      ((lenBase + (iW <<< 3)) ↦ₘ BitVec.ofNat 64 Li) **
+      (.x8 ↦ᵣ nN) ** (.x19 ↦ᵣ s3) ** (.x20 ↦ᵣ s4) ** (.x14 ↦ᵣ old14) **
+      regOwn .x6 ** regOwn .x7 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+      (.x0 ↦ᵣ (0 : Word)) **
+      frameSlotsOwn EvmAsm.Codegen.RlpFieldToU64SAsm.frame calleeNewSp **
+      stackFree calleeNewSp 8 **
+      (GasUsed ↦ₘ oldOut) ** (RfuOff ↦ₘ oldOff) ** (RfuLen ↦ₘ oldLen) **
+      bytesRegion hbi bytes ** savedFrame spC csaved)
+    (by repeat' first | apply pcFree_sepConj | exact pcFree_regIs | exact pcFree_regOwn
+                      | exact pcFree_memIs | exact pcFree_memOwn
+                      | exact pcFree_frameSlotsOwn _ _ | exact pcFree_stackFree _ _
+                      | exact bytesRegion_pcFree _ _) hjalC
+  have hcallee0 := EvmAsm.Codegen.RlpFieldToU64SAsm.rlpFieldToU64_flat_spec_within
+    spC calleeNewSp hbi (BitVec.ofNat 64 Li) (10 : Word) GasUsed oldOut oldOff oldLen old14
+    (⟨LinkRA1, nN, lenBase⟩ : EvmAsm.Codegen.RlpFieldToU64SAsm.Saved) hbi s3 s4 iW bytes Li 10
+    hcalleeNewSp rfl (by decide) (by decide)
+    hsalign hslack hover hvalid (by show LinkRA1 &&& ~~~(1 : Word) = LinkRA1; decide)
+  have hcalleeC := cpsTripleWithin_extend_code k34_mono hcallee0
+  have hcallee : cpsTripleWithin (nCall 10) EvmAsm.Codegen.RlpFieldToU64SAsm.B LinkRA1 fullCode
+      (regOwn .x5 ** regOwn .x28 **
+        ((.x1 ↦ᵣ LinkRA1) ** (.x2 ↦ᵣ spC) ** (.x8 ↦ᵣ nN) ** (.x9 ↦ᵣ lenBase) **
+          (.x18 ↦ᵣ hbi) ** (.x19 ↦ᵣ s3) ** (.x20 ↦ᵣ s4) ** (.x21 ↦ᵣ iW) **
+          (.x10 ↦ᵣ hbi) ** (.x11 ↦ᵣ BitVec.ofNat 64 Li) ** (.x12 ↦ᵣ (10 : Word)) **
+          (.x13 ↦ᵣ GasUsed) ** (.x14 ↦ᵣ old14) ** regOwn .x6 ** regOwn .x7 **
+          regOwn .x29 ** regOwn .x30 ** regOwn .x31 ** (.x0 ↦ᵣ (0 : Word)) **
+          frameSlotsOwn EvmAsm.Codegen.RlpFieldToU64SAsm.frame calleeNewSp **
+          stackFree calleeNewSp 8 ** bytesRegion hbi bytes **
+          (GasUsed ↦ₘ oldOut) ** (RfuOff ↦ₘ oldOff) ** (RfuLen ↦ₘ oldLen)))
+      ((.x1 ↦ᵣ LinkRA1) **
+        EvmAsm.Codegen.RlpFieldToU64SAsm.flatPost spC calleeNewSp hbi oldOff oldLen
+          (⟨LinkRA1, nN, lenBase⟩ : EvmAsm.Codegen.RlpFieldToU64SAsm.Saved)
+          (⟨EvmAsm.Codegen.RlpFieldToU64SAsm.B + 48, hbi, GasUsed, hbi, s3, s4, iW⟩ : Saved)
+          bytes Li 10) :=
+    cpsTripleWithin_weaken (fun h hp => by
+      unfold EvmAsm.Codegen.RlpFieldToU64SAsm.flatPre EvmAsm.Codegen.RlpFieldToU64SAsm.wholeRest
+      xperm_hyp hp) (fun _ hq => hq) hcalleeC
+  have hcalleeF := cpsTripleWithin_frameR
+    ((IterPtr ↦ₘ hbi) ** (IterI ↦ₘ iW) **
+      ((lenBase + (iW <<< 3)) ↦ₘ BitVec.ofNat 64 Li) ** savedFrame spC csaved)
+    (by repeat' first | apply pcFree_sepConj | exact pcFree_memIs) hcallee
+  have hsj := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) hsetupF hjalF
+  refine cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp) (fun _ hq => by xperm_hyp hq)
+    (cpsTripleWithin_seq_perm_same_cr (fun h hp => ?_) hsj hcalleeF)
+  have hp' : ((.x5 ↦ᵣ IterI) ** (.x28 ↦ᵣ (lenBase + (iW <<< 3))) **
+      ((.x1 ↦ᵣ LinkRA1) ** (.x2 ↦ᵣ spC) ** (.x8 ↦ᵣ nN) ** (.x9 ↦ᵣ lenBase) **
+        (.x18 ↦ᵣ hbi) ** (.x19 ↦ᵣ s3) ** (.x20 ↦ᵣ s4) ** (.x21 ↦ᵣ iW) **
+        (.x10 ↦ᵣ hbi) ** (.x11 ↦ᵣ BitVec.ofNat 64 Li) ** (.x12 ↦ᵣ (10 : Word)) **
+        (.x13 ↦ᵣ GasUsed) ** (.x14 ↦ᵣ old14) ** regOwn .x6 ** regOwn .x7 **
+        regOwn .x29 ** regOwn .x30 ** regOwn .x31 ** (.x0 ↦ᵣ (0 : Word)) **
+        frameSlotsOwn EvmAsm.Codegen.RlpFieldToU64SAsm.frame calleeNewSp **
+        stackFree calleeNewSp 8 ** bytesRegion hbi bytes **
+        (GasUsed ↦ₘ oldOut) ** (RfuOff ↦ₘ oldOff) ** (RfuLen ↦ₘ oldLen) **
+        (IterPtr ↦ₘ hbi) ** (IterI ↦ₘ iW) **
+        ((lenBase + (iW <<< 3)) ↦ₘ BitVec.ofNat 64 Li) ** savedFrame spC csaved)) h := by
+    xperm_hyp hp
+  have hp'' := sepConj_mono (regIs_implies_regOwn .x5)
+    (sepConj_mono (regIs_implies_regOwn .x28) (fun _ x => x)) h hp'
+  xperm_hyp hp''
+
+#print axioms cvgulCall1
+
+/-! ## Call block 1 with the consumed scratch registers owned -/
+
+set_option maxRecDepth 8000 in
+theorem cvgulCall1Owned (hbi lenBase spC iW : Word) (Li : Nat)
+    (nN s3 s4 oldOut oldOff oldLen : Word) (bytes : List (BitVec 8)) (csaved : Saved)
+    (hsalign : hbi.toNat % 8 = 0)
+    (hslack : Li + 9 ≤ bytes.length)
+    (hover : hbi.toNat + bytes.length < 2 ^ 64)
+    (hvalid : ∀ k, k < bytes.length →
+      isValidByteAccess (hbi + BitVec.ofNat 64 k) = true) :
+    cpsTripleWithin (13 + 1 + nCall 10) (D + 72) (D + 128) fullCode
+      ((((.x2 ↦ᵣ spC) ** (.x9 ↦ᵣ lenBase) ** (.x18 ↦ᵣ hbi) ** (.x21 ↦ᵣ iW) **
+          memOwn IterPtr ** memOwn IterI **
+          ((lenBase + (iW <<< 3)) ↦ₘ BitVec.ofNat 64 Li) **
+          (.x8 ↦ᵣ nN) ** (.x19 ↦ᵣ s3) ** (.x20 ↦ᵣ s4) **
+          regOwn .x6 ** regOwn .x7 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+          (.x0 ↦ᵣ (0 : Word)) **
+          frameSlotsOwn EvmAsm.Codegen.RlpFieldToU64SAsm.frame (spC + signExtend12 (-32 : BitVec 12)) **
+          stackFree (spC + signExtend12 (-32 : BitVec 12)) 8 **
+          (GasUsed ↦ₘ oldOut) ** (RfuOff ↦ₘ oldOff) ** (RfuLen ↦ₘ oldLen) **
+          bytesRegion hbi bytes ** savedFrame spC csaved) **
+        regOwn .x5 ** regOwn .x10 ** regOwn .x11 ** regOwn .x12 ** regOwn .x13 **
+        regOwn .x14 ** regOwn .x28) ** regOwn .x1)
+      ((.x1 ↦ᵣ LinkRA1) **
+        EvmAsm.Codegen.RlpFieldToU64SAsm.flatPost spC (spC + signExtend12 (-32 : BitVec 12)) hbi
+          oldOff oldLen (⟨LinkRA1, nN, lenBase⟩ : EvmAsm.Codegen.RlpFieldToU64SAsm.Saved)
+          (⟨EvmAsm.Codegen.RlpFieldToU64SAsm.B + 48, hbi, GasUsed, hbi, s3, s4, iW⟩ : Saved)
+          bytes Li 10 **
+        (IterPtr ↦ₘ hbi) ** (IterI ↦ₘ iW) **
+        ((lenBase + (iW <<< 3)) ↦ₘ BitVec.ofNat 64 Li) ** savedFrame spC csaved) := by
+  refine cpsTripleWithin_of_forall_regIs_to_regOwn (fun v1 => ?_)
+  refine cpsTripleWithin_weaken (fun _ h => by xperm_hyp h) (fun _ h => h)
+    (show cpsTripleWithin (13 + 1 + nCall 10) (D + 72) (D + 128) fullCode
+      ((((.x2 ↦ᵣ spC) ** (.x9 ↦ᵣ lenBase) ** (.x18 ↦ᵣ hbi) ** (.x21 ↦ᵣ iW) **
+          memOwn IterPtr ** memOwn IterI **
+          ((lenBase + (iW <<< 3)) ↦ₘ BitVec.ofNat 64 Li) **
+          (.x8 ↦ᵣ nN) ** (.x19 ↦ᵣ s3) ** (.x20 ↦ᵣ s4) **
+          regOwn .x6 ** regOwn .x7 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+          (.x0 ↦ᵣ (0 : Word)) **
+          frameSlotsOwn EvmAsm.Codegen.RlpFieldToU64SAsm.frame (spC + signExtend12 (-32 : BitVec 12)) **
+          stackFree (spC + signExtend12 (-32 : BitVec 12)) 8 **
+          (GasUsed ↦ₘ oldOut) ** (RfuOff ↦ₘ oldOff) ** (RfuLen ↦ₘ oldLen) **
+          bytesRegion hbi bytes ** savedFrame spC csaved) ** (.x1 ↦ᵣ v1)) **
+        regOwn .x5 ** regOwn .x10 ** regOwn .x11 ** regOwn .x12 ** regOwn .x13 **
+        regOwn .x14 ** regOwn .x28)
+      ((.x1 ↦ᵣ LinkRA1) **
+        EvmAsm.Codegen.RlpFieldToU64SAsm.flatPost spC (spC + signExtend12 (-32 : BitVec 12)) hbi
+          oldOff oldLen (⟨LinkRA1, nN, lenBase⟩ : EvmAsm.Codegen.RlpFieldToU64SAsm.Saved)
+          (⟨EvmAsm.Codegen.RlpFieldToU64SAsm.B + 48, hbi, GasUsed, hbi, s3, s4, iW⟩ : Saved)
+          bytes Li 10 **
+        (IterPtr ↦ₘ hbi) ** (IterI ↦ₘ iW) **
+        ((lenBase + (iW <<< 3)) ↦ₘ BitVec.ofNat 64 Li) ** savedFrame spC csaved) from ?_)
+  refine EvmAsm.Codegen.RlpListNthItemSAsm.cpsTripleWithin_of_forall_regIs_to_regOwn7
+    (fun v5 v10 v11 v12 v13 v14 v28 => ?_)
+  exact cpsTripleWithin_weaken (fun _ h => by xperm_hyp h) (fun _ h => by xperm_hyp h)
+    (cvgulCall1 hbi lenBase spC iW Li nN s3 s4 oldOut oldOff oldLen v14 v1 v5 v10 v11 v12 v13 v28
+      bytes csaved hsalign hslack hover hvalid)
+
+#print axioms cvgulCall1Owned
+
 end EvmAsm.Codegen.ChainValidateGasUsedUnderLimitSpec

--- a/EvmAsm/Codegen/Programs/ChainValidateGasUsedUnderLimitLoop.lean
+++ b/EvmAsm/Codegen/Programs/ChainValidateGasUsedUnderLimitLoop.lean
@@ -434,4 +434,136 @@ theorem cvgulCall1Owned (hbi lenBase spC iW : Word) (Li : Nat)
 
 #print axioms cvgulCall1Owned
 
+/-! ## Call block 2 (instructions 33--46 + K34): reloadSetup2 ;; jal ;; rlp_field_to_u64
+
+    On the call-1-success path from `D+132` to the second return site (`D+188`),
+    producing K34's `flatPost` for header `hbi` field 9 (gas_limit → `GasLimit`).
+    The iterator is reloaded from the spill cells, so `x18`/`x21` on entry are
+    arbitrary; the `GasUsed` cell (holding the first field's value) is carried
+    unchanged by the caller. -/
+
+set_option maxRecDepth 8000 in
+theorem cvgulCall2 (hbi lenBase spC iW : Word) (Li : Nat)
+    (nN s3 s4 oldOut oldOff oldLen old14 oldX1 old5 o10 o11 o12 o13 o18 o21 o28 : Word)
+    (bytes : List (BitVec 8)) (csaved : Saved)
+    (hsalign : hbi.toNat % 8 = 0)
+    (hslack : Li + 9 ≤ bytes.length)
+    (hover : hbi.toNat + bytes.length < 2 ^ 64)
+    (hvalid : ∀ k, k < bytes.length →
+      isValidByteAccess (hbi + BitVec.ofNat 64 k) = true) :
+    cpsTripleWithin (13 + 1 + nCall 9) (D + 132) (D + 188) fullCode
+      ((.x2 ↦ᵣ spC) ** (.x9 ↦ᵣ lenBase) ** (.x18 ↦ᵣ o18) ** (.x21 ↦ᵣ o21) **
+        (.x5 ↦ᵣ old5) ** (.x10 ↦ᵣ o10) ** (.x11 ↦ᵣ o11) ** (.x12 ↦ᵣ o12) **
+        (.x13 ↦ᵣ o13) ** (.x28 ↦ᵣ o28) **
+        (IterPtr ↦ₘ hbi) ** (IterI ↦ₘ iW) **
+        ((lenBase + (iW <<< 3)) ↦ₘ BitVec.ofNat 64 Li) **
+        (.x1 ↦ᵣ oldX1) ** (.x8 ↦ᵣ nN) ** (.x19 ↦ᵣ s3) ** (.x20 ↦ᵣ s4) **
+        (.x14 ↦ᵣ old14) ** regOwn .x6 ** regOwn .x7 ** regOwn .x29 ** regOwn .x30 **
+        regOwn .x31 ** (.x0 ↦ᵣ (0 : Word)) **
+        frameSlotsOwn EvmAsm.Codegen.RlpFieldToU64SAsm.frame (spC + signExtend12 (-32 : BitVec 12)) **
+        stackFree (spC + signExtend12 (-32 : BitVec 12)) 8 **
+        (GasLimit ↦ₘ oldOut) ** (RfuOff ↦ₘ oldOff) ** (RfuLen ↦ₘ oldLen) **
+        bytesRegion hbi bytes ** savedFrame spC csaved)
+      ((.x1 ↦ᵣ LinkRA2) **
+        EvmAsm.Codegen.RlpFieldToU64SAsm.flatPost spC (spC + signExtend12 (-32 : BitVec 12)) hbi
+          oldOff oldLen (⟨LinkRA2, nN, lenBase⟩ : EvmAsm.Codegen.RlpFieldToU64SAsm.Saved)
+          (⟨EvmAsm.Codegen.RlpFieldToU64SAsm.B + 48, hbi, GasLimit, hbi, s3, s4, iW⟩ : Saved)
+          bytes Li 9 **
+        (IterPtr ↦ₘ hbi) ** (IterI ↦ₘ iW) **
+        ((lenBase + (iW <<< 3)) ↦ₘ BitVec.ofNat 64 Li) ** savedFrame spC csaved) := by
+  set calleeNewSp : Word := spC + signExtend12 (-32 : BitVec 12) with hcalleeNewSp
+  have hsetup := cpsTripleWithin_extend_code cvgul_mono
+    (cvgulReloadSetup2 hbi lenBase iW Li old5 o10 o11 o12 o13 o18 o21 o28)
+  have hsetupF := cpsTripleWithin_frameR
+    ((.x2 ↦ᵣ spC) ** (.x1 ↦ᵣ oldX1) ** (.x8 ↦ᵣ nN) ** (.x19 ↦ᵣ s3) ** (.x20 ↦ᵣ s4) **
+      (.x14 ↦ᵣ old14) ** regOwn .x6 ** regOwn .x7 ** regOwn .x29 ** regOwn .x30 **
+      regOwn .x31 ** (.x0 ↦ᵣ (0 : Word)) **
+      frameSlotsOwn EvmAsm.Codegen.RlpFieldToU64SAsm.frame calleeNewSp **
+      stackFree calleeNewSp 8 **
+      (GasLimit ↦ₘ oldOut) ** (RfuOff ↦ₘ oldOff) ** (RfuLen ↦ₘ oldLen) **
+      bytesRegion hbi bytes ** savedFrame spC csaved)
+    (by repeat' first | apply pcFree_sepConj | exact pcFree_regIs | exact pcFree_regOwn
+                      | exact pcFree_memIs | exact pcFree_memOwn
+                      | exact pcFree_frameSlotsOwn _ _ | exact pcFree_stackFree _ _
+                      | exact bytesRegion_pcFree _ _) hsetup
+  have hjal := jal_link_spec_within
+    (EvmAsm.Codegen.jalOff GuestAddrs.rlp_field_to_u64
+      (GuestAddrs.chain_validate_gas_used_under_limit + 184)) (D + 184) oldX1
+  rw [show (D + 184) + signExtend21 (EvmAsm.Codegen.jalOff GuestAddrs.rlp_field_to_u64
+      (GuestAddrs.chain_validate_gas_used_under_limit + 184))
+      = EvmAsm.Codegen.RlpFieldToU64SAsm.B from by decide,
+    show (D + 184 + 4 : Word) = LinkRA2 from by
+      change (D + 184 + 4 : Word) = D + 188; bv_omega] at hjal
+  have hjalC := cpsTripleWithin_extend_code cvgul_mono
+    (cpsTripleWithin_extend_code (cr' := cvgulCode)
+      (CodeReq.ofProg_mem_at D (D + 184) cvgulProg 46
+        (.JAL .x1 (EvmAsm.Codegen.jalOff GuestAddrs.rlp_field_to_u64
+          (GuestAddrs.chain_validate_gas_used_under_limit + 184))) (by bv_omega)
+        (by rw [cvgul_length]; decide) rfl (by rw [cvgul_length]; decide)) hjal)
+  have hjalF := cpsTripleWithin_frameR
+    ((.x2 ↦ᵣ spC) ** (.x9 ↦ᵣ lenBase) ** (.x18 ↦ᵣ hbi) ** (.x21 ↦ᵣ iW) **
+      (.x5 ↦ᵣ IterI) ** (.x10 ↦ᵣ hbi) ** (.x11 ↦ᵣ BitVec.ofNat 64 Li) **
+      (.x12 ↦ᵣ (9 : Word)) ** (.x13 ↦ᵣ GasLimit) **
+      (.x28 ↦ᵣ (lenBase + (iW <<< 3))) ** (IterPtr ↦ₘ hbi) ** (IterI ↦ₘ iW) **
+      ((lenBase + (iW <<< 3)) ↦ₘ BitVec.ofNat 64 Li) **
+      (.x8 ↦ᵣ nN) ** (.x19 ↦ᵣ s3) ** (.x20 ↦ᵣ s4) ** (.x14 ↦ᵣ old14) **
+      regOwn .x6 ** regOwn .x7 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+      (.x0 ↦ᵣ (0 : Word)) **
+      frameSlotsOwn EvmAsm.Codegen.RlpFieldToU64SAsm.frame calleeNewSp **
+      stackFree calleeNewSp 8 **
+      (GasLimit ↦ₘ oldOut) ** (RfuOff ↦ₘ oldOff) ** (RfuLen ↦ₘ oldLen) **
+      bytesRegion hbi bytes ** savedFrame spC csaved)
+    (by repeat' first | apply pcFree_sepConj | exact pcFree_regIs | exact pcFree_regOwn
+                      | exact pcFree_memIs | exact pcFree_memOwn
+                      | exact pcFree_frameSlotsOwn _ _ | exact pcFree_stackFree _ _
+                      | exact bytesRegion_pcFree _ _) hjalC
+  have hcallee0 := EvmAsm.Codegen.RlpFieldToU64SAsm.rlpFieldToU64_flat_spec_within
+    spC calleeNewSp hbi (BitVec.ofNat 64 Li) (9 : Word) GasLimit oldOut oldOff oldLen old14
+    (⟨LinkRA2, nN, lenBase⟩ : EvmAsm.Codegen.RlpFieldToU64SAsm.Saved) hbi s3 s4 iW bytes Li 9
+    hcalleeNewSp rfl (by decide) (by decide)
+    hsalign hslack hover hvalid (by show LinkRA2 &&& ~~~(1 : Word) = LinkRA2; decide)
+  have hcalleeC := cpsTripleWithin_extend_code k34_mono hcallee0
+  have hcallee : cpsTripleWithin (nCall 9) EvmAsm.Codegen.RlpFieldToU64SAsm.B LinkRA2 fullCode
+      (regOwn .x5 ** regOwn .x28 **
+        ((.x1 ↦ᵣ LinkRA2) ** (.x2 ↦ᵣ spC) ** (.x8 ↦ᵣ nN) ** (.x9 ↦ᵣ lenBase) **
+          (.x18 ↦ᵣ hbi) ** (.x19 ↦ᵣ s3) ** (.x20 ↦ᵣ s4) ** (.x21 ↦ᵣ iW) **
+          (.x10 ↦ᵣ hbi) ** (.x11 ↦ᵣ BitVec.ofNat 64 Li) ** (.x12 ↦ᵣ (9 : Word)) **
+          (.x13 ↦ᵣ GasLimit) ** (.x14 ↦ᵣ old14) ** regOwn .x6 ** regOwn .x7 **
+          regOwn .x29 ** regOwn .x30 ** regOwn .x31 ** (.x0 ↦ᵣ (0 : Word)) **
+          frameSlotsOwn EvmAsm.Codegen.RlpFieldToU64SAsm.frame calleeNewSp **
+          stackFree calleeNewSp 8 ** bytesRegion hbi bytes **
+          (GasLimit ↦ₘ oldOut) ** (RfuOff ↦ₘ oldOff) ** (RfuLen ↦ₘ oldLen)))
+      ((.x1 ↦ᵣ LinkRA2) **
+        EvmAsm.Codegen.RlpFieldToU64SAsm.flatPost spC calleeNewSp hbi oldOff oldLen
+          (⟨LinkRA2, nN, lenBase⟩ : EvmAsm.Codegen.RlpFieldToU64SAsm.Saved)
+          (⟨EvmAsm.Codegen.RlpFieldToU64SAsm.B + 48, hbi, GasLimit, hbi, s3, s4, iW⟩ : Saved)
+          bytes Li 9) :=
+    cpsTripleWithin_weaken (fun h hp => by
+      unfold EvmAsm.Codegen.RlpFieldToU64SAsm.flatPre EvmAsm.Codegen.RlpFieldToU64SAsm.wholeRest
+      xperm_hyp hp) (fun _ hq => hq) hcalleeC
+  have hcalleeF := cpsTripleWithin_frameR
+    ((IterPtr ↦ₘ hbi) ** (IterI ↦ₘ iW) **
+      ((lenBase + (iW <<< 3)) ↦ₘ BitVec.ofNat 64 Li) ** savedFrame spC csaved)
+    (by repeat' first | apply pcFree_sepConj | exact pcFree_memIs) hcallee
+  have hsj := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) hsetupF hjalF
+  refine cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp) (fun _ hq => by xperm_hyp hq)
+    (cpsTripleWithin_seq_perm_same_cr (fun h hp => ?_) hsj hcalleeF)
+  have hp' : ((.x5 ↦ᵣ IterI) ** (.x28 ↦ᵣ (lenBase + (iW <<< 3))) **
+      ((.x1 ↦ᵣ LinkRA2) ** (.x2 ↦ᵣ spC) ** (.x8 ↦ᵣ nN) ** (.x9 ↦ᵣ lenBase) **
+        (.x18 ↦ᵣ hbi) ** (.x19 ↦ᵣ s3) ** (.x20 ↦ᵣ s4) ** (.x21 ↦ᵣ iW) **
+        (.x10 ↦ᵣ hbi) ** (.x11 ↦ᵣ BitVec.ofNat 64 Li) ** (.x12 ↦ᵣ (9 : Word)) **
+        (.x13 ↦ᵣ GasLimit) ** (.x14 ↦ᵣ old14) ** regOwn .x6 ** regOwn .x7 **
+        regOwn .x29 ** regOwn .x30 ** regOwn .x31 ** (.x0 ↦ᵣ (0 : Word)) **
+        frameSlotsOwn EvmAsm.Codegen.RlpFieldToU64SAsm.frame calleeNewSp **
+        stackFree calleeNewSp 8 ** bytesRegion hbi bytes **
+        (GasLimit ↦ₘ oldOut) ** (RfuOff ↦ₘ oldOff) ** (RfuLen ↦ₘ oldLen) **
+        (IterPtr ↦ₘ hbi) ** (IterI ↦ₘ iW) **
+        ((lenBase + (iW <<< 3)) ↦ₘ BitVec.ofNat 64 Li) ** savedFrame spC csaved)) h := by
+    xperm_hyp hp
+  have hp'' := sepConj_mono (regIs_implies_regOwn .x5)
+    (sepConj_mono (regIs_implies_regOwn .x28) (fun _ x => x)) h hp'
+  xperm_hyp hp''
+
+#print axioms cvgulCall2
+
 end EvmAsm.Codegen.ChainValidateGasUsedUnderLimitSpec

--- a/EvmAsm/Codegen/Programs/ChainValidateGasUsedUnderLimitLoop.lean
+++ b/EvmAsm/Codegen/Programs/ChainValidateGasUsedUnderLimitLoop.lean
@@ -1,0 +1,247 @@
+/-
+  Per-iteration body + loop induction for `chain_validate_gas_used_under_limit`.
+
+  Builds on `ChainValidateGasUsedUnderLimitSpec` (model, prologue, epilogue,
+  exit blocks) and reuses the generic array pieces from
+  `ChainValidateExtraDataLengthSpec` plus the K34 call composition from the blob
+  sibling.  The per-header body makes TWO strict `rlp_field_to_u64` (K34) calls
+  (field 10 = gas_used → the `GasUsed` cell, field 9 = gas_limit → the
+  `GasLimit` cell) and compares the two decoded u64s with a dynamic `bltu`.
+-/
+
+import EvmAsm.Codegen.Programs.ChainValidateGasUsedUnderLimitSpec
+import EvmAsm.Evm64.StateAssertions
+
+namespace EvmAsm.Codegen.ChainValidateGasUsedUnderLimitSpec
+
+open EvmAsm.Rv64 EvmAsm.Rv64.RLP EvmAsm.Rv64.SAsm
+open EvmAsm.Codegen.RlpListNthItemSAsm
+  (Saved savedFrame savedVals listNthFrame regsAt_listNthFrame
+   frameSlotsSaved_listNthFrame)
+open EvmAsm.Codegen.ChainValidateExtraDataLengthSpec
+  (wordArray wordArrayFrom wordArray_split pcFree_wordArray pcFree_wordArrayFrom
+   wordArrayFrom_append shiftLeft3_ofNat hdrOff hdrBaseAt hdrOff_succ hdrBaseAt_succ
+   ofNat_ne_of_lt ofNat_succ_tie)
+
+/-- K34's whole-routine step count for field index `index` (matching the flat
+    spec's `((7 + 4 + callSteps) + ((1 + tailSteps) + 5))`). -/
+abbrev nCall (index : Nat) : Nat :=
+  (7 + 4 + (1 + ((12 + ((85 + 93 * (index + 2)) + 6)) + 9)))
+    + ((1 + ((7 + (1 + (7 * (2 ^ 64 - 1) + 11))) + 5)) + 5)
+
+theorem lengths_getElem_bang {lengths : List Nat} {i : Nat} (hi : i < lengths.length) :
+    lengths[i]! = lengths[i] := getElem!_pos lengths i hi
+
+/-! ## Setup block for call 1 (instructions 18--30)
+
+    From the loop-guard fall-through (`D+72`) to just before the first `jal`
+    (`D+124`).  Materializes `*IterPtr := hbi`, `*IterI := iW`, loads
+    `x11 := lengths[i]`, `x10 := hbi`, `x12 := 10` (gas_used), `x13 := GasUsed`. -/
+
+set_option maxRecDepth 8000 in
+theorem cvgulSetup1 (hbi lenBase spC iW : Word) (Li : Nat)
+    (old5 o10 o11 o12 o13 o28 : Word) :
+    cpsTripleWithin 13 (D + 72) (D + 124) cvgulCode
+      ((.x2 ↦ᵣ spC) ** (.x9 ↦ᵣ lenBase) ** (.x18 ↦ᵣ hbi) ** (.x21 ↦ᵣ iW) **
+        (.x5 ↦ᵣ old5) ** (.x10 ↦ᵣ o10) ** (.x11 ↦ᵣ o11) ** (.x12 ↦ᵣ o12) **
+        (.x13 ↦ᵣ o13) ** (.x28 ↦ᵣ o28) **
+        memOwn IterPtr ** memOwn IterI **
+        ((lenBase + (iW <<< 3)) ↦ₘ BitVec.ofNat 64 Li))
+      ((.x2 ↦ᵣ spC) ** (.x9 ↦ᵣ lenBase) ** (.x18 ↦ᵣ hbi) ** (.x21 ↦ᵣ iW) **
+        (.x5 ↦ᵣ IterI) ** (.x10 ↦ᵣ hbi) ** (.x11 ↦ᵣ BitVec.ofNat 64 Li) **
+        (.x12 ↦ᵣ (10 : Word)) ** (.x13 ↦ᵣ GasUsed) **
+        (.x28 ↦ᵣ (lenBase + (iW <<< 3))) **
+        (IterPtr ↦ₘ hbi) ** (IterI ↦ₘ iW) **
+        ((lenBase + (iW <<< 3)) ↦ₘ BitVec.ofNat 64 Li)) := by
+  have hla18 := la_materialize_within .x5 old5 (D + 72) IterPtr (by decide) (by decide)
+    (CodeReq.ofProg_mem_at D (D + 72) cvgulProg 18 (.AUIPC .x5 (EvmAsm.Rv64.laHi (D + 72) IterPtr)) (by bv_omega) (by rw [cvgul_length]; decide) (by decide) (by rw [cvgul_length]; decide))
+    (CodeReq.ofProg_mem_at D (D + 76) cvgulProg 19 (.ADDI .x5 .x5 (EvmAsm.Rv64.laLo (D + 72) IterPtr)) (by bv_omega) (by rw [cvgul_length]; decide) (by decide) (by rw [cvgul_length]; decide))
+  have s20 := sd_spec_gen_own_within .x5 .x18 IterPtr hbi (0 : BitVec 12) (D + 80)
+  rw [show signExtend12 (0 : BitVec 12) = (0 : Word) from by decide,
+    show IterPtr + (0 : Word) = IterPtr from by bv_omega] at s20
+  have s20' := cpsTripleWithin_extend_code
+    (CodeReq.ofProg_mem_at D (D + 80) cvgulProg 20 (.SD .x5 .x18 (0 : BitVec 12)) (by bv_omega) (by rw [cvgul_length]; decide) rfl (by rw [cvgul_length]; decide)) s20
+  have hla21 := la_materialize_within .x5 IterPtr (D + 84) IterI (by decide) (by decide)
+    (CodeReq.ofProg_mem_at D (D + 84) cvgulProg 21 (.AUIPC .x5 (EvmAsm.Rv64.laHi (D + 84) IterI)) (by bv_omega) (by rw [cvgul_length]; decide) (by decide) (by rw [cvgul_length]; decide))
+    (CodeReq.ofProg_mem_at D (D + 88) cvgulProg 22 (.ADDI .x5 .x5 (EvmAsm.Rv64.laLo (D + 84) IterI)) (by bv_omega) (by rw [cvgul_length]; decide) (by decide) (by rw [cvgul_length]; decide))
+  have s23 := sd_spec_gen_own_within .x5 .x21 IterI iW (0 : BitVec 12) (D + 92)
+  rw [show signExtend12 (0 : BitVec 12) = (0 : Word) from by decide,
+    show IterI + (0 : Word) = IterI from by bv_omega] at s23
+  have s23' := cpsTripleWithin_extend_code
+    (CodeReq.ofProg_mem_at D (D + 92) cvgulProg 23 (.SD .x5 .x21 (0 : BitVec 12)) (by bv_omega) (by rw [cvgul_length]; decide) rfl (by rw [cvgul_length]; decide)) s23
+  have s24 := slli_spec_gen_within .x28 .x21 o28 iW (3 : BitVec 6) (D + 96) (by decide)
+  rw [show (3 : BitVec 6).toNat = 3 from by decide] at s24
+  have s24' := cpsTripleWithin_extend_code
+    (CodeReq.ofProg_mem_at D (D + 96) cvgulProg 24 (.SLLI .x28 .x21 (3 : BitVec 6)) (by bv_omega) (by rw [cvgul_length]; decide) rfl (by rw [cvgul_length]; decide)) s24
+  have s25 := add_spec_gen_rd_eq_rs2_within .x28 .x9 lenBase (iW <<< 3) (D + 100) (by decide)
+  have s25' := cpsTripleWithin_extend_code
+    (CodeReq.ofProg_mem_at D (D + 100) cvgulProg 25 (.ADD .x28 .x9 .x28) (by bv_omega) (by rw [cvgul_length]; decide) rfl (by rw [cvgul_length]; decide)) s25
+  have s26 := ld_spec_gen_within .x11 .x28 (lenBase + (iW <<< 3)) o11 (BitVec.ofNat 64 Li)
+    (0 : BitVec 12) (D + 104) (by decide)
+  rw [show signExtend12 (0 : BitVec 12) = (0 : Word) from by decide,
+    show (lenBase + (iW <<< 3)) + (0 : Word) = lenBase + (iW <<< 3) from by bv_omega] at s26
+  have s26' := cpsTripleWithin_extend_code
+    (CodeReq.ofProg_mem_at D (D + 104) cvgulProg 26 (.LD .x11 .x28 (0 : BitVec 12)) (by bv_omega) (by rw [cvgul_length]; decide) rfl (by rw [cvgul_length]; decide)) s26
+  have s27 := mv_spec_gen_within .x10 .x18 hbi o10 (D + 108) (by decide)
+  have s27' := cpsTripleWithin_extend_code
+    (CodeReq.ofProg_mem_at D (D + 108) cvgulProg 27 (.MV .x10 .x18) (by bv_omega) (by rw [cvgul_length]; decide) rfl (by rw [cvgul_length]; decide)) s27
+  have s28 := li_spec_gen_within .x12 o12 (10 : Word) (D + 112) (by decide)
+  have s28' := cpsTripleWithin_extend_code
+    (CodeReq.ofProg_mem_at D (D + 112) cvgulProg 28 (.LI .x12 (10 : Word)) (by bv_omega) (by rw [cvgul_length]; decide) rfl (by rw [cvgul_length]; decide)) s28
+  have hla29 := la_materialize_within .x13 o13 (D + 116) GasUsed (by decide) (by decide)
+    (CodeReq.ofProg_mem_at D (D + 116) cvgulProg 29 (.AUIPC .x13 (EvmAsm.Rv64.laHi (D + 116) GasUsed)) (by bv_omega) (by rw [cvgul_length]; decide) (by decide) (by rw [cvgul_length]; decide))
+    (CodeReq.ofProg_mem_at D (D + 120) cvgulProg 30 (.ADDI .x13 .x13 (EvmAsm.Rv64.laLo (D + 116) GasUsed)) (by bv_omega) (by rw [cvgul_length]; decide) (by decide) (by rw [cvgul_length]; decide))
+  runBlock hla18 s20' hla21 s23' s24' s25' s26' s27' s28' hla29
+
+#print axioms cvgulSetup1
+
+/-! ## Reload + setup block for call 2 (instructions 33--45)
+
+    On the call-1-success (`bne` not-taken) path from `D+132` to `D+184`: reload
+    `x18 := *IterPtr`, `x21 := *IterI`, reload `x11 := lengths[i]`, set
+    `x10 := hbi`, `x12 := 9` (gas_limit), `x13 := GasLimit`. -/
+
+set_option maxRecDepth 8000 in
+theorem cvgulReloadSetup2 (hbi lenBase iW : Word) (Li : Nat)
+    (old5 o10 o11 o12 o13 o18 o21 o28 : Word) :
+    cpsTripleWithin 13 (D + 132) (D + 184) cvgulCode
+      ((.x9 ↦ᵣ lenBase) ** (.x5 ↦ᵣ old5) ** (.x18 ↦ᵣ o18) ** (.x21 ↦ᵣ o21) **
+        (.x10 ↦ᵣ o10) ** (.x11 ↦ᵣ o11) ** (.x12 ↦ᵣ o12) ** (.x13 ↦ᵣ o13) ** (.x28 ↦ᵣ o28) **
+        (IterPtr ↦ₘ hbi) ** (IterI ↦ₘ iW) ** ((lenBase + (iW <<< 3)) ↦ₘ BitVec.ofNat 64 Li))
+      ((.x9 ↦ᵣ lenBase) ** (.x5 ↦ᵣ IterI) ** (.x18 ↦ᵣ hbi) ** (.x21 ↦ᵣ iW) **
+        (.x10 ↦ᵣ hbi) ** (.x11 ↦ᵣ BitVec.ofNat 64 Li) ** (.x12 ↦ᵣ (9 : Word)) **
+        (.x13 ↦ᵣ GasLimit) ** (.x28 ↦ᵣ (lenBase + (iW <<< 3))) **
+        (IterPtr ↦ₘ hbi) ** (IterI ↦ₘ iW) ** ((lenBase + (iW <<< 3)) ↦ₘ BitVec.ofNat 64 Li)) := by
+  have hla33 := la_materialize_within .x5 old5 (D + 132) IterPtr (by decide) (by decide)
+    (CodeReq.ofProg_mem_at D (D + 132) cvgulProg 33 (.AUIPC .x5 (EvmAsm.Rv64.laHi (D + 132) IterPtr)) (by bv_omega) (by rw [cvgul_length]; decide) (by decide) (by rw [cvgul_length]; decide))
+    (CodeReq.ofProg_mem_at D (D + 136) cvgulProg 34 (.ADDI .x5 .x5 (EvmAsm.Rv64.laLo (D + 132) IterPtr)) (by bv_omega) (by rw [cvgul_length]; decide) (by decide) (by rw [cvgul_length]; decide))
+  have s35 := ld_spec_gen_within .x18 .x5 IterPtr o18 hbi (0 : BitVec 12) (D + 140) (by decide)
+  rw [show signExtend12 (0 : BitVec 12) = (0 : Word) from by decide,
+    show IterPtr + (0 : Word) = IterPtr from by bv_omega] at s35
+  have s35' := cpsTripleWithin_extend_code
+    (CodeReq.ofProg_mem_at D (D + 140) cvgulProg 35 (.LD .x18 .x5 (0 : BitVec 12)) (by bv_omega) (by rw [cvgul_length]; decide) rfl (by rw [cvgul_length]; decide)) s35
+  have hla36 := la_materialize_within .x5 IterPtr (D + 144) IterI (by decide) (by decide)
+    (CodeReq.ofProg_mem_at D (D + 144) cvgulProg 36 (.AUIPC .x5 (EvmAsm.Rv64.laHi (D + 144) IterI)) (by bv_omega) (by rw [cvgul_length]; decide) (by decide) (by rw [cvgul_length]; decide))
+    (CodeReq.ofProg_mem_at D (D + 148) cvgulProg 37 (.ADDI .x5 .x5 (EvmAsm.Rv64.laLo (D + 144) IterI)) (by bv_omega) (by rw [cvgul_length]; decide) (by decide) (by rw [cvgul_length]; decide))
+  have s38 := ld_spec_gen_within .x21 .x5 IterI o21 iW (0 : BitVec 12) (D + 152) (by decide)
+  rw [show signExtend12 (0 : BitVec 12) = (0 : Word) from by decide,
+    show IterI + (0 : Word) = IterI from by bv_omega] at s38
+  have s38' := cpsTripleWithin_extend_code
+    (CodeReq.ofProg_mem_at D (D + 152) cvgulProg 38 (.LD .x21 .x5 (0 : BitVec 12)) (by bv_omega) (by rw [cvgul_length]; decide) rfl (by rw [cvgul_length]; decide)) s38
+  have s39 := slli_spec_gen_within .x28 .x21 o28 iW (3 : BitVec 6) (D + 156) (by decide)
+  rw [show (3 : BitVec 6).toNat = 3 from by decide] at s39
+  have s39' := cpsTripleWithin_extend_code
+    (CodeReq.ofProg_mem_at D (D + 156) cvgulProg 39 (.SLLI .x28 .x21 (3 : BitVec 6)) (by bv_omega) (by rw [cvgul_length]; decide) rfl (by rw [cvgul_length]; decide)) s39
+  have s40 := add_spec_gen_rd_eq_rs2_within .x28 .x9 lenBase (iW <<< 3) (D + 160) (by decide)
+  have s40' := cpsTripleWithin_extend_code
+    (CodeReq.ofProg_mem_at D (D + 160) cvgulProg 40 (.ADD .x28 .x9 .x28) (by bv_omega) (by rw [cvgul_length]; decide) rfl (by rw [cvgul_length]; decide)) s40
+  have s41 := ld_spec_gen_within .x11 .x28 (lenBase + (iW <<< 3)) o11 (BitVec.ofNat 64 Li)
+    (0 : BitVec 12) (D + 164) (by decide)
+  rw [show signExtend12 (0 : BitVec 12) = (0 : Word) from by decide,
+    show (lenBase + (iW <<< 3)) + (0 : Word) = lenBase + (iW <<< 3) from by bv_omega] at s41
+  have s41' := cpsTripleWithin_extend_code
+    (CodeReq.ofProg_mem_at D (D + 164) cvgulProg 41 (.LD .x11 .x28 (0 : BitVec 12)) (by bv_omega) (by rw [cvgul_length]; decide) rfl (by rw [cvgul_length]; decide)) s41
+  have s42 := mv_spec_gen_within .x10 .x18 hbi o10 (D + 168) (by decide)
+  have s42' := cpsTripleWithin_extend_code
+    (CodeReq.ofProg_mem_at D (D + 168) cvgulProg 42 (.MV .x10 .x18) (by bv_omega) (by rw [cvgul_length]; decide) rfl (by rw [cvgul_length]; decide)) s42
+  have s43 := li_spec_gen_within .x12 o12 (9 : Word) (D + 172) (by decide)
+  have s43' := cpsTripleWithin_extend_code
+    (CodeReq.ofProg_mem_at D (D + 172) cvgulProg 43 (.LI .x12 (9 : Word)) (by bv_omega) (by rw [cvgul_length]; decide) rfl (by rw [cvgul_length]; decide)) s43
+  have hla44 := la_materialize_within .x13 o13 (D + 176) GasLimit (by decide) (by decide)
+    (CodeReq.ofProg_mem_at D (D + 176) cvgulProg 44 (.AUIPC .x13 (EvmAsm.Rv64.laHi (D + 176) GasLimit)) (by bv_omega) (by rw [cvgul_length]; decide) (by decide) (by rw [cvgul_length]; decide))
+    (CodeReq.ofProg_mem_at D (D + 180) cvgulProg 45 (.ADDI .x13 .x13 (EvmAsm.Rv64.laLo (D + 176) GasLimit)) (by bv_omega) (by rw [cvgul_length]; decide) (by decide) (by rw [cvgul_length]; decide))
+  runBlock hla33 s35' hla36 s38' s39' s40' s41' s42' s43' hla44
+
+#print axioms cvgulReloadSetup2
+
+/-! ## Compare block (instructions 48--59): reload iterator + both values
+
+    On the call-2-success (`bne` not-taken) path from `D+192` to `D+240`: reload
+    `x18 := *IterPtr`, `x21 := *IterI`, `x6 := *GasUsed`, `x7 := *GasLimit`. -/
+
+set_option maxRecDepth 8000 in
+theorem cvgulCompare (hbi iW gu gl : Word) (old5 o18 o21 o6 o7 : Word) :
+    cpsTripleWithin 12 (D + 192) (D + 240) cvgulCode
+      ((.x5 ↦ᵣ old5) ** (.x18 ↦ᵣ o18) ** (.x21 ↦ᵣ o21) ** (.x6 ↦ᵣ o6) ** (.x7 ↦ᵣ o7) **
+        (IterPtr ↦ₘ hbi) ** (IterI ↦ₘ iW) ** (GasUsed ↦ₘ gu) ** (GasLimit ↦ₘ gl))
+      ((.x5 ↦ᵣ GasLimit) ** (.x18 ↦ᵣ hbi) ** (.x21 ↦ᵣ iW) ** (.x6 ↦ᵣ gu) ** (.x7 ↦ᵣ gl) **
+        (IterPtr ↦ₘ hbi) ** (IterI ↦ₘ iW) ** (GasUsed ↦ₘ gu) ** (GasLimit ↦ₘ gl)) := by
+  have hla48 := la_materialize_within .x5 old5 (D + 192) IterPtr (by decide) (by decide)
+    (CodeReq.ofProg_mem_at D (D + 192) cvgulProg 48 (.AUIPC .x5 (EvmAsm.Rv64.laHi (D + 192) IterPtr)) (by bv_omega) (by rw [cvgul_length]; decide) (by decide) (by rw [cvgul_length]; decide))
+    (CodeReq.ofProg_mem_at D (D + 196) cvgulProg 49 (.ADDI .x5 .x5 (EvmAsm.Rv64.laLo (D + 192) IterPtr)) (by bv_omega) (by rw [cvgul_length]; decide) (by decide) (by rw [cvgul_length]; decide))
+  have s50 := ld_spec_gen_within .x18 .x5 IterPtr o18 hbi (0 : BitVec 12) (D + 200) (by decide)
+  rw [show signExtend12 (0 : BitVec 12) = (0 : Word) from by decide,
+    show IterPtr + (0 : Word) = IterPtr from by bv_omega] at s50
+  have s50' := cpsTripleWithin_extend_code
+    (CodeReq.ofProg_mem_at D (D + 200) cvgulProg 50 (.LD .x18 .x5 (0 : BitVec 12)) (by bv_omega) (by rw [cvgul_length]; decide) rfl (by rw [cvgul_length]; decide)) s50
+  have hla51 := la_materialize_within .x5 IterPtr (D + 204) IterI (by decide) (by decide)
+    (CodeReq.ofProg_mem_at D (D + 204) cvgulProg 51 (.AUIPC .x5 (EvmAsm.Rv64.laHi (D + 204) IterI)) (by bv_omega) (by rw [cvgul_length]; decide) (by decide) (by rw [cvgul_length]; decide))
+    (CodeReq.ofProg_mem_at D (D + 208) cvgulProg 52 (.ADDI .x5 .x5 (EvmAsm.Rv64.laLo (D + 204) IterI)) (by bv_omega) (by rw [cvgul_length]; decide) (by decide) (by rw [cvgul_length]; decide))
+  have s53 := ld_spec_gen_within .x21 .x5 IterI o21 iW (0 : BitVec 12) (D + 212) (by decide)
+  rw [show signExtend12 (0 : BitVec 12) = (0 : Word) from by decide,
+    show IterI + (0 : Word) = IterI from by bv_omega] at s53
+  have s53' := cpsTripleWithin_extend_code
+    (CodeReq.ofProg_mem_at D (D + 212) cvgulProg 53 (.LD .x21 .x5 (0 : BitVec 12)) (by bv_omega) (by rw [cvgul_length]; decide) rfl (by rw [cvgul_length]; decide)) s53
+  have hla54 := la_materialize_within .x5 IterI (D + 216) GasUsed (by decide) (by decide)
+    (CodeReq.ofProg_mem_at D (D + 216) cvgulProg 54 (.AUIPC .x5 (EvmAsm.Rv64.laHi (D + 216) GasUsed)) (by bv_omega) (by rw [cvgul_length]; decide) (by decide) (by rw [cvgul_length]; decide))
+    (CodeReq.ofProg_mem_at D (D + 220) cvgulProg 55 (.ADDI .x5 .x5 (EvmAsm.Rv64.laLo (D + 216) GasUsed)) (by bv_omega) (by rw [cvgul_length]; decide) (by decide) (by rw [cvgul_length]; decide))
+  have s56 := ld_spec_gen_within .x6 .x5 GasUsed o6 gu (0 : BitVec 12) (D + 224) (by decide)
+  rw [show signExtend12 (0 : BitVec 12) = (0 : Word) from by decide,
+    show GasUsed + (0 : Word) = GasUsed from by bv_omega] at s56
+  have s56' := cpsTripleWithin_extend_code
+    (CodeReq.ofProg_mem_at D (D + 224) cvgulProg 56 (.LD .x6 .x5 (0 : BitVec 12)) (by bv_omega) (by rw [cvgul_length]; decide) rfl (by rw [cvgul_length]; decide)) s56
+  have hla57 := la_materialize_within .x5 GasUsed (D + 228) GasLimit (by decide) (by decide)
+    (CodeReq.ofProg_mem_at D (D + 228) cvgulProg 57 (.AUIPC .x5 (EvmAsm.Rv64.laHi (D + 228) GasLimit)) (by bv_omega) (by rw [cvgul_length]; decide) (by decide) (by rw [cvgul_length]; decide))
+    (CodeReq.ofProg_mem_at D (D + 232) cvgulProg 58 (.ADDI .x5 .x5 (EvmAsm.Rv64.laLo (D + 228) GasLimit)) (by bv_omega) (by rw [cvgul_length]; decide) (by decide) (by rw [cvgul_length]; decide))
+  have s59 := ld_spec_gen_within .x7 .x5 GasLimit o7 gl (0 : BitVec 12) (D + 236) (by decide)
+  rw [show signExtend12 (0 : BitVec 12) = (0 : Word) from by decide,
+    show GasLimit + (0 : Word) = GasLimit from by bv_omega] at s59
+  have s59' := cpsTripleWithin_extend_code
+    (CodeReq.ofProg_mem_at D (D + 236) cvgulProg 59 (.LD .x7 .x5 (0 : BitVec 12)) (by bv_omega) (by rw [cvgul_length]; decide) rfl (by rw [cvgul_length]; decide)) s59
+  runBlock hla48 s50' hla51 s53' hla54 s56' hla57 s59'
+
+#print axioms cvgulCompare
+
+/-! ## Advance block (instructions 61--66): step the iterator, loop back
+
+    On the under-limit (`bltu` not-taken) path from `D+244`: `x18 += lengths[i]`,
+    `x21 += 1`, then `jal x0, -196` back to the loop guard at `D+68`. -/
+
+set_option maxRecDepth 8000 in
+theorem cvgulAdvance (hbi lenBase iW : Word) (Li : Nat) (o28 o29 : Word) :
+    cpsTripleWithin 6 (D + 244) (D + 68) cvgulCode
+      ((.x21 ↦ᵣ iW) ** (.x9 ↦ᵣ lenBase) ** (.x18 ↦ᵣ hbi) ** (.x28 ↦ᵣ o28) **
+        (.x29 ↦ᵣ o29) ** ((lenBase + (iW <<< 3)) ↦ₘ BitVec.ofNat 64 Li))
+      ((.x21 ↦ᵣ (iW + signExtend12 (1 : BitVec 12))) ** (.x9 ↦ᵣ lenBase) **
+        (.x18 ↦ᵣ (hbi + BitVec.ofNat 64 Li)) ** (.x28 ↦ᵣ (lenBase + (iW <<< 3))) **
+        (.x29 ↦ᵣ BitVec.ofNat 64 Li) **
+        ((lenBase + (iW <<< 3)) ↦ₘ BitVec.ofNat 64 Li)) := by
+  have s61 := slli_spec_gen_within .x28 .x21 o28 iW (3 : BitVec 6) (D + 244) (by decide)
+  rw [show (3 : BitVec 6).toNat = 3 from by decide] at s61
+  have s61' := cpsTripleWithin_extend_code
+    (CodeReq.ofProg_mem_at D (D + 244) cvgulProg 61 (.SLLI .x28 .x21 (3 : BitVec 6)) (by bv_omega) (by rw [cvgul_length]; decide) rfl (by rw [cvgul_length]; decide)) s61
+  have s62 := add_spec_gen_rd_eq_rs2_within .x28 .x9 lenBase (iW <<< 3) (D + 248) (by decide)
+  have s62' := cpsTripleWithin_extend_code
+    (CodeReq.ofProg_mem_at D (D + 248) cvgulProg 62 (.ADD .x28 .x9 .x28) (by bv_omega) (by rw [cvgul_length]; decide) rfl (by rw [cvgul_length]; decide)) s62
+  have s63 := ld_spec_gen_within .x29 .x28 (lenBase + (iW <<< 3)) o29 (BitVec.ofNat 64 Li)
+    (0 : BitVec 12) (D + 252) (by decide)
+  rw [show signExtend12 (0 : BitVec 12) = (0 : Word) from by decide,
+    show (lenBase + (iW <<< 3)) + (0 : Word) = lenBase + (iW <<< 3) from by bv_omega] at s63
+  have s63' := cpsTripleWithin_extend_code
+    (CodeReq.ofProg_mem_at D (D + 252) cvgulProg 63 (.LD .x29 .x28 (0 : BitVec 12)) (by bv_omega) (by rw [cvgul_length]; decide) rfl (by rw [cvgul_length]; decide)) s63
+  have s64 := add_spec_gen_rd_eq_rs1_within .x18 .x29 hbi (BitVec.ofNat 64 Li) (D + 256) (by decide)
+  have s64' := cpsTripleWithin_extend_code
+    (CodeReq.ofProg_mem_at D (D + 256) cvgulProg 64 (.ADD .x18 .x18 .x29) (by bv_omega) (by rw [cvgul_length]; decide) rfl (by rw [cvgul_length]; decide)) s64
+  have s65 := addi_spec_gen_same_within .x21 iW (1 : BitVec 12) (D + 260) (by decide)
+  have s65' := cpsTripleWithin_extend_code
+    (CodeReq.ofProg_mem_at D (D + 260) cvgulProg 65 (.ADDI .x21 .x21 (1 : BitVec 12)) (by bv_omega) (by rw [cvgul_length]; decide) rfl (by rw [cvgul_length]; decide)) s65
+  have s66 := jal_x0_spec_gen_within (-196 : BitVec 21) (D + 264)
+  rw [show (D + 264) + signExtend21 (-196 : BitVec 21) = D + 68 from by
+    rw [show signExtend21 (-196 : BitVec 21) = (-196 : Word) from by decide]; bv_omega] at s66
+  have s66' := cpsTripleWithin_extend_code
+    (CodeReq.ofProg_mem_at D (D + 264) cvgulProg 66 (.JAL .x0 (-196 : BitVec 21)) (by bv_omega) (by rw [cvgul_length]; decide) rfl (by rw [cvgul_length]; decide)) s66
+  runBlock s61' s62' s63' s64' s65' s66'
+
+#print axioms cvgulAdvance
+
+end EvmAsm.Codegen.ChainValidateGasUsedUnderLimitSpec

--- a/EvmAsm/Codegen/Programs/ChainValidateGasUsedUnderLimitLoopClose.lean
+++ b/EvmAsm/Codegen/Programs/ChainValidateGasUsedUnderLimitLoopClose.lean
@@ -1,0 +1,587 @@
+/-
+  Two-call status dispatch, loop induction, and whole-program caller contract
+  for `chain_validate_gas_used_under_limit`.
+
+  `cvgulDispatch2` handles the tail from K34's second `flatPost` (`D+188`): the
+  gas-limit `bne`, the value reload/compare, and the dynamic `bltu` splitting to
+  violation or advance+loop.  `cvgulDispatch1` prepends the gas-used `bne` and
+  the second K34 call.  `cvgulIter` shapes the loop invariant into one full
+  iteration, `cvgulLoop` runs the induction, and
+  `chain_validate_gas_used_under_limit_spec_within` glues the prologue in front.
+-/
+
+import EvmAsm.Codegen.Programs.ChainValidateGasUsedUnderLimitLoop
+
+namespace EvmAsm.Codegen.ChainValidateGasUsedUnderLimitSpec
+
+open EvmAsm.Rv64 EvmAsm.Rv64.RLP EvmAsm.Rv64.SAsm
+open EvmAsm.Codegen.RlpListNthItemSAsm
+  (Saved savedFrame savedVals listNthFrame regsAt_listNthFrame
+   frameSlotsSaved_listNthFrame)
+open EvmAsm.Codegen.ChainValidateExtraDataLengthSpec
+  (wordArray wordArrayFrom wordArray_split pcFree_wordArray pcFree_wordArrayFrom
+   wordArrayFrom_append shiftLeft3_ofNat hdrOff hdrBaseAt hdrOff_succ hdrBaseAt_succ
+   ofNat_ne_of_lt ofNat_succ_tie)
+
+local macro "pcfx" : tactic =>
+  `(tactic| repeat' first
+      | apply pcFree_sepConj | exact pcFree_regIs | exact pcFree_regOwn
+      | exact pcFree_memIs | exact pcFree_memOwn | exact pcFree_emp | exact pcFree_pure
+      | exact bytesRegion_pcFree _ _ | exact pcFree_frameSlotsOwn _ _
+      | exact pcFree_stackFree _ _
+      | exact pcFree_wordArray _ _ | exact pcFree_wordArrayFrom _ _ _ | unfold savedFrame
+      | unfold EvmAsm.Codegen.RlpFieldToU64SAsm.savedFrame)
+
+/-! ## Dispatch tail from the second call (`D+188` onward)
+
+    From K34's field-9 `flatPost` at the `bne` return site (`D+188`) to the
+    caller's post.  `flatPost_normalize` collapses the callee return into one
+    `Result`-carrying shape; `bne x10, x0` splits on the gas-limit status; on
+    success the reload/compare (`bltu gl, gu`) routes to violation or
+    continue+loop, using the carried field-10 `Result` for `gu`. -/
+set_option maxRecDepth 8000 in
+theorem cvgulDispatch2
+    (sp0 spC hdrBase lenBase validPtr firstBadPtr raIn : Word)
+    (csaved : Saved) (bigBytes : List (BitVec 8)) (lengths : List Nat) (i : Nat)
+    (oldOff oldLen gu : Word) (nTail : Nat)
+    (hi : i < lengths.length)
+    (hspC : spC = sp0 + signExtend12 (-56 : BitVec 12))
+    (hraSaved : csaved.ra = raIn)
+    (hret : raIn &&& ~~~(1 : Word) = raIn)
+    (halign : hdrOff lengths i % 8 = 0)
+    (hlen : hdrOff lengths i ≤ bigBytes.length)
+    (hResGu : EvmAsm.Codegen.RlpFieldToU64SAsm.Result (bigBytes.drop (hdrOff lengths i))
+      (hdrBaseAt hdrBase lengths i) lengths[i]! 10 0 gu)
+    (hprefix : ∀ j, j < i → hdrGasOk hdrBase bigBytes lengths j)
+    (htail : (∀ j, j < i + 1 → hdrGasOk hdrBase bigBytes lengths j) →
+      cpsTripleWithin nTail (D + 68) raIn fullCode
+        (LoopInv sp0 spC (spC + signExtend12 (-32 : BitVec 12)) hdrBase lenBase validPtr
+          firstBadPtr csaved bigBytes lengths (i + 1))
+        (cvgulPost sp0 spC (spC + signExtend12 (-32 : BitVec 12)) hdrBase lenBase validPtr
+          firstBadPtr csaved bigBytes lengths)) :
+    cpsTripleWithin (27 + nTail) (D + 188) raIn fullCode
+      ((.x1 ↦ᵣ LinkRA2) **
+        EvmAsm.Codegen.RlpFieldToU64SAsm.flatPost spC (spC + signExtend12 (-32 : BitVec 12))
+          (hdrBaseAt hdrBase lengths i) oldOff oldLen
+          (⟨LinkRA2, BitVec.ofNat 64 lengths.length, lenBase⟩ :
+            EvmAsm.Codegen.RlpFieldToU64SAsm.Saved)
+          (⟨EvmAsm.Codegen.RlpFieldToU64SAsm.B + 48, hdrBaseAt hdrBase lengths i, GasLimit,
+            hdrBaseAt hdrBase lengths i, validPtr, firstBadPtr, BitVec.ofNat 64 i⟩ : Saved)
+          (bigBytes.drop (hdrOff lengths i)) lengths[i]! 9 **
+        (GasUsed ↦ₘ gu) **
+        (IterPtr ↦ₘ hdrBaseAt hdrBase lengths i) ** (IterI ↦ₘ BitVec.ofNat 64 i) **
+        ((lenBase + BitVec.ofNat 64 (8 * i)) ↦ₘ BitVec.ofNat 64 lengths[i]!) **
+        wordArrayFrom lenBase 0 (lengths.take i) **
+        wordArrayFrom lenBase (i + 1) (lengths.drop (i + 1)) **
+        bytesRegion hdrBase (bigBytes.take (hdrOff lengths i)) **
+        (validPtr ↦ₘ (1 : Word)) ** (firstBadPtr ↦ₘ (0 : Word)) **
+        savedFrame spC csaved)
+      (cvgulPost sp0 spC (spC + signExtend12 (-32 : BitVec 12)) hdrBase lenBase validPtr
+        firstBadPtr csaved bigBytes lengths) := by
+  have hLi : lengths[i]! = lengths[i] := getElem!_pos lengths i hi
+  have hHB : hdrBaseAt hdrBase lengths i = hdrBase + BitVec.ofNat 64 (hdrOff lengths i) := rfl
+  have hsf : savedFrame spC csaved =
+      ((spC ↦ₘ raIn) ** ((spC + 8) ↦ₘ csaved.s0) ** ((spC + 16) ↦ₘ csaved.s1) **
+        ((spC + 24) ↦ₘ csaved.s2) ** ((spC + 32) ↦ₘ csaved.s3) **
+        ((spC + 40) ↦ₘ csaved.s4) ** ((spC + 48) ↦ₘ csaved.s5)) := by
+    unfold savedFrame; rw [hraSaved]
+  -- Normalize K34's flatPost, stripping the (status, value) existentials.
+  refine cpsTripleWithin_weaken (fun h hp => ?hstrip) (fun _ hq => hq)
+    (EvmAsm.Codegen.RlpListNthItemSAsm.cpsTripleWithin_exists_assertion (fun status =>
+      EvmAsm.Codegen.RlpListNthItemSAsm.cpsTripleWithin_exists_assertion (fun value =>
+        (show cpsTripleWithin (27 + nTail) (D + 188) raIn fullCode
+          ((.x1 ↦ᵣ LinkRA2) **
+            (dispNorm spC (spC + signExtend12 (-32 : BitVec 12)) (hdrBaseAt hdrBase lengths i)
+                validPtr firstBadPtr (BitVec.ofNat 64 lengths.length) lenBase (BitVec.ofNat 64 i)
+                LinkRA2 GasLimit value status (bigBytes.drop (hdrOff lengths i)) **
+              ⌜EvmAsm.Codegen.RlpFieldToU64SAsm.Result (bigBytes.drop (hdrOff lengths i))
+                (hdrBaseAt hdrBase lengths i) lengths[i]! 9 status value⌝) **
+            ((GasUsed ↦ₘ gu) **
+              (IterPtr ↦ₘ hdrBaseAt hdrBase lengths i) ** (IterI ↦ₘ BitVec.ofNat 64 i) **
+              ((lenBase + BitVec.ofNat 64 (8 * i)) ↦ₘ BitVec.ofNat 64 lengths[i]!) **
+              wordArrayFrom lenBase 0 (lengths.take i) **
+              wordArrayFrom lenBase (i + 1) (lengths.drop (i + 1)) **
+              bytesRegion hdrBase (bigBytes.take (hdrOff lengths i)) **
+              (validPtr ↦ₘ (1 : Word)) ** (firstBadPtr ↦ₘ (0 : Word)) **
+              savedFrame spC csaved))
+          (cvgulPost sp0 spC (spC + signExtend12 (-32 : BitVec 12)) hdrBase lenBase validPtr
+            firstBadPtr csaved bigBytes lengths) from ?core))))
+  case hstrip =>
+    obtain ⟨s1, s2, hd, hu, hx1, s3, s4, hd2, hu2, hfp, hREST⟩ := hp
+    obtain ⟨status, value, hnorm⟩ := flatPost_normalize spC (hdrBaseAt hdrBase lengths i)
+      validPtr firstBadPtr (BitVec.ofNat 64 lengths.length) lenBase (BitVec.ofNat 64 i)
+      LinkRA2 GasLimit oldOff oldLen (bigBytes.drop (hdrOff lengths i)) lengths[i]! 9 s3 hfp
+    exact ⟨status, value, s1, s2, hd, hu, hx1, s3, s4, hd2, hu2, hnorm, hREST⟩
+  case core =>
+    refine cpsTripleWithin_weaken (fun h hp => ?hpull) (fun _ hq => hq)
+      (cpsTripleWithin_pure_pre
+        (P := EvmAsm.Codegen.RlpFieldToU64SAsm.Result (bigBytes.drop (hdrOff lengths i))
+          (hdrBaseAt hdrBase lengths i) lengths[i]! 9 status value)
+        (H := (.x1 ↦ᵣ LinkRA2) ** (.x2 ↦ᵣ spC) ** (.x8 ↦ᵣ BitVec.ofNat 64 lengths.length) **
+          (.x9 ↦ᵣ lenBase) ** (.x18 ↦ᵣ hdrBaseAt hdrBase lengths i) ** (.x19 ↦ᵣ validPtr) **
+          (.x20 ↦ᵣ firstBadPtr) ** (.x21 ↦ᵣ BitVec.ofNat 64 i) ** (.x10 ↦ᵣ status) **
+          (.x0 ↦ᵣ (0 : Word)) ** (GasLimit ↦ₘ value) ** (GasUsed ↦ₘ gu) **
+          regOwn .x5 ** regOwn .x6 ** regOwn .x7 ** regOwn .x11 ** regOwn .x12 **
+          regOwn .x13 ** regOwn .x14 ** regOwn .x28 ** regOwn .x29 ** regOwn .x30 **
+          regOwn .x31 ** memOwn RfuOff ** memOwn RfuLen **
+          stackFree (spC + signExtend12 (-32 : BitVec 12)) 8 **
+          bytesRegion (hdrBaseAt hdrBase lengths i) (bigBytes.drop (hdrOff lengths i)) **
+          EvmAsm.Codegen.RlpFieldToU64SAsm.savedFrame (spC + signExtend12 (-32 : BitVec 12))
+            ⟨LinkRA2, BitVec.ofNat 64 lengths.length, lenBase⟩ **
+          (IterPtr ↦ₘ hdrBaseAt hdrBase lengths i) ** (IterI ↦ₘ BitVec.ofNat 64 i) **
+          ((lenBase + BitVec.ofNat 64 (8 * i)) ↦ₘ BitVec.ofNat 64 lengths[i]!) **
+          wordArrayFrom lenBase 0 (lengths.take i) **
+          wordArrayFrom lenBase (i + 1) (lengths.drop (i + 1)) **
+          bytesRegion hdrBase (bigBytes.take (hdrOff lengths i)) **
+          (validPtr ↦ₘ (1 : Word)) ** (firstBadPtr ↦ₘ (0 : Word)) **
+          savedFrame spC csaved)
+        (fun hResult => ?body))
+    case hpull =>
+      unfold dispNorm at hp
+      xperm_hyp hp
+    case body =>
+      rw [hsf]
+      by_cases hstatus : status = 0
+      · -- SUCCESS arm: gas-limit `bne` not taken → reload → value compare.
+        subst hstatus
+        set RframeOk : Assertion :=
+          ((.x1 ↦ᵣ LinkRA2) ** (.x2 ↦ᵣ spC) ** (.x8 ↦ᵣ BitVec.ofNat 64 lengths.length) **
+            (.x9 ↦ᵣ lenBase) ** (.x18 ↦ᵣ hdrBaseAt hdrBase lengths i) ** (.x19 ↦ᵣ validPtr) **
+            (.x20 ↦ᵣ firstBadPtr) ** (.x21 ↦ᵣ BitVec.ofNat 64 i) ** (GasLimit ↦ₘ value) **
+            (GasUsed ↦ₘ gu) **
+            regOwn .x5 ** regOwn .x6 ** regOwn .x7 ** regOwn .x11 ** regOwn .x12 **
+            regOwn .x13 ** regOwn .x14 ** regOwn .x28 ** regOwn .x29 ** regOwn .x30 **
+            regOwn .x31 ** memOwn RfuOff ** memOwn RfuLen **
+            stackFree (spC + signExtend12 (-32 : BitVec 12)) 8 **
+            bytesRegion (hdrBaseAt hdrBase lengths i) (bigBytes.drop (hdrOff lengths i)) **
+            EvmAsm.Codegen.RlpFieldToU64SAsm.savedFrame (spC + signExtend12 (-32 : BitVec 12))
+              ⟨LinkRA2, BitVec.ofNat 64 lengths.length, lenBase⟩ **
+            (IterPtr ↦ₘ hdrBaseAt hdrBase lengths i) ** (IterI ↦ₘ BitVec.ofNat 64 i) **
+            ((lenBase + BitVec.ofNat 64 (8 * i)) ↦ₘ BitVec.ofNat 64 lengths[i]!) **
+            wordArrayFrom lenBase 0 (lengths.take i) **
+            wordArrayFrom lenBase (i + 1) (lengths.drop (i + 1)) **
+            bytesRegion hdrBase (bigBytes.take (hdrOff lengths i)) **
+            (validPtr ↦ₘ (1 : Word)) ** (firstBadPtr ↦ₘ (0 : Word)) **
+            (spC ↦ₘ raIn) ** ((spC + 8) ↦ₘ csaved.s0) ** ((spC + 16) ↦ₘ csaved.s1) **
+            ((spC + 24) ↦ₘ csaved.s2) ** ((spC + 32) ↦ₘ csaved.s3) **
+            ((spC + 40) ↦ₘ csaved.s4) ** ((spC + 48) ↦ₘ csaved.s5)) with hRframeOk
+        have hbne := bne_spec_gen_within .x10 .x0 (96 : BitVec 13) (0 : Word) (0 : Word)
+          (D + 188)
+        have hbneC := cpsBranchWithin_extend_code cvgul_mono
+          (cpsBranchWithin_extend_code (cr' := cvgulCode)
+            (CodeReq.ofProg_mem_at D (D + 188) cvgulProg 47 (.BNE .x10 .x0 (96 : BitVec 13))
+              (by bv_omega) (by rw [cvgul_length]; decide) rfl
+              (by rw [cvgul_length]; decide)) hbne)
+        have hntaken := cpsBranchWithin_ntakenStripPure2 hbneC (fun hp hq => by
+          obtain ⟨_, _, _, _, _, hrest⟩ := hq
+          exact absurd rfl ((sepConj_pure_right _).1 hrest).2)
+        rw [show (D + 188 + 4 : Word) = D + 192 from by bv_omega] at hntaken
+        have hcont : cpsTripleWithin (26 + nTail) (D + 192) raIn fullCode
+            (((.x10 ↦ᵣ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word))) ** RframeOk)
+            (cvgulPost sp0 spC (spC + signExtend12 (-32 : BitVec 12)) hdrBase lenBase
+              validPtr firstBadPtr csaved bigBytes lengths) := by
+          rw [hRframeOk]
+          refine cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp) (fun _ hq => hq)
+            (show cpsTripleWithin (26 + nTail) (D + 192) raIn fullCode
+              (((.x10 ↦ᵣ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) ** (.x1 ↦ᵣ LinkRA2) **
+                (.x2 ↦ᵣ spC) ** (.x8 ↦ᵣ BitVec.ofNat 64 lengths.length) ** (.x9 ↦ᵣ lenBase) **
+                (.x18 ↦ᵣ hdrBaseAt hdrBase lengths i) ** (.x19 ↦ᵣ validPtr) **
+                (.x20 ↦ᵣ firstBadPtr) ** (.x21 ↦ᵣ BitVec.ofNat 64 i) ** (GasLimit ↦ₘ value) **
+                (GasUsed ↦ₘ gu) **
+                regOwn .x11 ** regOwn .x12 ** regOwn .x13 ** regOwn .x14 **
+                memOwn RfuOff ** memOwn RfuLen **
+                stackFree (spC + signExtend12 (-32 : BitVec 12)) 8 **
+                bytesRegion (hdrBaseAt hdrBase lengths i) (bigBytes.drop (hdrOff lengths i)) **
+                EvmAsm.Codegen.RlpFieldToU64SAsm.savedFrame (spC + signExtend12 (-32 : BitVec 12))
+                  ⟨LinkRA2, BitVec.ofNat 64 lengths.length, lenBase⟩ **
+                (IterPtr ↦ₘ hdrBaseAt hdrBase lengths i) ** (IterI ↦ₘ BitVec.ofNat 64 i) **
+                ((lenBase + BitVec.ofNat 64 (8 * i)) ↦ₘ BitVec.ofNat 64 lengths[i]!) **
+                wordArrayFrom lenBase 0 (lengths.take i) **
+                wordArrayFrom lenBase (i + 1) (lengths.drop (i + 1)) **
+                bytesRegion hdrBase (bigBytes.take (hdrOff lengths i)) **
+                (validPtr ↦ₘ (1 : Word)) ** (firstBadPtr ↦ₘ (0 : Word)) **
+                (spC ↦ₘ raIn) ** ((spC + 8) ↦ₘ csaved.s0) ** ((spC + 16) ↦ₘ csaved.s1) **
+                ((spC + 24) ↦ₘ csaved.s2) ** ((spC + 32) ↦ₘ csaved.s3) **
+                ((spC + 40) ↦ₘ csaved.s4) ** ((spC + 48) ↦ₘ csaved.s5)) **
+                regOwn .x5 ** regOwn .x6 ** regOwn .x7 ** regOwn .x28 ** regOwn .x29 **
+                regOwn .x30 ** regOwn .x31)
+              (cvgulPost sp0 spC (spC + signExtend12 (-32 : BitVec 12)) hdrBase lenBase
+                validPtr firstBadPtr csaved bigBytes lengths) from ?_)
+          refine EvmAsm.Codegen.RlpListNthItemSAsm.cpsTripleWithin_of_forall_regIs_to_regOwn7
+            (fun v5 v6 v7 v28 v29 v30 v31 => ?_)
+          set Rreload : Assertion :=
+            ((.x10 ↦ᵣ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) ** (.x1 ↦ᵣ LinkRA2) ** (.x2 ↦ᵣ spC) **
+              (.x8 ↦ᵣ BitVec.ofNat 64 lengths.length) ** (.x9 ↦ᵣ lenBase) ** (.x19 ↦ᵣ validPtr) **
+              (.x20 ↦ᵣ firstBadPtr) ** regOwn .x11 ** regOwn .x12 ** regOwn .x13 **
+              regOwn .x14 ** memOwn RfuOff ** memOwn RfuLen **
+              stackFree (spC + signExtend12 (-32 : BitVec 12)) 8 **
+              bytesRegion (hdrBaseAt hdrBase lengths i) (bigBytes.drop (hdrOff lengths i)) **
+              EvmAsm.Codegen.RlpFieldToU64SAsm.savedFrame (spC + signExtend12 (-32 : BitVec 12))
+                ⟨LinkRA2, BitVec.ofNat 64 lengths.length, lenBase⟩ **
+              ((lenBase + BitVec.ofNat 64 (8 * i)) ↦ₘ BitVec.ofNat 64 lengths[i]!) **
+              wordArrayFrom lenBase 0 (lengths.take i) **
+              wordArrayFrom lenBase (i + 1) (lengths.drop (i + 1)) **
+              bytesRegion hdrBase (bigBytes.take (hdrOff lengths i)) **
+              (validPtr ↦ₘ (1 : Word)) ** (firstBadPtr ↦ₘ (0 : Word)) **
+              (spC ↦ₘ raIn) ** ((spC + 8) ↦ₘ csaved.s0) ** ((spC + 16) ↦ₘ csaved.s1) **
+              ((spC + 24) ↦ₘ csaved.s2) ** ((spC + 32) ↦ₘ csaved.s3) **
+              ((spC + 40) ↦ₘ csaved.s4) ** ((spC + 48) ↦ₘ csaved.s5) **
+              (.x28 ↦ᵣ v28) ** (.x29 ↦ᵣ v29) ** (.x30 ↦ᵣ v30) ** (.x31 ↦ᵣ v31)) with hRreload
+          set Rstate2 : Assertion :=
+            ((.x5 ↦ᵣ GasLimit) ** (.x18 ↦ᵣ hdrBaseAt hdrBase lengths i) **
+              (.x21 ↦ᵣ BitVec.ofNat 64 i) ** (IterPtr ↦ₘ hdrBaseAt hdrBase lengths i) **
+              (IterI ↦ₘ BitVec.ofNat 64 i) ** (GasUsed ↦ₘ gu) ** (GasLimit ↦ₘ value)) **
+              Rreload with hRstate2
+          have hreload := cpsTripleWithin_extend_code cvgul_mono
+            (cvgulCompare (hdrBaseAt hdrBase lengths i) (BitVec.ofNat 64 i) gu value v5
+              (hdrBaseAt hdrBase lengths i) (BitVec.ofNat 64 i) v6 v7)
+          have hreloadF := cpsTripleWithin_frameR Rreload (by rw [hRreload]; pcfx) hreload
+          have hbltu := bltu_spec_gen_within .x7 .x6 (28 : BitVec 13) value gu (D + 240)
+          rw [show (D + 240) + signExtend13 (28 : BitVec 13) = D + 268 from by
+            rw [show signExtend13 (28 : BitVec 13) = (28 : Word) from by decide]; bv_omega] at hbltu
+          have hbltuC := cpsBranchWithin_extend_code cvgul_mono
+            (cpsBranchWithin_extend_code (cr' := cvgulCode)
+              (CodeReq.ofProg_mem_at D (D + 240) cvgulProg 60 (.BLTU .x7 .x6 (28 : BitVec 13))
+                (by bv_omega) (by rw [cvgul_length]; decide) rfl
+                (by rw [cvgul_length]; decide)) hbltu)
+          have hbltuF := cpsBranchWithin_frameR Rstate2 (by rw [hRstate2, hRreload]; pcfx) hbltuC
+          have hbranch := cpsTripleWithin_seq_cpsBranchWithin_perm_same_cr
+            (fun h hp => by rw [hRstate2]; xperm_hyp hp) hreloadF hbltuF
+          have h_t : cpsTripleWithin (13 + nTail) (D + 268) raIn fullCode
+              (((.x7 ↦ᵣ value) ** (.x6 ↦ᵣ gu) ** ⌜BitVec.ult value gu⌝) ** Rstate2)
+              (cvgulPost sp0 spC (spC + signExtend12 (-32 : BitVec 12)) hdrBase lenBase
+                validPtr firstBadPtr csaved bigBytes lengths) := by
+            rw [hRstate2, hRreload]
+            refine cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp) (fun _ hq => hq)
+              (cpsTripleWithin_pure_pre (P := BitVec.ult value gu)
+                (H := (.x7 ↦ᵣ value) ** (.x6 ↦ᵣ gu) ** (.x5 ↦ᵣ GasLimit) **
+                  (.x18 ↦ᵣ hdrBaseAt hdrBase lengths i) ** (.x21 ↦ᵣ BitVec.ofNat 64 i) **
+                  (IterPtr ↦ₘ hdrBaseAt hdrBase lengths i) ** (IterI ↦ₘ BitVec.ofNat 64 i) **
+                  (GasUsed ↦ₘ gu) ** (GasLimit ↦ₘ value) ** (.x10 ↦ᵣ (0 : Word)) **
+                  (.x0 ↦ᵣ (0 : Word)) **
+                  (.x1 ↦ᵣ LinkRA2) ** (.x2 ↦ᵣ spC) ** (.x8 ↦ᵣ BitVec.ofNat 64 lengths.length) **
+                  (.x9 ↦ᵣ lenBase) ** (.x19 ↦ᵣ validPtr) ** (.x20 ↦ᵣ firstBadPtr) **
+                  regOwn .x11 ** regOwn .x12 ** regOwn .x13 ** regOwn .x14 **
+                  memOwn RfuOff ** memOwn RfuLen **
+                  stackFree (spC + signExtend12 (-32 : BitVec 12)) 8 **
+                  bytesRegion (hdrBaseAt hdrBase lengths i) (bigBytes.drop (hdrOff lengths i)) **
+                  EvmAsm.Codegen.RlpFieldToU64SAsm.savedFrame (spC + signExtend12 (-32 : BitVec 12))
+                    ⟨LinkRA2, BitVec.ofNat 64 lengths.length, lenBase⟩ **
+                  ((lenBase + BitVec.ofNat 64 (8 * i)) ↦ₘ BitVec.ofNat 64 lengths[i]!) **
+                  wordArrayFrom lenBase 0 (lengths.take i) **
+                  wordArrayFrom lenBase (i + 1) (lengths.drop (i + 1)) **
+                  bytesRegion hdrBase (bigBytes.take (hdrOff lengths i)) **
+                  (validPtr ↦ₘ (1 : Word)) ** (firstBadPtr ↦ₘ (0 : Word)) **
+                  (spC ↦ₘ raIn) ** ((spC + 8) ↦ₘ csaved.s0) ** ((spC + 16) ↦ₘ csaved.s1) **
+                  ((spC + 24) ↦ₘ csaved.s2) ** ((spC + 32) ↦ₘ csaved.s3) **
+                  ((spC + 40) ↦ₘ csaved.s4) ** ((spC + 48) ↦ₘ csaved.s5) **
+                  (.x28 ↦ᵣ v28) ** (.x29 ↦ᵣ v29) ** (.x30 ↦ᵣ v30) ** (.x31 ↦ᵣ v31))
+                (fun hult => ?_))
+            have hviol := cpsTripleWithin_extend_code cvgul_mono
+              (retViolation sp0 spC raIn (BitVec.ofNat 64 i) validPtr firstBadPtr csaved
+                ((.x7 ↦ᵣ value) ** (.x6 ↦ᵣ gu) ** (.x5 ↦ᵣ GasLimit) **
+                  (IterPtr ↦ₘ hdrBaseAt hdrBase lengths i) ** (IterI ↦ₘ BitVec.ofNat 64 i) **
+                  (GasUsed ↦ₘ gu) ** (GasLimit ↦ₘ value) ** regOwn .x11 ** regOwn .x12 **
+                  regOwn .x13 ** regOwn .x14 ** memOwn RfuOff ** memOwn RfuLen **
+                  stackFree (spC + signExtend12 (-32 : BitVec 12)) 8 **
+                  bytesRegion (hdrBaseAt hdrBase lengths i) (bigBytes.drop (hdrOff lengths i)) **
+                  EvmAsm.Codegen.RlpFieldToU64SAsm.savedFrame (spC + signExtend12 (-32 : BitVec 12))
+                    ⟨LinkRA2, BitVec.ofNat 64 lengths.length, lenBase⟩ **
+                  ((lenBase + BitVec.ofNat 64 (8 * i)) ↦ₘ BitVec.ofNat 64 lengths[i]!) **
+                  wordArrayFrom lenBase 0 (lengths.take i) **
+                  wordArrayFrom lenBase (i + 1) (lengths.drop (i + 1)) **
+                  bytesRegion hdrBase (bigBytes.take (hdrOff lengths i)) **
+                  (.x28 ↦ᵣ v28) ** (.x29 ↦ᵣ v29) ** (.x30 ↦ᵣ v30) ** (.x31 ↦ᵣ v31))
+                (by pcfx) (0 : Word) LinkRA2 (BitVec.ofNat 64 lengths.length) lenBase
+                (hdrBaseAt hdrBase lengths i) hspC hraSaved hret)
+            refine cpsTripleWithin_weaken (fun h hp => by
+              have hp1 : ((validPtr ↦ₘ (1 : Word)) ** (firstBadPtr ↦ₘ (0 : Word)) **
+                  ((.x19 ↦ᵣ validPtr) ** (.x20 ↦ᵣ firstBadPtr) ** (.x21 ↦ᵣ BitVec.ofNat 64 i) **
+                    (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ (0 : Word)) ** (.x2 ↦ᵣ spC) **
+                    (.x1 ↦ᵣ LinkRA2) ** (.x8 ↦ᵣ BitVec.ofNat 64 lengths.length) **
+                    (.x9 ↦ᵣ lenBase) ** (.x18 ↦ᵣ hdrBaseAt hdrBase lengths i) **
+                    (spC ↦ₘ raIn) ** ((spC + 8) ↦ₘ csaved.s0) ** ((spC + 16) ↦ₘ csaved.s1) **
+                    ((spC + 24) ↦ₘ csaved.s2) ** ((spC + 32) ↦ₘ csaved.s3) **
+                    ((spC + 40) ↦ₘ csaved.s4) ** ((spC + 48) ↦ₘ csaved.s5) **
+                    ((.x7 ↦ᵣ value) ** (.x6 ↦ᵣ gu) ** (.x5 ↦ᵣ GasLimit) **
+                      (IterPtr ↦ₘ hdrBaseAt hdrBase lengths i) ** (IterI ↦ₘ BitVec.ofNat 64 i) **
+                      (GasUsed ↦ₘ gu) ** (GasLimit ↦ₘ value) ** regOwn .x11 ** regOwn .x12 **
+                      regOwn .x13 ** regOwn .x14 ** memOwn RfuOff ** memOwn RfuLen **
+                      stackFree (spC + signExtend12 (-32 : BitVec 12)) 8 **
+                      bytesRegion (hdrBaseAt hdrBase lengths i) (bigBytes.drop (hdrOff lengths i)) **
+                      EvmAsm.Codegen.RlpFieldToU64SAsm.savedFrame
+                        (spC + signExtend12 (-32 : BitVec 12))
+                        ⟨LinkRA2, BitVec.ofNat 64 lengths.length, lenBase⟩ **
+                      ((lenBase + BitVec.ofNat 64 (8 * i)) ↦ₘ BitVec.ofNat 64 lengths[i]!) **
+                      wordArrayFrom lenBase 0 (lengths.take i) **
+                      wordArrayFrom lenBase (i + 1) (lengths.drop (i + 1)) **
+                      bytesRegion hdrBase (bigBytes.take (hdrOff lengths i)) **
+                      (.x28 ↦ᵣ v28) ** (.x29 ↦ᵣ v29) ** (.x30 ↦ᵣ v30) ** (.x31 ↦ᵣ v31)))) h := by
+                xperm_hyp hp
+              have hp2 := sepConj_mono memIs_implies_memOwn
+                (sepConj_mono memIs_implies_memOwn (fun _ x => x)) h hp1
+              xperm_hyp hp2) (fun h hq => ?_)
+              (cpsTripleWithin_mono_nSteps (show 13 ≤ 13 + nTail by omega) hviol)
+            refine Or.inr (Or.inl ⟨i, ?_⟩)
+            refine (sepConj_pure_left h).mpr ⟨⟨hi, hprefix, ⟨gu, value, hResGu, hResult, hult⟩⟩, ?_⟩
+            unfold commonRet payload
+            rw [hsf, hraSaved, wordArray_split lenBase lengths i hi,
+              EvmAsm.Evm64.bytesRegion_split hdrBase bigBytes (hdrOff lengths i) halign hlen, ← hHB]
+            have hp1 : ((.x5 ↦ᵣ GasLimit) ** (.x6 ↦ᵣ gu) ** (.x7 ↦ᵣ value) **
+                (.x28 ↦ᵣ v28) ** (.x29 ↦ᵣ v29) ** (.x30 ↦ᵣ v30) ** (.x31 ↦ᵣ v31) **
+                (GasUsed ↦ₘ gu) ** (GasLimit ↦ₘ value) **
+                (IterPtr ↦ₘ hdrBaseAt hdrBase lengths i) **
+                (IterI ↦ₘ BitVec.ofNat 64 i) **
+                EvmAsm.Codegen.RlpFieldToU64SAsm.savedFrame (spC + signExtend12 (-32 : BitVec 12))
+                  ⟨LinkRA2, BitVec.ofNat 64 lengths.length, lenBase⟩ **
+                ((.x10 ↦ᵣ (0 : Word)) ** (validPtr ↦ₘ (0 : Word)) **
+                  (firstBadPtr ↦ₘ BitVec.ofNat 64 i) ** (.x1 ↦ᵣ raIn) ** (.x2 ↦ᵣ sp0) **
+                  (.x8 ↦ᵣ csaved.s0) ** (.x9 ↦ᵣ csaved.s1) ** (.x18 ↦ᵣ csaved.s2) **
+                  (.x19 ↦ᵣ csaved.s3) ** (.x20 ↦ᵣ csaved.s4) ** (.x21 ↦ᵣ csaved.s5) **
+                  (spC ↦ₘ raIn) ** ((spC + 8) ↦ₘ csaved.s0) ** ((spC + 16) ↦ₘ csaved.s1) **
+                  ((spC + 24) ↦ₘ csaved.s2) ** ((spC + 32) ↦ₘ csaved.s3) **
+                  ((spC + 40) ↦ₘ csaved.s4) ** ((spC + 48) ↦ₘ csaved.s5) **
+                  (.x0 ↦ᵣ (0 : Word)) ** regOwn .x11 ** regOwn .x12 ** regOwn .x13 **
+                  regOwn .x14 ** memOwn RfuOff ** memOwn RfuLen **
+                  stackFree (spC + signExtend12 (-32 : BitVec 12)) 8 **
+                  bytesRegion hdrBase (bigBytes.take (hdrOff lengths i)) **
+                  bytesRegion (hdrBaseAt hdrBase lengths i) (bigBytes.drop (hdrOff lengths i)) **
+                  wordArrayFrom lenBase 0 (lengths.take i) **
+                  ((lenBase + BitVec.ofNat 64 (8 * i)) ↦ₘ BitVec.ofNat 64 lengths[i]) **
+                  wordArrayFrom lenBase (i + 1) (lengths.drop (i + 1)))) h := by
+              rw [← hLi]; xperm_hyp hq
+            have hp2 := sepConj_mono (regIs_implies_regOwn .x5) (sepConj_mono
+              (regIs_implies_regOwn .x6) (sepConj_mono (regIs_implies_regOwn .x7)
+              (sepConj_mono (regIs_implies_regOwn .x28) (sepConj_mono (regIs_implies_regOwn .x29)
+              (sepConj_mono (regIs_implies_regOwn .x30) (sepConj_mono (regIs_implies_regOwn .x31)
+              (sepConj_mono memIs_implies_memOwn (sepConj_mono memIs_implies_memOwn
+              (sepConj_mono memIs_implies_memOwn (sepConj_mono memIs_implies_memOwn
+              (sepConj_mono (k34SavedFrame_implies_frameSlotsOwn _ _)
+              (fun _ x => x)))))))))))) h hp1
+            xperm_hyp hp2
+          have h_f : cpsTripleWithin (13 + nTail) (D + 244) raIn fullCode
+              (((.x7 ↦ᵣ value) ** (.x6 ↦ᵣ gu) ** ⌜¬ BitVec.ult value gu⌝) ** Rstate2)
+              (cvgulPost sp0 spC (spC + signExtend12 (-32 : BitVec 12)) hdrBase lenBase
+                validPtr firstBadPtr csaved bigBytes lengths) := by
+            rw [hRstate2, hRreload]
+            refine cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp) (fun _ hq => hq)
+              (cpsTripleWithin_pure_pre (P := ¬ BitVec.ult value gu)
+                (H := (.x7 ↦ᵣ value) ** (.x6 ↦ᵣ gu) ** (.x5 ↦ᵣ GasLimit) **
+                  (.x18 ↦ᵣ hdrBaseAt hdrBase lengths i) ** (.x21 ↦ᵣ BitVec.ofNat 64 i) **
+                  (IterPtr ↦ₘ hdrBaseAt hdrBase lengths i) ** (IterI ↦ₘ BitVec.ofNat 64 i) **
+                  (GasUsed ↦ₘ gu) ** (GasLimit ↦ₘ value) ** (.x10 ↦ᵣ (0 : Word)) **
+                  (.x0 ↦ᵣ (0 : Word)) **
+                  (.x1 ↦ᵣ LinkRA2) ** (.x2 ↦ᵣ spC) ** (.x8 ↦ᵣ BitVec.ofNat 64 lengths.length) **
+                  (.x9 ↦ᵣ lenBase) ** (.x19 ↦ᵣ validPtr) ** (.x20 ↦ᵣ firstBadPtr) **
+                  regOwn .x11 ** regOwn .x12 ** regOwn .x13 ** regOwn .x14 **
+                  memOwn RfuOff ** memOwn RfuLen **
+                  stackFree (spC + signExtend12 (-32 : BitVec 12)) 8 **
+                  bytesRegion (hdrBaseAt hdrBase lengths i) (bigBytes.drop (hdrOff lengths i)) **
+                  EvmAsm.Codegen.RlpFieldToU64SAsm.savedFrame (spC + signExtend12 (-32 : BitVec 12))
+                    ⟨LinkRA2, BitVec.ofNat 64 lengths.length, lenBase⟩ **
+                  ((lenBase + BitVec.ofNat 64 (8 * i)) ↦ₘ BitVec.ofNat 64 lengths[i]!) **
+                  wordArrayFrom lenBase 0 (lengths.take i) **
+                  wordArrayFrom lenBase (i + 1) (lengths.drop (i + 1)) **
+                  bytesRegion hdrBase (bigBytes.take (hdrOff lengths i)) **
+                  (validPtr ↦ₘ (1 : Word)) ** (firstBadPtr ↦ₘ (0 : Word)) **
+                  (spC ↦ₘ raIn) ** ((spC + 8) ↦ₘ csaved.s0) ** ((spC + 16) ↦ₘ csaved.s1) **
+                  ((spC + 24) ↦ₘ csaved.s2) ** ((spC + 32) ↦ₘ csaved.s3) **
+                  ((spC + 40) ↦ₘ csaved.s4) ** ((spC + 48) ↦ₘ csaved.s5) **
+                  (.x28 ↦ᵣ v28) ** (.x29 ↦ᵣ v29) ** (.x30 ↦ᵣ v30) ** (.x31 ↦ᵣ v31))
+                (fun hnult => ?_))
+            have hprefix' : ∀ j, j < i + 1 → hdrGasOk hdrBase bigBytes lengths j := by
+              intro j hj
+              rcases (by omega : j < i ∨ j = i) with hlt | heq
+              · exact hprefix j hlt
+              · subst heq; exact ⟨gu, value, hResGu, hResult, hnult⟩
+            have hadv := cpsTripleWithin_extend_code cvgul_mono
+              (cvgulAdvance (hdrBaseAt hdrBase lengths i) lenBase (BitVec.ofNat 64 i)
+                lengths[i]! v28 v29)
+            rw [shiftLeft3_ofNat i] at hadv
+            have hadvF := cpsTripleWithin_frameR
+              ((.x7 ↦ᵣ value) ** (.x6 ↦ᵣ gu) ** (.x5 ↦ᵣ GasLimit) **
+                (IterPtr ↦ₘ hdrBaseAt hdrBase lengths i) ** (IterI ↦ₘ BitVec.ofNat 64 i) **
+                (GasUsed ↦ₘ gu) ** (GasLimit ↦ₘ value) ** (.x10 ↦ᵣ (0 : Word)) **
+                (.x0 ↦ᵣ (0 : Word)) **
+                (.x1 ↦ᵣ LinkRA2) ** (.x2 ↦ᵣ spC) ** (.x8 ↦ᵣ BitVec.ofNat 64 lengths.length) **
+                (.x19 ↦ᵣ validPtr) ** (.x20 ↦ᵣ firstBadPtr) ** regOwn .x11 ** regOwn .x12 **
+                regOwn .x13 ** regOwn .x14 ** memOwn RfuOff ** memOwn RfuLen **
+                stackFree (spC + signExtend12 (-32 : BitVec 12)) 8 **
+                bytesRegion (hdrBaseAt hdrBase lengths i) (bigBytes.drop (hdrOff lengths i)) **
+                EvmAsm.Codegen.RlpFieldToU64SAsm.savedFrame (spC + signExtend12 (-32 : BitVec 12))
+                  ⟨LinkRA2, BitVec.ofNat 64 lengths.length, lenBase⟩ **
+                wordArrayFrom lenBase 0 (lengths.take i) **
+                wordArrayFrom lenBase (i + 1) (lengths.drop (i + 1)) **
+                bytesRegion hdrBase (bigBytes.take (hdrOff lengths i)) **
+                (validPtr ↦ₘ (1 : Word)) ** (firstBadPtr ↦ₘ (0 : Word)) **
+                (spC ↦ₘ raIn) ** ((spC + 8) ↦ₘ csaved.s0) ** ((spC + 16) ↦ₘ csaved.s1) **
+                ((spC + 24) ↦ₘ csaved.s2) ** ((spC + 32) ↦ₘ csaved.s3) **
+                ((spC + 40) ↦ₘ csaved.s4) ** ((spC + 48) ↦ₘ csaved.s5) **
+                (.x30 ↦ᵣ v30) ** (.x31 ↦ᵣ v31)) (by pcfx) hadv
+            refine cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp) (fun _ hq => hq)
+              (cpsTripleWithin_mono_nSteps (show 6 + nTail ≤ 13 + nTail by omega)
+                (cpsTripleWithin_seq_perm_same_cr (fun h hp => by
+                  unfold LoopInv payload scratchRegs
+                  rw [hsf, wordArray_split lenBase lengths i hi,
+                    EvmAsm.Evm64.bytesRegion_split hdrBase bigBytes (hdrOff lengths i) halign hlen,
+                    ← hHB, hdrBaseAt_succ hdrBase lengths i hi, ← ofNat_succ_tie i, ← hLi]
+                  have hp1 : ((.x1 ↦ᵣ LinkRA2) ** (.x5 ↦ᵣ GasLimit) ** (.x6 ↦ᵣ gu) **
+                      (.x7 ↦ᵣ value) ** (.x10 ↦ᵣ (0 : Word)) **
+                      (.x28 ↦ᵣ (lenBase + BitVec.ofNat 64 (8 * i))) **
+                      (.x29 ↦ᵣ BitVec.ofNat 64 lengths[i]!) ** (.x30 ↦ᵣ v30) ** (.x31 ↦ᵣ v31) **
+                      (GasUsed ↦ₘ gu) ** (GasLimit ↦ₘ value) **
+                      (IterPtr ↦ₘ hdrBaseAt hdrBase lengths i) **
+                      (IterI ↦ₘ BitVec.ofNat 64 i) **
+                      EvmAsm.Codegen.RlpFieldToU64SAsm.savedFrame
+                        (spC + signExtend12 (-32 : BitVec 12))
+                        ⟨LinkRA2, BitVec.ofNat 64 lengths.length, lenBase⟩ **
+                      ((.x2 ↦ᵣ spC) ** (.x8 ↦ᵣ BitVec.ofNat 64 lengths.length) **
+                        (.x9 ↦ᵣ lenBase) **
+                        (.x18 ↦ᵣ (hdrBaseAt hdrBase lengths i + BitVec.ofNat 64 lengths[i]!)) **
+                        (.x19 ↦ᵣ validPtr) ** (.x20 ↦ᵣ firstBadPtr) **
+                        (.x21 ↦ᵣ (BitVec.ofNat 64 i + signExtend12 (1 : BitVec 12))) **
+                        (validPtr ↦ₘ (1 : Word)) ** (firstBadPtr ↦ₘ (0 : Word)) **
+                        (spC ↦ₘ raIn) ** ((spC + 8) ↦ₘ csaved.s0) ** ((spC + 16) ↦ₘ csaved.s1) **
+                        ((spC + 24) ↦ₘ csaved.s2) ** ((spC + 32) ↦ₘ csaved.s3) **
+                        ((spC + 40) ↦ₘ csaved.s4) ** ((spC + 48) ↦ₘ csaved.s5) **
+                        regOwn .x11 ** regOwn .x12 ** regOwn .x13 ** regOwn .x14 **
+                        (.x0 ↦ᵣ (0 : Word)) ** memOwn RfuOff ** memOwn RfuLen **
+                        stackFree (spC + signExtend12 (-32 : BitVec 12)) 8 **
+                        wordArrayFrom lenBase 0 (lengths.take i) **
+                        ((lenBase + BitVec.ofNat 64 (8 * i)) ↦ₘ BitVec.ofNat 64 lengths[i]!) **
+                        wordArrayFrom lenBase (i + 1) (lengths.drop (i + 1)) **
+                        bytesRegion hdrBase (bigBytes.take (hdrOff lengths i)) **
+                        bytesRegion (hdrBaseAt hdrBase lengths i)
+                          (bigBytes.drop (hdrOff lengths i)))) h := by
+                    xperm_hyp hp
+                  have hp2 := sepConj_mono (regIs_implies_regOwn .x1) (sepConj_mono
+                    (regIs_implies_regOwn .x5) (sepConj_mono (regIs_implies_regOwn .x6)
+                    (sepConj_mono (regIs_implies_regOwn .x7) (sepConj_mono (regIs_implies_regOwn .x10)
+                    (sepConj_mono (regIs_implies_regOwn .x28) (sepConj_mono (regIs_implies_regOwn .x29)
+                    (sepConj_mono (regIs_implies_regOwn .x30) (sepConj_mono (regIs_implies_regOwn .x31)
+                    (sepConj_mono memIs_implies_memOwn (sepConj_mono memIs_implies_memOwn
+                    (sepConj_mono memIs_implies_memOwn (sepConj_mono memIs_implies_memOwn
+                    (sepConj_mono (k34SavedFrame_implies_frameSlotsOwn _ _)
+                    (fun _ x => x)))))))))))))) h hp1
+                  xperm_hyp hp2) hadvF (htail hprefix')))
+          refine cpsTripleWithin_weaken (fun h hp => by rw [hRreload]; xperm_hyp hp)
+            (fun _ hq => hq)
+            (cpsTripleWithin_mono_nSteps (show 12 + 1 + (13 + nTail) ≤ 26 + nTail by omega)
+              (cpsBranchWithin_merge_same_cr hbranch h_t h_f))
+        have hntakenF := cpsTripleWithin_frameR RframeOk (by rw [hRframeOk]; pcfx) hntaken
+        refine cpsTripleWithin_weaken (fun h hp => by rw [hRframeOk]; xperm_hyp hp)
+          (fun _ hq => hq)
+          (cpsTripleWithin_mono_nSteps (show 1 + (26 + nTail) ≤ 27 + nTail by omega)
+            (cpsTripleWithin_seq_perm_same_cr (fun _ hp => hp) hntakenF hcont))
+      · -- PARSE-FAIL arm (gas_limit): `bne` taken → status ≠ 0 exit.
+        have hbne := bne_spec_gen_within .x10 .x0 (96 : BitVec 13) status (0 : Word) (D + 188)
+        have hbneC := cpsBranchWithin_extend_code cvgul_mono
+          (cpsBranchWithin_extend_code (cr' := cvgulCode)
+            (CodeReq.ofProg_mem_at D (D + 188) cvgulProg 47 (.BNE .x10 .x0 (96 : BitVec 13))
+              (by bv_omega) (by rw [cvgul_length]; decide) rfl
+              (by rw [cvgul_length]; decide)) hbne)
+        have htaken := cpsBranchWithin_takenStripPure2 hbneC (fun hp hq => by
+          obtain ⟨_, _, _, _, _, hrest⟩ := hq
+          exact absurd ((sepConj_pure_right _).1 hrest).2 hstatus)
+        rw [show (D + 188) + signExtend13 (96 : BitVec 13) = D + 284 from by
+          rw [show signExtend13 (96 : BitVec 13) = (96 : Word) from by decide]; bv_omega] at htaken
+        have htakenF := cpsTripleWithin_frameR
+          ((.x1 ↦ᵣ LinkRA2) ** (.x2 ↦ᵣ spC) ** (.x8 ↦ᵣ BitVec.ofNat 64 lengths.length) **
+            (.x9 ↦ᵣ lenBase) ** (.x18 ↦ᵣ hdrBaseAt hdrBase lengths i) ** (.x19 ↦ᵣ validPtr) **
+            (.x20 ↦ᵣ firstBadPtr) ** (.x21 ↦ᵣ BitVec.ofNat 64 i) ** (GasLimit ↦ₘ value) **
+            (GasUsed ↦ₘ gu) **
+            regOwn .x5 ** regOwn .x6 ** regOwn .x7 ** regOwn .x11 ** regOwn .x12 **
+            regOwn .x13 ** regOwn .x14 ** regOwn .x28 ** regOwn .x29 ** regOwn .x30 **
+            regOwn .x31 ** memOwn RfuOff ** memOwn RfuLen **
+            stackFree (spC + signExtend12 (-32 : BitVec 12)) 8 **
+            bytesRegion (hdrBaseAt hdrBase lengths i) (bigBytes.drop (hdrOff lengths i)) **
+            EvmAsm.Codegen.RlpFieldToU64SAsm.savedFrame (spC + signExtend12 (-32 : BitVec 12))
+              ⟨LinkRA2, BitVec.ofNat 64 lengths.length, lenBase⟩ **
+            (IterPtr ↦ₘ hdrBaseAt hdrBase lengths i) ** (IterI ↦ₘ BitVec.ofNat 64 i) **
+            ((lenBase + BitVec.ofNat 64 (8 * i)) ↦ₘ BitVec.ofNat 64 lengths[i]!) **
+            wordArrayFrom lenBase 0 (lengths.take i) **
+            wordArrayFrom lenBase (i + 1) (lengths.drop (i + 1)) **
+            bytesRegion hdrBase (bigBytes.take (hdrOff lengths i)) **
+            (validPtr ↦ₘ (1 : Word)) ** (firstBadPtr ↦ₘ (0 : Word)) **
+            (spC ↦ₘ raIn) ** ((spC + 8) ↦ₘ csaved.s0) ** ((spC + 16) ↦ₘ csaved.s1) **
+            ((spC + 24) ↦ₘ csaved.s2) ** ((spC + 32) ↦ₘ csaved.s3) **
+            ((spC + 40) ↦ₘ csaved.s4) ** ((spC + 48) ↦ₘ csaved.s5)) (by pcfx) htaken
+        have hpfC := cpsTripleWithin_extend_code cvgul_mono
+          (retParseFail sp0 spC raIn (BitVec.ofNat 64 i) firstBadPtr csaved
+            ((.x0 ↦ᵣ (0 : Word)) ** regOwn .x5 ** regOwn .x6 ** regOwn .x7 ** regOwn .x11 **
+              regOwn .x12 ** regOwn .x13 ** regOwn .x14 ** regOwn .x28 ** regOwn .x29 **
+              regOwn .x30 ** regOwn .x31 ** (GasLimit ↦ₘ value) ** (GasUsed ↦ₘ gu) **
+              memOwn RfuOff ** memOwn RfuLen **
+              stackFree (spC + signExtend12 (-32 : BitVec 12)) 8 **
+              bytesRegion (hdrBaseAt hdrBase lengths i) (bigBytes.drop (hdrOff lengths i)) **
+              EvmAsm.Codegen.RlpFieldToU64SAsm.savedFrame (spC + signExtend12 (-32 : BitVec 12))
+                ⟨LinkRA2, BitVec.ofNat 64 lengths.length, lenBase⟩ **
+              (IterPtr ↦ₘ hdrBaseAt hdrBase lengths i) ** (IterI ↦ₘ BitVec.ofNat 64 i) **
+              ((lenBase + BitVec.ofNat 64 (8 * i)) ↦ₘ BitVec.ofNat 64 lengths[i]!) **
+              wordArrayFrom lenBase 0 (lengths.take i) **
+              wordArrayFrom lenBase (i + 1) (lengths.drop (i + 1)) **
+              bytesRegion hdrBase (bigBytes.take (hdrOff lengths i)) ** (validPtr ↦ₘ (1 : Word)))
+            (by pcfx) LinkRA2 (BitVec.ofNat 64 lengths.length) lenBase
+            (hdrBaseAt hdrBase lengths i) validPtr status hspC hraSaved hret)
+        have hcompose := cpsTripleWithin_seq_perm_same_cr (fun h hp => by
+          have hp1 : ((firstBadPtr ↦ₘ (0 : Word)) **
+              ((.x20 ↦ᵣ firstBadPtr) ** (.x21 ↦ᵣ BitVec.ofNat 64 i) ** (.x10 ↦ᵣ status) **
+                (.x2 ↦ᵣ spC) ** (.x1 ↦ᵣ LinkRA2) ** (.x8 ↦ᵣ BitVec.ofNat 64 lengths.length) **
+                (.x9 ↦ᵣ lenBase) ** (.x18 ↦ᵣ hdrBaseAt hdrBase lengths i) ** (.x19 ↦ᵣ validPtr) **
+                (spC ↦ₘ raIn) ** ((spC + 8) ↦ₘ csaved.s0) ** ((spC + 16) ↦ₘ csaved.s1) **
+                ((spC + 24) ↦ₘ csaved.s2) ** ((spC + 32) ↦ₘ csaved.s3) **
+                ((spC + 40) ↦ₘ csaved.s4) ** ((spC + 48) ↦ₘ csaved.s5) **
+                ((.x0 ↦ᵣ (0 : Word)) ** regOwn .x5 ** regOwn .x6 ** regOwn .x7 ** regOwn .x11 **
+                  regOwn .x12 ** regOwn .x13 ** regOwn .x14 ** regOwn .x28 ** regOwn .x29 **
+                  regOwn .x30 ** regOwn .x31 ** (GasLimit ↦ₘ value) ** (GasUsed ↦ₘ gu) **
+                  memOwn RfuOff ** memOwn RfuLen **
+                  stackFree (spC + signExtend12 (-32 : BitVec 12)) 8 **
+                  bytesRegion (hdrBaseAt hdrBase lengths i) (bigBytes.drop (hdrOff lengths i)) **
+                  EvmAsm.Codegen.RlpFieldToU64SAsm.savedFrame (spC + signExtend12 (-32 : BitVec 12))
+                    ⟨LinkRA2, BitVec.ofNat 64 lengths.length, lenBase⟩ **
+                  (IterPtr ↦ₘ hdrBaseAt hdrBase lengths i) ** (IterI ↦ₘ BitVec.ofNat 64 i) **
+                  ((lenBase + BitVec.ofNat 64 (8 * i)) ↦ₘ BitVec.ofNat 64 lengths[i]!) **
+                  wordArrayFrom lenBase 0 (lengths.take i) **
+                  wordArrayFrom lenBase (i + 1) (lengths.drop (i + 1)) **
+                  bytesRegion hdrBase (bigBytes.take (hdrOff lengths i)) **
+                  (validPtr ↦ₘ (1 : Word))))) h := by xperm_hyp hp
+          have hp2 := sepConj_mono_left memIs_implies_memOwn h hp1
+          xperm_hyp hp2) htakenF hpfC
+        refine cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp) (fun h hq => ?_)
+          (cpsTripleWithin_mono_nSteps (show 1 + 11 ≤ 27 + nTail by omega) hcompose)
+        refine Or.inr (Or.inr ⟨i, status, ?_⟩)
+        refine (sepConj_pure_left h).mpr
+          ⟨⟨hi, hprefix, Or.inr ⟨gu, value, hResGu, hResult, hstatus⟩⟩, ?_⟩
+        unfold commonRet payload
+        rw [hsf, hraSaved, wordArray_split lenBase lengths i hi,
+          EvmAsm.Evm64.bytesRegion_split hdrBase bigBytes (hdrOff lengths i) halign hlen, ← hHB]
+        have hp1 : ((GasLimit ↦ₘ value) ** (GasUsed ↦ₘ gu) **
+            (IterPtr ↦ₘ hdrBaseAt hdrBase lengths i) **
+            (IterI ↦ₘ BitVec.ofNat 64 i) **
+            EvmAsm.Codegen.RlpFieldToU64SAsm.savedFrame (spC + signExtend12 (-32 : BitVec 12))
+              ⟨LinkRA2, BitVec.ofNat 64 lengths.length, lenBase⟩ **
+            ((.x10 ↦ᵣ status) ** (validPtr ↦ₘ (1 : Word)) **
+              (firstBadPtr ↦ₘ BitVec.ofNat 64 i) ** (.x1 ↦ᵣ raIn) ** (.x2 ↦ᵣ sp0) **
+              (.x8 ↦ᵣ csaved.s0) ** (.x9 ↦ᵣ csaved.s1) ** (.x18 ↦ᵣ csaved.s2) **
+              (.x19 ↦ᵣ csaved.s3) ** (.x20 ↦ᵣ csaved.s4) ** (.x21 ↦ᵣ csaved.s5) **
+              (spC ↦ₘ raIn) ** ((spC + 8) ↦ₘ csaved.s0) ** ((spC + 16) ↦ₘ csaved.s1) **
+              ((spC + 24) ↦ₘ csaved.s2) ** ((spC + 32) ↦ₘ csaved.s3) **
+              ((spC + 40) ↦ₘ csaved.s4) ** ((spC + 48) ↦ₘ csaved.s5) **
+              (.x0 ↦ᵣ (0 : Word)) ** regOwn .x5 ** regOwn .x6 ** regOwn .x7 ** regOwn .x11 **
+              regOwn .x12 ** regOwn .x13 ** regOwn .x14 ** regOwn .x28 ** regOwn .x29 **
+              regOwn .x30 ** regOwn .x31 ** memOwn RfuOff ** memOwn RfuLen **
+              stackFree (spC + signExtend12 (-32 : BitVec 12)) 8 **
+              bytesRegion hdrBase (bigBytes.take (hdrOff lengths i)) **
+              bytesRegion (hdrBaseAt hdrBase lengths i) (bigBytes.drop (hdrOff lengths i)) **
+              wordArrayFrom lenBase 0 (lengths.take i) **
+              ((lenBase + BitVec.ofNat 64 (8 * i)) ↦ₘ BitVec.ofNat 64 lengths[i]) **
+              wordArrayFrom lenBase (i + 1) (lengths.drop (i + 1)))) h := by
+          rw [← hLi]; xperm_hyp hq
+        have hp2 := sepConj_mono memIs_implies_memOwn (sepConj_mono memIs_implies_memOwn
+          (sepConj_mono memIs_implies_memOwn (sepConj_mono memIs_implies_memOwn
+          (sepConj_mono (k34SavedFrame_implies_frameSlotsOwn _ _) (fun _ x => x))))) h hp1
+        xperm_hyp hp2
+
+#print axioms cvgulDispatch2
+
+end EvmAsm.Codegen.ChainValidateGasUsedUnderLimitSpec

--- a/EvmAsm/Codegen/Programs/ChainValidateGasUsedUnderLimitLoopClose.lean
+++ b/EvmAsm/Codegen/Programs/ChainValidateGasUsedUnderLimitLoopClose.lean
@@ -1031,4 +1031,101 @@ theorem cvgulDispatch1
 
 #print axioms cvgulDispatch1
 
+/-! ## One full iteration: guard → call 1 → dispatch 1 (`D+68 → raIn`, `i < N`)
+
+    Shapes `LoopInv i` into `cvgulIterEntry`'s split precondition (splitting the
+    arrays and peeling the four K34 scratch cells to arbitrary incumbents), runs
+    the entry half to K34's first `flatPost`, then the two-call dispatch. -/
+
+set_option maxRecDepth 8000 in
+theorem cvgulIter (sp0 spC hdrBase lenBase validPtr firstBadPtr raIn : Word)
+    (csaved : Saved) (bigBytes : List (BitVec 8)) (lengths : List Nat) (i nTail : Nat)
+    (hi : i < lengths.length)
+    (hN : lengths.length < 2 ^ 64)
+    (hspC : spC = sp0 + signExtend12 (-56 : BitVec 12))
+    (hraSaved : csaved.ra = raIn)
+    (hret : raIn &&& ~~~(1 : Word) = raIn)
+    (halign : hdrOff lengths i % 8 = 0)
+    (hlen : hdrOff lengths i ≤ bigBytes.length)
+    (hsalign : (hdrBaseAt hdrBase lengths i).toNat % 8 = 0)
+    (hslack : lengths[i]! + 9 ≤ (bigBytes.drop (hdrOff lengths i)).length)
+    (hover : (hdrBaseAt hdrBase lengths i).toNat +
+      (bigBytes.drop (hdrOff lengths i)).length < 2 ^ 64)
+    (hvalid : ∀ k, k < (bigBytes.drop (hdrOff lengths i)).length →
+      isValidByteAccess (hdrBaseAt hdrBase lengths i + BitVec.ofNat 64 k) = true)
+    (hprefix : ∀ j, j < i → hdrGasOk hdrBase bigBytes lengths j)
+    (htail : (∀ j, j < i + 1 → hdrGasOk hdrBase bigBytes lengths j) →
+      cpsTripleWithin nTail (D + 68) raIn fullCode
+        (LoopInv sp0 spC (spC + signExtend12 (-32 : BitVec 12)) hdrBase lenBase validPtr
+          firstBadPtr csaved bigBytes lengths (i + 1))
+        (cvgulPost sp0 spC (spC + signExtend12 (-32 : BitVec 12)) hdrBase lenBase validPtr
+          firstBadPtr csaved bigBytes lengths)) :
+    cpsTripleWithin ((1 + (13 + 1 + nCall 10)) +
+        (1 + ((13 + 1 + nCall 9) + (27 + nTail)))) (D + 68) raIn fullCode
+      (LoopInv sp0 spC (spC + signExtend12 (-32 : BitVec 12)) hdrBase lenBase validPtr
+        firstBadPtr csaved bigBytes lengths i)
+      (cvgulPost sp0 spC (spC + signExtend12 (-32 : BitVec 12)) hdrBase lenBase validPtr
+        firstBadPtr csaved bigBytes lengths) := by
+  have hLi : lengths[i]! = lengths[i] := getElem!_pos lengths i hi
+  have hHB : hdrBaseAt hdrBase lengths i = hdrBase + BitVec.ofNat 64 (hdrOff lengths i) := rfl
+  set EBody : Assertion :=
+    ((.x2 ↦ᵣ spC) ** (.x8 ↦ᵣ BitVec.ofNat 64 lengths.length) ** (.x9 ↦ᵣ lenBase) **
+      (.x18 ↦ᵣ hdrBaseAt hdrBase lengths i) ** (.x19 ↦ᵣ validPtr) ** (.x20 ↦ᵣ firstBadPtr) **
+      (.x21 ↦ᵣ BitVec.ofNat 64 i) ** savedFrame spC csaved ** (validPtr ↦ₘ (1 : Word)) **
+      (firstBadPtr ↦ₘ (0 : Word)) ** wordArrayFrom lenBase 0 (lengths.take i) **
+      ((lenBase + BitVec.ofNat 64 (8 * i)) ↦ₘ BitVec.ofNat 64 lengths[i]!) **
+      wordArrayFrom lenBase (i + 1) (lengths.drop (i + 1)) **
+      bytesRegion hdrBase (bigBytes.take (hdrOff lengths i)) **
+      bytesRegion (hdrBaseAt hdrBase lengths i) (bigBytes.drop (hdrOff lengths i)) **
+      memOwn IterPtr ** memOwn IterI ** regOwn .x1 ** regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+      regOwn .x10 ** regOwn .x11 ** regOwn .x12 ** regOwn .x13 ** regOwn .x14 ** regOwn .x28 **
+      regOwn .x29 ** regOwn .x30 ** regOwn .x31 ** (.x0 ↦ᵣ (0 : Word)) **
+      frameSlotsOwn EvmAsm.Codegen.RlpFieldToU64SAsm.frame (spC + signExtend12 (-32 : BitVec 12)) **
+      stackFree (spC + signExtend12 (-32 : BitVec 12)) 8) with hEBody
+  refine cpsTripleWithin_weaken (fun h hp => by
+    unfold LoopInv payload scratchRegs at hp
+    rw [wordArray_split lenBase lengths i hi,
+      EvmAsm.Evm64.bytesRegion_split hdrBase bigBytes (hdrOff lengths i) halign hlen,
+      ← hHB, ← hLi] at hp
+    rw [hEBody]; xperm_hyp hp) (fun _ hq => hq)
+    (show cpsTripleWithin ((1 + (13 + 1 + nCall 10)) +
+        (1 + ((13 + 1 + nCall 9) + (27 + nTail)))) (D + 68) raIn fullCode
+      ((((EBody ** memOwn GasUsed) ** memOwn GasLimit) ** memOwn RfuOff) ** memOwn RfuLen)
+      (cvgulPost sp0 spC (spC + signExtend12 (-32 : BitVec 12)) hdrBase lenBase validPtr
+        firstBadPtr csaved bigBytes lengths) from ?_)
+  refine cpsTripleWithin_of_forall_memIs_to_memOwn (fun oldLen => ?_)
+  refine cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp) (fun _ hq => hq)
+    (show cpsTripleWithin ((1 + (13 + 1 + nCall 10)) +
+        (1 + ((13 + 1 + nCall 9) + (27 + nTail)))) (D + 68) raIn fullCode
+      ((((EBody ** (RfuLen ↦ₘ oldLen)) ** memOwn GasUsed) ** memOwn GasLimit) ** memOwn RfuOff)
+      (cvgulPost sp0 spC (spC + signExtend12 (-32 : BitVec 12)) hdrBase lenBase validPtr
+        firstBadPtr csaved bigBytes lengths) from ?_)
+  refine cpsTripleWithin_of_forall_memIs_to_memOwn (fun oldOff => ?_)
+  refine cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp) (fun _ hq => hq)
+    (show cpsTripleWithin ((1 + (13 + 1 + nCall 10)) +
+        (1 + ((13 + 1 + nCall 9) + (27 + nTail)))) (D + 68) raIn fullCode
+      ((((EBody ** (RfuLen ↦ₘ oldLen)) ** (RfuOff ↦ₘ oldOff)) ** memOwn GasUsed) **
+        memOwn GasLimit)
+      (cvgulPost sp0 spC (spC + signExtend12 (-32 : BitVec 12)) hdrBase lenBase validPtr
+        firstBadPtr csaved bigBytes lengths) from ?_)
+  refine cpsTripleWithin_of_forall_memIs_to_memOwn (fun oldLimit => ?_)
+  refine cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp) (fun _ hq => hq)
+    (show cpsTripleWithin ((1 + (13 + 1 + nCall 10)) +
+        (1 + ((13 + 1 + nCall 9) + (27 + nTail)))) (D + 68) raIn fullCode
+      ((((EBody ** (RfuLen ↦ₘ oldLen)) ** (RfuOff ↦ₘ oldOff)) ** (GasLimit ↦ₘ oldLimit)) **
+        memOwn GasUsed)
+      (cvgulPost sp0 spC (spC + signExtend12 (-32 : BitVec 12)) hdrBase lenBase validPtr
+        firstBadPtr csaved bigBytes lengths) from ?_)
+  refine cpsTripleWithin_of_forall_memIs_to_memOwn (fun oldOut => ?_)
+  refine cpsTripleWithin_weaken (fun h hp => by rw [hEBody] at hp; xperm_hyp hp)
+    (fun _ hq => hq)
+    (cpsTripleWithin_seq_same_cr
+      (cvgulIterEntry spC hdrBase lenBase validPtr firstBadPtr csaved bigBytes lengths i
+        oldOut oldLimit oldOff oldLen hi hN hsalign hslack hover hvalid)
+      (cvgulDispatch1 sp0 spC hdrBase lenBase validPtr firstBadPtr raIn csaved bigBytes lengths i
+        oldOff oldLen oldLimit nTail hi hspC hraSaved hret halign hlen hsalign hslack hover
+        hvalid hprefix htail))
+
+#print axioms cvgulIter
+
 end EvmAsm.Codegen.ChainValidateGasUsedUnderLimitSpec

--- a/EvmAsm/Codegen/Programs/ChainValidateGasUsedUnderLimitLoopClose.lean
+++ b/EvmAsm/Codegen/Programs/ChainValidateGasUsedUnderLimitLoopClose.lean
@@ -694,4 +694,341 @@ theorem cvgulCall2Owned (hbi lenBase spC iW : Word) (Li : Nat)
 
 #print axioms cvgulCall2Owned
 
+/-! ## Dispatch from the first call (`D+128` onward): gas-used status + call 2
+
+    From K34's field-10 `flatPost` at the first return site (`D+128`).  Normalize
+    the callee return, `bne x10, x0` on the gas-used status: taken → parse-fail
+    exit (field-10 status ≠ 0); not-taken (gas_used decoded to `gu`) → the second
+    K34 call (`cvgulCall2Owned`) followed by `cvgulDispatch2` for the gas-limit
+    field. -/
+set_option maxRecDepth 8000 in
+theorem cvgulDispatch1
+    (sp0 spC hdrBase lenBase validPtr firstBadPtr raIn : Word)
+    (csaved : Saved) (bigBytes : List (BitVec 8)) (lengths : List Nat) (i : Nat)
+    (oldOff oldLen oldLimit : Word) (nTail : Nat)
+    (hi : i < lengths.length)
+    (hspC : spC = sp0 + signExtend12 (-56 : BitVec 12))
+    (hraSaved : csaved.ra = raIn)
+    (hret : raIn &&& ~~~(1 : Word) = raIn)
+    (halign : hdrOff lengths i % 8 = 0)
+    (hlen : hdrOff lengths i ≤ bigBytes.length)
+    (hsalign : (hdrBaseAt hdrBase lengths i).toNat % 8 = 0)
+    (hslack : lengths[i]! + 9 ≤ (bigBytes.drop (hdrOff lengths i)).length)
+    (hover : (hdrBaseAt hdrBase lengths i).toNat +
+      (bigBytes.drop (hdrOff lengths i)).length < 2 ^ 64)
+    (hvalid : ∀ k, k < (bigBytes.drop (hdrOff lengths i)).length →
+      isValidByteAccess (hdrBaseAt hdrBase lengths i + BitVec.ofNat 64 k) = true)
+    (hprefix : ∀ j, j < i → hdrGasOk hdrBase bigBytes lengths j)
+    (htail : (∀ j, j < i + 1 → hdrGasOk hdrBase bigBytes lengths j) →
+      cpsTripleWithin nTail (D + 68) raIn fullCode
+        (LoopInv sp0 spC (spC + signExtend12 (-32 : BitVec 12)) hdrBase lenBase validPtr
+          firstBadPtr csaved bigBytes lengths (i + 1))
+        (cvgulPost sp0 spC (spC + signExtend12 (-32 : BitVec 12)) hdrBase lenBase validPtr
+          firstBadPtr csaved bigBytes lengths)) :
+    cpsTripleWithin (1 + ((13 + 1 + nCall 9) + (27 + nTail))) (D + 128) raIn fullCode
+      ((.x1 ↦ᵣ LinkRA1) **
+        EvmAsm.Codegen.RlpFieldToU64SAsm.flatPost spC (spC + signExtend12 (-32 : BitVec 12))
+          (hdrBaseAt hdrBase lengths i) oldOff oldLen
+          (⟨LinkRA1, BitVec.ofNat 64 lengths.length, lenBase⟩ :
+            EvmAsm.Codegen.RlpFieldToU64SAsm.Saved)
+          (⟨EvmAsm.Codegen.RlpFieldToU64SAsm.B + 48, hdrBaseAt hdrBase lengths i, GasUsed,
+            hdrBaseAt hdrBase lengths i, validPtr, firstBadPtr, BitVec.ofNat 64 i⟩ : Saved)
+          (bigBytes.drop (hdrOff lengths i)) lengths[i]! 10 **
+        (IterPtr ↦ₘ hdrBaseAt hdrBase lengths i) ** (IterI ↦ₘ BitVec.ofNat 64 i) **
+        ((lenBase + BitVec.ofNat 64 (8 * i)) ↦ₘ BitVec.ofNat 64 lengths[i]!) **
+        wordArrayFrom lenBase 0 (lengths.take i) **
+        wordArrayFrom lenBase (i + 1) (lengths.drop (i + 1)) **
+        bytesRegion hdrBase (bigBytes.take (hdrOff lengths i)) **
+        (GasLimit ↦ₘ oldLimit) ** (validPtr ↦ₘ (1 : Word)) ** (firstBadPtr ↦ₘ (0 : Word)) **
+        savedFrame spC csaved)
+      (cvgulPost sp0 spC (spC + signExtend12 (-32 : BitVec 12)) hdrBase lenBase validPtr
+        firstBadPtr csaved bigBytes lengths) := by
+  have hLi : lengths[i]! = lengths[i] := getElem!_pos lengths i hi
+  have hHB : hdrBaseAt hdrBase lengths i = hdrBase + BitVec.ofNat 64 (hdrOff lengths i) := rfl
+  have hsf : savedFrame spC csaved =
+      ((spC ↦ₘ raIn) ** ((spC + 8) ↦ₘ csaved.s0) ** ((spC + 16) ↦ₘ csaved.s1) **
+        ((spC + 24) ↦ₘ csaved.s2) ** ((spC + 32) ↦ₘ csaved.s3) **
+        ((spC + 40) ↦ₘ csaved.s4) ** ((spC + 48) ↦ₘ csaved.s5)) := by
+    unfold savedFrame; rw [hraSaved]
+  refine cpsTripleWithin_weaken (fun h hp => ?hstrip) (fun _ hq => hq)
+    (EvmAsm.Codegen.RlpListNthItemSAsm.cpsTripleWithin_exists_assertion (fun status =>
+      EvmAsm.Codegen.RlpListNthItemSAsm.cpsTripleWithin_exists_assertion (fun value =>
+        (show cpsTripleWithin (1 + ((13 + 1 + nCall 9) + (27 + nTail))) (D + 128) raIn fullCode
+          ((.x1 ↦ᵣ LinkRA1) **
+            (dispNorm spC (spC + signExtend12 (-32 : BitVec 12)) (hdrBaseAt hdrBase lengths i)
+                validPtr firstBadPtr (BitVec.ofNat 64 lengths.length) lenBase (BitVec.ofNat 64 i)
+                LinkRA1 GasUsed value status (bigBytes.drop (hdrOff lengths i)) **
+              ⌜EvmAsm.Codegen.RlpFieldToU64SAsm.Result (bigBytes.drop (hdrOff lengths i))
+                (hdrBaseAt hdrBase lengths i) lengths[i]! 10 status value⌝) **
+            ((IterPtr ↦ₘ hdrBaseAt hdrBase lengths i) ** (IterI ↦ₘ BitVec.ofNat 64 i) **
+              ((lenBase + BitVec.ofNat 64 (8 * i)) ↦ₘ BitVec.ofNat 64 lengths[i]!) **
+              wordArrayFrom lenBase 0 (lengths.take i) **
+              wordArrayFrom lenBase (i + 1) (lengths.drop (i + 1)) **
+              bytesRegion hdrBase (bigBytes.take (hdrOff lengths i)) **
+              (GasLimit ↦ₘ oldLimit) ** (validPtr ↦ₘ (1 : Word)) ** (firstBadPtr ↦ₘ (0 : Word)) **
+              savedFrame spC csaved))
+          (cvgulPost sp0 spC (spC + signExtend12 (-32 : BitVec 12)) hdrBase lenBase validPtr
+            firstBadPtr csaved bigBytes lengths) from ?core))))
+  case hstrip =>
+    obtain ⟨s1, s2, hd, hu, hx1, s3, s4, hd2, hu2, hfp, hREST⟩ := hp
+    obtain ⟨status, value, hnorm⟩ := flatPost_normalize spC (hdrBaseAt hdrBase lengths i)
+      validPtr firstBadPtr (BitVec.ofNat 64 lengths.length) lenBase (BitVec.ofNat 64 i)
+      LinkRA1 GasUsed oldOff oldLen (bigBytes.drop (hdrOff lengths i)) lengths[i]! 10 s3 hfp
+    exact ⟨status, value, s1, s2, hd, hu, hx1, s3, s4, hd2, hu2, hnorm, hREST⟩
+  case core =>
+    refine cpsTripleWithin_weaken (fun h hp => ?hpull) (fun _ hq => hq)
+      (cpsTripleWithin_pure_pre
+        (P := EvmAsm.Codegen.RlpFieldToU64SAsm.Result (bigBytes.drop (hdrOff lengths i))
+          (hdrBaseAt hdrBase lengths i) lengths[i]! 10 status value)
+        (H := (.x1 ↦ᵣ LinkRA1) ** (.x2 ↦ᵣ spC) ** (.x8 ↦ᵣ BitVec.ofNat 64 lengths.length) **
+          (.x9 ↦ᵣ lenBase) ** (.x18 ↦ᵣ hdrBaseAt hdrBase lengths i) ** (.x19 ↦ᵣ validPtr) **
+          (.x20 ↦ᵣ firstBadPtr) ** (.x21 ↦ᵣ BitVec.ofNat 64 i) ** (.x10 ↦ᵣ status) **
+          (.x0 ↦ᵣ (0 : Word)) ** (GasUsed ↦ₘ value) **
+          regOwn .x5 ** regOwn .x6 ** regOwn .x7 ** regOwn .x11 ** regOwn .x12 **
+          regOwn .x13 ** regOwn .x14 ** regOwn .x28 ** regOwn .x29 ** regOwn .x30 **
+          regOwn .x31 ** memOwn RfuOff ** memOwn RfuLen **
+          stackFree (spC + signExtend12 (-32 : BitVec 12)) 8 **
+          bytesRegion (hdrBaseAt hdrBase lengths i) (bigBytes.drop (hdrOff lengths i)) **
+          EvmAsm.Codegen.RlpFieldToU64SAsm.savedFrame (spC + signExtend12 (-32 : BitVec 12))
+            ⟨LinkRA1, BitVec.ofNat 64 lengths.length, lenBase⟩ **
+          (IterPtr ↦ₘ hdrBaseAt hdrBase lengths i) ** (IterI ↦ₘ BitVec.ofNat 64 i) **
+          ((lenBase + BitVec.ofNat 64 (8 * i)) ↦ₘ BitVec.ofNat 64 lengths[i]!) **
+          wordArrayFrom lenBase 0 (lengths.take i) **
+          wordArrayFrom lenBase (i + 1) (lengths.drop (i + 1)) **
+          bytesRegion hdrBase (bigBytes.take (hdrOff lengths i)) **
+          (GasLimit ↦ₘ oldLimit) ** (validPtr ↦ₘ (1 : Word)) ** (firstBadPtr ↦ₘ (0 : Word)) **
+          savedFrame spC csaved)
+        (fun hResult => ?body))
+    case hpull =>
+      unfold dispNorm at hp
+      xperm_hyp hp
+    case body =>
+      by_cases hstatus : status = 0
+      · -- SUCCESS arm: gas-used `bne` not taken → second K34 call → dispatch 2.
+        subst hstatus
+        set RframeOk1 : Assertion :=
+          ((.x1 ↦ᵣ LinkRA1) ** (.x2 ↦ᵣ spC) ** (.x8 ↦ᵣ BitVec.ofNat 64 lengths.length) **
+            (.x9 ↦ᵣ lenBase) ** (.x18 ↦ᵣ hdrBaseAt hdrBase lengths i) ** (.x19 ↦ᵣ validPtr) **
+            (.x20 ↦ᵣ firstBadPtr) ** (.x21 ↦ᵣ BitVec.ofNat 64 i) ** (GasUsed ↦ₘ value) **
+            regOwn .x5 ** regOwn .x6 ** regOwn .x7 ** regOwn .x11 ** regOwn .x12 **
+            regOwn .x13 ** regOwn .x14 ** regOwn .x28 ** regOwn .x29 ** regOwn .x30 **
+            regOwn .x31 ** memOwn RfuOff ** memOwn RfuLen **
+            stackFree (spC + signExtend12 (-32 : BitVec 12)) 8 **
+            bytesRegion (hdrBaseAt hdrBase lengths i) (bigBytes.drop (hdrOff lengths i)) **
+            EvmAsm.Codegen.RlpFieldToU64SAsm.savedFrame (spC + signExtend12 (-32 : BitVec 12))
+              ⟨LinkRA1, BitVec.ofNat 64 lengths.length, lenBase⟩ **
+            (IterPtr ↦ₘ hdrBaseAt hdrBase lengths i) ** (IterI ↦ₘ BitVec.ofNat 64 i) **
+            ((lenBase + BitVec.ofNat 64 (8 * i)) ↦ₘ BitVec.ofNat 64 lengths[i]!) **
+            wordArrayFrom lenBase 0 (lengths.take i) **
+            wordArrayFrom lenBase (i + 1) (lengths.drop (i + 1)) **
+            bytesRegion hdrBase (bigBytes.take (hdrOff lengths i)) **
+            (GasLimit ↦ₘ oldLimit) ** (validPtr ↦ₘ (1 : Word)) ** (firstBadPtr ↦ₘ (0 : Word)) **
+            savedFrame spC csaved) with hRframeOk1
+        have hbne := bne_spec_gen_within .x10 .x0 (156 : BitVec 13) (0 : Word) (0 : Word)
+          (D + 128)
+        have hbneC := cpsBranchWithin_extend_code cvgul_mono
+          (cpsBranchWithin_extend_code (cr' := cvgulCode)
+            (CodeReq.ofProg_mem_at D (D + 128) cvgulProg 32 (.BNE .x10 .x0 (156 : BitVec 13))
+              (by bv_omega) (by rw [cvgul_length]; decide) rfl
+              (by rw [cvgul_length]; decide)) hbne)
+        have hntaken := cpsBranchWithin_ntakenStripPure2 hbneC (fun hp hq => by
+          obtain ⟨_, _, _, _, _, hrest⟩ := hq
+          exact absurd rfl ((sepConj_pure_right _).1 hrest).2)
+        rw [show (D + 128 + 4 : Word) = D + 132 from by bv_omega] at hntaken
+        have hcont : cpsTripleWithin ((13 + 1 + nCall 9) + (27 + nTail)) (D + 132) raIn fullCode
+            (((.x10 ↦ᵣ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word))) ** RframeOk1)
+            (cvgulPost sp0 spC (spC + signExtend12 (-32 : BitVec 12)) hdrBase lenBase
+              validPtr firstBadPtr csaved bigBytes lengths) := by
+          set BODY : Assertion :=
+            ((.x10 ↦ᵣ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) ** (.x1 ↦ᵣ LinkRA1) ** (.x2 ↦ᵣ spC) **
+              (.x8 ↦ᵣ BitVec.ofNat 64 lengths.length) ** (.x9 ↦ᵣ lenBase) **
+              (.x18 ↦ᵣ hdrBaseAt hdrBase lengths i) ** (.x19 ↦ᵣ validPtr) **
+              (.x20 ↦ᵣ firstBadPtr) ** (.x21 ↦ᵣ BitVec.ofNat 64 i) ** (GasUsed ↦ₘ value) **
+              regOwn .x5 ** regOwn .x6 ** regOwn .x7 ** regOwn .x11 ** regOwn .x12 **
+              regOwn .x13 ** regOwn .x14 ** regOwn .x28 ** regOwn .x29 ** regOwn .x30 **
+              regOwn .x31 ** stackFree (spC + signExtend12 (-32 : BitVec 12)) 8 **
+              bytesRegion (hdrBaseAt hdrBase lengths i) (bigBytes.drop (hdrOff lengths i)) **
+              EvmAsm.Codegen.RlpFieldToU64SAsm.savedFrame (spC + signExtend12 (-32 : BitVec 12))
+                ⟨LinkRA1, BitVec.ofNat 64 lengths.length, lenBase⟩ **
+              (IterPtr ↦ₘ hdrBaseAt hdrBase lengths i) ** (IterI ↦ₘ BitVec.ofNat 64 i) **
+              ((lenBase + BitVec.ofNat 64 (8 * i)) ↦ₘ BitVec.ofNat 64 lengths[i]!) **
+              wordArrayFrom lenBase 0 (lengths.take i) **
+              wordArrayFrom lenBase (i + 1) (lengths.drop (i + 1)) **
+              bytesRegion hdrBase (bigBytes.take (hdrOff lengths i)) **
+              (GasLimit ↦ₘ oldLimit) ** (validPtr ↦ₘ (1 : Word)) ** (firstBadPtr ↦ₘ (0 : Word)) **
+              savedFrame spC csaved) with hBODY
+          refine cpsTripleWithin_weaken (fun h hp => by
+            rw [hRframeOk1] at hp; rw [hBODY]; xperm_hyp hp) (fun _ hq => hq)
+            (show cpsTripleWithin ((13 + 1 + nCall 9) + (27 + nTail)) (D + 132) raIn fullCode
+              ((BODY ** memOwn RfuOff) ** memOwn RfuLen)
+              (cvgulPost sp0 spC (spC + signExtend12 (-32 : BitVec 12)) hdrBase lenBase
+                validPtr firstBadPtr csaved bigBytes lengths) from ?_)
+          refine cpsTripleWithin_of_forall_memIs_to_memOwn (fun oldLen2 => ?_)
+          refine cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp) (fun _ hq => hq)
+            (show cpsTripleWithin ((13 + 1 + nCall 9) + (27 + nTail)) (D + 132) raIn fullCode
+              ((BODY ** (RfuLen ↦ₘ oldLen2)) ** memOwn RfuOff)
+              (cvgulPost sp0 spC (spC + signExtend12 (-32 : BitVec 12)) hdrBase lenBase
+                validPtr firstBadPtr csaved bigBytes lengths) from ?_)
+          refine cpsTripleWithin_of_forall_memIs_to_memOwn (fun oldOff2 => ?_)
+          have hc2 := cvgulCall2Owned (hdrBaseAt hdrBase lengths i) lenBase spC
+            (BitVec.ofNat 64 i) lengths[i]! (BitVec.ofNat 64 lengths.length) validPtr firstBadPtr
+            oldLimit oldOff2 oldLen2 (bigBytes.drop (hdrOff lengths i)) csaved hsalign hslack
+            hover hvalid
+          rw [show (BitVec.ofNat 64 i) <<< 3 = BitVec.ofNat 64 (8 * i) from shiftLeft3_ofNat i]
+            at hc2
+          have hc2F := cpsTripleWithin_frameR
+            ((GasUsed ↦ₘ value) ** wordArrayFrom lenBase 0 (lengths.take i) **
+              wordArrayFrom lenBase (i + 1) (lengths.drop (i + 1)) **
+              bytesRegion hdrBase (bigBytes.take (hdrOff lengths i)) **
+              (validPtr ↦ₘ (1 : Word)) ** (firstBadPtr ↦ₘ (0 : Word)))
+            (by pcfx) hc2
+          have hd2 := cvgulDispatch2 sp0 spC hdrBase lenBase validPtr firstBadPtr raIn csaved
+            bigBytes lengths i oldOff2 oldLen2 value nTail hi hspC hraSaved hret halign hlen
+            hResult hprefix htail
+          refine cpsTripleWithin_weaken (fun h hp => by
+            rw [hBODY] at hp
+            have hp1 : ((.x10 ↦ᵣ (0 : Word)) ** (.x1 ↦ᵣ LinkRA1) **
+                (.x18 ↦ᵣ hdrBaseAt hdrBase lengths i) ** (.x21 ↦ᵣ BitVec.ofNat 64 i) **
+                EvmAsm.Codegen.RlpFieldToU64SAsm.savedFrame (spC + signExtend12 (-32 : BitVec 12))
+                  ⟨LinkRA1, BitVec.ofNat 64 lengths.length, lenBase⟩ **
+                ((.x2 ↦ᵣ spC) ** (.x9 ↦ᵣ lenBase) **
+                  (IterPtr ↦ₘ hdrBaseAt hdrBase lengths i) ** (IterI ↦ₘ BitVec.ofNat 64 i) **
+                  ((lenBase + BitVec.ofNat 64 (8 * i)) ↦ₘ BitVec.ofNat 64 lengths[i]!) **
+                  (.x8 ↦ᵣ BitVec.ofNat 64 lengths.length) ** (.x19 ↦ᵣ validPtr) **
+                  (.x20 ↦ᵣ firstBadPtr) ** regOwn .x6 ** regOwn .x7 ** regOwn .x29 **
+                  regOwn .x30 ** regOwn .x31 ** (.x0 ↦ᵣ (0 : Word)) **
+                  stackFree (spC + signExtend12 (-32 : BitVec 12)) 8 **
+                  (GasLimit ↦ₘ oldLimit) ** (RfuOff ↦ₘ oldOff2) ** (RfuLen ↦ₘ oldLen2) **
+                  bytesRegion (hdrBaseAt hdrBase lengths i) (bigBytes.drop (hdrOff lengths i)) **
+                  savedFrame spC csaved **
+                  regOwn .x5 ** regOwn .x11 ** regOwn .x12 ** regOwn .x13 ** regOwn .x14 **
+                  regOwn .x28 **
+                  (GasUsed ↦ₘ value) ** wordArrayFrom lenBase 0 (lengths.take i) **
+                  wordArrayFrom lenBase (i + 1) (lengths.drop (i + 1)) **
+                  bytesRegion hdrBase (bigBytes.take (hdrOff lengths i)) **
+                  (validPtr ↦ₘ (1 : Word)) ** (firstBadPtr ↦ₘ (0 : Word)))) h := by
+              xperm_hyp hp
+            have hp2 := sepConj_mono (regIs_implies_regOwn .x10) (sepConj_mono
+              (regIs_implies_regOwn .x1) (sepConj_mono (regIs_implies_regOwn .x18)
+              (sepConj_mono (regIs_implies_regOwn .x21)
+              (sepConj_mono (k34SavedFrame_implies_frameSlotsOwn _ _) (fun _ x => x))))) h hp1
+            xperm_hyp hp2) (fun _ hq => hq)
+            (cpsTripleWithin_seq_perm_same_cr (fun h hq => by xperm_hyp hq) hc2F hd2)
+        have hntakenF := cpsTripleWithin_frameR RframeOk1 (by rw [hRframeOk1]; pcfx) hntaken
+        refine cpsTripleWithin_weaken (fun h hp => by rw [hRframeOk1]; xperm_hyp hp)
+          (fun _ hq => hq)
+          (cpsTripleWithin_seq_perm_same_cr (fun _ hp => hp) hntakenF hcont)
+      · -- PARSE-FAIL arm (gas_used): `bne` taken → status ≠ 0 exit.
+        rw [hsf]
+        have hbne := bne_spec_gen_within .x10 .x0 (156 : BitVec 13) status (0 : Word) (D + 128)
+        have hbneC := cpsBranchWithin_extend_code cvgul_mono
+          (cpsBranchWithin_extend_code (cr' := cvgulCode)
+            (CodeReq.ofProg_mem_at D (D + 128) cvgulProg 32 (.BNE .x10 .x0 (156 : BitVec 13))
+              (by bv_omega) (by rw [cvgul_length]; decide) rfl
+              (by rw [cvgul_length]; decide)) hbne)
+        have htaken := cpsBranchWithin_takenStripPure2 hbneC (fun hp hq => by
+          obtain ⟨_, _, _, _, _, hrest⟩ := hq
+          exact absurd ((sepConj_pure_right _).1 hrest).2 hstatus)
+        rw [show (D + 128) + signExtend13 (156 : BitVec 13) = D + 284 from by
+          rw [show signExtend13 (156 : BitVec 13) = (156 : Word) from by decide]; bv_omega] at htaken
+        have htakenF := cpsTripleWithin_frameR
+          ((.x1 ↦ᵣ LinkRA1) ** (.x2 ↦ᵣ spC) ** (.x8 ↦ᵣ BitVec.ofNat 64 lengths.length) **
+            (.x9 ↦ᵣ lenBase) ** (.x18 ↦ᵣ hdrBaseAt hdrBase lengths i) ** (.x19 ↦ᵣ validPtr) **
+            (.x20 ↦ᵣ firstBadPtr) ** (.x21 ↦ᵣ BitVec.ofNat 64 i) **
+            (GasUsed ↦ₘ value) ** (GasLimit ↦ₘ oldLimit) **
+            regOwn .x5 ** regOwn .x6 ** regOwn .x7 ** regOwn .x11 ** regOwn .x12 **
+            regOwn .x13 ** regOwn .x14 ** regOwn .x28 ** regOwn .x29 ** regOwn .x30 **
+            regOwn .x31 ** memOwn RfuOff ** memOwn RfuLen **
+            stackFree (spC + signExtend12 (-32 : BitVec 12)) 8 **
+            bytesRegion (hdrBaseAt hdrBase lengths i) (bigBytes.drop (hdrOff lengths i)) **
+            EvmAsm.Codegen.RlpFieldToU64SAsm.savedFrame (spC + signExtend12 (-32 : BitVec 12))
+              ⟨LinkRA1, BitVec.ofNat 64 lengths.length, lenBase⟩ **
+            (IterPtr ↦ₘ hdrBaseAt hdrBase lengths i) ** (IterI ↦ₘ BitVec.ofNat 64 i) **
+            ((lenBase + BitVec.ofNat 64 (8 * i)) ↦ₘ BitVec.ofNat 64 lengths[i]!) **
+            wordArrayFrom lenBase 0 (lengths.take i) **
+            wordArrayFrom lenBase (i + 1) (lengths.drop (i + 1)) **
+            bytesRegion hdrBase (bigBytes.take (hdrOff lengths i)) **
+            (validPtr ↦ₘ (1 : Word)) ** (firstBadPtr ↦ₘ (0 : Word)) **
+            (spC ↦ₘ raIn) ** ((spC + 8) ↦ₘ csaved.s0) ** ((spC + 16) ↦ₘ csaved.s1) **
+            ((spC + 24) ↦ₘ csaved.s2) ** ((spC + 32) ↦ₘ csaved.s3) **
+            ((spC + 40) ↦ₘ csaved.s4) ** ((spC + 48) ↦ₘ csaved.s5)) (by pcfx) htaken
+        have hpfC := cpsTripleWithin_extend_code cvgul_mono
+          (retParseFail sp0 spC raIn (BitVec.ofNat 64 i) firstBadPtr csaved
+            ((.x0 ↦ᵣ (0 : Word)) ** regOwn .x5 ** regOwn .x6 ** regOwn .x7 ** regOwn .x11 **
+              regOwn .x12 ** regOwn .x13 ** regOwn .x14 ** regOwn .x28 ** regOwn .x29 **
+              regOwn .x30 ** regOwn .x31 ** (GasUsed ↦ₘ value) ** (GasLimit ↦ₘ oldLimit) **
+              memOwn RfuOff ** memOwn RfuLen **
+              stackFree (spC + signExtend12 (-32 : BitVec 12)) 8 **
+              bytesRegion (hdrBaseAt hdrBase lengths i) (bigBytes.drop (hdrOff lengths i)) **
+              EvmAsm.Codegen.RlpFieldToU64SAsm.savedFrame (spC + signExtend12 (-32 : BitVec 12))
+                ⟨LinkRA1, BitVec.ofNat 64 lengths.length, lenBase⟩ **
+              (IterPtr ↦ₘ hdrBaseAt hdrBase lengths i) ** (IterI ↦ₘ BitVec.ofNat 64 i) **
+              ((lenBase + BitVec.ofNat 64 (8 * i)) ↦ₘ BitVec.ofNat 64 lengths[i]!) **
+              wordArrayFrom lenBase 0 (lengths.take i) **
+              wordArrayFrom lenBase (i + 1) (lengths.drop (i + 1)) **
+              bytesRegion hdrBase (bigBytes.take (hdrOff lengths i)) ** (validPtr ↦ₘ (1 : Word)))
+            (by pcfx) LinkRA1 (BitVec.ofNat 64 lengths.length) lenBase
+            (hdrBaseAt hdrBase lengths i) validPtr status hspC hraSaved hret)
+        have hcompose := cpsTripleWithin_seq_perm_same_cr (fun h hp => by
+          have hp1 : ((firstBadPtr ↦ₘ (0 : Word)) **
+              ((.x20 ↦ᵣ firstBadPtr) ** (.x21 ↦ᵣ BitVec.ofNat 64 i) ** (.x10 ↦ᵣ status) **
+                (.x2 ↦ᵣ spC) ** (.x1 ↦ᵣ LinkRA1) ** (.x8 ↦ᵣ BitVec.ofNat 64 lengths.length) **
+                (.x9 ↦ᵣ lenBase) ** (.x18 ↦ᵣ hdrBaseAt hdrBase lengths i) ** (.x19 ↦ᵣ validPtr) **
+                (spC ↦ₘ raIn) ** ((spC + 8) ↦ₘ csaved.s0) ** ((spC + 16) ↦ₘ csaved.s1) **
+                ((spC + 24) ↦ₘ csaved.s2) ** ((spC + 32) ↦ₘ csaved.s3) **
+                ((spC + 40) ↦ₘ csaved.s4) ** ((spC + 48) ↦ₘ csaved.s5) **
+                ((.x0 ↦ᵣ (0 : Word)) ** regOwn .x5 ** regOwn .x6 ** regOwn .x7 ** regOwn .x11 **
+                  regOwn .x12 ** regOwn .x13 ** regOwn .x14 ** regOwn .x28 ** regOwn .x29 **
+                  regOwn .x30 ** regOwn .x31 ** (GasUsed ↦ₘ value) ** (GasLimit ↦ₘ oldLimit) **
+                  memOwn RfuOff ** memOwn RfuLen **
+                  stackFree (spC + signExtend12 (-32 : BitVec 12)) 8 **
+                  bytesRegion (hdrBaseAt hdrBase lengths i) (bigBytes.drop (hdrOff lengths i)) **
+                  EvmAsm.Codegen.RlpFieldToU64SAsm.savedFrame (spC + signExtend12 (-32 : BitVec 12))
+                    ⟨LinkRA1, BitVec.ofNat 64 lengths.length, lenBase⟩ **
+                  (IterPtr ↦ₘ hdrBaseAt hdrBase lengths i) ** (IterI ↦ₘ BitVec.ofNat 64 i) **
+                  ((lenBase + BitVec.ofNat 64 (8 * i)) ↦ₘ BitVec.ofNat 64 lengths[i]!) **
+                  wordArrayFrom lenBase 0 (lengths.take i) **
+                  wordArrayFrom lenBase (i + 1) (lengths.drop (i + 1)) **
+                  bytesRegion hdrBase (bigBytes.take (hdrOff lengths i)) **
+                  (validPtr ↦ₘ (1 : Word))))) h := by xperm_hyp hp
+          have hp2 := sepConj_mono_left memIs_implies_memOwn h hp1
+          xperm_hyp hp2) htakenF hpfC
+        refine cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp) (fun h hq => ?_)
+          (cpsTripleWithin_mono_nSteps
+            (show 1 + 11 ≤ 1 + ((13 + 1 + nCall 9) + (27 + nTail)) by omega) hcompose)
+        refine Or.inr (Or.inr ⟨i, status, ?_⟩)
+        refine (sepConj_pure_left h).mpr
+          ⟨⟨hi, hprefix, Or.inl ⟨value, hResult, hstatus⟩⟩, ?_⟩
+        unfold commonRet payload
+        rw [hsf, hraSaved, wordArray_split lenBase lengths i hi,
+          EvmAsm.Evm64.bytesRegion_split hdrBase bigBytes (hdrOff lengths i) halign hlen, ← hHB]
+        have hp1 : ((GasUsed ↦ₘ value) ** (GasLimit ↦ₘ oldLimit) **
+            (IterPtr ↦ₘ hdrBaseAt hdrBase lengths i) **
+            (IterI ↦ₘ BitVec.ofNat 64 i) **
+            EvmAsm.Codegen.RlpFieldToU64SAsm.savedFrame (spC + signExtend12 (-32 : BitVec 12))
+              ⟨LinkRA1, BitVec.ofNat 64 lengths.length, lenBase⟩ **
+            ((.x10 ↦ᵣ status) ** (validPtr ↦ₘ (1 : Word)) **
+              (firstBadPtr ↦ₘ BitVec.ofNat 64 i) ** (.x1 ↦ᵣ raIn) ** (.x2 ↦ᵣ sp0) **
+              (.x8 ↦ᵣ csaved.s0) ** (.x9 ↦ᵣ csaved.s1) ** (.x18 ↦ᵣ csaved.s2) **
+              (.x19 ↦ᵣ csaved.s3) ** (.x20 ↦ᵣ csaved.s4) ** (.x21 ↦ᵣ csaved.s5) **
+              (spC ↦ₘ raIn) ** ((spC + 8) ↦ₘ csaved.s0) ** ((spC + 16) ↦ₘ csaved.s1) **
+              ((spC + 24) ↦ₘ csaved.s2) ** ((spC + 32) ↦ₘ csaved.s3) **
+              ((spC + 40) ↦ₘ csaved.s4) ** ((spC + 48) ↦ₘ csaved.s5) **
+              (.x0 ↦ᵣ (0 : Word)) ** regOwn .x5 ** regOwn .x6 ** regOwn .x7 ** regOwn .x11 **
+              regOwn .x12 ** regOwn .x13 ** regOwn .x14 ** regOwn .x28 ** regOwn .x29 **
+              regOwn .x30 ** regOwn .x31 ** memOwn RfuOff ** memOwn RfuLen **
+              stackFree (spC + signExtend12 (-32 : BitVec 12)) 8 **
+              bytesRegion hdrBase (bigBytes.take (hdrOff lengths i)) **
+              bytesRegion (hdrBaseAt hdrBase lengths i) (bigBytes.drop (hdrOff lengths i)) **
+              wordArrayFrom lenBase 0 (lengths.take i) **
+              ((lenBase + BitVec.ofNat 64 (8 * i)) ↦ₘ BitVec.ofNat 64 lengths[i]) **
+              wordArrayFrom lenBase (i + 1) (lengths.drop (i + 1)))) h := by
+          rw [← hLi]; xperm_hyp hq
+        have hp2 := sepConj_mono memIs_implies_memOwn (sepConj_mono memIs_implies_memOwn
+          (sepConj_mono memIs_implies_memOwn (sepConj_mono memIs_implies_memOwn
+          (sepConj_mono (k34SavedFrame_implies_frameSlotsOwn _ _) (fun _ x => x))))) h hp1
+        xperm_hyp hp2
+
+#print axioms cvgulDispatch1
+
 end EvmAsm.Codegen.ChainValidateGasUsedUnderLimitSpec

--- a/EvmAsm/Codegen/Programs/ChainValidateGasUsedUnderLimitLoopClose.lean
+++ b/EvmAsm/Codegen/Programs/ChainValidateGasUsedUnderLimitLoopClose.lean
@@ -584,4 +584,114 @@ theorem cvgulDispatch2
 
 #print axioms cvgulDispatch2
 
+/-! ## Call block 2 with the consumed scratch registers owned
+
+    Mirror of `cvgulCall1Owned` for the second K34 call, presenting `cvgulCall2`'s
+    registers as `regOwn` (matching the loop invariant).  Since `cvgulReloadSetup2`
+    reloads `x18`/`x21` from the spill cells, they are two EXTRA owned peels on top
+    of the call-1 set. -/
+
+set_option maxRecDepth 8000 in
+theorem cvgulCall2Owned (hbi lenBase spC iW : Word) (Li : Nat)
+    (nN s3 s4 oldOut oldOff oldLen : Word) (bytes : List (BitVec 8)) (csaved : Saved)
+    (hsalign : hbi.toNat % 8 = 0)
+    (hslack : Li + 9 ≤ bytes.length)
+    (hover : hbi.toNat + bytes.length < 2 ^ 64)
+    (hvalid : ∀ k, k < bytes.length →
+      isValidByteAccess (hbi + BitVec.ofNat 64 k) = true) :
+    cpsTripleWithin (13 + 1 + nCall 9) (D + 132) (D + 188) fullCode
+      ((((((.x2 ↦ᵣ spC) ** (.x9 ↦ᵣ lenBase) **
+            (IterPtr ↦ₘ hbi) ** (IterI ↦ₘ iW) **
+            ((lenBase + (iW <<< 3)) ↦ₘ BitVec.ofNat 64 Li) **
+            (.x8 ↦ᵣ nN) ** (.x19 ↦ᵣ s3) ** (.x20 ↦ᵣ s4) **
+            regOwn .x6 ** regOwn .x7 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+            (.x0 ↦ᵣ (0 : Word)) **
+            frameSlotsOwn EvmAsm.Codegen.RlpFieldToU64SAsm.frame (spC + signExtend12 (-32 : BitVec 12)) **
+            stackFree (spC + signExtend12 (-32 : BitVec 12)) 8 **
+            (GasLimit ↦ₘ oldOut) ** (RfuOff ↦ₘ oldOff) ** (RfuLen ↦ₘ oldLen) **
+            bytesRegion hbi bytes ** savedFrame spC csaved) **
+          regOwn .x5 ** regOwn .x10 ** regOwn .x11 ** regOwn .x12 ** regOwn .x13 **
+          regOwn .x14 ** regOwn .x28) ** regOwn .x1) ** regOwn .x18) ** regOwn .x21)
+      ((.x1 ↦ᵣ LinkRA2) **
+        EvmAsm.Codegen.RlpFieldToU64SAsm.flatPost spC (spC + signExtend12 (-32 : BitVec 12)) hbi
+          oldOff oldLen (⟨LinkRA2, nN, lenBase⟩ : EvmAsm.Codegen.RlpFieldToU64SAsm.Saved)
+          (⟨EvmAsm.Codegen.RlpFieldToU64SAsm.B + 48, hbi, GasLimit, hbi, s3, s4, iW⟩ : Saved)
+          bytes Li 9 **
+        (IterPtr ↦ₘ hbi) ** (IterI ↦ₘ iW) **
+        ((lenBase + (iW <<< 3)) ↦ₘ BitVec.ofNat 64 Li) ** savedFrame spC csaved) := by
+  refine cpsTripleWithin_of_forall_regIs_to_regOwn (fun v21 => ?_)
+  refine cpsTripleWithin_weaken (fun _ h => by xperm_hyp h) (fun _ h => h)
+    (show cpsTripleWithin (13 + 1 + nCall 9) (D + 132) (D + 188) fullCode
+      ((((((.x2 ↦ᵣ spC) ** (.x9 ↦ᵣ lenBase) **
+            (IterPtr ↦ₘ hbi) ** (IterI ↦ₘ iW) **
+            ((lenBase + (iW <<< 3)) ↦ₘ BitVec.ofNat 64 Li) **
+            (.x8 ↦ᵣ nN) ** (.x19 ↦ᵣ s3) ** (.x20 ↦ᵣ s4) **
+            regOwn .x6 ** regOwn .x7 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+            (.x0 ↦ᵣ (0 : Word)) **
+            frameSlotsOwn EvmAsm.Codegen.RlpFieldToU64SAsm.frame (spC + signExtend12 (-32 : BitVec 12)) **
+            stackFree (spC + signExtend12 (-32 : BitVec 12)) 8 **
+            (GasLimit ↦ₘ oldOut) ** (RfuOff ↦ₘ oldOff) ** (RfuLen ↦ₘ oldLen) **
+            bytesRegion hbi bytes ** savedFrame spC csaved) **
+          regOwn .x5 ** regOwn .x10 ** regOwn .x11 ** regOwn .x12 ** regOwn .x13 **
+          regOwn .x14 ** regOwn .x28) ** regOwn .x1) ** (.x21 ↦ᵣ v21)) ** regOwn .x18)
+      ((.x1 ↦ᵣ LinkRA2) **
+        EvmAsm.Codegen.RlpFieldToU64SAsm.flatPost spC (spC + signExtend12 (-32 : BitVec 12)) hbi
+          oldOff oldLen (⟨LinkRA2, nN, lenBase⟩ : EvmAsm.Codegen.RlpFieldToU64SAsm.Saved)
+          (⟨EvmAsm.Codegen.RlpFieldToU64SAsm.B + 48, hbi, GasLimit, hbi, s3, s4, iW⟩ : Saved)
+          bytes Li 9 **
+        (IterPtr ↦ₘ hbi) ** (IterI ↦ₘ iW) **
+        ((lenBase + (iW <<< 3)) ↦ₘ BitVec.ofNat 64 Li) ** savedFrame spC csaved) from ?_)
+  refine cpsTripleWithin_of_forall_regIs_to_regOwn (fun v18 => ?_)
+  refine cpsTripleWithin_weaken (fun _ h => by xperm_hyp h) (fun _ h => h)
+    (show cpsTripleWithin (13 + 1 + nCall 9) (D + 132) (D + 188) fullCode
+      (((((.x2 ↦ᵣ spC) ** (.x9 ↦ᵣ lenBase) **
+            (IterPtr ↦ₘ hbi) ** (IterI ↦ₘ iW) **
+            ((lenBase + (iW <<< 3)) ↦ₘ BitVec.ofNat 64 Li) **
+            (.x8 ↦ᵣ nN) ** (.x19 ↦ᵣ s3) ** (.x20 ↦ᵣ s4) **
+            regOwn .x6 ** regOwn .x7 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+            (.x0 ↦ᵣ (0 : Word)) **
+            frameSlotsOwn EvmAsm.Codegen.RlpFieldToU64SAsm.frame (spC + signExtend12 (-32 : BitVec 12)) **
+            stackFree (spC + signExtend12 (-32 : BitVec 12)) 8 **
+            (GasLimit ↦ₘ oldOut) ** (RfuOff ↦ₘ oldOff) ** (RfuLen ↦ₘ oldLen) **
+            bytesRegion hbi bytes ** savedFrame spC csaved) **
+          regOwn .x5 ** regOwn .x10 ** regOwn .x11 ** regOwn .x12 ** regOwn .x13 **
+          regOwn .x14 ** regOwn .x28) ** (.x21 ↦ᵣ v21) ** (.x18 ↦ᵣ v18)) ** regOwn .x1)
+      ((.x1 ↦ᵣ LinkRA2) **
+        EvmAsm.Codegen.RlpFieldToU64SAsm.flatPost spC (spC + signExtend12 (-32 : BitVec 12)) hbi
+          oldOff oldLen (⟨LinkRA2, nN, lenBase⟩ : EvmAsm.Codegen.RlpFieldToU64SAsm.Saved)
+          (⟨EvmAsm.Codegen.RlpFieldToU64SAsm.B + 48, hbi, GasLimit, hbi, s3, s4, iW⟩ : Saved)
+          bytes Li 9 **
+        (IterPtr ↦ₘ hbi) ** (IterI ↦ₘ iW) **
+        ((lenBase + (iW <<< 3)) ↦ₘ BitVec.ofNat 64 Li) ** savedFrame spC csaved) from ?_)
+  refine cpsTripleWithin_of_forall_regIs_to_regOwn (fun v1 => ?_)
+  refine cpsTripleWithin_weaken (fun _ h => by xperm_hyp h) (fun _ h => h)
+    (show cpsTripleWithin (13 + 1 + nCall 9) (D + 132) (D + 188) fullCode
+      (((.x2 ↦ᵣ spC) ** (.x9 ↦ᵣ lenBase) **
+          (IterPtr ↦ₘ hbi) ** (IterI ↦ₘ iW) **
+          ((lenBase + (iW <<< 3)) ↦ₘ BitVec.ofNat 64 Li) **
+          (.x8 ↦ᵣ nN) ** (.x19 ↦ᵣ s3) ** (.x20 ↦ᵣ s4) **
+          regOwn .x6 ** regOwn .x7 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+          (.x0 ↦ᵣ (0 : Word)) **
+          frameSlotsOwn EvmAsm.Codegen.RlpFieldToU64SAsm.frame (spC + signExtend12 (-32 : BitVec 12)) **
+          stackFree (spC + signExtend12 (-32 : BitVec 12)) 8 **
+          (GasLimit ↦ₘ oldOut) ** (RfuOff ↦ₘ oldOff) ** (RfuLen ↦ₘ oldLen) **
+          bytesRegion hbi bytes ** savedFrame spC csaved ** (.x1 ↦ᵣ v1) **
+          (.x18 ↦ᵣ v18) ** (.x21 ↦ᵣ v21)) **
+        regOwn .x5 ** regOwn .x10 ** regOwn .x11 ** regOwn .x12 ** regOwn .x13 **
+        regOwn .x14 ** regOwn .x28)
+      ((.x1 ↦ᵣ LinkRA2) **
+        EvmAsm.Codegen.RlpFieldToU64SAsm.flatPost spC (spC + signExtend12 (-32 : BitVec 12)) hbi
+          oldOff oldLen (⟨LinkRA2, nN, lenBase⟩ : EvmAsm.Codegen.RlpFieldToU64SAsm.Saved)
+          (⟨EvmAsm.Codegen.RlpFieldToU64SAsm.B + 48, hbi, GasLimit, hbi, s3, s4, iW⟩ : Saved)
+          bytes Li 9 **
+        (IterPtr ↦ₘ hbi) ** (IterI ↦ₘ iW) **
+        ((lenBase + (iW <<< 3)) ↦ₘ BitVec.ofNat 64 Li) ** savedFrame spC csaved) from ?_)
+  refine EvmAsm.Codegen.RlpListNthItemSAsm.cpsTripleWithin_of_forall_regIs_to_regOwn7
+    (fun v5 v10 v11 v12 v13 v14 v28 => ?_)
+  exact cpsTripleWithin_weaken (fun _ h => by xperm_hyp h) (fun _ h => by xperm_hyp h)
+    (cvgulCall2 hbi lenBase spC iW Li nN s3 s4 oldOut oldOff oldLen v14 v1 v5 v10 v11 v12 v13
+      v18 v21 v28 bytes csaved hsalign hslack hover hvalid)
+
+#print axioms cvgulCall2Owned
+
 end EvmAsm.Codegen.ChainValidateGasUsedUnderLimitSpec

--- a/EvmAsm/Codegen/Programs/ChainValidateGasUsedUnderLimitLoopClose.lean
+++ b/EvmAsm/Codegen/Programs/ChainValidateGasUsedUnderLimitLoopClose.lean
@@ -1128,4 +1128,245 @@ theorem cvgulIter (sp0 spC hdrBase lenBase validPtr firstBadPtr raIn : Word)
 
 #print axioms cvgulIter
 
+/-- Step budget for the loop with `r = N − i` iterations remaining: each full
+    iteration is `cvgulIter`'s cost (two K34 calls); the exhausted guard +
+    all-valid exit is `11`. -/
+def cvgulLoopSteps : Nat → Nat
+  | 0 => 11
+  | r + 1 => (1 + (13 + 1 + nCall 10)) + (1 + ((13 + 1 + nCall 9) + (27 + cvgulLoopSteps r)))
+
+theorem cvgulLoopSteps_succ (r : Nat) :
+    cvgulLoopSteps (r + 1) =
+      (1 + (13 + 1 + nCall 10)) + (1 + ((13 + 1 + nCall 9) + (27 + cvgulLoopSteps r))) := rfl
+
+set_option maxRecDepth 8000 in
+/-- The guard/loop from `D+68` entering iteration `i` (`i ≤ N`), with all earlier
+    headers known gas-used ≤ gas-limit.  On `i = N` the guard falls through to the
+    all-valid exit; otherwise one `cvgulIter` runs and the induction hypothesis
+    handles the rest (with `hprefix` extended by the freshly-decoded header). -/
+theorem cvgulLoop (sp0 spC hdrBase lenBase validPtr firstBadPtr raIn : Word)
+    (csaved : Saved) (bigBytes : List (BitVec 8)) (lengths : List Nat)
+    (hN : lengths.length < 2 ^ 64)
+    (hspC : spC = sp0 + signExtend12 (-56 : BitVec 12))
+    (hraSaved : csaved.ra = raIn)
+    (hret : raIn &&& ~~~(1 : Word) = raIn)
+    (hAllAlign : ∀ i, i < lengths.length → hdrOff lengths i % 8 = 0)
+    (hAllLen : ∀ i, i < lengths.length → hdrOff lengths i ≤ bigBytes.length)
+    (hAllSalign : ∀ i, i < lengths.length → (hdrBaseAt hdrBase lengths i).toNat % 8 = 0)
+    (hAllSlack : ∀ i, i < lengths.length →
+      lengths[i]! + 9 ≤ (bigBytes.drop (hdrOff lengths i)).length)
+    (hAllOver : ∀ i, i < lengths.length →
+      (hdrBaseAt hdrBase lengths i).toNat + (bigBytes.drop (hdrOff lengths i)).length < 2 ^ 64)
+    (hAllValid : ∀ i, i < lengths.length → ∀ k, k < (bigBytes.drop (hdrOff lengths i)).length →
+      isValidByteAccess (hdrBaseAt hdrBase lengths i + BitVec.ofNat 64 k) = true) :
+    ∀ (f i : Nat), lengths.length - i ≤ f → i ≤ lengths.length →
+      (∀ j, j < i → hdrGasOk hdrBase bigBytes lengths j) →
+      cpsTripleWithin (cvgulLoopSteps (lengths.length - i)) (D + 68) raIn fullCode
+        (LoopInv sp0 spC (spC + signExtend12 (-32 : BitVec 12)) hdrBase lenBase validPtr
+          firstBadPtr csaved bigBytes lengths i)
+        (cvgulPost sp0 spC (spC + signExtend12 (-32 : BitVec 12)) hdrBase lenBase validPtr
+          firstBadPtr csaved bigBytes lengths) := by
+  have hsf : savedFrame spC csaved =
+      ((spC ↦ₘ raIn) ** ((spC + 8) ↦ₘ csaved.s0) ** ((spC + 16) ↦ₘ csaved.s1) **
+        ((spC + 24) ↦ₘ csaved.s2) ** ((spC + 32) ↦ₘ csaved.s3) **
+        ((spC + 40) ↦ₘ csaved.s4) ** ((spC + 48) ↦ₘ csaved.s5)) := by
+    unfold savedFrame; rw [hraSaved]
+  have base : (∀ j, j < lengths.length → hdrGasOk hdrBase bigBytes lengths j) →
+      cpsTripleWithin (cvgulLoopSteps 0) (D + 68) raIn fullCode
+        (LoopInv sp0 spC (spC + signExtend12 (-32 : BitVec 12)) hdrBase lenBase validPtr
+          firstBadPtr csaved bigBytes lengths lengths.length)
+        (cvgulPost sp0 spC (spC + signExtend12 (-32 : BitVec 12)) hdrBase lenBase validPtr
+          firstBadPtr csaved bigBytes lengths) := by
+    intro hpre
+    refine cpsTripleWithin_weaken (fun h hp => by unfold LoopInv scratchRegs at hp; xperm_hyp hp)
+      (fun _ hq => hq)
+      (show cpsTripleWithin (cvgulLoopSteps 0) (D + 68) raIn fullCode
+        ((((.x2 ↦ᵣ spC) ** (.x8 ↦ᵣ BitVec.ofNat 64 lengths.length) ** (.x9 ↦ᵣ lenBase) **
+            (.x18 ↦ᵣ hdrBaseAt hdrBase lengths lengths.length) ** (.x19 ↦ᵣ validPtr) **
+            (.x20 ↦ᵣ firstBadPtr) ** (.x21 ↦ᵣ BitVec.ofNat 64 lengths.length) **
+            savedFrame spC csaved ** (validPtr ↦ₘ (1 : Word)) ** (firstBadPtr ↦ₘ (0 : Word)) **
+            payload hdrBase lenBase bigBytes lengths ** regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+            regOwn .x11 ** regOwn .x12 ** regOwn .x13 ** regOwn .x14 ** regOwn .x28 **
+            regOwn .x29 ** regOwn .x30 ** regOwn .x31 ** (.x0 ↦ᵣ (0 : Word)) **
+            frameSlotsOwn EvmAsm.Codegen.RlpFieldToU64SAsm.frame
+              (spC + signExtend12 (-32 : BitVec 12)) **
+            stackFree (spC + signExtend12 (-32 : BitVec 12)) 8) ** regOwn .x1) **
+          regOwn .x10)
+        (cvgulPost sp0 spC (spC + signExtend12 (-32 : BitVec 12)) hdrBase lenBase validPtr
+          firstBadPtr csaved bigBytes lengths) from ?_)
+    refine cpsTripleWithin_of_forall_regIs_to_regOwn (fun o10 => ?_)
+    refine cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp) (fun _ hq => hq)
+      (show cpsTripleWithin (cvgulLoopSteps 0) (D + 68) raIn fullCode
+        (((.x2 ↦ᵣ spC) ** (.x8 ↦ᵣ BitVec.ofNat 64 lengths.length) ** (.x9 ↦ᵣ lenBase) **
+            (.x18 ↦ᵣ hdrBaseAt hdrBase lengths lengths.length) ** (.x19 ↦ᵣ validPtr) **
+            (.x20 ↦ᵣ firstBadPtr) ** (.x21 ↦ᵣ BitVec.ofNat 64 lengths.length) **
+            savedFrame spC csaved ** (validPtr ↦ₘ (1 : Word)) ** (firstBadPtr ↦ₘ (0 : Word)) **
+            payload hdrBase lenBase bigBytes lengths ** regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+            regOwn .x11 ** regOwn .x12 ** regOwn .x13 ** regOwn .x14 ** regOwn .x28 **
+            regOwn .x29 ** regOwn .x30 ** regOwn .x31 ** (.x0 ↦ᵣ (0 : Word)) **
+            frameSlotsOwn EvmAsm.Codegen.RlpFieldToU64SAsm.frame
+              (spC + signExtend12 (-32 : BitVec 12)) **
+            stackFree (spC + signExtend12 (-32 : BitVec 12)) 8 **
+            (.x10 ↦ᵣ o10)) ** regOwn .x1)
+        (cvgulPost sp0 spC (spC + signExtend12 (-32 : BitVec 12)) hdrBase lenBase validPtr
+          firstBadPtr csaved bigBytes lengths) from ?_)
+    refine cpsTripleWithin_of_forall_regIs_to_regOwn (fun o1 => ?_)
+    have hbeq := beq_spec_gen_within .x21 .x8 (224 : BitVec 13)
+      (BitVec.ofNat 64 lengths.length) (BitVec.ofNat 64 lengths.length) (D + 68)
+    have hbeqC := cpsBranchWithin_extend_code cvgul_mono
+      (cpsBranchWithin_extend_code (cr' := cvgulCode)
+        (CodeReq.ofProg_mem_at D (D + 68) cvgulProg 17 (.BEQ .x21 .x8 (224 : BitVec 13))
+          (by bv_omega) (by rw [cvgul_length]; decide) rfl (by rw [cvgul_length]; decide)) hbeq)
+    have htaken := cpsBranchWithin_takenStripPure2 hbeqC (fun hp hq => by
+      obtain ⟨_, _, _, _, _, hrest⟩ := hq
+      exact absurd rfl ((sepConj_pure_right _).1 hrest).2)
+    rw [show (D + 68) + signExtend13 (224 : BitVec 13) = D + 292 from by
+      rw [show signExtend13 (224 : BitVec 13) = (224 : Word) from by decide]; bv_omega] at htaken
+    have htakenF := cpsTripleWithin_frameR
+      ((.x2 ↦ᵣ spC) ** (.x1 ↦ᵣ o1) ** (.x9 ↦ᵣ lenBase) **
+        (.x18 ↦ᵣ hdrBaseAt hdrBase lengths lengths.length) ** (.x19 ↦ᵣ validPtr) **
+        (.x20 ↦ᵣ firstBadPtr) ** (.x10 ↦ᵣ o10) ** (validPtr ↦ₘ (1 : Word)) **
+        (firstBadPtr ↦ₘ (0 : Word)) ** payload hdrBase lenBase bigBytes lengths **
+        regOwn .x5 ** regOwn .x6 ** regOwn .x7 ** regOwn .x11 ** regOwn .x12 ** regOwn .x13 **
+        regOwn .x14 ** regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+        (.x0 ↦ᵣ (0 : Word)) ** frameSlotsOwn EvmAsm.Codegen.RlpFieldToU64SAsm.frame
+          (spC + signExtend12 (-32 : BitVec 12)) **
+        stackFree (spC + signExtend12 (-32 : BitVec 12)) 8 **
+        savedFrame spC csaved) (by unfold payload; pcfx) htaken
+    have hallv := cpsTripleWithin_extend_code cvgul_mono
+      (retAllValid sp0 spC raIn csaved
+        (payload hdrBase lenBase bigBytes lengths ** regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+          regOwn .x11 ** regOwn .x12 ** regOwn .x13 ** regOwn .x14 ** regOwn .x28 ** regOwn .x29 **
+          regOwn .x30 ** regOwn .x31 ** (.x0 ↦ᵣ (0 : Word)) **
+          frameSlotsOwn EvmAsm.Codegen.RlpFieldToU64SAsm.frame
+            (spC + signExtend12 (-32 : BitVec 12)) **
+          stackFree (spC + signExtend12 (-32 : BitVec 12)) 8 **
+          (validPtr ↦ₘ (1 : Word)) ** (firstBadPtr ↦ₘ (0 : Word)))
+        (by unfold payload; pcfx) o10 o1 (BitVec.ofNat 64 lengths.length) lenBase
+        (hdrBaseAt hdrBase lengths lengths.length) validPtr firstBadPtr
+        (BitVec.ofNat 64 lengths.length) hspC hraSaved hret)
+    refine cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp) (fun h hq => ?_)
+      (cpsTripleWithin_seq_perm_same_cr (fun h hp => by rw [hsf] at hp; xperm_hyp hp)
+        htakenF hallv)
+    refine Or.inl ?_
+    unfold postAllValid commonRet
+    refine (sepConj_pure_left h).mpr ⟨hpre, ?_⟩
+    rw [hsf, hraSaved]
+    xperm_hyp hq
+  intro f
+  induction f with
+  | zero =>
+    intro i hf hiN hpre
+    have hi : i = lengths.length := by omega
+    subst hi
+    rw [Nat.sub_self]
+    exact base hpre
+  | succ f ih =>
+    intro i hf hiN hpre
+    rcases (by omega : i = lengths.length ∨ i < lengths.length) with hi | hi
+    · subst hi; rw [Nat.sub_self]; exact base hpre
+    · rw [show lengths.length - i = (lengths.length - (i + 1)) + 1 from by omega,
+        cvgulLoopSteps_succ]
+      exact cvgulIter sp0 spC hdrBase lenBase validPtr firstBadPtr raIn csaved bigBytes lengths i
+        (cvgulLoopSteps (lengths.length - (i + 1))) hi hN hspC hraSaved hret
+        (hAllAlign i hi) (hAllLen i hi) (hAllSalign i hi) (hAllSlack i hi) (hAllOver i hi)
+        (hAllValid i hi) hpre
+        (fun hpre' => ih (i + 1) (by omega) (by omega) hpre')
+
+#print axioms cvgulLoop
+
+set_option maxRecDepth 8000 in
+/-- **`chain_validate_gas_used_under_limit` caller contract.**  The 83-instruction
+    accessor iterates over `N = lengths.length` block headers, validating that
+    every header's `gas_used` (RLP field 10) decodes to a `u64` at most its
+    `gas_limit` (RLP field 9).  Its three-way post pins the result: all-valid
+    (`a0 = 0`, `*validPtr = 1`, every header gas_used ≤ gas_limit), first-violation
+    (`a0 = 0`, `*validPtr = 0`, `*firstBad = k`, header `k` over limit and all
+    earlier valid), or first parse-failure (`a0 = status`, `*firstBad = k`, header
+    `k` fails a strict field-10 or field-9 decode and all earlier valid) — each
+    genuinely tied to K34's per-header `Result`s for BOTH fields. -/
+theorem chain_validate_gas_used_under_limit_spec_within
+    (sp0 spC nWord lenBase hdrBase validPtr firstBadPtr raIn
+      cs0 cs1 cs2 cs3 cs4 cs5 old5 : Word) (bigBytes : List (BitVec 8)) (lengths : List Nat)
+    (hspC : spC = sp0 + signExtend12 (-56 : BitVec 12))
+    (hret : raIn &&& ~~~(1 : Word) = raIn)
+    (hnWord : nWord = BitVec.ofNat 64 lengths.length)
+    (hN : lengths.length < 2 ^ 64)
+    (hAllAlign : ∀ i, i < lengths.length → hdrOff lengths i % 8 = 0)
+    (hAllLen : ∀ i, i < lengths.length → hdrOff lengths i ≤ bigBytes.length)
+    (hAllSalign : ∀ i, i < lengths.length → (hdrBaseAt hdrBase lengths i).toNat % 8 = 0)
+    (hAllSlack : ∀ i, i < lengths.length →
+      lengths[i]! + 9 ≤ (bigBytes.drop (hdrOff lengths i)).length)
+    (hAllOver : ∀ i, i < lengths.length →
+      (hdrBaseAt hdrBase lengths i).toNat + (bigBytes.drop (hdrOff lengths i)).length < 2 ^ 64)
+    (hAllValid : ∀ i, i < lengths.length → ∀ k, k < (bigBytes.drop (hdrOff lengths i)).length →
+      isValidByteAccess (hdrBaseAt hdrBase lengths i + BitVec.ofNat 64 k) = true) :
+    cpsTripleWithin (17 + cvgulLoopSteps lengths.length) D raIn fullCode
+      (((.x2 ↦ᵣ sp0) ** (.x1 ↦ᵣ raIn) ** (.x8 ↦ᵣ cs0) ** (.x9 ↦ᵣ cs1) **
+          (.x18 ↦ᵣ cs2) ** (.x19 ↦ᵣ cs3) ** (.x20 ↦ᵣ cs4) ** (.x21 ↦ᵣ cs5) **
+          (.x10 ↦ᵣ nWord) ** (.x11 ↦ᵣ lenBase) ** (.x12 ↦ᵣ hdrBase) **
+          (.x13 ↦ᵣ validPtr) ** (.x14 ↦ᵣ firstBadPtr) ** (.x5 ↦ᵣ old5) **
+          (.x0 ↦ᵣ (0 : Word)) **
+          memOwn spC ** memOwn (spC + 8) ** memOwn (spC + 16) ** memOwn (spC + 24) **
+          memOwn (spC + 32) ** memOwn (spC + 40) ** memOwn (spC + 48) **
+          memOwn validPtr ** memOwn firstBadPtr) **
+        wordArray lenBase lengths ** bytesRegion hdrBase bigBytes **
+        memOwn GasUsed ** memOwn GasLimit ** memOwn RfuOff ** memOwn RfuLen **
+        memOwn IterPtr ** memOwn IterI **
+        regOwn .x6 ** regOwn .x7 ** regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+        frameSlotsOwn EvmAsm.Codegen.RlpFieldToU64SAsm.frame (spC + signExtend12 (-32 : BitVec 12)) **
+        stackFree (spC + signExtend12 (-32 : BitVec 12)) 8)
+      (cvgulPost sp0 spC (spC + signExtend12 (-32 : BitVec 12)) hdrBase lenBase validPtr
+        firstBadPtr ⟨raIn, cs0, cs1, cs2, cs3, cs4, cs5⟩ bigBytes lengths) := by
+  have h0 : hdrBaseAt hdrBase lengths 0 = hdrBase := by
+    unfold hdrBaseAt hdrOff; simp
+  have hsf : savedFrame spC (⟨raIn, cs0, cs1, cs2, cs3, cs4, cs5⟩ : Saved) =
+      ((spC ↦ₘ raIn) ** ((spC + 8) ↦ₘ cs0) ** ((spC + 16) ↦ₘ cs1) ** ((spC + 24) ↦ₘ cs2) **
+        ((spC + 32) ↦ₘ cs3) ** ((spC + 40) ↦ₘ cs4) ** ((spC + 48) ↦ₘ cs5)) := by
+    unfold savedFrame; rfl
+  have hpro := cpsTripleWithin_frameR
+    (wordArray lenBase lengths ** bytesRegion hdrBase bigBytes **
+      memOwn GasUsed ** memOwn GasLimit ** memOwn RfuOff ** memOwn RfuLen **
+      memOwn IterPtr ** memOwn IterI **
+      regOwn .x6 ** regOwn .x7 ** regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+      frameSlotsOwn EvmAsm.Codegen.RlpFieldToU64SAsm.frame (spC + signExtend12 (-32 : BitVec 12)) **
+      stackFree (spC + signExtend12 (-32 : BitVec 12)) 8)
+    (by pcfx)
+    (cpsTripleWithin_extend_code cvgul_mono
+      (cvgulPrologue sp0 spC nWord lenBase hdrBase validPtr firstBadPtr raIn
+        cs0 cs1 cs2 cs3 cs4 cs5 old5 hspC))
+  have hloop := cvgulLoop sp0 spC hdrBase lenBase validPtr firstBadPtr raIn
+    ⟨raIn, cs0, cs1, cs2, cs3, cs4, cs5⟩ bigBytes lengths hN hspC rfl hret
+    hAllAlign hAllLen hAllSalign hAllSlack hAllOver hAllValid
+    lengths.length 0 (by omega) (by omega) (fun j hj => absurd hj (Nat.not_lt_zero j))
+  rw [Nat.sub_zero] at hloop
+  refine cpsTripleWithin_seq_perm_same_cr (fun h hp => by
+    unfold LoopInv payload scratchRegs
+    rw [hsf, h0, show (BitVec.ofNat 64 0 : Word) = (0 : Word) from by decide]
+    have hp1 : ((.x1 ↦ᵣ raIn) ** (.x5 ↦ᵣ (1 : Word)) **
+        (.x10 ↦ᵣ BitVec.ofNat 64 lengths.length) **
+        (.x11 ↦ᵣ lenBase) ** (.x12 ↦ᵣ hdrBase) ** (.x13 ↦ᵣ validPtr) ** (.x14 ↦ᵣ firstBadPtr) **
+        ((.x2 ↦ᵣ spC) ** (.x8 ↦ᵣ BitVec.ofNat 64 lengths.length) ** (.x9 ↦ᵣ lenBase) **
+          (.x18 ↦ᵣ hdrBase) **
+          (.x19 ↦ᵣ validPtr) ** (.x20 ↦ᵣ firstBadPtr) ** (.x21 ↦ᵣ (0 : Word)) **
+          (spC ↦ₘ raIn) ** ((spC + 8) ↦ₘ cs0) ** ((spC + 16) ↦ₘ cs1) ** ((spC + 24) ↦ₘ cs2) **
+          ((spC + 32) ↦ₘ cs3) ** ((spC + 40) ↦ₘ cs4) ** ((spC + 48) ↦ₘ cs5) **
+          (validPtr ↦ₘ (1 : Word)) ** (firstBadPtr ↦ₘ (0 : Word)) **
+          wordArray lenBase lengths ** bytesRegion hdrBase bigBytes **
+          memOwn GasUsed ** memOwn GasLimit ** memOwn RfuOff ** memOwn RfuLen **
+          memOwn IterPtr ** memOwn IterI **
+          regOwn .x6 ** regOwn .x7 ** regOwn .x28 ** regOwn .x29 ** regOwn .x30 **
+          regOwn .x31 ** (.x0 ↦ᵣ (0 : Word)) **
+          frameSlotsOwn EvmAsm.Codegen.RlpFieldToU64SAsm.frame
+            (spC + signExtend12 (-32 : BitVec 12)) **
+          stackFree (spC + signExtend12 (-32 : BitVec 12)) 8)) h := by
+      rw [hnWord] at hp; xperm_hyp hp
+    have hp2 := sepConj_mono (regIs_implies_regOwn .x1) (sepConj_mono (regIs_implies_regOwn .x5)
+      (sepConj_mono (regIs_implies_regOwn .x10) (sepConj_mono (regIs_implies_regOwn .x11)
+      (sepConj_mono (regIs_implies_regOwn .x12) (sepConj_mono (regIs_implies_regOwn .x13)
+      (sepConj_mono (regIs_implies_regOwn .x14) (fun _ x => x))))))) h hp1
+    xperm_hyp hp2) hpro hloop
+
+#print axioms chain_validate_gas_used_under_limit_spec_within
+
 end EvmAsm.Codegen.ChainValidateGasUsedUnderLimitSpec

--- a/EvmAsm/Codegen/Programs/ChainValidateGasUsedUnderLimitSpec.lean
+++ b/EvmAsm/Codegen/Programs/ChainValidateGasUsedUnderLimitSpec.lean
@@ -1,0 +1,580 @@
+/-
+  Whole-program caller contract for the 83-instruction
+  `chain_validate_gas_used_under_limit` accessor.
+
+  `chainValidateGasUsedUnderLimit_prog` iterates over an array of `N` block
+  headers and validates that EVERY header's `gas_used` (RLP field 10) is at
+  most its `gas_limit` (RLP field 9).
+
+  It is the THIRD sibling of the `chain_validate_extra_data_length`
+  pattern-setter, reusing the generic array-loop infrastructure
+  (`wordArray`, `hdrOff`/`hdrBaseAt`, the `ret*` exit shapes) from
+  `ChainValidateExtraDataLengthSpec` and the strict `rlp_field_to_u64` (K34)
+  call composition from `ChainValidateBlobGasUnderMaxSpec`.  Unlike the blob
+  sibling the per-header body makes TWO K34 calls (field 10 = gas_used, field
+  9 = gas_limit) and compares the two decoded u64s with a dynamic `bltu`.
+
+  Calling convention (see `ChainValidate.lean`):
+    a0 (input)  : N (header count)
+    a1 (input)  : header_lengths ptr (array of N u64 byte-lengths, 8-aligned)
+    a2 (input)  : headers ptr (concatenated header blobs)
+    a3 (input)  : u64 out cell (is_valid)
+    a4 (input)  : u64 out cell (first_bad_index)
+    ra (input)  : return
+    a0 (output) : 0 = every header has gas_used ≤ gas_limit; nonzero = some
+                  header's field 10 or field 9 failed the strict RLP u64 decode.
+
+  The real validity verdict lives in the two output memory cells:
+    *is_valid       : 1 iff every header's gas_used ≤ gas_limit, else 0.
+    *first_bad_index: index of the first bad header (violation or parse-fail).
+
+  Per iteration `i` (`i < N`) the program:
+    * loads `len_i := header_lengths[i]` (aligned array load at `x9 + i*8`);
+    * calls the verified strict `rlp_field_to_u64` on the current header for
+      field 10 (gas_used → the `GasUsed` cell);
+    * on status ≠ 0 → `a0 = status`, `*first_bad = i`, return (parse-fail);
+    * reloads iterator state and calls `rlp_field_to_u64` again for field 9
+      (gas_limit → the `GasLimit` cell);
+    * on status ≠ 0 → `a0 = status`, `*first_bad = i`, return (parse-fail);
+    * else reloads both decoded values and compares (`bltu x7=gl, x6=gu` =
+      `gl <ᵤ gu`):
+        - `gu > gl` → `*is_valid = 0`, `*first_bad = i`, `a0 = 0`;
+        - `gu ≤ gl` → advance `x18 += header_lengths[i]`, `i += 1`.
+    * loop exhausted (`i = N`) → `a0 = 0`, `*is_valid` stays 1.
+
+  Both per-header values are tied to the ACTUAL decoded u64 via K34's `Result`
+  at the actual header base, so the final `∀ i < N` postcondition is genuine.
+-/
+
+import EvmAsm.Codegen.Programs.ChainValidateBlobGasUnderMaxSpec
+import EvmAsm.Codegen.Programs.ChainValidateExtraDataLengthLoop
+import EvmAsm.Codegen.Programs.RlpFieldToU64FlatSAsm
+import EvmAsm.Rv64.LaResolve
+import EvmAsm.Rv64.Tactics.RunBlock
+
+namespace EvmAsm.Codegen.ChainValidateGasUsedUnderLimitSpec
+
+open EvmAsm.Rv64 EvmAsm.Rv64.RLP EvmAsm.Rv64.SAsm
+open EvmAsm.Codegen.RlpListNthItemSAsm
+  (Saved savedFrame savedVals listNthFrame regsAt_listNthFrame
+   frameSlotsSaved_listNthFrame)
+open EvmAsm.Codegen.ChainValidateExtraDataLengthSpec
+  (wordArray wordArrayFrom wordArray_split pcFree_wordArray pcFree_wordArrayFrom
+   wordArrayFrom_append shiftLeft3_ofNat hdrOff hdrBaseAt hdrOff_succ hdrBaseAt_succ
+   ofNat_ne_of_lt ofNat_succ_tie)
+
+/-! ## Base addresses and linked code -/
+
+/-- Chain accessor base address. -/
+abbrev D : Word := (GuestAddrs.chain_validate_gas_used_under_limit : Word)
+
+/-- The chain accessor's own program. -/
+abbrev cvgulProg : Program := EvmAsm.Codegen.chainValidateGasUsedUnderLimit_prog
+
+theorem cvgul_length : cvgulProg.length = 83 := by decide
+
+/-- The chain accessor's re-emitted instructions at its base. -/
+def cvgulCode : CodeReq := CodeReq.ofProg D cvgulProg
+
+/-- The full linked closure: the chain accessor plus the strict K34
+    `rlp_field_to_u64` wrapper and its transitive callees. -/
+def fullCode : CodeReq := cvgulCode.union EvmAsm.Codegen.RlpFieldToU64SAsm.code
+
+theorem cvgul_disjoint :
+    cvgulCode.Disjoint EvmAsm.Codegen.RlpFieldToU64SAsm.code := by
+  unfold cvgulCode EvmAsm.Codegen.RlpFieldToU64SAsm.code
+    EvmAsm.Codegen.RlpFieldToU64SAsm.wrapperCode EvmAsm.Codegen.RlpFieldToU64SAsm.contentCode
+  refine CodeReq.Disjoint.union_right ?_ (CodeReq.Disjoint.union_right ?_ ?_)
+  · apply CodeReq.Disjoint.ofProg_ranges
+    · rw [cvgul_length]; decide
+    · rw [EvmAsm.Codegen.RlpFieldToU64SAsm.program_length]; decide
+    · right; rw [EvmAsm.Codegen.RlpFieldToU64SAsm.program_length]; decide
+  · apply CodeReq.Disjoint.ofProg_ranges
+    · rw [cvgul_length]; decide
+    · rw [EvmAsm.Codegen.RlpListNthItemSAsm.total_length]; decide
+    · right; rw [EvmAsm.Codegen.RlpListNthItemSAsm.total_length]; decide
+  · unfold EvmAsm.Rv64.RLP.rlp_content_to_u64_code
+    apply CodeReq.Disjoint.ofProg_ranges
+    · rw [cvgul_length]; decide
+    · rw [EvmAsm.Rv64.RLP.rlp_content_to_u64_prog_length]; decide
+    · left; rw [cvgul_length]; decide
+
+#print axioms cvgul_disjoint
+
+/-- K34's linked code is subsumed by the chain accessor's full closure. -/
+theorem k34_mono :
+    ∀ a i, EvmAsm.Codegen.RlpFieldToU64SAsm.code a = some i → fullCode a = some i := by
+  intro a i hi
+  unfold fullCode
+  exact CodeReq.mono_union_right cvgul_disjoint (fun _ _ h => h) a i hi
+
+theorem cvgul_mono : ∀ a i, cvgulCode a = some i → fullCode a = some i := by
+  intro a i hi
+  unfold fullCode
+  exact CodeReq.union_mono_left a i hi
+
+/-! ## Model of the header array -/
+
+/-- Scratch-cell addresses. -/
+abbrev IterPtr : Word := (GuestAddrs.cvgul_iter_ptr : Word)
+abbrev IterI : Word := (GuestAddrs.cvgul_iter_i : Word)
+abbrev GasUsed : Word := (GuestAddrs.cvgul_gas_used : Word)
+abbrev GasLimit : Word := (GuestAddrs.cvgul_gas_limit : Word)
+
+/-- K34's internal scratch cells (owned across the call, threaded unchanged). -/
+abbrev RfuOff : Word := (GuestAddrs.rfu_offset : Word)
+abbrev RfuLen : Word := (GuestAddrs.rfu_length : Word)
+
+/-- The link address written into `ra` by the first loop-body `jal` (the K34
+    return site of call 1), = `D + 128`. -/
+abbrev LinkRA1 : Word := D + 128
+
+/-- The link address written into `ra` by the second loop-body `jal` (the K34
+    return site of call 2), = `D + 188`. -/
+abbrev LinkRA2 : Word := D + 188
+
+/-- Header `i` decodes field 10 to `gu` and field 9 to `gl`, both strictly, with
+    `gas_used ≤ gas_limit` (`¬ gl <ᵤ gu`). -/
+def hdrGasOk (hdrBase : Word) (bigBytes : List (BitVec 8)) (lengths : List Nat)
+    (i : Nat) : Prop :=
+  ∃ gu gl,
+    EvmAsm.Codegen.RlpFieldToU64SAsm.Result (bigBytes.drop (hdrOff lengths i))
+      (hdrBaseAt hdrBase lengths i) (lengths[i]!) 10 0 gu ∧
+    EvmAsm.Codegen.RlpFieldToU64SAsm.Result (bigBytes.drop (hdrOff lengths i))
+      (hdrBaseAt hdrBase lengths i) (lengths[i]!) 9 0 gl ∧
+    ¬ BitVec.ult gl gu
+
+/-- Header `i` decodes both fields but `gas_used > gas_limit` (`gl <ᵤ gu`). -/
+def hdrGasBad (hdrBase : Word) (bigBytes : List (BitVec 8)) (lengths : List Nat)
+    (i : Nat) : Prop :=
+  ∃ gu gl,
+    EvmAsm.Codegen.RlpFieldToU64SAsm.Result (bigBytes.drop (hdrOff lengths i))
+      (hdrBaseAt hdrBase lengths i) (lengths[i]!) 10 0 gu ∧
+    EvmAsm.Codegen.RlpFieldToU64SAsm.Result (bigBytes.drop (hdrOff lengths i))
+      (hdrBaseAt hdrBase lengths i) (lengths[i]!) 9 0 gl ∧
+    BitVec.ult gl gu
+
+/-- Header `i` fails a strict field decode with nonzero `status`: either field
+    10 (gas_used) fails, or field 10 succeeds and field 9 (gas_limit) fails. -/
+def hdrGasParseFail (hdrBase : Word) (bigBytes : List (BitVec 8)) (lengths : List Nat)
+    (i : Nat) (status : Word) : Prop :=
+  (∃ gu,
+    EvmAsm.Codegen.RlpFieldToU64SAsm.Result (bigBytes.drop (hdrOff lengths i))
+      (hdrBaseAt hdrBase lengths i) (lengths[i]!) 10 status gu ∧ status ≠ 0) ∨
+  (∃ gu gl,
+    EvmAsm.Codegen.RlpFieldToU64SAsm.Result (bigBytes.drop (hdrOff lengths i))
+      (hdrBaseAt hdrBase lengths i) (lengths[i]!) 10 0 gu ∧
+    EvmAsm.Codegen.RlpFieldToU64SAsm.Result (bigBytes.drop (hdrOff lengths i))
+      (hdrBaseAt hdrBase lengths i) (lengths[i]!) 9 status gl ∧ status ≠ 0)
+
+/-! ## Frames -/
+
+/-- Static memory/register footprint carried unchanged through the whole loop:
+    the header-length array, the concatenated header blob, and the six scratch
+    cells (owned).  The accessor's saved-register slots sit separately. -/
+def payload (hdrBase lenBase : Word) (bigBytes : List (BitVec 8))
+    (lengths : List Nat) : Assertion :=
+  wordArray lenBase lengths ** bytesRegion hdrBase bigBytes **
+  memOwn GasUsed ** memOwn GasLimit ** memOwn RfuOff ** memOwn RfuLen **
+  memOwn IterPtr ** memOwn IterI
+
+/-- Callee-perturbed registers owned + the K34 frame slots owned + the callee's
+    8-dword allocatable stack + `x0`. -/
+def scratchRegs (calleeNewSp : Word) : Assertion :=
+  regOwn .x1 ** regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+  regOwn .x10 ** regOwn .x11 ** regOwn .x12 ** regOwn .x13 ** regOwn .x14 **
+  regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+  (.x0 ↦ᵣ (0 : Word)) ** frameSlotsOwn EvmAsm.Codegen.RlpFieldToU64SAsm.frame calleeNewSp **
+  stackFree calleeNewSp 8
+
+/-- Loop invariant at the guard (`D + 68`) entering iteration `i` (`i ≤ N`). -/
+def LoopInv (_sp0 spC calleeNewSp hdrBase lenBase validPtr firstBadPtr : Word)
+    (csaved : Saved) (bigBytes : List (BitVec 8)) (lengths : List Nat)
+    (i : Nat) : Assertion :=
+  (.x2 ↦ᵣ spC) ** (.x8 ↦ᵣ BitVec.ofNat 64 lengths.length) ** (.x9 ↦ᵣ lenBase) **
+  (.x18 ↦ᵣ hdrBaseAt hdrBase lengths i) ** (.x19 ↦ᵣ validPtr) **
+  (.x20 ↦ᵣ firstBadPtr) ** (.x21 ↦ᵣ BitVec.ofNat 64 i) **
+  savedFrame spC csaved ** (validPtr ↦ₘ (1 : Word)) ** (firstBadPtr ↦ₘ (0 : Word)) **
+  payload hdrBase lenBase bigBytes lengths ** scratchRegs calleeNewSp
+
+/-- Return footprint shared by all three post arms. -/
+def commonRet (sp0 spC calleeNewSp hdrBase lenBase : Word) (csaved : Saved)
+    (bigBytes : List (BitVec 8)) (lengths : List Nat) : Assertion :=
+  (.x1 ↦ᵣ csaved.ra) ** (.x2 ↦ᵣ sp0) ** (.x8 ↦ᵣ csaved.s0) ** (.x9 ↦ᵣ csaved.s1) **
+  (.x18 ↦ᵣ csaved.s2) ** (.x19 ↦ᵣ csaved.s3) ** (.x20 ↦ᵣ csaved.s4) **
+  (.x21 ↦ᵣ csaved.s5) ** savedFrame spC csaved **
+  regOwn .x5 ** regOwn .x6 ** regOwn .x7 ** regOwn .x11 **
+  regOwn .x12 ** regOwn .x13 ** regOwn .x14 ** regOwn .x28 ** regOwn .x29 **
+  regOwn .x30 ** regOwn .x31 ** (.x0 ↦ᵣ (0 : Word)) **
+  frameSlotsOwn EvmAsm.Codegen.RlpFieldToU64SAsm.frame calleeNewSp **
+  stackFree calleeNewSp 8 ** payload hdrBase lenBase bigBytes lengths
+
+/-- All headers valid: `a0 = 0`, `*validPtr = 1`, `*firstBadPtr = 0`, and every
+    header `< N` has gas_used ≤ gas_limit. -/
+def postAllValid (sp0 spC calleeNewSp hdrBase lenBase validPtr firstBadPtr : Word)
+    (csaved : Saved) (bigBytes : List (BitVec 8)) (lengths : List Nat) : Assertion :=
+  ⌜∀ j, j < lengths.length → hdrGasOk hdrBase bigBytes lengths j⌝ **
+  (.x10 ↦ᵣ (0 : Word)) ** (validPtr ↦ₘ (1 : Word)) ** (firstBadPtr ↦ₘ (0 : Word)) **
+  commonRet sp0 spC calleeNewSp hdrBase lenBase csaved bigBytes lengths
+
+/-- First violation at `k`: `a0 = 0`, `*validPtr = 0`, `*firstBadPtr = k`,
+    header `k` has gas_used > gas_limit, and all earlier headers are valid. -/
+def postViolation (sp0 spC calleeNewSp hdrBase lenBase validPtr firstBadPtr : Word)
+    (csaved : Saved) (bigBytes : List (BitVec 8)) (lengths : List Nat) : Assertion :=
+  fun h => ∃ k,
+    (⌜k < lengths.length ∧ (∀ j, j < k → hdrGasOk hdrBase bigBytes lengths j) ∧
+        hdrGasBad hdrBase bigBytes lengths k⌝ **
+      (.x10 ↦ᵣ (0 : Word)) ** (validPtr ↦ₘ (0 : Word)) **
+      (firstBadPtr ↦ₘ BitVec.ofNat 64 k) **
+      commonRet sp0 spC calleeNewSp hdrBase lenBase csaved bigBytes lengths) h
+
+/-- First parse failure at `k`: `a0 = status` (the actual nonzero K34 status),
+    `*firstBadPtr = k`, `*validPtr = 1`, header `k` fails a strict field decode,
+    and all earlier headers are valid. -/
+def postParseFail (sp0 spC calleeNewSp hdrBase lenBase validPtr firstBadPtr : Word)
+    (csaved : Saved) (bigBytes : List (BitVec 8)) (lengths : List Nat) : Assertion :=
+  fun h => ∃ k status,
+    (⌜k < lengths.length ∧ (∀ j, j < k → hdrGasOk hdrBase bigBytes lengths j) ∧
+        hdrGasParseFail hdrBase bigBytes lengths k status⌝ **
+      (.x10 ↦ᵣ status) ** (validPtr ↦ₘ (1 : Word)) **
+      (firstBadPtr ↦ₘ BitVec.ofNat 64 k) **
+      commonRet sp0 spC calleeNewSp hdrBase lenBase csaved bigBytes lengths) h
+
+/-- Three-way whole-program post: all-valid, first-violation, or first
+    parse-failure, each genuinely tied to the actual per-header `Result`s. -/
+def cvgulPost (sp0 spC calleeNewSp hdrBase lenBase validPtr firstBadPtr : Word)
+    (csaved : Saved) (bigBytes : List (BitVec 8)) (lengths : List Nat) : Assertion :=
+  fun h =>
+    postAllValid sp0 spC calleeNewSp hdrBase lenBase validPtr firstBadPtr csaved
+        bigBytes lengths h ∨
+    postViolation sp0 spC calleeNewSp hdrBase lenBase validPtr firstBadPtr csaved
+        bigBytes lengths h ∨
+    postParseFail sp0 spC calleeNewSp hdrBase lenBase validPtr firstBadPtr csaved
+        bigBytes lengths h
+
+/-! ## Prologue (instructions 0--16): set up the loop-entry state
+
+    Byte-identical to the `chain_validate_extra_data_length` prologue. -/
+
+set_option maxRecDepth 8000 in
+theorem cvgulPrologue
+    (sp0 spC nWord lenBase hdrBase validPtr firstBadPtr raIn
+      cs0 cs1 cs2 cs3 cs4 cs5 old5 : Word)
+    (hspC : spC = sp0 + signExtend12 (-56 : BitVec 12)) :
+    cpsTripleWithin 17 D (D + 68) cvgulCode
+      ((.x2 ↦ᵣ sp0) ** (.x1 ↦ᵣ raIn) ** (.x8 ↦ᵣ cs0) ** (.x9 ↦ᵣ cs1) **
+        (.x18 ↦ᵣ cs2) ** (.x19 ↦ᵣ cs3) ** (.x20 ↦ᵣ cs4) ** (.x21 ↦ᵣ cs5) **
+        (.x10 ↦ᵣ nWord) ** (.x11 ↦ᵣ lenBase) ** (.x12 ↦ᵣ hdrBase) **
+        (.x13 ↦ᵣ validPtr) ** (.x14 ↦ᵣ firstBadPtr) ** (.x5 ↦ᵣ old5) **
+        (.x0 ↦ᵣ (0 : Word)) **
+        memOwn spC ** memOwn (spC + 8) ** memOwn (spC + 16) ** memOwn (spC + 24) **
+        memOwn (spC + 32) ** memOwn (spC + 40) ** memOwn (spC + 48) **
+        memOwn validPtr ** memOwn firstBadPtr)
+      ((.x2 ↦ᵣ spC) ** (.x1 ↦ᵣ raIn) ** (.x8 ↦ᵣ nWord) ** (.x9 ↦ᵣ lenBase) **
+        (.x18 ↦ᵣ hdrBase) ** (.x19 ↦ᵣ validPtr) ** (.x20 ↦ᵣ firstBadPtr) **
+        (.x21 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ nWord) ** (.x11 ↦ᵣ lenBase) **
+        (.x12 ↦ᵣ hdrBase) ** (.x13 ↦ᵣ validPtr) ** (.x14 ↦ᵣ firstBadPtr) **
+        (.x5 ↦ᵣ (1 : Word)) ** (.x0 ↦ᵣ (0 : Word)) **
+        (spC ↦ₘ raIn) ** ((spC + 8) ↦ₘ cs0) ** ((spC + 16) ↦ₘ cs1) **
+        ((spC + 24) ↦ₘ cs2) ** ((spC + 32) ↦ₘ cs3) ** ((spC + 40) ↦ₘ cs4) **
+        ((spC + 48) ↦ₘ cs5) ** (validPtr ↦ₘ (1 : Word)) **
+        (firstBadPtr ↦ₘ (0 : Word))) := by
+  subst hspC
+  have h0 := addi_spec_gen_same_within .x2 sp0 (-56 : BitVec 12) D (by decide)
+  have h1 := sd_spec_gen_own_within .x2 .x1
+    (sp0 + signExtend12 (-56 : BitVec 12)) raIn (0 : BitVec 12) (D + 4)
+  rw [show signExtend12 (0 : BitVec 12) = (0 : Word) from by decide,
+    show (sp0 + signExtend12 (-56 : BitVec 12)) + (0 : Word)
+      = sp0 + signExtend12 (-56 : BitVec 12) from by bv_omega] at h1
+  have h2 := sd_spec_gen_own_within .x2 .x8
+    (sp0 + signExtend12 (-56 : BitVec 12)) cs0 (8 : BitVec 12) (D + 8)
+  rw [show signExtend12 (8 : BitVec 12) = (8 : Word) from by decide] at h2
+  have h3 := sd_spec_gen_own_within .x2 .x9
+    (sp0 + signExtend12 (-56 : BitVec 12)) cs1 (16 : BitVec 12) (D + 12)
+  rw [show signExtend12 (16 : BitVec 12) = (16 : Word) from by decide] at h3
+  have h4 := sd_spec_gen_own_within .x2 .x18
+    (sp0 + signExtend12 (-56 : BitVec 12)) cs2 (24 : BitVec 12) (D + 16)
+  rw [show signExtend12 (24 : BitVec 12) = (24 : Word) from by decide] at h4
+  have h5 := sd_spec_gen_own_within .x2 .x19
+    (sp0 + signExtend12 (-56 : BitVec 12)) cs3 (32 : BitVec 12) (D + 20)
+  rw [show signExtend12 (32 : BitVec 12) = (32 : Word) from by decide] at h5
+  have h6 := sd_spec_gen_own_within .x2 .x20
+    (sp0 + signExtend12 (-56 : BitVec 12)) cs4 (40 : BitVec 12) (D + 24)
+  rw [show signExtend12 (40 : BitVec 12) = (40 : Word) from by decide] at h6
+  have h7 := sd_spec_gen_own_within .x2 .x21
+    (sp0 + signExtend12 (-56 : BitVec 12)) cs5 (48 : BitVec 12) (D + 28)
+  rw [show signExtend12 (48 : BitVec 12) = (48 : Word) from by decide] at h7
+  have h8 := mv_spec_gen_within .x8 .x10 nWord cs0 (D + 32) (by decide)
+  have h9 := mv_spec_gen_within .x9 .x11 lenBase cs1 (D + 36) (by decide)
+  have h10 := mv_spec_gen_within .x18 .x12 hdrBase cs2 (D + 40) (by decide)
+  have h11 := mv_spec_gen_within .x19 .x13 validPtr cs3 (D + 44) (by decide)
+  have h12 := mv_spec_gen_within .x20 .x14 firstBadPtr cs4 (D + 48) (by decide)
+  have h13 := li_spec_gen_within .x5 old5 (1 : Word) (D + 52) (by decide)
+  have h14 := sd_spec_gen_own_within .x19 .x5 validPtr (1 : Word) (0 : BitVec 12) (D + 56)
+  rw [show signExtend12 (0 : BitVec 12) = (0 : Word) from by decide,
+    show validPtr + (0 : Word) = validPtr from by bv_omega] at h14
+  have h15 := sd_spec_gen_own_within .x20 .x0 firstBadPtr (0 : Word) (0 : BitVec 12) (D + 60)
+  rw [show signExtend12 (0 : BitVec 12) = (0 : Word) from by decide,
+    show firstBadPtr + (0 : Word) = firstBadPtr from by bv_omega] at h15
+  have h16 := li_spec_gen_within .x21 cs5 (0 : Word) (D + 64) (by decide)
+  runBlock h0 h1 h2 h3 h4 h5 h6 h7 h8 h9 h10 h11 h12 h13 h14 h15 h16
+
+#print axioms cvgulPrologue
+
+/-! ## Epilogue (instructions 74--82): restore + return -/
+
+set_option maxRecDepth 8000 in
+theorem cvgulEpilogue
+    (sp0 spC raIn cs0 cs1 cs2 cs3 cs4 cs5 o1 o8 o9 o18 o19 o20 o21 : Word)
+    (hspC : spC = sp0 + signExtend12 (-56 : BitVec 12))
+    (hret : raIn &&& ~~~(1 : Word) = raIn) :
+    cpsTripleWithin 9 (D + 296) raIn cvgulCode
+      ((.x2 ↦ᵣ spC) ** (.x1 ↦ᵣ o1) ** (.x8 ↦ᵣ o8) ** (.x9 ↦ᵣ o9) **
+        (.x18 ↦ᵣ o18) ** (.x19 ↦ᵣ o19) ** (.x20 ↦ᵣ o20) ** (.x21 ↦ᵣ o21) **
+        (spC ↦ₘ raIn) ** ((spC + 8) ↦ₘ cs0) ** ((spC + 16) ↦ₘ cs1) **
+        ((spC + 24) ↦ₘ cs2) ** ((spC + 32) ↦ₘ cs3) ** ((spC + 40) ↦ₘ cs4) **
+        ((spC + 48) ↦ₘ cs5))
+      ((.x1 ↦ᵣ raIn) ** (.x2 ↦ᵣ sp0) ** (.x8 ↦ᵣ cs0) ** (.x9 ↦ᵣ cs1) **
+        (.x18 ↦ᵣ cs2) ** (.x19 ↦ᵣ cs3) ** (.x20 ↦ᵣ cs4) ** (.x21 ↦ᵣ cs5) **
+        (spC ↦ₘ raIn) ** ((spC + 8) ↦ₘ cs0) ** ((spC + 16) ↦ₘ cs1) **
+        ((spC + 24) ↦ₘ cs2) ** ((spC + 32) ↦ₘ cs3) ** ((spC + 40) ↦ₘ cs4) **
+        ((spC + 48) ↦ₘ cs5)) := by
+  subst hspC
+  have l0 := ld_spec_gen_within .x1 .x2 (sp0 + signExtend12 (-56 : BitVec 12)) o1 raIn
+    (0 : BitVec 12) (D + 296) (by decide)
+  rw [show signExtend12 (0 : BitVec 12) = (0 : Word) from by decide,
+    show (sp0 + signExtend12 (-56 : BitVec 12)) + (0 : Word)
+      = sp0 + signExtend12 (-56 : BitVec 12) from by bv_omega] at l0
+  have l1 := ld_spec_gen_within .x8 .x2 (sp0 + signExtend12 (-56 : BitVec 12)) o8 cs0
+    (8 : BitVec 12) (D + 300) (by decide)
+  rw [show signExtend12 (8 : BitVec 12) = (8 : Word) from by decide] at l1
+  have l2 := ld_spec_gen_within .x9 .x2 (sp0 + signExtend12 (-56 : BitVec 12)) o9 cs1
+    (16 : BitVec 12) (D + 304) (by decide)
+  rw [show signExtend12 (16 : BitVec 12) = (16 : Word) from by decide] at l2
+  have l3 := ld_spec_gen_within .x18 .x2 (sp0 + signExtend12 (-56 : BitVec 12)) o18 cs2
+    (24 : BitVec 12) (D + 308) (by decide)
+  rw [show signExtend12 (24 : BitVec 12) = (24 : Word) from by decide] at l3
+  have l4 := ld_spec_gen_within .x19 .x2 (sp0 + signExtend12 (-56 : BitVec 12)) o19 cs3
+    (32 : BitVec 12) (D + 312) (by decide)
+  rw [show signExtend12 (32 : BitVec 12) = (32 : Word) from by decide] at l4
+  have l5 := ld_spec_gen_within .x20 .x2 (sp0 + signExtend12 (-56 : BitVec 12)) o20 cs4
+    (40 : BitVec 12) (D + 316) (by decide)
+  rw [show signExtend12 (40 : BitVec 12) = (40 : Word) from by decide] at l5
+  have l6 := ld_spec_gen_within .x21 .x2 (sp0 + signExtend12 (-56 : BitVec 12)) o21 cs5
+    (48 : BitVec 12) (D + 320) (by decide)
+  rw [show signExtend12 (48 : BitVec 12) = (48 : Word) from by decide] at l6
+  have l7 := addi_spec_gen_same_within .x2 (sp0 + signExtend12 (-56 : BitVec 12))
+    (56 : BitVec 12) (D + 324) (by decide)
+  rw [show (sp0 + signExtend12 (-56 : BitVec 12)) + signExtend12 (56 : BitVec 12) = sp0
+      from by rw [show signExtend12 (-56 : BitVec 12) = (-56 : Word) from by decide,
+        show signExtend12 (56 : BitVec 12) = (56 : Word) from by decide]; bv_omega] at l7
+  have hblock : cpsTripleWithin 8 (D + 296) (D + 328) cvgulCode
+      ((.x2 ↦ᵣ (sp0 + signExtend12 (-56 : BitVec 12))) ** (.x1 ↦ᵣ o1) ** (.x8 ↦ᵣ o8) **
+        (.x9 ↦ᵣ o9) ** (.x18 ↦ᵣ o18) ** (.x19 ↦ᵣ o19) ** (.x20 ↦ᵣ o20) **
+        (.x21 ↦ᵣ o21) **
+        ((sp0 + signExtend12 (-56 : BitVec 12)) ↦ₘ raIn) **
+        ((sp0 + signExtend12 (-56 : BitVec 12) + 8) ↦ₘ cs0) **
+        ((sp0 + signExtend12 (-56 : BitVec 12) + 16) ↦ₘ cs1) **
+        ((sp0 + signExtend12 (-56 : BitVec 12) + 24) ↦ₘ cs2) **
+        ((sp0 + signExtend12 (-56 : BitVec 12) + 32) ↦ₘ cs3) **
+        ((sp0 + signExtend12 (-56 : BitVec 12) + 40) ↦ₘ cs4) **
+        ((sp0 + signExtend12 (-56 : BitVec 12) + 48) ↦ₘ cs5))
+      ((.x1 ↦ᵣ raIn) ** (.x8 ↦ᵣ cs0) ** (.x9 ↦ᵣ cs1) ** (.x18 ↦ᵣ cs2) **
+        (.x19 ↦ᵣ cs3) ** (.x20 ↦ᵣ cs4) ** (.x21 ↦ᵣ cs5) ** (.x2 ↦ᵣ sp0) **
+        ((sp0 + signExtend12 (-56 : BitVec 12)) ↦ₘ raIn) **
+        ((sp0 + signExtend12 (-56 : BitVec 12) + 8) ↦ₘ cs0) **
+        ((sp0 + signExtend12 (-56 : BitVec 12) + 16) ↦ₘ cs1) **
+        ((sp0 + signExtend12 (-56 : BitVec 12) + 24) ↦ₘ cs2) **
+        ((sp0 + signExtend12 (-56 : BitVec 12) + 32) ↦ₘ cs3) **
+        ((sp0 + signExtend12 (-56 : BitVec 12) + 40) ↦ₘ cs4) **
+        ((sp0 + signExtend12 (-56 : BitVec 12) + 48) ↦ₘ cs5)) := by
+    runBlock l0 l1 l2 l3 l4 l5 l6 l7
+  have hjalr := EvmAsm.Evm64.ret_spec_within' (D + 328) raIn
+  rw [hret] at hjalr
+  have hjalrC := cpsTripleWithin_extend_code
+    (CodeReq.ofProg_mem_at D (D + 328) cvgulProg 82 (.JALR .x0 .x1 (0 : BitVec 12))
+      (by bv_omega) (by rw [cvgul_length]; decide) rfl (by rw [cvgul_length]; decide))
+    hjalr
+  have hjalrF := cpsTripleWithin_frameR
+    ((.x8 ↦ᵣ cs0) ** (.x9 ↦ᵣ cs1) ** (.x18 ↦ᵣ cs2) ** (.x19 ↦ᵣ cs3) **
+      (.x20 ↦ᵣ cs4) ** (.x21 ↦ᵣ cs5) ** (.x2 ↦ᵣ sp0) **
+      ((sp0 + signExtend12 (-56 : BitVec 12)) ↦ₘ raIn) **
+      ((sp0 + signExtend12 (-56 : BitVec 12) + 8) ↦ₘ cs0) **
+      ((sp0 + signExtend12 (-56 : BitVec 12) + 16) ↦ₘ cs1) **
+      ((sp0 + signExtend12 (-56 : BitVec 12) + 24) ↦ₘ cs2) **
+      ((sp0 + signExtend12 (-56 : BitVec 12) + 32) ↦ₘ cs3) **
+      ((sp0 + signExtend12 (-56 : BitVec 12) + 40) ↦ₘ cs4) **
+      ((sp0 + signExtend12 (-56 : BitVec 12) + 48) ↦ₘ cs5)) (by pcf) hjalrC
+  have hall := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) hblock hjalrF
+  exact cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
+    (fun _ hq => by xperm_hyp hq) hall
+
+#print axioms cvgulEpilogue
+
+/-! ## All-valid exit (instruction 73 → epilogue): `a0 := 0`, then return -/
+
+set_option maxRecDepth 8000 in
+theorem retAllValid
+    (sp0 spC raIn : Word) (csaved : Saved) (G : Assertion) (hG : G.pcFree)
+    (o10 o1 o8 o9 o18 o19 o20 o21 : Word)
+    (hspC : spC = sp0 + signExtend12 (-56 : BitVec 12))
+    (hraSaved : csaved.ra = raIn)
+    (hret : raIn &&& ~~~(1 : Word) = raIn) :
+    cpsTripleWithin 10 (D + 292) raIn cvgulCode
+      ((.x10 ↦ᵣ o10) ** (.x2 ↦ᵣ spC) ** (.x1 ↦ᵣ o1) ** (.x8 ↦ᵣ o8) ** (.x9 ↦ᵣ o9) **
+        (.x18 ↦ᵣ o18) ** (.x19 ↦ᵣ o19) ** (.x20 ↦ᵣ o20) ** (.x21 ↦ᵣ o21) **
+        (spC ↦ₘ raIn) ** ((spC + 8) ↦ₘ csaved.s0) ** ((spC + 16) ↦ₘ csaved.s1) **
+        ((spC + 24) ↦ₘ csaved.s2) ** ((spC + 32) ↦ₘ csaved.s3) **
+        ((spC + 40) ↦ₘ csaved.s4) ** ((spC + 48) ↦ₘ csaved.s5) ** G)
+      ((.x10 ↦ᵣ (0 : Word)) ** (.x1 ↦ᵣ raIn) ** (.x2 ↦ᵣ sp0) **
+        (.x8 ↦ᵣ csaved.s0) ** (.x9 ↦ᵣ csaved.s1) ** (.x18 ↦ᵣ csaved.s2) **
+        (.x19 ↦ᵣ csaved.s3) ** (.x20 ↦ᵣ csaved.s4) ** (.x21 ↦ᵣ csaved.s5) **
+        (spC ↦ₘ raIn) ** ((spC + 8) ↦ₘ csaved.s0) ** ((spC + 16) ↦ₘ csaved.s1) **
+        ((spC + 24) ↦ₘ csaved.s2) ** ((spC + 32) ↦ₘ csaved.s3) **
+        ((spC + 40) ↦ₘ csaved.s4) ** ((spC + 48) ↦ₘ csaved.s5) ** G) := by
+  subst hraSaved
+  have h73 := li_spec_gen_within .x10 o10 (0 : Word) (D + 292) (by decide)
+  have h73C := cpsTripleWithin_extend_code
+    (CodeReq.ofProg_mem_at D (D + 292) cvgulProg 73 (.LI .x10 (0 : Word))
+      (by bv_omega) (by rw [cvgul_length]; decide) rfl (by rw [cvgul_length]; decide))
+    h73
+  have h73F := cpsTripleWithin_frameR
+    ((.x2 ↦ᵣ spC) ** (.x1 ↦ᵣ o1) ** (.x8 ↦ᵣ o8) ** (.x9 ↦ᵣ o9) ** (.x18 ↦ᵣ o18) **
+      (.x19 ↦ᵣ o19) ** (.x20 ↦ᵣ o20) ** (.x21 ↦ᵣ o21) **
+      (spC ↦ₘ csaved.ra) ** ((spC + 8) ↦ₘ csaved.s0) ** ((spC + 16) ↦ₘ csaved.s1) **
+      ((spC + 24) ↦ₘ csaved.s2) ** ((spC + 32) ↦ₘ csaved.s3) **
+      ((spC + 40) ↦ₘ csaved.s4) ** ((spC + 48) ↦ₘ csaved.s5) ** G)
+    (by repeat' first | exact hG | apply pcFree_sepConj | exact pcFree_regIs
+                      | exact pcFree_memIs) h73C
+  have hepi := cvgulEpilogue sp0 spC csaved.ra csaved.s0 csaved.s1 csaved.s2 csaved.s3
+    csaved.s4 csaved.s5 o1 o8 o9 o18 o19 o20 o21 hspC hret
+  have hepiF := cpsTripleWithin_frameR ((.x10 ↦ᵣ (0 : Word)) ** G)
+    (by refine pcFree_sepConj ?_ hG; pcf) hepi
+  have hall := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) h73F hepiF
+  exact cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
+    (fun _ hq => by xperm_hyp hq) hall
+
+#print axioms retAllValid
+
+/-! ## Violation exit (instructions 67--70 → epilogue)
+
+    `*validPtr := 0`, `*firstBadPtr := i`, `a0 := 0`, `jal +16` to epilogue. -/
+
+set_option maxRecDepth 8000 in
+theorem retViolation
+    (sp0 spC raIn iWord validPtr firstBadPtr : Word) (csaved : Saved)
+    (G : Assertion) (hG : G.pcFree) (o10 o1 o8 o9 o18 : Word)
+    (hspC : spC = sp0 + signExtend12 (-56 : BitVec 12))
+    (hraSaved : csaved.ra = raIn)
+    (hret : raIn &&& ~~~(1 : Word) = raIn) :
+    cpsTripleWithin 13 (D + 268) raIn cvgulCode
+      ((.x19 ↦ᵣ validPtr) ** (.x20 ↦ᵣ firstBadPtr) ** (.x21 ↦ᵣ iWord) **
+        (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ o10) ** (.x2 ↦ᵣ spC) ** (.x1 ↦ᵣ o1) **
+        (.x8 ↦ᵣ o8) ** (.x9 ↦ᵣ o9) ** (.x18 ↦ᵣ o18) **
+        memOwn validPtr ** memOwn firstBadPtr **
+        (spC ↦ₘ raIn) ** ((spC + 8) ↦ₘ csaved.s0) ** ((spC + 16) ↦ₘ csaved.s1) **
+        ((spC + 24) ↦ₘ csaved.s2) ** ((spC + 32) ↦ₘ csaved.s3) **
+        ((spC + 40) ↦ₘ csaved.s4) ** ((spC + 48) ↦ₘ csaved.s5) ** G)
+      ((.x10 ↦ᵣ (0 : Word)) ** (validPtr ↦ₘ (0 : Word)) ** (firstBadPtr ↦ₘ iWord) **
+        (.x0 ↦ᵣ (0 : Word)) ** (.x1 ↦ᵣ raIn) ** (.x2 ↦ᵣ sp0) **
+        (.x8 ↦ᵣ csaved.s0) ** (.x9 ↦ᵣ csaved.s1) ** (.x18 ↦ᵣ csaved.s2) **
+        (.x19 ↦ᵣ csaved.s3) ** (.x20 ↦ᵣ csaved.s4) ** (.x21 ↦ᵣ csaved.s5) **
+        (spC ↦ₘ raIn) ** ((spC + 8) ↦ₘ csaved.s0) ** ((spC + 16) ↦ₘ csaved.s1) **
+        ((spC + 24) ↦ₘ csaved.s2) ** ((spC + 32) ↦ₘ csaved.s3) **
+        ((spC + 40) ↦ₘ csaved.s4) ** ((spC + 48) ↦ₘ csaved.s5) ** G) := by
+  subst hraSaved
+  have s67 := sd_spec_gen_own_within .x19 .x0 validPtr (0 : Word) (0 : BitVec 12) (D + 268)
+  rw [show signExtend12 (0 : BitVec 12) = (0 : Word) from by decide,
+    show validPtr + (0 : Word) = validPtr from by bv_omega] at s67
+  have s68 := sd_spec_gen_own_within .x20 .x21 firstBadPtr iWord (0 : BitVec 12) (D + 272)
+  rw [show signExtend12 (0 : BitVec 12) = (0 : Word) from by decide,
+    show firstBadPtr + (0 : Word) = firstBadPtr from by bv_omega] at s68
+  have s69 := li_spec_gen_within .x10 o10 (0 : Word) (D + 276) (by decide)
+  have s70 := jal_x0_spec_gen_within (16 : BitVec 21) (D + 280)
+  rw [show (D + 280) + signExtend21 (16 : BitVec 21) = D + 296 from by
+    rw [show signExtend21 (16 : BitVec 21) = (16 : Word) from by decide]; bv_omega] at s70
+  have hblock : cpsTripleWithin 4 (D + 268) (D + 296) cvgulCode
+      ((.x19 ↦ᵣ validPtr) ** (.x0 ↦ᵣ (0 : Word)) ** memOwn validPtr **
+        (.x20 ↦ᵣ firstBadPtr) ** (.x21 ↦ᵣ iWord) ** memOwn firstBadPtr ** (.x10 ↦ᵣ o10))
+      ((.x19 ↦ᵣ validPtr) ** (.x0 ↦ᵣ (0 : Word)) ** (validPtr ↦ₘ (0 : Word)) **
+        (.x20 ↦ᵣ firstBadPtr) ** (.x21 ↦ᵣ iWord) ** (firstBadPtr ↦ₘ iWord) **
+        (.x10 ↦ᵣ (0 : Word))) := by
+    runBlock s67 s68 s69 s70
+  have hblockF := cpsTripleWithin_frameR
+    ((.x2 ↦ᵣ spC) ** (.x1 ↦ᵣ o1) ** (.x8 ↦ᵣ o8) ** (.x9 ↦ᵣ o9) ** (.x18 ↦ᵣ o18) **
+      (spC ↦ₘ csaved.ra) ** ((spC + 8) ↦ₘ csaved.s0) ** ((spC + 16) ↦ₘ csaved.s1) **
+      ((spC + 24) ↦ₘ csaved.s2) ** ((spC + 32) ↦ₘ csaved.s3) **
+      ((spC + 40) ↦ₘ csaved.s4) ** ((spC + 48) ↦ₘ csaved.s5) ** G)
+    (by repeat' first | exact hG | apply pcFree_sepConj | exact pcFree_regIs
+                      | exact pcFree_memIs) hblock
+  have hepi := cvgulEpilogue sp0 spC csaved.ra csaved.s0 csaved.s1 csaved.s2 csaved.s3
+    csaved.s4 csaved.s5 o1 o8 o9 o18 validPtr firstBadPtr iWord hspC hret
+  have hepiF := cpsTripleWithin_frameR
+    ((.x10 ↦ᵣ (0 : Word)) ** (validPtr ↦ₘ (0 : Word)) ** (firstBadPtr ↦ₘ iWord) **
+      (.x0 ↦ᵣ (0 : Word)) ** G)
+    (by repeat' first | exact hG | apply pcFree_sepConj | exact pcFree_regIs
+                      | exact pcFree_memIs) hepi
+  have hall := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) hblockF hepiF
+  exact cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
+    (fun _ hq => by xperm_hyp hq) hall
+
+#print axioms retViolation
+
+/-! ## Parse-fail exit (instructions 71--72 → epilogue)
+
+    `*firstBadPtr := i`, `jal +8` to epilogue.  `a0` (=`x10`) is left holding the
+    callee's nonzero status, threaded in `G`. -/
+
+set_option maxRecDepth 8000 in
+theorem retParseFail
+    (sp0 spC raIn iWord firstBadPtr : Word) (csaved : Saved)
+    (G : Assertion) (hG : G.pcFree) (o1 o8 o9 o18 o19 o10 : Word)
+    (hspC : spC = sp0 + signExtend12 (-56 : BitVec 12))
+    (hraSaved : csaved.ra = raIn)
+    (hret : raIn &&& ~~~(1 : Word) = raIn) :
+    cpsTripleWithin 11 (D + 284) raIn cvgulCode
+      ((.x20 ↦ᵣ firstBadPtr) ** (.x21 ↦ᵣ iWord) ** (.x10 ↦ᵣ o10) ** (.x2 ↦ᵣ spC) **
+        (.x1 ↦ᵣ o1) ** (.x8 ↦ᵣ o8) ** (.x9 ↦ᵣ o9) ** (.x18 ↦ᵣ o18) ** (.x19 ↦ᵣ o19) **
+        memOwn firstBadPtr **
+        (spC ↦ₘ raIn) ** ((spC + 8) ↦ₘ csaved.s0) ** ((spC + 16) ↦ₘ csaved.s1) **
+        ((spC + 24) ↦ₘ csaved.s2) ** ((spC + 32) ↦ₘ csaved.s3) **
+        ((spC + 40) ↦ₘ csaved.s4) ** ((spC + 48) ↦ₘ csaved.s5) ** G)
+      ((.x10 ↦ᵣ o10) ** (firstBadPtr ↦ₘ iWord) ** (.x1 ↦ᵣ raIn) **
+        (.x2 ↦ᵣ sp0) ** (.x8 ↦ᵣ csaved.s0) ** (.x9 ↦ᵣ csaved.s1) **
+        (.x18 ↦ᵣ csaved.s2) ** (.x19 ↦ᵣ csaved.s3) ** (.x20 ↦ᵣ csaved.s4) **
+        (.x21 ↦ᵣ csaved.s5) **
+        (spC ↦ₘ raIn) ** ((spC + 8) ↦ₘ csaved.s0) ** ((spC + 16) ↦ₘ csaved.s1) **
+        ((spC + 24) ↦ₘ csaved.s2) ** ((spC + 32) ↦ₘ csaved.s3) **
+        ((spC + 40) ↦ₘ csaved.s4) ** ((spC + 48) ↦ₘ csaved.s5) ** G) := by
+  subst hraSaved
+  have s71 := sd_spec_gen_own_within .x20 .x21 firstBadPtr iWord (0 : BitVec 12) (D + 284)
+  rw [show signExtend12 (0 : BitVec 12) = (0 : Word) from by decide,
+    show firstBadPtr + (0 : Word) = firstBadPtr from by bv_omega] at s71
+  have s72 := jal_x0_spec_gen_within (8 : BitVec 21) (D + 288)
+  rw [show (D + 288) + signExtend21 (8 : BitVec 21) = D + 296 from by
+    rw [show signExtend21 (8 : BitVec 21) = (8 : Word) from by decide]; bv_omega] at s72
+  have hblock : cpsTripleWithin 2 (D + 284) (D + 296) cvgulCode
+      ((.x20 ↦ᵣ firstBadPtr) ** (.x21 ↦ᵣ iWord) ** memOwn firstBadPtr)
+      ((.x20 ↦ᵣ firstBadPtr) ** (.x21 ↦ᵣ iWord) ** (firstBadPtr ↦ₘ iWord)) := by
+    runBlock s71 s72
+  have hblockF := cpsTripleWithin_frameR
+    ((.x10 ↦ᵣ o10) ** (.x2 ↦ᵣ spC) ** (.x1 ↦ᵣ o1) ** (.x8 ↦ᵣ o8) ** (.x9 ↦ᵣ o9) **
+      (.x18 ↦ᵣ o18) ** (.x19 ↦ᵣ o19) **
+      (spC ↦ₘ csaved.ra) ** ((spC + 8) ↦ₘ csaved.s0) ** ((spC + 16) ↦ₘ csaved.s1) **
+      ((spC + 24) ↦ₘ csaved.s2) ** ((spC + 32) ↦ₘ csaved.s3) **
+      ((spC + 40) ↦ₘ csaved.s4) ** ((spC + 48) ↦ₘ csaved.s5) ** G)
+    (by repeat' first | exact hG | apply pcFree_sepConj | exact pcFree_regIs
+                      | exact pcFree_memIs) hblock
+  have hepi := cvgulEpilogue sp0 spC csaved.ra csaved.s0 csaved.s1 csaved.s2 csaved.s3
+    csaved.s4 csaved.s5 o1 o8 o9 o18 o19 firstBadPtr iWord hspC hret
+  have hepiF := cpsTripleWithin_frameR
+    ((.x10 ↦ᵣ o10) ** (firstBadPtr ↦ₘ iWord) ** G)
+    (by repeat' first | exact hG | apply pcFree_sepConj | exact pcFree_regIs
+                      | exact pcFree_memIs) hepi
+  have hall := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) hblockF hepiF
+  exact cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
+    (fun _ hq => by xperm_hyp hq) hall
+
+#print axioms retParseFail
+
+end EvmAsm.Codegen.ChainValidateGasUsedUnderLimitSpec

--- a/EvmAsm/Codegen/Programs/Imports.lean
+++ b/EvmAsm/Codegen/Programs/Imports.lean
@@ -512,3 +512,5 @@ import EvmAsm.Codegen.Programs.ChainValidateBlobGasUnderMaxSpec
 import EvmAsm.Codegen.Programs.ChainValidateBlobGasUnderMaxLoop
 
 import EvmAsm.Codegen.Programs.ChainValidateBlobGasUnderMaxLoopClose
+
+import EvmAsm.Codegen.Programs.ChainValidateGasUsedUnderLimitSpec

--- a/EvmAsm/Codegen/Programs/Imports.lean
+++ b/EvmAsm/Codegen/Programs/Imports.lean
@@ -514,3 +514,5 @@ import EvmAsm.Codegen.Programs.ChainValidateBlobGasUnderMaxLoop
 import EvmAsm.Codegen.Programs.ChainValidateBlobGasUnderMaxLoopClose
 
 import EvmAsm.Codegen.Programs.ChainValidateGasUsedUnderLimitSpec
+
+import EvmAsm.Codegen.Programs.ChainValidateGasUsedUnderLimitLoop

--- a/EvmAsm/Codegen/Programs/Imports.lean
+++ b/EvmAsm/Codegen/Programs/Imports.lean
@@ -516,3 +516,5 @@ import EvmAsm.Codegen.Programs.ChainValidateBlobGasUnderMaxLoopClose
 import EvmAsm.Codegen.Programs.ChainValidateGasUsedUnderLimitSpec
 
 import EvmAsm.Codegen.Programs.ChainValidateGasUsedUnderLimitLoop
+
+import EvmAsm.Codegen.Programs.ChainValidateGasUsedUnderLimitLoopClose


### PR DESCRIPTION
## `chainValidateGasUsedUnderLimit` caller `Fn.Spec` (chain-validate batch, sibling 3)

Proves `chain_validate_gas_used_under_limit_spec_within` — every header has
`gas_used ≤ gas_limit`.

**Proof-only. No `merge!`.** Spot-check approved by coord. Stacked on #10339. Per-header body
makes **two** `rlp_field_to_u64` calls (field 10 = gas_used, field 9 = gas_limit) and compares
them — reusing the banked K34 call crux twice per iteration on the shared array-loop induction.

Genuine 3-way `cvgulPost` over the true header count: `a0=0 ⟺ ∀ i<lengths.length, hdrGasOk i`
where `hdrGasOk i := ∃ gu gl, Result … 10 0 gu ∧ Result … 9 0 gl ∧ ¬ BitVec.ult gl gu` — **both**
fields tied to `Result` at the actual header base; first-violation gives a real first-bad `k`
(`gl <ᵤ gu`); compound parse-fail (`∃ k status`, either field, a0=status).

`#print axioms` → `[propext, Classical.choice, Quot.sound]`. Full guard set green, files ≤1500
(max 1372), no `sorry`/`native_decide`/`bv_decide`/`maxHeartbeats`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
