### PR TITLE
fix(codegen): pass codes base explicitly to bal_same_block_delegation_code_resolve

### DIFF
--- a/EvmAsm/Codegen/Programs/BalCodePreimages.lean
+++ b/EvmAsm/Codegen/Programs/BalCodePreimages.lean
@@ -1029,7 +1029,7 @@ def balCodePreimagesValidFunction : String :=
   "# a0 = 20-byte target address ptr, a1/a2 = witness.state ptr/len, a3 = charge delegation access.\n" ++
   "# On success, cahsr_code_offset/cahsr_code_length name the delegated pre-state code.\n" ++
   "bal_same_block_delegation_code_resolve:\n" ++
-  "  addi sp, sp, -112\n" ++
+  "  addi sp, sp, -128\n" ++
   "  sd ra, 0(sp)\n" ++
   "  sd s0, 8(sp); sd s1, 16(sp); sd s2, 24(sp); sd s3, 32(sp)\n" ++
   "  sd s4, 40(sp); sd s5, 48(sp); sd s6, 56(sp); sd s7, 64(sp)\n" ++
@@ -1038,6 +1038,16 @@ def balCodePreimagesValidFunction : String :=
   "  mv s1, a1                  # witness.state ptr\n" ++
   "  mv s2, a2                  # witness.state len\n" ++
   "  mv s10, a3                 # charge delegated access when nonzero\n" ++
+  -- evm-asm-uzb6b: the codes base that cahsr_code_offset is re-based against is
+  -- an explicit argument (a4), NOT the caller's x20. Top-level callers
+  -- (dispatch_tx_runtime_code / block_verdict contract + mtx paths) have no
+  -- runtime env in x20 (x20 is evm_env scratch there, slot 608 unread zero-page
+  -- .bss), so reading *(x20+608) subtracted a garbage base and the top-level
+  -- `.Ldtrc_have_code` re-add of *svf_codes_ptr produced a wild code pointer
+  -- (load-access fault in bytecode_is_self_contained on the EIP-7702
+  -- chain/self-delegation + pointer_to_pointer cluster). Callers pass
+  -- a4 = *svf_codes_ptr (top level) or a4 = 608(x20) (nested CALL frames).
+  "  sd a4, 112(sp)             # codes base for the cahsr_code_offset re-base\n" ++
   "  la t0, bsbd_code_from_bal; sd zero, 0(t0)\n" ++
   "  la t0, bv_bal_start; ld s3, 0(t0)\n" ++
   "  la t0, bv_bal_len; ld s4, 0(t0)\n" ++
@@ -1157,8 +1167,7 @@ def balCodePreimagesValidFunction : String :=
   -- in the BAL and point cahsr_code_* at it so the descend runs the marker bytes (-> invalid
   -- opcode -> 0). Soundness: descending runs the EXACT single-hop code the spec runs;
   -- the BAL comparator independently checks each declared final, so this can only fix a
-  -- false-REJECT. s9 (target marker ptr), s10 (charge flag) are callee-saved by both helpers;
-  -- x20 (env) is preserved here (the buggy 40(sp) reload above is on the pre-state-hit path).
+  -- false-REJECT. s9 (target marker ptr), s10 (charge flag) are callee-saved by both helpers.
   ".Lbsbd_target_sameblock:\n" ++
   -- The BAL contains the block-final code, but an address currently being
   -- CREATEd has empty code until its constructor returns successfully and the
@@ -1191,12 +1200,13 @@ def balCodePreimagesValidFunction : String :=
   "  la t0, bacc_finals; ld t1, 56(t0); beqz t1, .Lbsbd_target_create_effect\n" ++
   "  la t0, bacc_finals; ld t1, 72(t0); beqz t1, .Lbsbd_target_create_effect\n" ++
   -- cahsr_code_length = target final code length; cahsr_code_offset = absolute code bytes
-  -- ptr (bsbd_tgt_ptr + bacc_finals.code_off) minus the CALLER env's codes
-  -- base. The callable dispatcher stages witness.codes into its runtime payload,
-  -- so `svf_codes_ptr` is not necessarily the base that `.Lcd_descend_` adds.
+  -- ptr (bsbd_tgt_ptr + bacc_finals.code_off) minus the codes base passed by the
+  -- caller in a4 (saved at 112(sp)): *svf_codes_ptr at top level (whose
+  -- `.Ldtrc_have_code` re-adds *svf_codes_ptr), 608(x20) in nested CALL frames
+  -- (whose `.Lcd_descend_` re-adds 608(x20)).
   "  la t2, cahsr_code_length; sd t1, 0(t2)\n" ++
   "  la t0, bsbd_tgt_ptr; ld t3, 0(t0); la t0, bacc_finals; ld t4, 64(t0); add t3, t3, t4\n" ++
