### PR TITLE
chore: batch-merge #10377 #10378 #10379

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ rust-u256-asm/
 gen-out/
 .claude/
 .codex/
+.opencode/
 __pycache__/
 
 # jscpd duplication-watch output (scripts/check-duplication.sh)

--- a/EvmAsm/Codegen/Proofs/DoWhileDemo.lean
+++ b/EvmAsm/Codegen/Proofs/DoWhileDemo.lean
@@ -236,7 +236,6 @@ theorem nestedDoWhileDemoFn_spec (base : Word) : nestedDoWhileDemoFn.Spec base :
     rintro rf ws A ⟨⟨i, hi, hx5, hx6, hx29⟩, -⟩
     exact ⟨hx5, hx6, hx29⟩
 
-#print axioms nestedDoWhileDemoFn_spec
 
 -- ============================================================================
 -- 3. A fully verified nested `doWhileS`: the outer loop rereads a register
@@ -364,6 +363,5 @@ theorem nestedDoWhileSDemoFn_spec (base : Word) : nestedDoWhileSDemoFn.Spec base
     have heq : rf.get .x5 = rf.get .x6 := Decidable.of_not_not hng
     exact ⟨heq.trans hx6, hx6⟩
 
-#print axioms nestedDoWhileSDemoFn_spec
 
 end EvmAsm.Codegen.Proofs

--- a/EvmAsm/Evm64/EvmWordArith/LowMask.lean
+++ b/EvmAsm/Evm64/EvmWordArith/LowMask.lean
@@ -19,5 +19,3 @@ theorem BitVec.and_two_pow_sub_one_eq_zero_iff
     rw [BitVec.toNat_ofNat]
   rw [← BitVec.toNat_inj, hzero, BitVec.toNat_and, hmask,
     Nat.and_two_pow_sub_one_eq_mod, Nat.dvd_iff_mod_eq_zero]
-
-#print axioms BitVec.and_two_pow_sub_one_eq_zero_iff

--- a/EvmAsm/Evm64/MLoad/MemoryRegionStackSpec.lean
+++ b/EvmAsm/Evm64/MLoad/MemoryRegionStackSpec.lean
@@ -1097,6 +1097,4 @@ theorem evm_mload_stack_spec_within_evmMemoryArea
     h_off_ne_x0 h_addr_ne_x0 h_byte_ne_x0 h_acc_ne_x0
     hlen (by decide) hguard EVM_MEMORY_AREA_aligned hin hbound hvalid
 
-#print axioms evm_mload_stack_spec_within
-
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/Terminating/ReturnHaltResolved.lean
+++ b/EvmAsm/Evm64/Terminating/ReturnHaltResolved.lean
@@ -124,7 +124,5 @@ theorem evm_return_stack_spec_resolved
     (la_resolve (hbase + 276 + 4) flag hr2)
     (la_resolve (hbase + 276 + 16) resume hr1)
 
-#print axioms evm_return_halt_spec_resolved
-#print axioms evm_return_stack_spec_resolved
 
 end EvmAsm.Evm64.Terminating

--- a/EvmAsm/Evm64/Terminating/SelfdestructHaltResolved.lean
+++ b/EvmAsm/Evm64/Terminating/SelfdestructHaltResolved.lean
@@ -49,6 +49,5 @@ theorem evm_selfdestruct_stack_spec_resolved (hbase flag resume v5 v6 v1 f0 : Wo
     (la_resolve (hbase + 4) flag hr2)
     (la_resolve (hbase + 16) resume hr1)
 
-#print axioms evm_selfdestruct_stack_spec_resolved
 
 end EvmAsm.Evm64.Terminating

--- a/EvmAsm/Rv64/LaResolve.lean
+++ b/EvmAsm/Rv64/LaResolve.lean
@@ -151,7 +151,4 @@ theorem la_materialize_within (rd : Reg) (vOld pc target : Word) {cr : CodeReq}
     show (pc + 4 : Word) + 4 = pc + 8 from by bv_omega] at h2
   exact cpsTripleWithin_seq_same_cr h1 h2
 
-#print axioms la_resolve
-#print axioms la_materialize_within
-
 end EvmAsm.Rv64

