### PR TITLE
chore: remove redundant in-source #print axioms in header routines

### DIFF
--- a/EvmAsm/Codegen/Programs/HeaderExtractLogsBloomSpec.lean
+++ b/EvmAsm/Codegen/Programs/HeaderExtractLogsBloomSpec.lean
@@ -134,7 +134,6 @@ theorem headerExtractLogsBloom_call_spec_within
     helbCalleeMem
   exact h
 
-#print axioms headerExtractLogsBloom_call_spec_within
 
 /-! ## `la` materialize helpers (address-specific AUIPC hi/lo) -/
 
@@ -332,7 +331,6 @@ theorem helbPrologue
       unfold callEntryRest entryRest savedRegTail
       xperm_chunked hq) call)
 
-#print axioms helbPrologue
 
 /-! ## The shared return postcondition
 
@@ -448,7 +446,6 @@ theorem helbEpilogue (newSp a0v v1 v8 v9 v18 : Word) (fsaved : HeaderFieldsSpec.
   exact cpsTripleWithin_mono_nSteps (by omega)
     (cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp) (fun _ hp => by xperm_hyp hp) s2)
 
-#print axioms helbEpilogue
 
 /-! ## Copy-loop helpers -/
 
@@ -1420,6 +1417,5 @@ theorem headerExtractLogsBloom_spec_within
   have c2 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_chunked hp) c1 hpost
   exact c2
 
-#print axioms headerExtractLogsBloom_spec_within
 
 end EvmAsm.Codegen.HeaderExtractLogsBloomSpec

--- a/EvmAsm/Codegen/Programs/HeaderExtractNumberSpec.lean
+++ b/EvmAsm/Codegen/Programs/HeaderExtractNumberSpec.lean
@@ -57,7 +57,6 @@ theorem hdr_disjoint :
     · rw [rlp_content_to_u64_prog_length]; decide
     · rw [hdr_length, rlp_content_to_u64_prog_length]; decide
 
-#print axioms hdr_disjoint
 
 /-- K34's linked code is subsumed by the wrapper's full closure. -/
 theorem k34_mono :
@@ -213,7 +212,6 @@ theorem hdrPrologue
       unfold flatPre wholeRest
       xperm_hyp hq) hall
 
-#print axioms hdrPrologue
 
 /-! ## Epilogue core (instructions 5--7) -/
 
@@ -267,7 +265,6 @@ theorem epiCore (sp0 spH raIn : Word) (G : Assertion) (hG : G.pcFree)
   exact cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
     (fun _ hq => by xperm_hyp hq) hframed
 
-#print axioms epiCore
 
 /-! ## Epilogue over K34's result post (instructions 5--7) -/
 
@@ -364,7 +361,6 @@ theorem hdrEpilogue
             bytes listLen 8 h'')) h') => sepConj_or_split h' hh) h hp
   exact sepConj_or_split h hinner
 
-#print axioms hdrEpilogue
 
 /-! ## Whole-program caller contract -/
 
@@ -447,6 +443,5 @@ theorem header_extract_number_spec_within
     hpro hcall'
   exact cpsTripleWithin_seq_perm_same_cr (fun _ hp => hp) h01 hepi
 
-#print axioms header_extract_number_spec_within
 
 end EvmAsm.Codegen.HeaderExtractNumberSpec

--- a/EvmAsm/Codegen/Programs/HeaderFieldsGenericBlocks.lean
+++ b/EvmAsm/Codegen/Programs/HeaderFieldsGenericBlocks.lean
@@ -406,10 +406,5 @@ theorem hfMarshalNextBundled {code : CodeReq}
     (fun h hp => by unfold hfWalkAmbient hesrAmbRegs hesrSpill at hp; xperm_chunked hp)
     (fun h hq => by unfold hfWalkAmbient hesrAmbRegs hesrSpill; xperm_chunked hq) hmF
 
-#print axioms hfEpilogue
-#print axioms hfStatus1Bundled
-#print axioms hfStatus2Return
-#print axioms hfSuccessFinish
-#print axioms hfMarshalNextBundled
 
 end EvmAsm.Codegen.HeaderFieldsSpec

