### PR TITLE
chore: remove redundant in-source #print axioms in crypto precompiles

### DIFF
--- a/EvmAsm/Codegen/Programs/Bls12Fq12EqSAsm.lean
+++ b/EvmAsm/Codegen/Programs/Bls12Fq12EqSAsm.lean
@@ -57,7 +57,6 @@ theorem blqEq_spec (ptr1 ptr2 ret : Word) (bs1 bs2 : List (BitVec 8))
       72).flatten (GuestAddrs.blq_eq : Word) = blqEq_prog from rfl] at h
   exact h
 
-#print axioms blqEq_spec
 
 end Bls12Fq12EqSAsm
 end EvmAsm.Codegen

--- a/EvmAsm/Codegen/Programs/Bls12G1Eq48SAsm.lean
+++ b/EvmAsm/Codegen/Programs/Bls12G1Eq48SAsm.lean
@@ -542,7 +542,6 @@ theorem blsgEq48Fn_spec (ptr1 ptr2 : Word) (bs1 bs2 : List (BitVec 8))
       rw [hx10rf, if_pos heq]
 
 
-#print axioms blsgEq48Fn_spec
 
 end Bls12G1Eq48SAsm
 

--- a/EvmAsm/Codegen/Programs/Bls12G1IsZeroNSAsm.lean
+++ b/EvmAsm/Codegen/Programs/Bls12G1IsZeroNSAsm.lean
@@ -261,7 +261,6 @@ theorem blsgIsZeroNFn_spec (ptr : Word) (bs : List (BitVec 8)) (len : Nat)
       refine ⟨?_, hlen, hptr⟩
       rw [hx10rf, isZeroNResult, if_pos heq]
 
-#print axioms blsgIsZeroNFn_spec
 
 end Bls12G1IsZeroNSAsm
 end EvmAsm.Codegen

--- a/EvmAsm/Codegen/Programs/Bls12G1LeToBeSAsm.lean
+++ b/EvmAsm/Codegen/Programs/Bls12G1LeToBeSAsm.lean
@@ -863,7 +863,6 @@ theorem blsgLeToBeFn_spec (src dst : Word) (inBytes orig : List (BitVec 8))
     exact outer_step_engine src dst inBytes rf₀ ws₀ A₀ rf2 ws' A' (i + 1) (by omega)
       hs5 hs28 hws0len hlimbs hInv
 
-#print axioms blsgLeToBeFn_spec
 
 end Bls12G1LeToBeSAsm
 

--- a/EvmAsm/Codegen/Programs/Bls12G1LtPSAsm.lean
+++ b/EvmAsm/Codegen/Programs/Bls12G1LtPSAsm.lean
@@ -834,7 +834,6 @@ theorem blsgLtP_spec (inPtr ret : Word) (xs : List (BitVec 8))
     (fun h hq => by unfold ltPost at hq; exact hq)
     (cpsTripleWithin_mono_nSteps (by omega) hc3)
 
-#print axioms blsgLtP_spec
 
 end Bls12G1LtPSAsm
 

--- a/EvmAsm/Codegen/Programs/Bls12G2EncodeSAsm.lean
+++ b/EvmAsm/Codegen/Programs/Bls12G2EncodeSAsm.lean
@@ -815,8 +815,6 @@ theorem blsg2Encode_spec (sp0 ret src dst arb8 arb9 arb18 : Word)
     xperm_hyp hq2
   abi_frame (40 : BitVec 12) halign hbody
 
-#print axioms blsg2Encode_spec
-#print axioms blsgLeToBeFlat_spec
 
 end Bls12G2EncodeSAsm
 

--- a/EvmAsm/Codegen/Programs/Bls12G2EqNSAsm.lean
+++ b/EvmAsm/Codegen/Programs/Bls12G2EqNSAsm.lean
@@ -535,7 +535,6 @@ theorem blsg2EqNFn_spec (ptr1 ptr2 : Word) (bs1 bs2 : List (BitVec 8)) (n : Nat)
       rw [hx10rf, if_pos heq]
 
 
-#print axioms blsg2EqNFn_spec
 
 /-! ## The byte-transparent whole-routine spec (genuine byte-equality post)
 
@@ -684,7 +683,6 @@ theorem blsg2EqN_spec (ptr1 ptr2 ret : Word) (bs1 bs2 : List (BitVec 8))
     (fun h hq => by xperm_hyp hq)
     (cpsTripleWithin_mono_nSteps (by omega) hc3)
 