--- a/EvmAsm/Rv64/RLP/Field0ToU64.lean
+++ b/EvmAsm/Rv64/RLP/Field0ToU64.lean
@@ -486,9 +486,6 @@ theorem rlp_field0_to_u64_call_content
   rw [show (base + 32 + 4 : Word) = base + 36 from by bv_omega] at hcall
   exact cpsTripleWithin_extend_code hmono hcall
 
-#print axioms rlp_field0_to_u64_call_walk_init
-#print axioms rlp_field0_to_u64_call_walk_next
-#print axioms rlp_field0_to_u64_call_content
 
 /-! ## Wrapper parse-failure branches. -/
 
@@ -558,7 +555,6 @@ theorem rlp_field0_to_u64_init_failure_spec_within
       obtain ⟨_, hp'⟩ := hp
       xperm_hyp hp') hseq
 
-#print axioms rlp_field0_to_u64_init_failure_spec_within
 
 /-- If `rlp_walk_next` returns a nonzero status in `x11`, the wrapper's
 index-4 branch normalizes it to the public parse-failure result. -/
@@ -625,7 +621,6 @@ theorem rlp_field0_to_u64_next_failure_spec_within
       obtain ⟨_, hp'⟩ := hp
       xperm_hyp hp') hseq
 
-#print axioms rlp_field0_to_u64_next_failure_spec_within
 
 /-! ## Successful list-init handoff to the unified first-item walk. -/
 
@@ -774,7 +769,6 @@ theorem rlp_field0_to_u64_walk_next_call_spec_within
   refine cpsTripleWithin_mono_nSteps (by omega)
     (cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp) (fun _ hp => hp) hseq)
 
-#print axioms rlp_field0_to_u64_walk_next_call_spec_within
 
 /-! ## Unified content-decoder return path. -/
 
@@ -915,6 +909,5 @@ theorem rlp_field0_to_u64_content_call_spec_within
     (cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp)
       (fun h hp => by xperm_hyp hp) hs2)
 
-#print axioms rlp_field0_to_u64_content_call_spec_within
 
 end EvmAsm.Rv64.RLP

--- a/EvmAsm/Rv64/RLP/Field0ToU64Top.lean
+++ b/EvmAsm/Rv64/RLP/Field0ToU64Top.lean
@@ -102,7 +102,6 @@ theorem rlp_field0_to_u64_content_spec_within
     (cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp)
       (fun h hp => by xperm_hyp hp) s3)
 
-#print axioms rlp_field0_to_u64_content_spec_within
 
 /-- Successful first-item walk continuation, with the walk relation retained
 as a pure semantic witness.  The bridge theorem converts the walk's word
@@ -183,7 +182,6 @@ theorem rlp_field0_to_u64_decode_success_exact_spec_within
     (cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp)
       (fun h hp => (sepConj_pure_right h).2 ⟨hp, hdecode⟩) hseq)
 
-#print axioms rlp_field0_to_u64_decode_success_exact_spec_within
 
 /-- Caller-visible result after the first field has either been decoded by
 the scalar routine or rejected by one of the strict walk checks. -/
@@ -322,7 +320,6 @@ theorem rlp_field0_to_u64_next_outcome_exact_spec_within
   · exact Or.inr (Or.inr (Or.inr (Or.inr (Or.inr
       (dropGuard 6 _ h ⟨hc, ho, hd, hu, hcommon, hout⟩)))))
 
-#print axioms rlp_field0_to_u64_next_outcome_exact_spec_within
 
 /-- Introduce the seven scratch-register values owned by the walk-next
 continuation.  This local adapter keeps the generic SAsm framework unchanged. -/
@@ -398,7 +395,6 @@ theorem rlp_field0_to_u64_next_outcome_spec_within
     dsimp only [P]
     xperm_hyp hp) (fun _ hp => hp) ho
 
-#print axioms rlp_field0_to_u64_next_outcome_spec_within
 
 /-- Compose the successful init fallthrough with the complete walk-next and
 scalar continuation, from the wrapper's status branch through final return. -/
@@ -432,7 +428,6 @@ theorem rlp_field0_to_u64_after_init_success_spec_within
     hover hvalid hoff
   exact cpsTripleWithin_seq_perm_same_cr (fun _ hp => hp) hcall hcont
 
-#print axioms rlp_field0_to_u64_after_init_success_spec_within
 
 /-- Ownership-only form of the successful-init continuation, matching the
 scratch ownership returned by `rlp_walk_init`. -/