--- a/EvmAsm/Codegen/Programs/HeaderFieldsGenericDispatch.lean
+++ b/EvmAsm/Codegen/Programs/HeaderFieldsGenericDispatch.lean
@@ -319,7 +319,6 @@ theorem hfStageRec {code : CodeReq} {nCont : Nat}
       (fun _ h => h) (cpsTripleWithin_or_pre hOK hFAIL)
   exact cpsTripleWithin_seq_same_cr hwalk' hdisp
 
-#print axioms hfStageRec
 
 set_option maxRecDepth 8000 in
 /-- Generic selecting walk stage (the final field walk).  Walk-call at `entryPC`,
@@ -562,6 +561,5 @@ theorem hfStageSel {code : CodeReq} {nTail : Nat}
       (fun _ h => h) (cpsTripleWithin_or_pre hOK hFAIL)
   exact cpsTripleWithin_seq_same_cr hwalk' hdisp
 
-#print axioms hfStageSel
 
 end EvmAsm.Codegen.HeaderFieldsSpec

--- a/EvmAsm/Codegen/Programs/HeaderFieldsGenericInit.lean
+++ b/EvmAsm/Codegen/Programs/HeaderFieldsGenericInit.lean
@@ -568,9 +568,5 @@ theorem hfInitDispatch {code : CodeReq} {nStage1 : Nat}
   unfold hfScratchConst
   xperm_chunked hq
 
-#print axioms hfPrologue
-#print axioms hfInitStep
-#print axioms hfMarshalInitBundled
-#print axioms hfInitDispatch
 
 end EvmAsm.Codegen.HeaderFieldsSpec

--- a/EvmAsm/Codegen/Programs/HeaderFieldsSpec.lean
+++ b/EvmAsm/Codegen/Programs/HeaderFieldsSpec.lean
@@ -108,6 +108,5 @@ theorem header_extract_state_root_fnspec
     (fun h hq => by unfold hesrAmbient; xperm_chunked hq) hproF hdisp
   exact cpsTripleWithin_weaken (fun h hp => by xperm_chunked hp) (fun _ h => h) hcomp
 
-#print axioms header_extract_state_root_fnspec
 
 end EvmAsm.Codegen.HeaderFieldsSpec

--- a/EvmAsm/Codegen/Programs/HeaderFieldsSpecBlocks.lean
+++ b/EvmAsm/Codegen/Programs/HeaderFieldsSpecBlocks.lean
@@ -537,10 +537,5 @@ theorem hesrSuccessFinish (newSp a0old v1 v8 v9 v18 : Word) (saved : Saved)
   refine cpsTripleWithin_mono_nSteps (by omega)
     (cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp) (fun _ hp => by xperm_hyp hp) s2)
 
-#print axioms hesrInitStep
-#print axioms hesrEpilogue
-#print axioms hesrStatus1Return
-#print axioms hesrStatus2Return
-#print axioms hesrSuccessFinish
 
 end EvmAsm.Codegen.HeaderFieldsSpec

--- a/EvmAsm/Codegen/Programs/HeaderFieldsSpecBlocksTail.lean
+++ b/EvmAsm/Codegen/Programs/HeaderFieldsSpecBlocksTail.lean
@@ -963,14 +963,5 @@ theorem hesrSuccessTailBundled
     · exact Or.inl ⟨ha0, hsucc, hlen, hfin⟩
     · exact Or.inr (Or.inl ⟨ha0, hsucc, hlen, hfin⟩)
 
-#print axioms hesrSuccessTail
-#print axioms hesrLenDispatch
-#print axioms hesrSuccessContinue
-#print axioms hesrCopyThenFinish
-#print axioms hesrLenLoad
-#print axioms hesrOffsetLoadAdd
-#print axioms hesrOffsetStore
-#print axioms hesrCopyLoop
-#print axioms hesrSuccessTailBundled
 
 end EvmAsm.Codegen.HeaderFieldsSpec