-#print axioms blsg2EqN_spec
 
 end Bls12G2EqNSAsm
 

--- a/EvmAsm/Codegen/Programs/Bls12KzgG2WireSAsm.lean
+++ b/EvmAsm/Codegen/Programs/Bls12KzgG2WireSAsm.lean
@@ -1062,8 +1062,6 @@ theorem blskG2Wire_spec (sp0 ret src dst arb8 arb9 arb18 : Word)
     xperm_hyp hq2
   abi_frame (32 : BitVec 12) halign hbody
 
-#print axioms blskG2Wire_spec
-#print axioms blsgLeToBeWireFlat_spec
 
 end Bls12KzgG2WireSAsm
 

--- a/EvmAsm/Codegen/Programs/Bls12KzgLtBeSAsm.lean
+++ b/EvmAsm/Codegen/Programs/Bls12KzgLtBeSAsm.lean
@@ -810,7 +810,6 @@ theorem blskLtBe_spec (aPtr bPtr ret : Word) (len : Nat) (xs bs : List (BitVec 8
     (fun h hq => by unfold ltPost at hq; exact hq)
     (cpsTripleWithin_mono_nSteps (by omega) hc3)
 
-#print axioms blskLtBe_spec
 
 end Bls12KzgLtBeSAsm
 

--- a/EvmAsm/Codegen/Programs/Bls12PtCopySAsm.lean
+++ b/EvmAsm/Codegen/Programs/Bls12PtCopySAsm.lean
@@ -354,7 +354,6 @@ theorem blqPtCopyFn_spec (src dst : Word) (srcBytes orig : List (BitVec 8))
     rw [hws, copyWin1728_216_eq srcBytes orig hs ho]
     rfl
 
-#print axioms blqPtCopyFn_spec
 
 end Bls12PtCopySAsm
 

--- a/EvmAsm/Codegen/Programs/Bn254CallAllotmentSAsm.lean
+++ b/EvmAsm/Codegen/Programs/Bn254CallAllotmentSAsm.lean
@@ -533,7 +533,6 @@ theorem bn254CallAllotment_spec (gp sp ret : Word) (w0 w1 w2 w3 rem : Word)
     (fun h hq => by rw [hPOST] at hq; xperm_hyp hq)
     (cpsTripleWithin_mono_nSteps (by omega) hc8)
 
-#print axioms bn254CallAllotment_spec
 
 end Bn254CallAllotmentSAsm
 

--- a/EvmAsm/Codegen/Programs/Bn254CurveIsInfSAsm.lean
+++ b/EvmAsm/Codegen/Programs/Bn254CurveIsInfSAsm.lean
@@ -303,7 +303,6 @@ theorem bncIsInf64Fn_spec (ptr : Word) (bs : List (BitVec 8))
       refine ⟨?_, hle, hpl⟩
       rw [hx10rf, if_pos heq]
 
-#print axioms bncIsInf64Fn_spec
 
 end Bn254CurveIsInfSAsm
 

--- a/EvmAsm/Codegen/Programs/Bn254FieldAddModPSAsm.lean
+++ b/EvmAsm/Codegen/Programs/Bn254FieldAddModPSAsm.lean
@@ -734,10 +734,6 @@ theorem bnfAddModP_spec (sp0 aPtr bPtr outPtr ret v8 v9 : Word)
     (hsub := by code_mem)
     (hbody := hbody)
 
-#print axioms bnfBeToLeFlat_spec
-#print axioms bnfLeToBeFlat_spec
-#print axioms csrsStep_spec
-#print axioms bnfAddModP_spec
 
 end Bn254FieldAddModPSAsm
 

--- a/EvmAsm/Codegen/Programs/Bn254FieldLtPSAsm.lean
+++ b/EvmAsm/Codegen/Programs/Bn254FieldLtPSAsm.lean
@@ -832,7 +832,6 @@ theorem bnfLtP_spec (inPtr ret : Word) (xs : List (BitVec 8))
     (fun h hq => by unfold ltPost at hq; exact hq)
     (cpsTripleWithin_mono_nSteps (by omega) hc3)
 
-#print axioms bnfLtP_spec
 
 end Bn254FieldLtPSAsm
 

--- a/EvmAsm/Codegen/Programs/Bn254FieldMulModPSAsm.lean
+++ b/EvmAsm/Codegen/Programs/Bn254FieldMulModPSAsm.lean
@@ -733,10 +733,6 @@ theorem bnfMulModP_spec (sp0 aPtr bPtr outPtr ret v8 v9 : Word)
     (hsub := by code_mem)
     (hbody := hbody)
 
-#print axioms bnfBeToLeFlat_spec
-#print axioms bnfLeToBeFlat_spec
-#print axioms csrsStep_spec
-#print axioms bnfMulModP_spec
 
 end Bn254FieldMulModPSAsm
 

--- a/EvmAsm/Codegen/Programs/Bn254Fp2EqSAsm.lean
+++ b/EvmAsm/Codegen/Programs/Bn254Fp2EqSAsm.lean
@@ -55,7 +55,6 @@ theorem bnpFp2Eq_spec (ptr1 ptr2 ret : Word) (bs1 bs2 : List (BitVec 8))
       8).flatten (GuestAddrs.bnp_fp2_eq : Word) = bnpFp2Eq_prog from rfl] at h
   exact h
 