@@ -484,7 +479,6 @@ theorem rlp_field0_to_u64_after_init_success_owned_spec_within
     dsimp only [P]
     xperm_hyp hp) (fun _ hp => hp) ho
 
-#print axioms rlp_field0_to_u64_after_init_success_owned_spec_within
 
 /-- Resources common to all nine strict walk-init outcomes at wrapper index 2. -/
 def rlpField0InitCommon (base srcBase savedRa : Word)
@@ -665,7 +659,6 @@ theorem rlp_field0_to_u64_init_call_spec_within
       dsimp only [Prest]
       pcFree) hwiCall)
 
-#print axioms rlp_field0_to_u64_init_call_spec_within
 
 /-- Eliminate all nine strict walk-init outcomes: seven failures normalize to
 public status 1, while the short- and long-list successes continue at field 0. -/
@@ -903,7 +896,6 @@ theorem rlp_field0_to_u64_init_outcome_spec_within
   · exact Or.inr (Or.inr (Or.inr (Or.inr (Or.inr (Or.inr
       (Or.inr (Or.inr ⟨h1, h2, hd, hu, hc, hout⟩)))))))
 
-#print axioms rlp_field0_to_u64_init_outcome_spec_within
 
 /-- Caller-facing unified specification for the complete emitted
 `rlp_field0_to_u64` wrapper.  The postcondition reports either a strict parse
@@ -967,6 +959,5 @@ theorem rlp_field0_to_u64_spec_within
       (fun h hp => by xperm_hyp hp) hsaveF
   exact cpsTripleWithin_seq_perm_same_cr (fun _ hp => hp) hsave' hafter
 
-#print axioms rlp_field0_to_u64_spec_within
 
 end EvmAsm.Rv64.RLP

--- a/EvmAsm/Rv64/SAsm/AbiFrameCallDemo.lean
+++ b/EvmAsm/Rv64/SAsm/AbiFrameCallDemo.lean
@@ -412,8 +412,6 @@ theorem twiceFrame_spec (sp0 ret ptr arb8 arb11 v : Word)
   rw [hNS] at hbody ⊢
   abi_frame (8 : BitVec 12) halign hbody
 
-#print axioms twiceFrame_spec
-#print axioms bumpCall_spec
 
 end AbiFrameCallDemo
 end SAsm

--- a/EvmAsm/Rv64/SAsm/AbiFrameDemo.lean
+++ b/EvmAsm/Rv64/SAsm/AbiFrameDemo.lean
@@ -183,8 +183,6 @@ theorem demoFrame_spec (ret v0 v1 va0 va1 jt : Word)
     (hbody := hbody)
   exact h
 
-#print axioms demoBody_spec
-#print axioms demoFrame_spec
 
 end AbiFrameDemo
 end SAsm

--- a/EvmAsm/Rv64/SAsm/AbiFrameLoopDemo.lean
+++ b/EvmAsm/Rv64/SAsm/AbiFrameLoopDemo.lean
@@ -312,8 +312,6 @@ theorem mulFrame_spec (ret inc kw outPtr arb8 arb9 oldD : Word)
     exact cpsTripleWithin_weaken (by xsimp) (by xsimp) hframed
   abi_frame (32 : BitVec 12) halign hbody
 
-#print axioms countdownLoop_spec
-#print axioms mulFrame_spec
 
 end AbiFrameLoopDemo
 end SAsm

--- a/EvmAsm/Rv64/SAsm/AccumLoop.lean
+++ b/EvmAsm/Rv64/SAsm/AccumLoop.lean
@@ -179,8 +179,5 @@ theorem bytesRegion_ld_cursor_within (rd rs1 : Reg) (regionBase vOld : Word)
     (fun _ hq' => by xperm_hyp hq')
     (cpsTripleWithin_frameR (front ** rest) (pcFree_sepConj hf hr) hld)
 
-#print axioms retLoop_spec
-#print axioms AccumLoop.xorAcc_eq_zero_iff_bytes_eq
-#print axioms bytesRegion_ld_cursor_within
 
 end EvmAsm.Rv64.SAsm

--- a/EvmAsm/Rv64/SAsm/BlockAtBridge.lean
+++ b/EvmAsm/Rv64/SAsm/BlockAtBridge.lean
@@ -123,7 +123,5 @@ theorem blockAt_regs_spec (instrs : List Instr) (rf : RegFile) (base : Word)
       bytesRegion_nil, bytesRegion_nil, sepConj_emp_right', sepConj_emp_right'] at hq
     exact hq
 
