### PR TITLE
chore: gitignore .codex/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ build/
 rust-u256-asm/
 gen-out/
 .claude/
+.codex/
 __pycache__/
 
 # jscpd duplication-watch output (scripts/check-duplication.sh)


### PR DESCRIPTION
`.gitignore` ignored `.claude/` (line 6) but not `.codex/`, so local `.codex/` agent
artifacts (e.g. `.codex/hooks.json`) were untracked-but-not-ignored and kept landing
in PR diffs. This adds `.codex/` next to `.claude/`.

Byte-neutral — nothing under `.codex/` is tracked on main; no guest/regen impact.
Permanent fix (stops the stray recurring for all agents). Complements dropping the
already-committed `.codex/hooks.json` from the in-flight proof branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)