--- a/EvmAsm/Codegen/Programs/HeaderFieldsSpecCommon.lean
+++ b/EvmAsm/Codegen/Programs/HeaderFieldsSpecCommon.lean
@@ -262,8 +262,6 @@ theorem hesrNextOutcome_to_norm (listBase endPtr : Word) (bytes : List (BitVec 8
     refine sepConj_mono_right (sepConj_mono_right (sepConj_mono_right ?_)) h hb6
     exact fun h' ⟨he, hP⟩ => ⟨he, by decide, Or.inr hP⟩
 
-#print axioms cpsTripleWithin_or_pre
-#print axioms hesrNextOutcome_to_norm
 
 /-! ## Stage 4 — the selected item (`next4`, `BNE[32]` @+128 → ret)
 
@@ -365,7 +363,6 @@ theorem cpsTripleWithin_of_forall_memIs_to_memOwn2
     ⟨hp, hcompat, h1, h2, hd, hu,
       ⟨g0, g1, d1, u1, hP, g2, g3, d2, u2, hv1, hv2⟩, hRb⟩ hpc
 
-#print axioms hesrNextStep
 /-! ## Stages 1-3 — walk-and-recurse dispatch around a non-selected item
 
     Each of the first three `rlp_walk_next` calls decodes the zero-based child
@@ -386,7 +383,6 @@ theorem pcFree_hesrSpill (newSp cursor endPtr : Word) :
   unfold hesrSpill
   exact pcFree_sepConj pcFree_memIs pcFree_memIs
 
-#print axioms hesrSpill
 /-- Peel seven owned scratch registers at once (local mirror of the committed
     `cpsTripleWithin_of_forall_regIs_to_regOwn7`). -/
 theorem cpsTripleWithin_of_forall_regIs_to_regOwn7

--- a/EvmAsm/Codegen/Programs/HeaderFieldsSpecDispatch.lean
+++ b/EvmAsm/Codegen/Programs/HeaderFieldsSpecDispatch.lean
@@ -329,8 +329,6 @@ private theorem hesrStage4
   rw [show (hesrBase + 124 : Word) + 4 = hesrBase + 128 from by bv_omega] at hwalk'
   exact cpsTripleWithin_seq_same_cr hwalk' hdisp
 
-#print axioms hesrMarshalNext
-#print axioms hesrStage4
 /-- Bundled-entry wrapper for the inter-call marshalling: the ambient registers
     and the two spill cells stay folded (`hesrWalkAmbient`/`hesrSpill`) so the
     stage feeds it over few atoms.  Internally it unfolds them, frames the
@@ -363,7 +361,6 @@ theorem hesrMarshalNextBundled
     (fun h hp => by unfold hesrWalkAmbient hesrAmbRegs hesrSpill at hp; xperm_chunked hp)
     (fun h hq => by unfold hesrWalkAmbient hesrAmbRegs hesrSpill; xperm_chunked hq) hmF
 
-#print axioms hesrMarshalNextBundled
 set_option maxRecDepth 8000 in
 theorem hesrStage3
     (listBase endPtr outPtr newSp : Word) (offPrev listLen cursorOff : Nat)
@@ -681,6 +678,5 @@ theorem hesrStage3
   rw [show (hesrBase + 104 : Word) + 4 = hesrBase + 108 from by bv_omega] at hwalk'
   exact cpsTripleWithin_seq_same_cr hwalk' hdisp
 
-#print axioms hesrStage3
 
 end EvmAsm.Codegen.HeaderFieldsSpec

--- a/EvmAsm/Codegen/Programs/HeaderFieldsSpecDispatch2.lean
+++ b/EvmAsm/Codegen/Programs/HeaderFieldsSpecDispatch2.lean
@@ -80,7 +80,6 @@ private theorem hesrMarshalInit (cursor endPtr newSp : Word) :
   have s3 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) s2 f15
   exact cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp) (fun _ hp => by xperm_hyp hp) s3
 
-#print axioms hesrMarshalInit
 set_option maxRecDepth 8000 in
 private theorem hesrStage2
     (listBase endPtr outPtr newSp : Word) (offPrev listLen cursorOff : Nat)