-#print axioms blockAt_flat_spec
-#print axioms blockAt_regs_spec
 
 end EvmAsm.Rv64.SAsm

--- a/EvmAsm/Rv64/SAsm/ContForwardJoin.lean
+++ b/EvmAsm/Rv64/SAsm/ContForwardJoin.lean
@@ -70,7 +70,5 @@ theorem cpsTripleWithin_stay (n : Nat) (addr : Word) (cr : CodeReq)
     cpsTripleWithin n addr addr cr P P :=
   fun _R _hR s _hcr h hpc => ⟨0, Nat.zero_le _, s, rfl, hpc, h⟩
 
-#print axioms contJoinStation_spec
-#print axioms cpsTripleWithin_stay
 
 end EvmAsm.Rv64.SAsm

--- a/EvmAsm/Rv64/SAsm/DoWhileBreakDemo.lean
+++ b/EvmAsm/Rv64/SAsm/DoWhileBreakDemo.lean
@@ -104,7 +104,6 @@ theorem countBreakFn_spec (base : Word) : countBreakFn.Spec base := by
     intro rf ws A h
     exact h
 
-#print axioms countBreakFn_spec
 
 end DoWhileBreakDemo
 end SAsm

--- a/EvmAsm/Rv64/SAsm/DualReadByteScan.lean
+++ b/EvmAsm/Rv64/SAsm/DualReadByteScan.lean
@@ -904,8 +904,6 @@ theorem scan_spec
 
 end Scan
 
-#print axioms bytes_eq_of_prefix_eq
-#print axioms scan_spec
 
 end DualReadByteScan
 

--- a/EvmAsm/Rv64/SAsm/DualReadScan.lean
+++ b/EvmAsm/Rv64/SAsm/DualReadScan.lean
@@ -690,7 +690,6 @@ theorem scan_spec (base ret : Word)
       hlenA hlenB hNlt)))
     hsound
 
-#print axioms scan_spec
 
 end ScanProof
 

--- a/EvmAsm/Rv64/SAsm/EarlyRet.lean
+++ b/EvmAsm/Rv64/SAsm/EarlyRet.lean
@@ -99,7 +99,6 @@ theorem twoRet_spec (flag base ret : Word)
   exact cpsTripleWithin_weaken (fun _ hp => hp)
     (sepConj_mono_right (asrtM_mono (twoRet_sp_post flag))) hsound
 
-#print axioms twoRet_spec
 
 end EarlyRet
 end SAsm

--- a/EvmAsm/Rv64/SAsm/FnFlat.lean
+++ b/EvmAsm/Rv64/SAsm/FnFlat.lean
@@ -475,7 +475,3 @@ theorem length_flatMap_dwordBytes (vs : List Word) :
 end SAsm
 end EvmAsm.Rv64
 
-#print axioms EvmAsm.Rv64.SAsm.regFileIs_eq_regAtoms
-#print axioms EvmAsm.Rv64.SAsm.cpsTripleWithin_peel_regOwns
-#print axioms EvmAsm.Rv64.SAsm.Fn.retSpecFlat
-#print axioms EvmAsm.Rv64.SAsm.Fn.retSpecFlatAmbient

--- a/EvmAsm/Rv64/SAsm/FnFlatAmbientDemo.lean
+++ b/EvmAsm/Rv64/SAsm/FnFlatAmbientDemo.lean
@@ -83,7 +83,6 @@ theorem multiReadFlat_spec (a0 a1 dst ret base : Word)
       xperm_hyp hq)
     had
 
-#print axioms multiReadFlat_spec
 
 end FnFlatAmbientDemo
 

--- a/EvmAsm/Rv64/SAsm/GlobalData.lean
+++ b/EvmAsm/Rv64/SAsm/GlobalData.lean
@@ -323,7 +323,5 @@ theorem globalCellIs_to_own (addr v : Word) :
     ∀ h, globalCellIs addr v h → globalCellOwn addr h :=
   fun _ hh => memIs_implies_memOwn _ hh
 
-#print axioms execBlockAt_sound
-#print axioms regFile_auipc_spec_within
 
 end EvmAsm.Rv64.SAsm

