### PR TITLE
perf(xperm): O(n) permCheck bitmask side condition for the certificate prover

### DIFF
--- a/EvmAsm/Rv64/SepLogic.lean
+++ b/EvmAsm/Rv64/SepLogic.lean
@@ -3048,6 +3048,68 @@ theorem seps_permute (l : List Assertion) (σ : List Nat)
       = seps ((List.range l.length).map (fun i => l.getD i empAssertion)) := by rw [hrec]
     _ = seps (σ.map (fun i => l.getD i empAssertion)) := seps_perm hp
 
+/-- XOR-clearing bitmask permutation checker: `mask` holds the still-unused
+    indices as set bits; each visited index must have its bit set (else a
+    duplicate or out-of-range index) and is cleared; success means the run
+    ends with every bit consumed.
+
+    This is the kernel-cheap replacement for deciding
+    `σ.Perm (List.range n)` directly: reducing the `List.Perm` `Decidable`
+    instance costs ~500ms at 83 atoms and overflows the recursion depth near
+    200, while this checker is n GMP bit-operations (~7ms at n = 83). -/
+def permCheckGo (mask : Nat) : List Nat → Bool
+  | [] => mask == 0
+  | i :: rest => mask.testBit i && permCheckGo (mask ^^^ (1 <<< i)) rest
+
+/-- `permCheck σ n = true` iff `σ` is a permutation of `[0, …, n)`
+    (see `perm_range_of_permCheck`). Kernel-reduces in O(n) GMP bit ops. -/
+def permCheck (σ : List Nat) (n : Nat) : Bool :=
+  permCheckGo ((1 <<< n) - 1) σ
+
+/-- Count invariant for `permCheckGo`: a successful run means each index `j`
+    occurs in `σ` exactly once if `j`'s bit is set in `mask`, never otherwise. -/
+theorem count_of_permCheckGo (σ : List Nat) (mask : Nat)
+    (h : permCheckGo mask σ = true) (j : Nat) :
+    σ.count j = if mask.testBit j then 1 else 0 := by
+  induction σ generalizing mask with
+  | nil =>
+    simp only [permCheckGo, Nat.beq_eq_true_eq] at h
+    subst h
+    simp [Nat.zero_testBit]
+  | cons i rest ih =>
+    simp only [permCheckGo, Bool.and_eq_true] at h
+    obtain ⟨hbit, hrest⟩ := h
+    have hcnt := ih (mask ^^^ (1 <<< i)) hrest
+    rw [List.count_cons, hcnt]
+    by_cases hji : j = i
+    · subst hji
+      simp [Nat.testBit_xor, Nat.shiftLeft_eq, Nat.testBit_two_pow_self, hbit]
+    · have : (1 <<< i).testBit j = false := by
+        rw [Nat.shiftLeft_eq, Nat.one_mul]
+        exact Nat.testBit_two_pow_of_ne (fun hh => hji hh.symm)
+      simp [Nat.testBit_xor, this, Ne.symm hji]
+
+/-- Soundness of `permCheck`: the certificate's side condition really is
+    `σ.Perm (List.range n)`. Proved once here so per-proof certificates only
+    pay the O(n) `decide` on the `Bool` checker. -/
+theorem perm_range_of_permCheck (σ : List Nat) (n : Nat)
+    (h : permCheck σ n = true) : σ.Perm (List.range n) := by
+  rw [List.perm_iff_count]
+  intro j
+  rw [count_of_permCheckGo σ _ h j, List.count_range]
+  have : ((1 <<< n) - 1).testBit j = decide (j < n) := by
+    rw [Nat.shiftLeft_eq, Nat.one_mul]
+    exact Nat.testBit_two_pow_sub_one n j
+  rw [this]
+  by_cases hj : j < n <;> simp [hj]
+
+/-- `seps_permute` with the kernel-cheap `permCheck` side condition. This is
+    the certificate lemma `buildPermProofCert` actually applies. -/
+theorem seps_permute_check (l : List Assertion) (σ : List Nat)
+    (h : permCheck σ l.length = true) :
+    seps l = seps (σ.map (fun i => l.getD i empAssertion)) :=
+  seps_permute l σ (perm_range_of_permCheck σ l.length h)
+
 /-- `sep_perm h` closes a goal of the form `(A₁ ** ... ** Aₙ) s` given a hypothesis `h`
     that is a permutation of the same assertions applied to the same state.
     Works by proving assertion equality via `ac_rfl` and transporting with `congrFun`.