-#print axioms bnpFp2Eq_spec
 
 end Bn254Fp2EqSAsm
 end EvmAsm.Codegen

--- a/EvmAsm/Codegen/Programs/Bn254Fq12EqSAsm.lean
+++ b/EvmAsm/Codegen/Programs/Bn254Fq12EqSAsm.lean
@@ -57,7 +57,6 @@ theorem bnqEq_spec (ptr1 ptr2 ret : Word) (bs1 bs2 : List (BitVec 8))
       48).flatten (GuestAddrs.bnq_eq : Word) = bnqEq_prog from rfl] at h
   exact h
 
-#print axioms bnqEq_spec
 
 end Bn254Fq12EqSAsm
 end EvmAsm.Codegen

--- a/EvmAsm/Codegen/Programs/Bn254Fq12SetOneSAsm.lean
+++ b/EvmAsm/Codegen/Programs/Bn254Fq12SetOneSAsm.lean
@@ -391,8 +391,6 @@ theorem bnqSetOneFrame_spec (sp0 ret dst arb8 v5 v7 : Word) (vs : List Word)
     xperm_hyp hq2
   abi_frame (16 : BitVec 12) halign hbody
 
-#print axioms bnqZeroFlat_spec
-#print axioms bnqSetOneFrame_spec
 
 end Bn254Fq12SetOneSAsm
 

--- a/EvmAsm/Codegen/Programs/Bn254PtCopySAsm.lean
+++ b/EvmAsm/Codegen/Programs/Bn254PtCopySAsm.lean
@@ -354,7 +354,6 @@ theorem bnqPtCopyFn_spec (src dst : Word) (srcBytes orig : List (BitVec 8))
     rw [hws, copyWin1152_144_eq srcBytes orig hs ho]
     rfl
 
-#print axioms bnqPtCopyFn_spec
 
 end Bn254PtCopySAsm
 

--- a/EvmAsm/Codegen/Programs/P256Eq32SAsm.lean
+++ b/EvmAsm/Codegen/Programs/P256Eq32SAsm.lean
@@ -58,7 +58,6 @@ theorem p256Eq32Fn_spec (ptr1 ptr2 : Word) (bs1 bs2 : List (BitVec 8))
   simpa [p256Eq32Fn, p256Eq32Body, Secp256k1FieldEq32SAsm.secfEq32Fn] using
     Secp256k1FieldEq32SAsm.secfEq32Fn_spec ptr1 ptr2 bs1 bs2 hwf1 hwf2 base
 
-#print axioms p256Eq32Fn_spec
 
 end P256Eq32SAsm
 end EvmAsm.Codegen

--- a/EvmAsm/Codegen/Programs/P256IsZeroNSAsm.lean
+++ b/EvmAsm/Codegen/Programs/P256IsZeroNSAsm.lean
@@ -261,7 +261,6 @@ theorem p256IsZeroNFn_spec (ptr : Word) (bs : List (BitVec 8)) (len : Nat)
       refine ⟨?_, hlen, hptr⟩
       rw [hx10rf, isZeroNResult, if_pos heq]
 
-#print axioms p256IsZeroNFn_spec
 
 end P256IsZeroNSAsm
 end EvmAsm.Codegen

--- a/EvmAsm/Codegen/Programs/P256LtBeSAsm.lean
+++ b/EvmAsm/Codegen/Programs/P256LtBeSAsm.lean
@@ -795,7 +795,6 @@ theorem p256LtBe_spec (aPtr bPtr ret : Word) (xs bs : List (BitVec 8))
     (fun h hq => by unfold ltPost at hq; exact hq)
     (cpsTripleWithin_mono_nSteps (by omega) hc3)
 