--- a/EvmAsm/Rv64/SAsm/GlobalDataDemo.lean
+++ b/EvmAsm/Rv64/SAsm/GlobalDataDemo.lean
@@ -122,7 +122,6 @@ theorem gdDemo_spec (K old ret v5 v6 v7 : Word)
   exact cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
     (fun _ hq => by xperm_hyp hq) c4
 
-#print axioms gdDemo_spec
 
 end GlobalDataDemo
 

--- a/EvmAsm/Rv64/SAsm/MultiRead.lean
+++ b/EvmAsm/Rv64/SAsm/MultiRead.lean
@@ -287,7 +287,6 @@ theorem multiReadFn_spec (base : Word)
     · rw [hAeq1, hptr1, hrob1, hrest1]; xperm
 end Demo
 
-#print axioms multiReadFn_spec
 
 end MultiRead
 

--- a/EvmAsm/Rv64/SAsm/MultiRegRetTail.lean
+++ b/EvmAsm/Rv64/SAsm/MultiRegRetTail.lean
@@ -157,6 +157,5 @@ theorem multiRegRetTail_spec (cr : CodeReq) (addr ret : Word)
           xperm_hyp hq)
         (cpsTripleWithin_mono_nSteps (by simp only [List.length_cons]; omega) hc)
 
-#print axioms multiRegRetTail_spec
 
 end EvmAsm.Rv64.SAsm

--- a/EvmAsm/Rv64/SAsm/MultiRw.lean
+++ b/EvmAsm/Rv64/SAsm/MultiRw.lean
@@ -314,7 +314,6 @@ theorem twoRwFn_spec (base : Word)
 
 end Demo
 
-#print axioms twoRwFn_spec
 
 end MultiRw
 

--- a/EvmAsm/Rv64/SAsm/ParentHeaderFrame.lean
+++ b/EvmAsm/Rv64/SAsm/ParentHeaderFrame.lean
@@ -1841,5 +1841,3 @@ end ParentHeaderFrame
 end SAsm
 end EvmAsm.Rv64
 
-#print axioms EvmAsm.Rv64.SAsm.ParentHeaderFrame.phmwCore_spec
-#print axioms EvmAsm.Rv64.SAsm.ParentHeaderFrame.phmwFrame_spec

--- a/EvmAsm/Rv64/SAsm/ParentHeaderMemcmp.lean
+++ b/EvmAsm/Rv64/SAsm/ParentHeaderMemcmp.lean
@@ -395,5 +395,3 @@ end ParentHeaderMemcmp
 end SAsm
 end EvmAsm.Rv64
 
-#print axioms EvmAsm.Rv64.SAsm.ParentHeaderMemcmp.memcmpLoop_spec
-#print axioms EvmAsm.Rv64.SAsm.ParentHeaderMemcmp.memcmpFlag_eq_one_iff

--- a/EvmAsm/Rv64/SAsm/RetFromLoop.lean
+++ b/EvmAsm/Rv64/SAsm/RetFromLoop.lean
@@ -170,7 +170,6 @@ theorem multiRegJumpTail_spec (cr : CodeReq) (addr : Word) (ofs : BitVec 21)
           xperm_hyp hq)
         (cpsTripleWithin_mono_nSteps (by simp only [List.length_cons]; omega) hc)
 
-#print axioms multiRegJumpTail_spec
 
 -- ============================================================================
 -- §2  whileBreak-to-epilogue: the tail joined to the shared epilogue
@@ -201,7 +200,6 @@ theorem jumpJoinTail_spec {m : Nat} (cr : CodeReq) (addr ret : Word)
       (multiRegJumpTail_spec cr addr ofs assigns hnz hlen hmem))
     hjoin
 
-#print axioms jumpJoinTail_spec
 
 -- ============================================================================
 -- §3  End-to-end mechanism demo: the minimal early-return-from-loop routine
@@ -610,7 +608,6 @@ theorem earlyRetLoop_spec (base ret N flag : Word)
   rw [show N - BitVec.ofNat 64 0 = N from by bv_omega]
   exact hp
 
-#print axioms earlyRetLoop_spec
 
 end EarlyRetLoop
 

--- a/EvmAsm/Rv64/SAsm/RwSubwindow.lean
+++ b/EvmAsm/Rv64/SAsm/RwSubwindow.lean
@@ -277,8 +277,5 @@ theorem pcFree_exists {α : Sort _} {F : α → Assertion}
   rintro hp ⟨a, hF⟩
   exact h a hp hF
 