-  "  ld t5, 104(sp); ld t5, 608(t5); sub t3, t3, t5\n" ++
+  "  ld t5, 112(sp); sub t3, t3, t5\n" ++
   "  la t2, cahsr_code_offset; sd t3, 0(t2)\n" ++
   "  li t0, 1; la t2, bsbd_code_from_bal; sd t0, 0(t2)\n" ++
   -- charge already applied above (.Lbsbd_skip_charge)
@@ -1222,7 +1232,7 @@ def balCodePreimagesValidFunction : String :=
   -- which makes the caller fall back to and charge the stale pre-state marker.
   "  beqz a0, .Lbsbd_active_create_empty\n" ++
   "  ld t1, 40(a0); la t2, cahsr_code_length; sd t1, 0(t2)\n" ++
-  "  addi t1, a0, 48; ld t2, 104(sp); ld t2, 608(t2); sub t1, t1, t2\n" ++
+  "  addi t1, a0, 48; ld t2, 112(sp); sub t1, t1, t2\n" ++
   "  la t2, cahsr_code_offset; sd t1, 0(t2)\n" ++
   "  li t0, 1; la t2, bsbd_code_from_bal; sd t0, 0(t2)\n" ++
   "  li a0, 0\n" ++
@@ -1242,7 +1252,7 @@ def balCodePreimagesValidFunction : String :=
   "  ld s0, 8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp)\n" ++
   "  ld s4, 40(sp); ld s5, 48(sp); ld s6, 56(sp); ld s7, 64(sp)\n" ++
   "  ld s8, 72(sp); ld s9, 80(sp); ld s10, 88(sp); ld x20, 104(sp)\n" ++
-  "  addi sp, sp, 112\n" ++
+  "  addi sp, sp, 128\n" ++
   "  ret\n" ++
   "\n" ++
   "# Return 1 iff any legacy transaction data contains PUSH20 <addr>; SELFDESTRUCT.\n" ++

--- a/EvmAsm/Codegen/Programs/BlockVerdictDispatchTx.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictDispatchTx.lean
@@ -355,6 +355,10 @@ def dispatchTxRuntimeCodeFunction : String :=
   "  la t0, sv_pre_rlp_ptr; ld t1, 0(t0); la t2, dtrc_hdr_ptr; sd t1, 0(t2)\n" ++
   "  la t0, sv_pre_rlp_len; ld t1, 0(t0); la t2, dtrc_hdr_len; sd t1, 0(t2)\n" ++
   "  addi a0, s2, 72; mv a1, s0; mv a2, s1; li a3, 0\n" ++
+  -- evm-asm-uzb6b: a4 = the codes base this top-level path re-adds at
+  -- `.Ldtrc_have_code` (*svf_codes_ptr); the resolver re-bases cahsr_code_offset
+  -- against it (top-level x20 is evm_env scratch, NOT a runtime env).
+  "  la t0, svf_codes_ptr; ld a4, 0(t0)\n" ++
   "  jal ra, bal_same_block_delegation_code_resolve\n" ++
   "  beqz a0, .Ldtrc_same_block_delegation_code\n" ++
   "  li t0, 2; beq a0, t0, .Ldtrc_same_block_empty_code\n" ++

--- a/EvmAsm/Codegen/Programs/BlockVerdictFunction.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictFunction.lean
@@ -317,6 +317,7 @@ def blockVerdictFunction : String :=
   "  bnez a0, .Lbv_cd_eoa_restore        # code-hash lookup failed -> conservative EOA path\n" ++
   "  la t2, bv_simple_transfer_tx\n" ++
   "  addi a0, t2, 72; ld a1, 80(s0); ld a2, 88(s0); li a3, 0\n" ++
+  "  la t0, svf_codes_ptr; ld a4, 0(t0)\n" ++          -- evm-asm-uzb6b: resolver codes base (top level re-adds *svf_codes_ptr)
   "  jal ra, bal_same_block_delegation_code_resolve\n" ++
   "  beqz a0, .Lbv_cd_same_block_delegation\n" ++
   "  la t0, bv_tx_recipient_code_hash; la t1, chahsr_empty_code_hash\n" ++
