### PR TITLE
fix(codegen): avoid misaligned withdrawal address loads

### DIFF
--- a/EvmAsm/Codegen/Programs/Withdrawal.lean
+++ b/EvmAsm/Codegen/Programs/Withdrawal.lean
@@ -430,12 +430,12 @@ def withdrawalDecode_prog : Program :=
     .LD .x28 .x5 (0 : BitVec 12),
     .ADD .x28 .x8 .x28,
     .ADDI .x29 .x18 (16 : BitVec 12),
-    .LD .x30 .x28 (0 : BitVec 12),
-    .SD .x29 .x30 (0 : BitVec 12),
-    .LD .x30 .x28 (8 : BitVec 12),
-    .SD .x29 .x30 (8 : BitVec 12),
-    .LWU .x30 .x28 (16 : BitVec 12),
-    .SW .x29 .x30 (16 : BitVec 12),
+    .LBU .x30 .x28 (0 : BitVec 12),
+    .SB .x29 .x30 (0 : BitVec 12),
+    .ADDI .x28 .x28 (1 : BitVec 12),
+    .ADDI .x29 .x29 (1 : BitVec 12),
+    .ADDI .x6 .x6 (-1 : BitVec 12),
+    .BNE .x6 .x0 (-20 : BitVec 13),
     .MV .x10 .x8,
     .MV .x11 .x9,
     .LI .x12 (3 : Word),
@@ -502,6 +502,7 @@ def ziskWithdrawalDecodePrologue : String :=
   "  sd a0, 0(t0)                # status\n" ++
   "  j .Lwd_pdone\n" ++
   rlpListNthItemFunction ++ "\n" ++
+  rlpContentToU64Function ++ "\n" ++
   rlpFieldToU64Function ++ "\n" ++
   withdrawalDecodeFunction ++ "\n" ++
   ".Lwd_pdone:"

--- a/scripts/asm-fixtures/withdrawalDecodeFunction.s
+++ b/scripts/asm-fixtures/withdrawalDecodeFunction.s
@@ -24,9 +24,9 @@ withdrawal_decode:
   bne t1, t2, .Lwd_fail
   la t0, wd_offset; ld t3, 0(t0); add t3, s0, t3
   addi t4, s2, 16
-  ld t5,  0(t3); sd t5,  0(t4)
-  ld t5,  8(t3); sd t5,  8(t4)
-  lwu t5, 16(t3); sw t5, 16(t4)
+  lbu t5, 0(t3); sb t5, 0(t4)
+  addi t3, t3, 1; addi t4, t4, 1; addi t1, t1, -1
+  bnez t1, .-20
   # Pad bytes 20..24 of address slot (struct 36..40) are zero (from caller zeroing).
   # Field 3: amount (u64 at offset 40)
   mv a0, s0; mv a1, s1; li a2, 3


### PR DESCRIPTION
Replaces the potentially unaligned 20-byte withdrawal address LD SD LWU SW copy with an alignment-safe LBU SB loop. The source length is validated as exactly 20 before the loop.

Also adds rlp_content_to_u64 to the standalone withdrawal_decode probe closure, which its existing rlp_field_to_u64 helper calls.

Validation:
- withdrawal_decode spec oracle 8 of 8 pass with execution-specs virtualenv
- full symbol and region regeneration; check-region-map and check-asm-to-program pass
- clean force relink on candidate and #10335 baseline
- Spike EEST random seed 20260716 limit 100: both 100 of 100, 0 errored fail budget, byte-identical outputs and result TSV
- after #10335 merged, merged current main and reran both layout gates