-#print axioms bytesRegion_window_focus
-#print axioms bytesRegion_window_update
-#print axioms cpsTripleWithin_rwWindow
 
 end EvmAsm.Rv64.SAsm

--- a/EvmAsm/Rv64/SAsm/SelectedRead.lean
+++ b/EvmAsm/Rv64/SAsm/SelectedRead.lean
@@ -352,9 +352,5 @@ theorem selectedDwordCopy_spec (src dst tmp : Reg)
       exact cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
         (fun _ hq => hq) hall
 
-#print axioms bytesRegion_ld_within
-#print axioms bytesRegion_sd_within
-#print axioms selectedDwordCopy_spec
-#print axioms copyDwords_covers
 
 end EvmAsm.Rv64.SAsm

--- a/EvmAsm/Rv64/SAsm/TriCmpStoreJoin.lean
+++ b/EvmAsm/Rv64/SAsm/TriCmpStoreJoin.lean
@@ -142,7 +142,5 @@ theorem triCmpStoreJoin_spec {nA nB m : Nat}
     (fun hnLt => breakStation_spec (hbrB hnLt) hentBT hentBF
       (htailGt hnLt) (hcont hnLt))
 
-#print axioms liStoreRetTail_spec
-#print axioms triCmpStoreJoin_spec
 
 end EvmAsm.Rv64.SAsm

--- a/EvmAsm/Rv64/SAsm/TwoBreakWritable.lean
+++ b/EvmAsm/Rv64/SAsm/TwoBreakWritable.lean
@@ -247,8 +247,5 @@ theorem twoBreakRetLoop_spec {hdr ret : Word} {cr : CodeReq} {Q : Assertion}
         rw [Nat.succ_mul]; omega]
       exact hmerge
 
-#print axioms storeRetTail_spec
-#print axioms breakStation_spec
-#print axioms twoBreakRetLoop_spec
 
 end EvmAsm.Rv64.SAsm

--- a/EvmAsm/Rv64/SAsm/TwoExitLoop.lean
+++ b/EvmAsm/Rv64/SAsm/TwoExitLoop.lean
@@ -155,9 +155,5 @@ theorem _root_.EvmAsm.Rv64.CodeReq.Disjoint.ofProg_ranges (base1 base2 : Word)
     intro k hk heq
     exact h1 ⟨k, hk, heq⟩
 
-#print axioms twoExitRetLoop_spec
-#print axioms twoExitRetLoopBottom_spec
-#print axioms bytesRegion_ld_cursor_imm_within
-#print axioms EvmAsm.Rv64.CodeReq.Disjoint.ofProg_ranges
 
 end EvmAsm.Rv64.SAsm

--- a/EvmAsm/Rv64/SAsm/WhileBreakDemo.lean
+++ b/EvmAsm/Rv64/SAsm/WhileBreakDemo.lean
@@ -320,7 +320,6 @@ theorem scanNzFn_spec (ptr : Word) (bs : List (BitVec 8)) (len : Nat)
     rintro rf ws A h
     exact h
 
-#print axioms scanNzFn_spec
 
 end WhileBreakDemo
 end SAsm

--- a/EvmAsm/Rv64/SAsm/ZeroPadLoop.lean
+++ b/EvmAsm/Rv64/SAsm/ZeroPadLoop.lean
@@ -226,7 +226,6 @@ theorem zeroPadLoop_spec (cr : CodeReq) (hdr : Word) (cur ctr : Reg)
         List.append_nil] at hq
     xperm_hyp hq
 
-#print axioms zeroPadLoop_spec
 
 end ZeroPadLoop
 

--- a/EvmAsm/Rv64/SepLogic.lean
+++ b/EvmAsm/Rv64/SepLogic.lean
@@ -3048,6 +3048,68 @@ theorem seps_permute (l : List Assertion) (σ : List Nat)
       = seps ((List.range l.length).map (fun i => l.getD i empAssertion)) := by rw [hrec]
     _ = seps (σ.map (fun i => l.getD i empAssertion)) := seps_perm hp
 