@@ -392,7 +391,6 @@ private theorem hesrStage2
   rw [show (hesrBase + 84 : Word) + 4 = hesrBase + 88 from by bv_omega] at hwalk'
   exact cpsTripleWithin_seq_same_cr hwalk' hdisp
 
-#print axioms hesrStage2
 set_option maxRecDepth 8000 in
 private theorem hesrStage1
     (listBase endPtr outPtr newSp : Word) (offPrev listLen cursorOff : Nat)
@@ -705,7 +703,6 @@ private theorem hesrStage1
   rw [show (hesrBase + 64 : Word) + 4 = hesrBase + 68 from by bv_omega] at hwalk'
   exact cpsTripleWithin_seq_same_cr hwalk' hdisp
 
-#print axioms hesrStage1
 /-! ## The init-call dispatch and the whole-program caller contract
 
     The init phase in front of `hesrStage1`: the `rlp_walk_init` call at [10]
@@ -755,7 +752,6 @@ private theorem hesrMarshalInitBundled
     (fun h hq => by
       unfold hesrWalkAmbient hesrAmbRegs hesrAmbConst hesrSpill; xperm_chunked hq) hmF
 
-#print axioms hesrMarshalInitBundled
 set_option maxRecDepth 8000 in
 theorem hesrInitDispatch
     (listBase outPtr newSp oldRa v5 v6 v7 v28 v29 v30 v31 : Word)
@@ -1041,6 +1037,5 @@ theorem hesrInitDispatch
   unfold hesrScratchConst
   xperm_chunked hq
 
-#print axioms hesrInitDispatch
 
 end EvmAsm.Codegen.HeaderFieldsSpec

--- a/EvmAsm/Codegen/Programs/HeaderReceiptsRootSpec.lean
+++ b/EvmAsm/Codegen/Programs/HeaderReceiptsRootSpec.lean
@@ -388,6 +388,5 @@ theorem header_extract_receipts_root_fnspec
     (fun h hq => by unfold hfAmbient; xperm_chunked hq) hproF hdisp
   exact cpsTripleWithin_weaken (fun h hp => by xperm_chunked hp) (fun _ h => h) hcomp
 
-#print axioms header_extract_receipts_root_fnspec
 
 end EvmAsm.Codegen.HeaderReceiptsRootSpec

--- a/EvmAsm/Codegen/Programs/HeaderReceiptsRootTail.lean
+++ b/EvmAsm/Codegen/Programs/HeaderReceiptsRootTail.lean
@@ -905,6 +905,5 @@ theorem herrSuccessTailBundled
     · exact Or.inl ⟨ha0, hsucc, hlen, hfin⟩
     · exact Or.inr (Or.inl ⟨ha0, hsucc, hlen, hfin⟩)
 
-#print axioms herrSuccessTailBundled
 
 end EvmAsm.Codegen.HeaderReceiptsRootSpec

--- a/EvmAsm/Codegen/Programs/HeaderValidateExtraDataLengthSpec.lean
+++ b/EvmAsm/Codegen/Programs/HeaderValidateExtraDataLengthSpec.lean
@@ -59,7 +59,6 @@ theorem hved_disjoint :
   · right
     rw [EvmAsm.Codegen.RlpListNthItemSAsm.total_length]; decide
 
-#print axioms hved_disjoint
 
 /-- K20's linked code is subsumed by the wrapper's full closure. -/
 theorem k20_mono :
@@ -299,7 +298,6 @@ theorem hvedHead
       unfold hvedPre at hp; xperm_hyp hp) (fun h hq => by
       unfold calleePre entryRest; xperm_hyp hq) hframed
 
-#print axioms hvedHead
 
 /-! ## Call (instruction 7): jal + K20 selector -/
 
@@ -368,7 +366,6 @@ theorem hvedCall
     hhead hjalF
   exact cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) hhj hcallee
 
-#print axioms hvedCall
 
 /-! ## Epilogue (instructions 19--21) -/
 
@@ -422,7 +419,6 @@ theorem hvedEpi (sp0 spH raIn : Word) (G : Assertion) (hG : G.pcFree)
   exact cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
     (fun _ hq => by xperm_hyp hq) hframed
 
