### PR TITLE
chore: ignore .opencode/ scratch dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ rust-u256-asm/
 gen-out/
 .claude/
 .codex/
+.opencode/
 __pycache__/
 
 # jscpd duplication-watch output (scripts/check-duplication.sh)


### PR DESCRIPTION
Adds `.opencode/` to `.gitignore`, mirroring the existing `.codex/` entry (#10345). opencode agents create this scratch directory locally and it should not be committed.

One-line change, no merge label.