-#print axioms p256LtBe_spec
 
 end P256LtBeSAsm
 

--- a/EvmAsm/Codegen/Programs/Secp256k1FieldCmpPSAsm.lean
+++ b/EvmAsm/Codegen/Programs/Secp256k1FieldCmpPSAsm.lean
@@ -935,7 +935,6 @@ theorem secfCmpP_spec (inPtr outPtr ret : Word) (xs : List (BitVec 8))
     (fun h hq => by unfold cmpPost at hq; exact hq)
     (cpsTripleWithin_mono_nSteps (by omega) hc3)
 
-#print axioms secfCmpP_spec
 
 end Secp256k1FieldCmpPSAsm
 

--- a/EvmAsm/Codegen/Programs/Secp256k1FieldMulModPSAsm.lean
+++ b/EvmAsm/Codegen/Programs/Secp256k1FieldMulModPSAsm.lean
@@ -734,10 +734,6 @@ theorem secfMulModP_spec (sp0 aPtr bPtr outPtr ret v8 v9 : Word)
     (hsub := by code_mem)
     (hbody := hbody)
 
-#print axioms secfBeToLeFlat_spec
-#print axioms secfLeToBeFlat_spec
-#print axioms csrsStep_spec
-#print axioms secfMulModP_spec
 
 end Secp256k1FieldMulModPSAsm
 

--- a/EvmAsm/Codegen/Programs/Secp256k1FieldReduceOnceNSAsm.lean
+++ b/EvmAsm/Codegen/Programs/Secp256k1FieldReduceOnceNSAsm.lean
@@ -515,7 +515,6 @@ theorem secfReduceOnceNFrame_spec (sp0 ret src dst s0 s1 v12 : Word)
       rw [hnewSp]
       xperm_hyp hq) h1234
 
-#print axioms secfReduceOnceNFrame_spec
 
 end Secp256k1FieldReduceOnceNSAsm
 

--- a/EvmAsm/Codegen/Programs/Secp256k1FieldReduceOnceSAsm.lean
+++ b/EvmAsm/Codegen/Programs/Secp256k1FieldReduceOnceSAsm.lean
@@ -513,7 +513,6 @@ theorem secfReduceOnceFrame_spec (sp0 ret src dst s0 s1 v12 : Word)
       rw [hnewSp]
       xperm_hyp hq) h1234
 
-#print axioms secfReduceOnceFrame_spec
 
 end Secp256k1FieldReduceOnceSAsm
 

--- a/EvmAsm/Codegen/Programs/Secp256k1FieldSubModPSAsm.lean
+++ b/EvmAsm/Codegen/Programs/Secp256k1FieldSubModPSAsm.lean
@@ -1232,7 +1232,6 @@ theorem secfSubModP_spec
   exact cpsTripleWithin_weaken (fun _ hp => by rw [hnewSp]; xperm_hyp hp)
     (fun _ hq => by rw [hnewSp]; xperm_hyp hq) h1234
 
-#print axioms secfSubModP_spec
 
 end Secp256k1FieldSubModPSAsm
 

--- a/EvmAsm/Codegen/Programs/Secp256k1PointDoubleSAsm.lean
+++ b/EvmAsm/Codegen/Programs/Secp256k1PointDoubleSAsm.lean
@@ -604,13 +604,6 @@ theorem pointDouble_spec (sp0 inPtr outPtr ret v8 v9 : Word)
         xBE yBE oX oY ws hxlen hylen hoXlen hoYlen hwslen hwfX hwfY
         hoal hoov hovalid harval hdIn hdOut hxlt hylt hy0)
 
-#print axioms pointDouble_spec
-#print axioms pointDoubleRegBody_spec
-#print axioms curveStep_spec
-#print axioms secfBeToLeFlat_spec
-#print axioms secfLeToBeFlat_spec
-#print axioms secfIsZero32Flat_spec
-#print axioms secfZero32Flat_spec
 
 end Secp256k1PointDoubleSAsm
 


### PR DESCRIPTION
Removes 47 redundant `#print axioms` commands across 28 files in `Codegen/Programs` (Secp256k1*, Bn254*, Bls12*, P256* SAsm routines).

`check-axioms.sh` audits the 88 witnesses in `Progress.lean` independently, so these in-source commands are pure build noise. Verified: `lake build` green, `check-axioms.sh` reports 88 witnesses unchanged.

No merge label.