-#print axioms hvedEpi
 
 /-! ## Length load + compare dispatch (instructions 9--15/16--17, then epilogue) -/
 
@@ -628,7 +624,6 @@ theorem hvedDispatch
   exact cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp) (fun _ hq => hq)
     (cpsBranchWithin_merge_same_cr hbranch hrej hsucc)
 
-#print axioms hvedDispatch
 
 set_option maxRecDepth 8000 in
 /-- `hvedDispatch` with `x5/x6` presented as owned (their pre-values are
@@ -662,7 +657,6 @@ theorem hvedDispatchOwned
     (hvedDispatch sp0 spH newSp raIn listBase oldOffset oldLen offset len v5 v6 saved
       bytes listLen hspH hret hResult)
 
-#print axioms hvedDispatchOwned
 
 /-! ## Status dispatch + full rest (instruction 8 onward) -/
 
@@ -828,7 +822,6 @@ theorem hvedRest
   refine cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp) (fun _ hq => hq)
     (cpsBranchWithin_merge_same_cr hbneF h_t h_f)
 
-#print axioms hvedRest
 
 /-! ## Whole-program caller contract -/
 
@@ -864,6 +857,5 @@ theorem header_validate_extra_data_length_spec_within
     listLen hspH hret hraSaved
   exact cpsTripleWithin_seq_same_cr hcall hrest
 
-#print axioms header_validate_extra_data_length_spec_within
 
 end EvmAsm.Codegen.HeaderValidateExtraDataLengthSpec

--- a/EvmAsm/Codegen/Programs/HeaderWithdrawalsRootChain.lean
+++ b/EvmAsm/Codegen/Programs/HeaderWithdrawalsRootChain.lean
@@ -146,7 +146,6 @@ theorem hewrStage16Chain
           h_src_align h_dst_align hb' h_dst_bound h_src_over h_dst_over h_src_valid h_dst_valid
           ⟨c0, listBase + BitVec.ofNat 64 listLenN, n', hpay', hnth, hoffeq⟩)))
 
-#print axioms hewrStage16Chain
 
 /-- Stage 15 (`hfStageRec`, count 15) at `hewrBase+364`. -/
 theorem hewrStage15Chain

--- a/EvmAsm/Codegen/Programs/HeaderWithdrawalsRootSpec.lean
+++ b/EvmAsm/Codegen/Programs/HeaderWithdrawalsRootSpec.lean
@@ -151,6 +151,5 @@ theorem header_extract_withdrawals_root_fnspec
     (fun h hq => by unfold hfAmbient; xperm_chunked hq) hproF hdisp
   exact cpsTripleWithin_weaken (fun h hp => by xperm_chunked hp) (fun _ h => h) hcomp
 
-#print axioms header_extract_withdrawals_root_fnspec
 
 end EvmAsm.Codegen.HeaderWithdrawalsRootSpec

--- a/EvmAsm/Codegen/Programs/HeaderWithdrawalsRootTail.lean
+++ b/EvmAsm/Codegen/Programs/HeaderWithdrawalsRootTail.lean
@@ -909,6 +909,5 @@ theorem hewrSuccessTailBundled
     · exact Or.inl ⟨ha0, hsucc, hlen, hfin⟩
     · exact Or.inr (Or.inl ⟨ha0, hsucc, hlen, hfin⟩)
 
-#print axioms hewrSuccessTailBundled
 
 end EvmAsm.Codegen.HeaderWithdrawalsRootSpec


### PR DESCRIPTION
Removes 61 redundant `#print axioms` commands across 17 `Header*` files in `Codegen/Programs` (HeaderFields*, HeaderExtract*, HeaderReceiptsRoot, HeaderWithdrawalsRoot, HeaderValidateExtraDataLength).

`check-axioms.sh` audits the 88 witnesses in `Progress.lean` independently, so these in-source commands are pure build noise. Verified: `lake build` green, `check-axioms.sh` reports 88 witnesses unchanged.

No merge label.