+/-- XOR-clearing bitmask permutation checker: `mask` holds the still-unused
+    indices as set bits; each visited index must have its bit set (else a
+    duplicate or out-of-range index) and is cleared; success means the run
+    ends with every bit consumed.
+
+    This is the kernel-cheap replacement for deciding
+    `σ.Perm (List.range n)` directly: reducing the `List.Perm` `Decidable`
+    instance costs ~500ms at 83 atoms and overflows the recursion depth near
+    200, while this checker is n GMP bit-operations (~7ms at n = 83). -/
+def permCheckGo (mask : Nat) : List Nat → Bool
+  | [] => mask == 0
+  | i :: rest => mask.testBit i && permCheckGo (mask ^^^ (1 <<< i)) rest
+
+/-- `permCheck σ n = true` iff `σ` is a permutation of `[0, …, n)`
+    (see `perm_range_of_permCheck`). Kernel-reduces in O(n) GMP bit ops. -/
+def permCheck (σ : List Nat) (n : Nat) : Bool :=
+  permCheckGo ((1 <<< n) - 1) σ
+
+/-- Count invariant for `permCheckGo`: a successful run means each index `j`
+    occurs in `σ` exactly once if `j`'s bit is set in `mask`, never otherwise. -/
+theorem count_of_permCheckGo (σ : List Nat) (mask : Nat)
+    (h : permCheckGo mask σ = true) (j : Nat) :
+    σ.count j = if mask.testBit j then 1 else 0 := by
+  induction σ generalizing mask with
+  | nil =>
+    simp only [permCheckGo, Nat.beq_eq_true_eq] at h
+    subst h
+    simp [Nat.zero_testBit]
+  | cons i rest ih =>
+    simp only [permCheckGo, Bool.and_eq_true] at h
+    obtain ⟨hbit, hrest⟩ := h
+    have hcnt := ih (mask ^^^ (1 <<< i)) hrest
+    rw [List.count_cons, hcnt]
+    by_cases hji : j = i
+    · subst hji
+      simp [Nat.testBit_xor, Nat.shiftLeft_eq, Nat.testBit_two_pow_self, hbit]
+    · have : (1 <<< i).testBit j = false := by
+        rw [Nat.shiftLeft_eq, Nat.one_mul]
+        exact Nat.testBit_two_pow_of_ne (fun hh => hji hh.symm)
+      simp [Nat.testBit_xor, this, Ne.symm hji]
+
+/-- Soundness of `permCheck`: the certificate's side condition really is
+    `σ.Perm (List.range n)`. Proved once here so per-proof certificates only
+    pay the O(n) `decide` on the `Bool` checker. -/
+theorem perm_range_of_permCheck (σ : List Nat) (n : Nat)
+    (h : permCheck σ n = true) : σ.Perm (List.range n) := by
+  rw [List.perm_iff_count]
+  intro j
+  rw [count_of_permCheckGo σ _ h j, List.count_range]
+  have : ((1 <<< n) - 1).testBit j = decide (j < n) := by
+    rw [Nat.shiftLeft_eq, Nat.one_mul]
+    exact Nat.testBit_two_pow_sub_one n j
+  rw [this]
+  by_cases hj : j < n <;> simp [hj]
+
+/-- `seps_permute` with the kernel-cheap `permCheck` side condition. This is
+    the certificate lemma `buildPermProofCert` actually applies. -/
+theorem seps_permute_check (l : List Assertion) (σ : List Nat)
+    (h : permCheck σ l.length = true) :
+    seps l = seps (σ.map (fun i => l.getD i empAssertion)) :=
+  seps_permute l σ (perm_range_of_permCheck σ l.length h)
+
 /-- `sep_perm h` closes a goal of the form `(A₁ ** ... ** Aₙ) s` given a hypothesis `h`
     that is a permutation of the same assertions applied to the same state.
     Works by proving assertion equality via `ac_rfl` and transporting with `congrFun`.

--- a/EvmAsm/Rv64/Tactics/XPerm.lean
+++ b/EvmAsm/Rv64/Tactics/XPerm.lean
@@ -435,9 +435,10 @@ partial def buildPermProof (lhs rhs : Expr) : MetaM Expr :=
   extensible operation-tag typeclasses, no recorded-tactic-script replay). Here
   the search result is recorded as a **data certificate** — an index permutation
   `σ : List Nat` — and the reordering is discharged by one