--- a/EvmAsm/Rv64/Tactics/XPerm.lean
+++ b/EvmAsm/Rv64/Tactics/XPerm.lean
@@ -435,9 +435,10 @@ partial def buildPermProof (lhs rhs : Expr) : MetaM Expr :=
   extensible operation-tag typeclasses, no recorded-tactic-script replay). Here
   the search result is recorded as a **data certificate** — an index permutation
   `σ : List Nat` — and the reordering is discharged by one
-  `EvmAsm.Rv64.seps_permute` whose side condition `σ.Perm (List.range n)` is a
-  decidable check on `List Nat`, kernel-checked by a single `decide` with no
-  `isDefEq` on atom expressions.
+  `EvmAsm.Rv64.seps_permute_check` whose side condition
+  `permCheck σ n = true` (an XOR-clearing bitmask checker equivalent to
+  `σ.Perm (List.range n)`, see `perm_range_of_permCheck`) is kernel-checked by
+  a single O(n) `decide` with no `isDefEq` on atom expressions.
 
   This collapses the `O(n²)` proof term / `whnf` count / kernel re-check of
   `buildPermProofFallback` to `O(n)` (the `O(n²)` `isDefEq` *search* is the same
@@ -498,12 +499,20 @@ partial def buildPermProofCertCore (lhs rhs : Expr) : MetaM Expr := do
   -- YOLO fast phase: search the index permutation once.
   let σ ← computeSigma rhsAtoms lhsAtoms
   -- Single verified certificate: seps lhsList = seps (σ.map (lhsList.getD · emp)).
+  -- The side condition is the O(n) `permCheck` Bool checker (n GMP bit ops),
+  -- NOT a `decide` on `σ.Perm (List.range n)`: kernel-reducing the `List.Perm`
+  -- `Decidable` instance costs ~500ms at 83 atoms and overflows the recursion
+  -- depth near 200 atoms (silently dropping to the slow fallback exactly on
+  -- the large chains the certificate exists for). Measured ~7ms at n = 83,
+  -- ~13ms at n = 200 (see `perm_range_of_permCheck`).
   let lhsList := mkAssertionList lhsAtoms
   let σExpr := mkNatListExpr σ
-  let rangeExpr ← mkAppM ``List.range #[mkNatLit lhsAtoms.size]
-  let permProp ← mkAppM ``List.Perm #[σExpr, rangeExpr]
-  let hσ ← mkDecideProof permProp
-  let certPf ← mkAppM ``EvmAsm.Rv64.seps_permute #[lhsList, σExpr, hσ]
+  let checkProp ← mkEq
+    (mkApp2 (mkConst ``EvmAsm.Rv64.permCheck) σExpr (mkNatLit lhsAtoms.size))
+    (mkConst ``Bool.true)
+  let hσ ← withTheReader Core.Context (fun c => { c with maxRecDepth := 1024 }) do
+    mkDecideProof checkProp
+  let certPf ← mkAppM ``EvmAsm.Rv64.seps_permute_check #[lhsList, σExpr, hσ]
   -- Emp bridges: lhsRA = empified(lhsRA) (=defeq seps lhsList); same for rhs.
   let (lhsEmpPf, _) ← buildAddEmpProof lhsRA
   let (rhsEmpPf, _) ← buildAddEmpProof rhsRA

--- a/PLAN.md
+++ b/PLAN.md
@@ -87,6 +87,16 @@ EVM stack: x12 is EVM stack pointer, stack grows upward, 32 bytes per element.
   then composed via `runBlock` tactic
 - **Key tactics**: `xperm`, `xsimp`, `xcancel`, `seqFrame`, `runBlock`,
   `validMem`, `liftSpec`, `pcFree`
+- **xperm certificate prover** (`xperm.cert`, default on since 2026-06-13):
+  permutation goals discharged via an index-permutation certificate +
+  `seps_permute_check`. The side condition is the O(n) `permCheck` bitmask
+  checker (`perm_range_of_permCheck` proves it sound once) — NOT a `decide`
+  on `List.Perm`, whose Decidable instance cost ~500ms at 83 atoms and
+  overflowed recursion depth near 200 atoms, silently falling back to the
+  O(n²) pick prover on exactly the large chains the certificate targets.
+  Post-fix: ~7ms kernel at n=83, works to n≈400; large unbundled atom
+  chains (40–80+) are viable, so ambient-bundling workarounds that fold
+  atoms into opaque descriptors purely for xperm cost can be retired.
 
 ---
 


### PR DESCRIPTION
## What

Replace the `xperm` certificate prover's side condition — `decide (σ.Perm (List.range n))` — with an O(n) bitmask Bool checker `permCheck`, backed by a once-proved soundness lemma `perm_range_of_permCheck` (via `List.perm_iff_count`). Applied through the new `seps_permute_check` wrapper in `buildPermProofCertCore`. Zero API change: same `xperm`/`xperm_hyp`/`xcancel`/`seqFrame`/`runBlock` entry points, same cert → AC → picks fallback routing.

## Why

Profiling (with prover1's nominated hot proofs + synthetic reversal chains of distinct `memIs` atoms) isolated the cert prover's residual per-call cost to the side condition itself:

- Kernel-reducing the `List.Perm` `Decidable` instance costs **496ms at n=83** (plus ~340ms elaborator-side in `mkDecideProof`).
- Near **n=200 it overflows `maxRecursionDepth`**, so the cert path *silently falls back to the O(n²) pick prover* — exactly in the 40–80+ atom regime where the certificate matters most. This cliff is why ambient-bundling hacks (opaque folded frame-descriptors holding atom counts ≲20) are currently load-bearing in the hesr/chainValidate/account contracts.

`permCheck` is an XOR-clearing bitmask walk: start from `2^n − 1`, require each index's bit set, clear it, end at zero — n GMP bit-ops for the kernel.

## Numbers

Side condition alone (kernel): **496ms → 7.4ms at n=83; crash → 13.2ms at n=200.**

End-to-end `xperm` on worst-case reversal chains (elaboration + kernel type-checking):

| atoms | before | after |
|---|---|---|
| 20 | 49ms | 31ms |
| 40 | 176ms | 80ms |
| 83 | 642ms | **299ms** |
| 120 | ~1.4s | **620ms** |
| 200 | recursion-depth crash → slow fallback | **works, 1.6s** |

Real files (re-elaboration wall time) — **unchanged within noise**, as expected: today's proofs are ambient-bundled to ~15–20 atoms, where the old side condition was still cheap. This confirms the change is drop-in safe; the payoff is the un-bundled regime.

| file | before | after |
|---|---|---|
| ChainValidateExtraDataLengthLoopClose | 2.75s | 2.75s |
| ChainValidateGasUsedUnderLimitLoopClose | 7.49s | 7.30s |
| ChainValidateIncreasingTimestampsLoopClose | 6.80s | 6.73s |
| ChainValidateConsecutiveNumbersLoopClose | 7.12s | 6.73s |
| AccountIsEip161EmptyClose | 5.54s | 5.94s |
| AccountIsEip161EmptyClose6 | 5.09s | 5.16s |

Verified via trace that no fallback fires on any benchmark size (the cert core handles n=200 directly).

## TCB / axiom cleanliness

No new axioms, no `native_decide`/`bv_decide`/`ofReduceBool`: the checker's soundness is an ordinary kernel-checked lemma, and the per-proof certificate is a plain `decide` on a `Bool` equality.

- `#print axioms EvmAsm.Rv64.perm_range_of_permCheck` → `[propext, Classical.choice, Quot.sound]`
- `#print axioms EvmAsm.Rv64.seps_permute_check` → `[propext, Classical.choice, Quot.sound]`
- probe theorem through the full `xperm` path → `[propext, Classical.choice, Quot.sound]`
- `scripts/check-forbidden-tactics.sh` → OK

## Follow-up unlocked

With the n≳150 cliff gone, prover1 can A/B a LoopClose file unbundled and start retiring the ambient-bundling descriptors (tracked with prover1 directly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