@@ -326,6 +327,7 @@ def blockVerdictFunction : String :=
   "  ld t3, 24(t0); ld t4, 24(t1); bne t3, t4, .Lbv_contract_dispatch\n" ++
   "  la t2, bv_simple_transfer_tx\n" ++
   "  addi a0, t2, 72; ld a1, 80(s0); ld a2, 88(s0); li a3, 0\n" ++
+  "  la t0, svf_codes_ptr; ld a4, 0(t0)\n" ++          -- evm-asm-uzb6b: resolver codes base (top level re-adds *svf_codes_ptr)
   "  jal ra, bal_same_block_delegation_code_resolve\n" ++
   "  bnez a0, .Lbv_cd_eoa_confirmed\n" ++
   ".Lbv_cd_same_block_delegation:\n" ++

--- a/EvmAsm/Codegen/Programs/BlockVerdictMtxRuntime.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictMtxRuntime.lean
@@ -203,6 +203,7 @@ def blockVerdictMtxRuntimeLoop : String :=
   "  ld t3, 16(t0); ld t4, 16(t1); bne t3, t4, .Lbv_mtx_is_contract\n" ++
   "  ld t3, 24(t0); ld t4, 24(t1); bne t3, t4, .Lbv_mtx_is_contract\n" ++
   "  la t0, bv_mtx_ctx; addi a0, t0, 72; ld a1, 80(s0); ld a2, 88(s0); li a3, 0\n" ++
+  "  la t0, svf_codes_ptr; ld a4, 0(t0)\n" ++          -- evm-asm-uzb6b: resolver codes base (top level re-adds *svf_codes_ptr)
   "  jal ra, bal_same_block_delegation_code_resolve\n" ++
   "  beqz a0, .Lbv_mtx_is_contract\n" ++
   blockVerdictMtxEoaSettlement ++

--- a/EvmAsm/Codegen/Programs/ChildFrameHandlerTails.lean
+++ b/EvmAsm/Codegen/Programs/ChildFrameHandlerTails.lean
@@ -39,6 +39,7 @@ def callDelegationAccessChargeAsm (tag : String) : String :=
   -- of the stale pre-state marker returned by code_at_header_state_root.
   "  addi sp, sp, -32\n  sd x10, 0(sp); sd x12, 8(sp); sd x13, 16(sp); sd t3, 24(sp)\n" ++
   "  la a0, " ++ runtimeAccessSeedScratchLabel ++ "; ld a1, 592(x20); ld a2, 600(x20); li a3, 1\n" ++
+  "  ld a4, 608(x20)\n" ++                                -- evm-asm-uzb6b: resolver codes base (descend re-adds 608(x20))
   "  jal ra, bal_same_block_delegation_code_resolve\n" ++
   "  mv t6, a0\n" ++
   "  ld x10, 0(sp); ld x12, 8(sp); ld x13, 16(sp); ld t3, 24(sp)\n  addi sp, sp, 32\n" ++

--- a/EvmAsm/Codegen/Programs/ChildFrameHandlers.lean
+++ b/EvmAsm/Codegen/Programs/ChildFrameHandlers.lean
@@ -629,6 +629,7 @@ def callDescendFallThrough
     -- alive, while status 1 is a miss.
     "  addi sp, sp, -32\n  sd x10, 0(sp)\n  sd x12, 8(sp)\n  sd x13, 16(sp)\n" ++
     "  la a0, cd_callee_be\n  ld a1, 592(x20)\n  ld a2, 600(x20)\n  li a3, 2\n" ++
+    "  ld a4, 608(x20)\n" ++                                -- evm-asm-uzb6b: resolver codes base (descend re-adds 608(x20))
     "  jal ra, bal_same_block_delegation_code_resolve\n" ++
     "  mv t6, a0\n" ++
     "  ld x10, 0(sp)\n  ld x12, 8(sp)\n  ld x13, 16(sp)\n  addi sp, sp, 32\n" ++
@@ -774,6 +775,7 @@ def callDescendFallThrough
   "  addi sp, sp, -32\n" ++
   "  sd x10, 0(sp); sd x12, 8(sp); sd x13, 16(sp); sd t3, 24(sp)\n" ++
   "  la a0, cd_callee_be; ld a1, 592(x20); ld a2, 600(x20); li a3, 0\n" ++