-  `EvmAsm.Rv64.seps_permute` whose side condition `σ.Perm (List.range n)` is a
-  decidable check on `List Nat`, kernel-checked by a single `decide` with no
-  `isDefEq` on atom expressions.
+  `EvmAsm.Rv64.seps_permute_check` whose side condition
+  `permCheck σ n = true` (an XOR-clearing bitmask checker equivalent to
+  `σ.Perm (List.range n)`, see `perm_range_of_permCheck`) is kernel-checked by
+  a single O(n) `decide` with no `isDefEq` on atom expressions.
 
   This collapses the `O(n²)` proof term / `whnf` count / kernel re-check of
   `buildPermProofFallback` to `O(n)` (the `O(n²)` `isDefEq` *search* is the same
@@ -498,12 +499,20 @@ partial def buildPermProofCertCore (lhs rhs : Expr) : MetaM Expr := do
   -- YOLO fast phase: search the index permutation once.
   let σ ← computeSigma rhsAtoms lhsAtoms
   -- Single verified certificate: seps lhsList = seps (σ.map (lhsList.getD · emp)).
+  -- The side condition is the O(n) `permCheck` Bool checker (n GMP bit ops),
+  -- NOT a `decide` on `σ.Perm (List.range n)`: kernel-reducing the `List.Perm`
+  -- `Decidable` instance costs ~500ms at 83 atoms and overflows the recursion
+  -- depth near 200 atoms (silently dropping to the slow fallback exactly on
+  -- the large chains the certificate exists for). Measured ~7ms at n = 83,
+  -- ~13ms at n = 200 (see `perm_range_of_permCheck`).
   let lhsList := mkAssertionList lhsAtoms
   let σExpr := mkNatListExpr σ
-  let rangeExpr ← mkAppM ``List.range #[mkNatLit lhsAtoms.size]
-  let permProp ← mkAppM ``List.Perm #[σExpr, rangeExpr]
-  let hσ ← mkDecideProof permProp
-  let certPf ← mkAppM ``EvmAsm.Rv64.seps_permute #[lhsList, σExpr, hσ]
+  let checkProp ← mkEq
+    (mkApp2 (mkConst ``EvmAsm.Rv64.permCheck) σExpr (mkNatLit lhsAtoms.size))
+    (mkConst ``Bool.true)
+  let hσ ← withTheReader Core.Context (fun c => { c with maxRecDepth := 1024 }) do
+    mkDecideProof checkProp
+  let certPf ← mkAppM ``EvmAsm.Rv64.seps_permute_check #[lhsList, σExpr, hσ]
   -- Emp bridges: lhsRA = empified(lhsRA) (=defeq seps lhsList); same for rhs.
   let (lhsEmpPf, _) ← buildAddEmpProof lhsRA
   let (rhsEmpPf, _) ← buildAddEmpProof rhsRA

--- a/PLAN.md
+++ b/PLAN.md
@@ -87,6 +87,16 @@ EVM stack: x12 is EVM stack pointer, stack grows upward, 32 bytes per element.
   then composed via `runBlock` tactic
 - **Key tactics**: `xperm`, `xsimp`, `xcancel`, `seqFrame`, `runBlock`,
   `validMem`, `liftSpec`, `pcFree`
+- **xperm certificate prover** (`xperm.cert`, default on since 2026-06-13):
+  permutation goals discharged via an index-permutation certificate +
+  `seps_permute_check`. The side condition is the O(n) `permCheck` bitmask
+  checker (`perm_range_of_permCheck` proves it sound once) — NOT a `decide`
+  on `List.Perm`, whose Decidable instance cost ~500ms at 83 atoms and
+  overflowed recursion depth near 200 atoms, silently falling back to the
+  O(n²) pick prover on exactly the large chains the certificate targets.
+  Post-fix: ~7ms kernel at n=83, works to n≈400; large unbundled atom
+  chains (40–80+) are viable, so ambient-bundling workarounds that fold
+  atoms into opaque descriptors purely for xperm cost can be retired.
 
 ---
 


### PR DESCRIPTION
Batch-merge of #10377 #10378 #10379 (all author pirapira).

Verified locally: `lake build` (4694/4694 jobs) + all `scripts/check-*.sh` gates green (no layout drift — none of these touched code size).

Combines these three independent PRs into a single integration branch to amortize CI cost. Merged with real merge commits (no squash) to preserve per-PR commit attribution.