+  "  ld a4, 608(x20)\n" ++
   "  jal ra, bal_same_block_delegation_code_resolve\n" ++
   "  mv t2, a0\n" ++
   "  ld x10, 0(sp); ld x12, 8(sp); ld x13, 16(sp); ld t3, 24(sp)\n" ++
@@ -797,6 +799,7 @@ def callDescendFallThrough
   "  addi sp, sp, -32\n" ++
   "  sd x10, 0(sp); sd x12, 8(sp); sd x13, 16(sp); sd t2, 24(sp)\n" ++
   "  la a0, cd_callee_be; ld a1, 592(x20); ld a2, 600(x20); li a3, 1\n" ++
+  "  ld a4, 608(x20)\n" ++
   "  jal ra, bal_same_block_delegation_code_resolve\n" ++
   "  mv t3, a0\n" ++
   "  ld x10, 0(sp); ld x12, 8(sp); ld x13, 16(sp); ld t2, 24(sp)\n" ++

--- a/scripts/codegen-eest-eip7702-delegation-codes-base-check.sh
+++ b/scripts/codegen-eest-eip7702-delegation-codes-base-check.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# codegen-eest-eip7702-delegation-codes-base-check.sh -- EIP-7702 delegation
+# code-pointer regression gate (evm-asm-uzb6b).
+#
+# bal_same_block_delegation_code_resolve used to re-base cahsr_code_offset
+# against *(caller-x20+608), but top-level callers (dispatch_tx_runtime_code,
+# block_verdict single-tx contract path, multi-tx path) have no runtime env in
+# x20 (x20 is evm_env scratch there; slot 608 is unread zero-page .bss), while
+# the top-level `.Ldtrc_have_code` re-adds *svf_codes_ptr. The wild pointer
+# faulted (load-access fault) in bytecode_is_self_contained on the
+# tx_into_{chain,self}_delegating_set_code and pointer_to_pointer EEST rows.
+# The resolver now takes the codes base as an explicit a4 argument; this gate
+# requires every row of the affected cluster to full-match the fixture's exact
+# expected output bytes.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+TAG="${EEST_FIXTURE_TAG:-$(cat scripts/eest-fixture-tag.txt)}"
+JOBS="${EEST_EIP7702_DELEG_CODES_BASE_JOBS:-${EEST_JOBS:-2}}"
+STEPS="${EEST_EIP7702_DELEG_CODES_BASE_STEPS:-${EEST_STEPS:-1000000000}}"
+RUN_DIR="${EEST_EIP7702_DELEG_CODES_BASE_RUN_DIR:-gen-out/eest-eip7702-delegation-codes-base}"
+FX="${EEST_FIXTURES_DIR:-$(pwd)/gen-out/eest-fixtures/$TAG/fixtures/fixtures}"
+FILTERS=(
+  "tx_into_chain_delegating_set_code"
+  "tx_into_self_delegating_set_code"
+  "pointer_to_pointer"
+)
+
+[[ -d "$FX" ]] || { echo "fixtures not found at $FX (run scripts/eest-fetch-fixtures.sh '$TAG')" >&2; exit 1; }
+
+total_selected=0
+total_ok_full=0
+
+for FILTER in "${FILTERS[@]}"; do
+  count_dir="$(pwd)/gen-out/eest-eip7702-delegation-codes-base-count"
+  rm -rf "$count_dir"
+  mkdir -p "$count_dir"
+  python3 scripts/eest-stateless-to-input.py \
+    --fixtures-dir "$FX" \
+    --out-dir "$count_dir" \
+    --filter "$FILTER" \
+    >/dev/null
+  manifest="$count_dir/manifest.tsv"
+  [[ -s "$manifest" ]] || { echo "no stateless blocks selected for $FILTER" >&2; exit 1; }
+  COUNT="$(wc -l < "$manifest" | tr -d " ")"
+
+  scripts/codegen-eest-stateless-check.sh \
+    --filter "$FILTER" \
+    --limit "$COUNT" \
+    --jobs "$JOBS" \
+    --quiet-passes \
+    --steps "$STEPS" \
+    --run-dir "$RUN_DIR" \
+    "$@"
+
+  RUN_MANIFEST="$RUN_DIR/manifest.tsv"
+  [[ -s "$RUN_MANIFEST" ]] || { echo "missing run manifest: $RUN_MANIFEST" >&2; exit 1; }
+
+  selected=0
+  ok_full=0
+  errors=0
+  missing_results=0
+  semantic_failures=0
+
+  while IFS=$'\t' read -r label input expected_hex succ_bit input_len gas_limit relpath; do
+    selected=$((selected + 1))
+    result="$RUN_DIR/$label.result.tsv"
+    if [[ ! -f "$result" ]]; then
+      missing_results=$((missing_results + 1))
+      echo "missing result for $relpath" >&2
+      continue
+    fi
+
+    if IFS=$'\t' read -r status detail < "$result"; then
+      if [[ "$status" == "OK" && "${detail:0:210}" == "${expected_hex:0:210}" ]]; then
+        ok_full=$((ok_full + 1))
+      elif [[ "$status" == ERROR* ]]; then
+        errors=$((errors + 1))
+        echo "EIP-7702 delegation codes-base error for $relpath: $status $detail" >&2
+      else
+        semantic_failures=$((semantic_failures + 1))
+        echo "EIP-7702 delegation codes-base mismatch for $relpath: status=$status" >&2
+      fi
+    fi
+  done < "$RUN_MANIFEST"
+
+  if [[ "$missing_results" -ne 0 ]]; then
+    echo "missing $missing_results result file(s) for filter $FILTER" >&2
+    exit 1
+  fi
+  if [[ "$errors" -ne 0 ]]; then
+    echo "found $errors error row(s) for filter $FILTER" >&2
+    exit 1
+  fi
+  if [[ "$semantic_failures" -ne 0 ]]; then
+    echo "found $semantic_failures semantic mismatch row(s) for filter $FILTER" >&2
+    exit 1
+  fi
+  if [[ "$ok_full" -ne "$selected" ]]; then
+    echo "only $ok_full of $selected row(s) full-matched for filter $FILTER" >&2
+    exit 1
+  fi
+
+  total_selected=$((total_selected + selected))
+  total_ok_full=$((total_ok_full + ok_full))
+done
+
+if [[ "$total_selected" -eq 0 ]]; then
+  echo "no EIP-7702 delegation codes-base rows selected" >&2
+  exit 1
+fi
+
+echo "==> PASS: EIP-7702 delegation codes-base rows full-match selected=$total_selected full=$total_ok_full"


### PR DESCRIPTION
## Root cause

`bal_same_block_delegation_code_resolve` (EvmAsm/Codegen/Programs/BalCodePreimages.lean) computed `cahsr_code_offset = abs_code_ptr - *(saved_caller_x20 + 608)` on its `.Lbsbd_target_sameblock` / `.Lbsbd_target_create_effect` paths.

- **Nested CALL-frame callers** hold a runtime env in x20 (slot 608 = payload-embedded codes base) and their `.Lcd_descend_` re-adds `608(x20)` — consistent.
- **Top-level callers** (`dispatch_tx_runtime_code`, block_verdict single-tx contract path, mtx path) never set x20 = env. The resolver subtracted a stale register while top-level `.Ldtrc_have_code` (BlockVerdictDispatchTx.lean) re-added `*svf_codes_ptr`, producing a wild code pointer → load-access fault `mcause=0x5` at the first `lbu` of `bytecode_is_self_contained` (`mepc=0x800217b0`, `mtval=0xffffffffd2873e26`).

## Fix

The resolver now takes the codes base as an **explicit argument a4** (spilled to 112(sp) at entry since a4 is clobbered mid-function; frame 112→128):

- Top-level call sites (4): `la t0, svf_codes_ptr; ld a4, 0(t0)`
- Nested call sites (4): `ld a4, 608(x20)` — byte-behavior-neutral on those paths

## Validation (Spike, EEST v0.6.2)

- **6-case EIP-7702 cluster** (24797 `tx_into_chain_delegating_set_code`, 24798 `tx_into_self_delegating_set_code`, 24974–77 `pointer_to_pointer`): all ERROR(exit) pre-fix → **all full-match exact fixture output bytes** post-fix; `mcause=0x5` gone.
- **A/B, seeded 200-case random Spike sample** (`--random --limit 200 --seed 20260716`, pre-fix ELF vs post-fix ELF): per-case statuses **and** full output bytes **identical** (200/200 OK both sides) — 0 flips, 0 new false-accepts.
- **New permanent regression gate** `scripts/codegen-eest-eip7702-delegation-codes-base-check.sh`: exact-output assertion over the 3 fixture filters — PASS (selected=6, full=6).
- `lake build` green.

Bead: evm-asm-uzb6b