### PR TITLE
chore: remove redundant in-source #print axioms in BAL routines

### DIFF
--- a/EvmAsm/Codegen/Programs/BalAccountNonstorageFinalsChainB.lean
+++ b/EvmAsm/Codegen/Programs/BalAccountNonstorageFinalsChainB.lean
@@ -106,7 +106,6 @@ theorem bansf_prologue_spec (aB aLenW oB v8 v9 v18 : Word) :
   have s15 := mv_spec_gen_within .x11 .x9 aLenW aLenW (B + 84) (by decide)
   runBlock s1 s2 s3 s4 s5 s6 s7 s8 s9 s10 s11 s12 s13 s14 s15
 
-#print axioms bansf_prologue_spec
 
 /-! ## §3  The outer `rlp_walk_init` call and status dispatch (slots 22–23)
 
@@ -182,7 +181,6 @@ private theorem outerFail (aB cur endW k : Word)
     h hq
   xperm_hyp hq2
 
-#print axioms outerFail
 
 /-- The pure residue of a successful outer `rlp_walk_init`: the content
     cursor offset is `listHeaderSize` of the window's first byte. -/
@@ -580,7 +578,6 @@ theorem bansf_outerInit_spec (aB : Word) (aLen : Nat)
       rw [hLn, hRn] at hfit'
       omega
 
-#print axioms bansf_outerInit_spec
 
 /-! ## §4  The four outer item units (slots 24–45)
 
@@ -1049,7 +1046,6 @@ theorem bansf_item0_spec (aB newSp : Word) (aLen off : Nat)
       xperm_hyp hR
     exact (sepConj_pure_right h).2 ⟨hflat, by decide⟩
 
-#print axioms bansf_item0_spec
 
 end BalAccountNonstorageFinalsSpec
 end EvmAsm.Codegen

--- a/EvmAsm/Codegen/Programs/BalAccountNonstorageFinalsChainB2.lean
+++ b/EvmAsm/Codegen/Programs/BalAccountNonstorageFinalsChainB2.lean
@@ -452,7 +452,6 @@ theorem bansf_item1_spec (aB newSp : Word) (aLen off : Nat)
       xperm_hyp hR
     exact (sepConj_pure_right h).2 ⟨hflat, by decide⟩
 
-#print axioms bansf_item1_spec
 
 /-- Outer item unit 2 (slots 36–40, `B + 144 → B + 164`). -/
 theorem bansf_item2_spec (aB newSp : Word) (aLen off : Nat)
@@ -886,7 +885,6 @@ theorem bansf_item2_spec (aB newSp : Word) (aLen off : Nat)
       xperm_hyp hR
     exact (sepConj_pure_right h).2 ⟨hflat, by decide⟩
 
-#print axioms bansf_item2_spec
 
 /-- Outer item unit 3 (slots 41–45, `B + 164 → B + 184`). -/
 theorem bansf_item3_spec (aB newSp : Word) (aLen off : Nat)
@@ -1320,7 +1318,6 @@ theorem bansf_item3_spec (aB newSp : Word) (aLen off : Nat)
       xperm_hyp hR
     exact (sepConj_pure_right h).2 ⟨hflat, by decide⟩
 
-#print axioms bansf_item3_spec
 
 end BalAccountNonstorageFinalsSpec
 end EvmAsm.Codegen

--- a/EvmAsm/Codegen/Programs/BalAccountNonstorageFinalsChainB3.lean
+++ b/EvmAsm/Codegen/Programs/BalAccountNonstorageFinalsChainB3.lean
@@ -276,7 +276,6 @@ theorem bansf_chainA_spec (aB newSp oB : Word) (aLen : Nat)
     xperm_hyp hq
   xperm_hyp hq2
 
-#print axioms bansf_chainA_spec
 
 /-! ## §2  The four-item chain (B + 104 → B + 184) -/
 
@@ -599,7 +598,6 @@ theorem bansf_chainItems_spec (aB newSp : Word) (aLen off0 : Nat)
       (cpsBranchWithin_chain_snd hstep1
         (cpsBranchWithin_chain_snd hstep2 hstep3)))
 
-#print axioms bansf_chainItems_spec
 
 end BalAccountNonstorageFinalsSpec
 end EvmAsm.Codegen

--- a/EvmAsm/Codegen/Programs/BalAccountNonstorageFinalsChainC.lean
+++ b/EvmAsm/Codegen/Programs/BalAccountNonstorageFinalsChainC.lean
@@ -505,7 +505,6 @@ theorem bansf_fieldInit50_spec (aB : Word) (aLen fOff : Nat) (fSpanW : Word)
       bv_omega
 
 
-#print axioms bansf_fieldInit50_spec
 
 /-! ## §2  Span capture (slots 46–49): `s3/s4 := (a0 - a2, a2)`, args -/
 
@@ -525,7 +524,6 @@ theorem bansf_spanCapture46_spec (n3 l3 v19 v20 : Word) :
   have s4 := mv_spec_gen_within .x11 .x20 l3 (0 : Word) (B + 196) (by decide)
   runBlock s1 s2 s3 s4
 
-#print axioms bansf_spanCapture46_spec
 
 /-! ## §3  The empty-list split (slot 52) -/
 
@@ -695,9 +693,6 @@ theorem bansf_loopEntry53_spec (aB newSp : Word) (cOff fEnd : Nat) :
   exact cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp)
     (fun h hq => by xperm_hyp hq) hchain
 
-#print axioms bansf_balEmptyTaken_spec
-#print axioms bansf_balEmptyFall_spec
-#print axioms bansf_loopEntry53_spec
 
 /-! ## §5  The tuple-window init (slot 68) -/
 
@@ -1151,7 +1146,6 @@ theorem bansf_fieldInit68_spec (aB : Word) (aLen fOff : Nat) (fSpanW : Word)
       bv_omega
 
 
-#print axioms bansf_fieldInit68_spec
 
 end BalAccountNonstorageFinalsSpec
 end EvmAsm.Codegen

--- a/EvmAsm/Codegen/Programs/BalAccountNonstorageFinalsChainC2.lean
+++ b/EvmAsm/Codegen/Programs/BalAccountNonstorageFinalsChainC2.lean
@@ -481,7 +481,6 @@ theorem bansf_tupleItem0_spec (aB newSp : Word) (aLen off : Nat)
       xperm_hyp hR
     exact (sepConj_pure_right h).2 ⟨hflat, by decide⟩
 
-#print axioms bansf_tupleItem0_spec
 
 /-- The value-unit success shape at `B + 324`: the value item's advanced
     cursor and length pinned in `a0`/`a2` with the decode fact; the spill
@@ -908,7 +907,6 @@ theorem bansf_tupleItem1_spec (aB newSp : Word) (aLen tEnd off : Nat)
       xperm_hyp hR
     exact (sepConj_pure_right h).2 ⟨hflat, by decide⟩
 
-#print axioms bansf_tupleItem1_spec
 
 theorem bansf_nonceTupleItem1_spec (aB newSp : Word) (aLen tEnd off : Nat)
     (acctBytes : List (BitVec 8))
@@ -1315,7 +1313,6 @@ theorem bansf_nonceTupleItem1_spec (aB newSp : Word) (aLen tEnd off : Nat)
       xperm_hyp hR
     exact (sepConj_pure_right h).2 ⟨hflat, by decide⟩
 
-#print axioms bansf_nonceTupleItem1_spec
 
 
 end BalAccountNonstorageFinalsSpec

--- a/EvmAsm/Codegen/Programs/BalAccountNonstorageFinalsChainC3.lean
+++ b/EvmAsm/Codegen/Programs/BalAccountNonstorageFinalsChainC3.lean
@@ -606,7 +606,6 @@ theorem bansf_balCapture_spec (aB newSp oB : Word) (aLen tEnd off : Nat)
                 (sepConj_mono (regIs_implies_regOwn .x1) (fun _ x => x))))))) h hq4
     refine (sepConj_pure_right h).2 ⟨?_, by omega⟩
     xperm_hyp hq5
-#print axioms bansf_balCapture_spec
 
 theorem bansf_nonceTupleItem0_spec (aB newSp : Word) (aLen off : Nat)
     (acctBytes : List (BitVec 8))
@@ -1038,7 +1037,6 @@ theorem bansf_nonceTupleItem0_spec (aB newSp : Word) (aLen off : Nat)
         bytesRegion aB acctBytes ** F)) h := by
       xperm_hyp hR
     exact (sepConj_pure_right h).2 ⟨hflat, by decide⟩
-#print axioms bansf_nonceTupleItem0_spec
 
 
 theorem bansf_nonceTupleSpill117_spec (newSp v10 v11 : Word) :
@@ -1073,7 +1071,6 @@ theorem bansf_nonceTupleSpill117_spec (newSp v10 v11 : Word) :
     hsd1F hsd2F
   exact cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp)
     (fun h hq => by xperm_hyp hq) hchain
-#print axioms bansf_nonceTupleSpill117_spec
 
 /-- Slots 113–114 (`B + 452 → B + 460`): move the last nonce tuple span
     into the tuple `rlp_walk_init` argument registers. -/
@@ -1086,7 +1083,6 @@ theorem bansf_nonceLoopExitMove113_spec (v19 v20 v10 v11 : Word) :
   have s1 := mv_spec_gen_within .x10 .x19 v19 v10 (B + 452) (by decide)
   have s2 := mv_spec_gen_within .x11 .x20 v20 v11 (B + 456) (by decide)
   runBlock s1 s2
-#print axioms bansf_nonceLoopExitMove113_spec
 
 /-- Loop-entry spills (slots 100–101): store the tuple-walk cursor and end. -/
 theorem bansf_nonceLoopEntry100_spec (aB newSp : Word) (cOff fEnd : Nat) :
@@ -1127,7 +1123,6 @@ theorem bansf_nonceLoopEntry100_spec (aB newSp : Word) (cOff fEnd : Nat) :
     hsd1F hsd2F
   exact cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp)
     (fun h hq => by xperm_hyp hq) hchain
-#print axioms bansf_nonceLoopEntry100_spec
 
 /-- Slot 99, taken arm: an empty nonce list skips to the station join. -/
 theorem bansf_nonceEmptyTaken_spec (aB : Word) (cOff fEnd : Nat)
@@ -1156,7 +1151,6 @@ theorem bansf_nonceEmptyTaken_spec (aB : Word) (cOff fEnd : Nat)
     (fun h hq => by
       exact sepConj_mono_right
         (fun h' hp' => ((sepConj_pure_right h').1 hp').1) h hq) h
-#print axioms bansf_nonceEmptyTaken_spec
 
 /-- Slot 99, fall-through arm: a nonempty nonce list enters its tuple loop. -/
 theorem bansf_nonceEmptyFall_spec (aB : Word) (aLen cOff fEnd : Nat)
@@ -1190,7 +1184,6 @@ theorem bansf_nonceEmptyFall_spec (aB : Word) (aLen cOff fEnd : Nat)
     (fun h hq => by
       exact sepConj_mono_right
         (fun h' hp' => ((sepConj_pure_right h').1 hp').1) h hq) h
-#print axioms bansf_nonceEmptyFall_spec
 
 /-- Slots 92–96 (`B + 368 → B + 388`): respill the outer item-4 cursor,
     capture its span in `s3`/`s4`, and prepare `rlp_walk_init`. -/
@@ -1239,7 +1232,6 @@ theorem bansf_nonceSpanCapture92_spec (newSp n4 l4 v19 v20 : Word) :
     (fun h hp => by xperm_hyp hp) hsdF hcapF
   exact cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp)
     (fun h hq => by xperm_hyp hq) hchain
-#print axioms bansf_nonceSpanCapture92_spec
 
 /-- Slot 98, status-zero arm (`B + 392 → B + 396`): preserve the successful
     nonce-field `rlp_walk_init` result as the unified field-init post. -/
@@ -1283,7 +1275,6 @@ theorem bansf_nonceFieldInitSuccess98_spec (aB : Word) (fOff fSpanN cOff : Nat)
   have hq' := sepConj_mono_left (sepConj_mono_right
     (fun h' hp' => ((sepConj_pure_right h').1 hp').1)) h hq
   xperm_hyp hq'
-#print axioms bansf_nonceFieldInitSuccess98_spec
 
 /-- Slot 98, nonzero-status arm (`B + 392 → B + 736`): branch through the
     shared reject stub and release the field-init registers to ownership. -/
@@ -1348,7 +1339,6 @@ theorem bansf_nonceFieldInitFailure98_spec (aB cur endW k : Word)
     (sepConj_mono (regIs_implies_regOwn .x12)
       (sepConj_mono (regIs_implies_regOwn .x1) (fun _ x => x))) h hq'
   xperm_hyp hqOwn
-#print axioms bansf_nonceFieldInitFailure98_spec
 
 /-- Concrete code witnesses for the four non-call instructions of the outer
     nonce item unit (slots 88, 89, 91, and 92). -/
@@ -1379,7 +1369,6 @@ theorem bansf_item4_code :
     exact CodeReq.union_mono_left a i
       (CodeReq.ofProg_mem_at B (B + 368) bansfProg 92 (.SD .x2 .x10 (48 : BitVec 12))
         (by decide +kernel) (by decide +kernel) (by decide +kernel) (by decide) a i h)
-#print axioms bansf_item4_code
 
 /-- Slots 93–96 (`B + 372 → B + 388`): capture the already-respilled outer
     nonce item span and prepare the field `rlp_walk_init` arguments. -/
@@ -1396,7 +1385,6 @@ theorem bansf_nonceSpanCapture93_spec (n4 l4 v19 v20 : Word) :
   have s3 := mv_spec_gen_within .x10 .x19 (n4 - l4) n4 (B + 380) (by decide)
   have s4 := mv_spec_gen_within .x11 .x20 l4 (0 : Word) (B + 384) (by decide)
   runBlock s1 s2 s3 s4
-#print axioms bansf_nonceSpanCapture93_spec
 
 /-- Slots 139–142 (`B + 556 → B + 572`): capture the outer code item span
     and prepare the code-field `rlp_walk_init` arguments. -/
@@ -1413,7 +1401,6 @@ theorem bansf_codeSpanCapture139_spec (n5 l5 v19 v20 : Word) :
   have s3 := mv_spec_gen_within .x10 .x19 (n5 - l5) n5 (B + 564) (by decide)
   have s4 := mv_spec_gen_within .x11 .x20 l5 (0 : Word) (B + 568) (by decide)
   runBlock s1 s2 s3 s4
-#print axioms bansf_codeSpanCapture139_spec
 
 /-- Concrete code witness for the code-field status gate at slot 144. -/
 theorem bansf_codeFieldStatus144_code :
@@ -1425,7 +1412,6 @@ theorem bansf_codeFieldStatus144_code :
       (.BNE .x12 .x0 (156 : BitVec 13))
       (by decide +kernel) (by decide +kernel) (by decide +kernel)
       (by decide) a i h)
-#print axioms bansf_codeFieldStatus144_code
 
 /-- Concrete code witness for the code-field empty split at slot 145. -/
 theorem bansf_codeEmpty145_code :
@@ -1436,7 +1422,6 @@ theorem bansf_codeEmpty145_code :
     (.BEQ .x10 .x11 (144 : BitVec 13))
     (by decide +kernel) (by decide +kernel) (by decide +kernel)
     (by decide) a i h
-#print axioms bansf_codeEmpty145_code
 
 /-- Concrete code witnesses for the station-3 loop-entry spills. -/
 theorem bansf_codeLoopEntry_code :
@@ -1453,7 +1438,6 @@ theorem bansf_codeLoopEntry_code :
     exact CodeReq.union_mono_left a i
       (CodeReq.ofProg_mem_at B (B + 588) bansfProg 147 (.SD .x2 .x11 (72 : BitVec 12))
         (by decide +kernel) (by decide +kernel) (by decide +kernel) (by decide) a i h)
-#print axioms bansf_codeLoopEntry_code
 
 /-- Concrete code witnesses for the code-window materialization tail. -/
 theorem bansf_codeMaterialize_code :
@@ -1470,7 +1454,6 @@ theorem bansf_codeMaterialize_code :
   · intro a i h; exact CodeReq.union_mono_left a i (CodeReq.ofProg_mem_at B (B+712) bansfProg 178 (.SD .x18 .x12 (72:BitVec 12)) (by decide +kernel) (by decide +kernel) (by decide +kernel) (by decide) a i h)
   · intro a i h; exact CodeReq.union_mono_left a i (CodeReq.ofProg_mem_at B (B+716) bansfProg 179 (.LI .x5 (1:Word)) (by decide +kernel) (by decide +kernel) (by decide +kernel) (by decide) a i h)
   · intro a i h; exact CodeReq.union_mono_left a i (CodeReq.ofProg_mem_at B (B+720) bansfProg 180 (.SD .x18 .x5 (56:BitVec 12)) (by decide +kernel) (by decide +kernel) (by decide +kernel) (by decide) a i h)
-#print axioms bansf_codeMaterialize_code
 
 /-- Concrete code witnesses for the code tuple's value-item argument setup. -/
 theorem bansf_codeValueArgs_code :
@@ -1481,14 +1464,12 @@ theorem bansf_codeValueArgs_code :
   · intro a i h; exact CodeReq.union_mono_left a i (CodeReq.ofProg_mem_at B (B+680) bansfProg 170 (.LD .x28 .x2 (64:BitVec 12)) (by decide +kernel) (by decide +kernel) (by decide +kernel) (by decide) a i h)
   · intro a i h; exact CodeReq.union_mono_left a i (CodeReq.ofProg_mem_at B (B+684) bansfProg 171 (.LD .x11 .x2 (72:BitVec 12)) (by decide +kernel) (by decide +kernel) (by decide +kernel) (by decide) a i h)
   · intro a i h; exact CodeReq.union_mono_left a i (CodeReq.ofProg_mem_at B (B+688) bansfProg 172 (.MV .x10 .x28) (by decide +kernel) (by decide +kernel) (by decide +kernel) (by decide) a i h)
-#print axioms bansf_codeValueArgs_code
 
 /-- Concrete code witness for the code tuple value-item status gate. -/
 theorem bansf_codeValueStatus174_code :
     ∀ a i, CodeReq.singleton (B+696) (.BNE .x11 .x0 (36:BitVec 13)) a = some i → bansfCR a = some i := by
   intro a i h
   exact CodeReq.union_mono_left a i (CodeReq.ofProg_mem_at B (B+696) bansfProg 174 (.BNE .x11 .x0 (36:BitVec 13)) (by decide +kernel) (by decide +kernel) (by decide +kernel) (by decide) a i h)
-#print axioms bansf_codeValueStatus174_code
 
 end BalAccountNonstorageFinalsSpec
 end EvmAsm.Codegen

--- a/EvmAsm/Codegen/Programs/BalAccountNonstorageFinalsChainD.lean
+++ b/EvmAsm/Codegen/Programs/BalAccountNonstorageFinalsChainD.lean
@@ -34,7 +34,6 @@ theorem bansf_loopExitMove66_spec (v19 v20 v10 v11 : Word) :
   have s2 := mv_spec_gen_within .x11 .x20 v20 v11 (B + 268) (by decide)
   runBlock s1 s2
 
-#print axioms bansf_loopExitMove66_spec
 
 /-- Slots 70–71 (`B + 280 → B + 288`): spill the tuple-walk cursor and
     window end for the item units. -/
@@ -71,7 +70,6 @@ theorem bansf_tupleSpill70_spec (newSp v10 v11 : Word) :
   exact cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp)
     (fun h hq => by xperm_hyp hq) hchain
 
-#print axioms bansf_tupleSpill70_spec
 
 /-- The station-level reject shape at the epilogue entry (`B + 736`):
     every failure path of the balance station (field init, find-last loop,
@@ -102,7 +100,6 @@ theorem cpsBranchWithin_swap {n : Nat} {entry : Word} {cr : CodeReq}
   obtain ⟨k, hk, s', hstep, hcase⟩ := h R hR s hcr hPR hpc
   exact ⟨k, hk, s', hstep, hcase.symm⟩
 
-#print axioms cpsBranchWithin_swap
 
 theorem bansf_nonceTupleInit115_spec (aB : Word) (aLen fOff : Nat) (fSpanW : Word)
     (acctBytes : List (BitVec 8))
@@ -550,7 +547,6 @@ theorem bansf_nonceTupleInit115_spec (aB : Word) (aLen fOff : Nat) (fSpanW : Wor
       bv_omega
 
 
-#print axioms bansf_nonceTupleInit115_spec
 
 
 /-!

--- a/EvmAsm/Codegen/Programs/BalAccountNonstorageFinalsChainE.lean
+++ b/EvmAsm/Codegen/Programs/BalAccountNonstorageFinalsChainE.lean
@@ -33,7 +33,6 @@ theorem cpsBranchWithin_of_forall_regIs_to_regOwn1
   exact h v1 R hR s hcr
     ⟨hp, hcompat, h1, h2, hd, hu, ⟨g0, g1, d1, u1, hP0, hv1⟩, hRb⟩ hpc
 
-#print axioms cpsBranchWithin_of_forall_regIs_to_regOwn1
 
 /-- Continuation at `B + 324` (the value item decoded): run the capture
     block; route its exits to the station posts.  `hFF` finishes the
@@ -141,7 +140,6 @@ theorem bansf_balStationCont324_spec (aB newSp oB : Word)
         regOwn .x19 ** regOwn .x20))) h := ⟨g1, g2, gd, gu, hX, hfr⟩
     xperm_hyp hR
 
-#print axioms bansf_balStationCont324_spec
 
 /-- Continuation at `B + 308` (the tuple's INDEX item decoded, cursor
     spilled): run the value item unit, then the capture continuation.
@@ -363,7 +361,6 @@ theorem bansf_balStationCont308_spec (aB newSp oB : Word)
     (fun _ x => x) (fun _ x => x)
     (cpsBranchWithin_mono_nSteps (by omega) hchain)
 
-#print axioms bansf_balStationCont308_spec
 
 /-- Continuation at `B + 280` (the tuple window's `rlp_walk_init`
     succeeded): spill the tuple cursor/end, run the index item unit, then
@@ -605,7 +602,6 @@ theorem bansf_balStationCont280_spec (aB newSp oB : Word)
     (fun _ x => x) (fun _ x => x)
     (cpsBranchWithin_mono_nSteps (by omega) hfull)
 
-#print axioms bansf_balStationCont280_spec
 
 /-- Seven-register variant of the `regOwn` introduction for branches. -/
 theorem cpsBranchWithin_of_forall_regIs_to_regOwn7
@@ -633,7 +629,6 @@ theorem cpsBranchWithin_of_forall_regIs_to_regOwn7
        g6, g7, d4, u4, hv3, g8, g9, d5, u5, hv4, g10, g11, d6, u6, hv5,
        g12, g13, d7, u7, hv6, hv7⟩, hRb⟩ hpc
 
-#print axioms cpsBranchWithin_of_forall_regIs_to_regOwn7
 
 /-- Continuation at `B + 264` (the find-last loop's clean exit): move the
     last tuple's span into the walker arguments, init the tuple window,
@@ -896,7 +891,6 @@ theorem bansf_balStationCont264_spec (aB newSp oB : Word)
     (fun _ x => x) (fun _ x => x)
     (cpsBranchWithin_mono_nSteps (by omega) hfull)
 
-#print axioms bansf_balStationCont264_spec
 
 /-- Continuation at `B + 208` (the balance-field `rlp_walk_init`
     succeeded): the empty-field split; on the non-empty side, spill the

--- a/EvmAsm/Codegen/Programs/BalAccountNonstorageFinalsChainE2.lean
+++ b/EvmAsm/Codegen/Programs/BalAccountNonstorageFinalsChainE2.lean
@@ -228,7 +228,6 @@ theorem bansf_balStation_spec (aB newSp oB : Word) (aLen off3 : Nat)
     (fun _ x => x) (fun _ x => x)
     (cpsBranchWithin_mono_nSteps (by omega) hfull)
 
-#print axioms bansf_balStation_spec
 
 end BalAccountNonstorageFinalsSpec
 end EvmAsm.Codegen

--- a/EvmAsm/Codegen/Programs/BalAccountNonstorageFinalsChainF.lean
+++ b/EvmAsm/Codegen/Programs/BalAccountNonstorageFinalsChainF.lean
@@ -110,7 +110,6 @@ theorem bansf_nonceCapture_callee_bounds (aB : Word) (aLen tEnd off : Nat)
   intro k hk
   exact hvalid ((vNext - vLen - aB).toNat + k) (by omega)
 
-#print axioms bansf_nonceCapture_callee_bounds
 
 /-- Status-zero tail of the nonce capture (slots 131--134): fall through the
     status check, store the scalar, and set `has_nonce`. -/
@@ -192,7 +191,6 @@ theorem bansf_nonceCapture_successTail_spec (oB image : Word) :
   exact cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp)
     (fun h hq => by xperm_hyp hq) h3
 
-#print axioms bansf_nonceCapture_successTail_spec
 
 /-- Nonzero-status route from the nonce parser check (slot 131) through the
     shared reject stub (slot 183). -/
@@ -236,7 +234,6 @@ theorem bansf_nonceCapture_rejectRoute_spec (st oldA0 : Word) (P : Assertion)
   exact cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp)
     (fun h hq => by xperm_hyp hq) hchain
 
-#print axioms bansf_nonceCapture_rejectRoute_spec
 
 /-- Exact four-way post exported by the nonce parser at slot 130. -/
 @[irreducible] def nonceParserPost (aB : Word) (srcOff len : Nat)
@@ -345,7 +342,6 @@ theorem bansf_nonceCapture_call_spec (aB : Word) (aLen tEnd off : Nat)
   rw [show 7 * vLen.toNat + 14 = 1 + 1 + (1 + (7 * vLen.toNat + 11)) from by omega]
   exact cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp) (fun _ hq => hq) hfull
 
-#print axioms bansf_nonceCapture_call_spec
 
 /-- The `8 < len` arm of the unified nonce parser is routed to rejection. -/
 theorem bansf_nonceCapture_tooLong_spec (aB oB vLen : Word) (len : Nat)
@@ -385,7 +381,6 @@ theorem bansf_nonceCapture_tooLong_spec (aB oB vLen : Word) (len : Nat)
       exact ((sepConj_pure_right h).1 hp2).1)
     (fun h hq => by xperm_hyp hq) hr
 
-#print axioms bansf_nonceCapture_tooLong_spec
 
 /-- The empty-content success arm stores scalar zero and sets the nonce flag. -/
 theorem bansf_nonceCapture_empty_spec (aB oB vLen : Word) (len : Nat)
@@ -413,7 +408,6 @@ theorem bansf_nonceCapture_empty_spec (aB oB vLen : Word) (len : Nat)
   exact cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp)
     (fun h hq => by xperm_hyp hq) htF
 
-#print axioms bansf_nonceCapture_empty_spec
 
 /-- The leading-zero noncanonical arm is routed to rejection. -/
 theorem bansf_nonceCapture_noncanonical_spec (aB oB vLen : Word)
@@ -454,7 +448,6 @@ theorem bansf_nonceCapture_noncanonical_spec (aB oB vLen : Word)
       exact ((sepConj_pure_right h).1 hp2).1)
     (fun h hq => by xperm_hyp hq) hr
 
-#print axioms bansf_nonceCapture_noncanonical_spec
 
 /-- The canonical status-zero arm stores the decoded scalar and sets the flag.
     The caller supplies the static length bound from its pre-call case split. -/
@@ -495,7 +488,6 @@ theorem bansf_nonceCapture_canonical_spec (aB oB vLen image : Word)
     xperm_hyp hq
   exact (sepConj_pure_right h).2 ⟨((sepConj_pure_right h).1 hq2).1, hlen8⟩
 
-#print axioms bansf_nonceCapture_canonical_spec
 
 def nonceCaptureRejectPost (aB oB vLen : Word)
     (acctBytes : List (BitVec 8)) (P : Assertion) : Assertion :=
@@ -622,7 +614,6 @@ theorem bansf_nonceCapture_dispatch_spec (aB oB vLen image : Word)
   exact cpsBranchWithin_pre_or htl
     (cpsBranchWithin_pre_or he (cpsBranchWithin_pre_or hnc hc))
 
-#print axioms bansf_nonceCapture_dispatch_spec
 
 /-- Distribute the station frame into the parser's four-way post for the
     nonce-capture dispatch theorem. -/
@@ -663,7 +654,6 @@ theorem nonceParserPost_to_dispatchPre (aB oB vLen image : Word)
     rw [himage]
     exact ⟨g1, g2, hd, hu, ⟨b1, b2, hdb, hub, hbase, hc⟩, hF⟩
 
-#print axioms nonceParserPost_to_dispatchPre
 
 /-- Slots 128--130 on the statically too-long path, using the precise public
     per-case u64 callee contract. -/
@@ -763,7 +753,6 @@ theorem bansf_nonceCapture_tooLongCall_spec (aB oB : Word)
       dsimp only [R] at hRp
       xperm_hyp hRp) hfull
 
-#print axioms bansf_nonceCapture_tooLongCall_spec
 
 /-- Complete nonce-value capture (slots 128--134), with reject/found exits. -/
 theorem bansf_nonceCapture_spec (aB oB : Word) (aLen tEnd off : Nat)
@@ -828,7 +817,6 @@ theorem bansf_nonceCapture_spec (aB oB : Word) (aLen tEnd off : Nat)
     exact cpsBranchWithin_weaken (fun h hp => by xperm_hyp hp)
       (fun _ hq => hq) (fun _ hq => hq) hfull
 
-#print axioms bansf_nonceCapture_spec
 
 /-- Reframe either nonce-parser rejection status as the station reject post. -/
 theorem nonceCaptureReject_to_stationRej (aB newSp oB n4 vLen : Word)
@@ -903,7 +891,6 @@ theorem nonceCaptureReject_to_stationRej (aB newSp oB n4 vLen : Word)
     unfold nonceStationRej
     xperm_hyp hq3
 
-#print axioms nonceCaptureReject_to_stationRej
 
 /-- Reframe either successful nonce-parser arm as the station found post. -/
 theorem nonceCaptureFound_to_stationPost (aB newSp oB n4 vNext vLen : Word)
@@ -1030,7 +1017,6 @@ theorem nonceCaptureFound_to_stationPost (aB newSp oB n4 vNext vLen : Word)
     dsimp only [image] at hR' ⊢
     xperm_hyp hR'
 
-#print axioms nonceCaptureFound_to_stationPost
 
 theorem cpsBranchWithin_of_forall_regIs_to_regOwn5
     {n : Nat} {entry : Word} {r1 r2 r3 r4 r5 : Reg}
@@ -1054,7 +1040,6 @@ theorem cpsBranchWithin_of_forall_regIs_to_regOwn5
       ⟨g0, g1, d1, u1, hP0, g2, g3, d2, u2, hv1, g4, g5, d3, u3,
        hv2, g6, g7, d4, u4, hv3, g8, g9, d5, u5, hv4, hv5⟩, hRb⟩ hpc
 
-#print axioms cpsBranchWithin_of_forall_regIs_to_regOwn5
 
 /-- Continuation at `B + 512` (the nonce value item decoded): run the scalar
     capture and route both exits to the nonce-station boundary assertions. -/
@@ -1120,7 +1105,6 @@ theorem bansf_nonceStationCont512_spec (aB newSp oB : Word)
       (hFF vNext vLen hdecV) h hq)
     (cpsBranchWithin_mono_nSteps (by omega) hc)
 
-#print axioms bansf_nonceStationCont512_spec
 
 /-- A rejected nonce value-item unit carries enough untouched station frame to
     establish the shared nonce-station reject assertion. -/
@@ -1161,7 +1145,6 @@ theorem nonceTupleReject_to_stationRej (aB newSp oB n4 : Word)
   unfold nonceStationRej
   xperm_hyp hq3
 
-#print axioms nonceTupleReject_to_stationRej
 
 @[irreducible]
 def nonceCont512Pre (aB newSp oB n4 : Word) (aLen tEnd off : Nat)
@@ -1250,7 +1233,6 @@ theorem nonceTupleValOk_to_cont512Pre (aB newSp oB n4 : Word)
   change R h
   exact (congrFun heq h).mp hL
 
-#print axioms nonceTupleValOk_to_cont512Pre
 
 /-- Continuation at `B + 496`: decode the tuple value item, then run the
     nonce scalar capture at `B + 512`. -/
@@ -1333,7 +1315,6 @@ theorem bansf_nonceStationCont496_spec (aB newSp oB : Word)
     (fun _ hq => hq) (fun _ hq => hq)
     (cpsBranchWithin_mono_nSteps (by omega) hchain)
 
-#print axioms bansf_nonceStationCont496_spec
 
 end BalAccountNonstorageFinalsSpec
 end EvmAsm.Codegen

--- a/EvmAsm/Codegen/Programs/BalAccountNonstorageFinalsChainG.lean
+++ b/EvmAsm/Codegen/Programs/BalAccountNonstorageFinalsChainG.lean
@@ -104,7 +104,6 @@ theorem nonceTupleOk_to_cont496Pre (aB newSp oB n4 : Word)
   change R h
   exact (congrFun heq h).mp hL
 
-#print axioms nonceTupleOk_to_cont496Pre
 
 /-- Continuation at `B + 476`: decode the nonce tuple's index item, then run
     the value/capture continuation. -/
@@ -178,7 +177,6 @@ theorem bansf_nonceStationCont476_spec (aB newSp oB : Word)
     (fun _ hq => hq) (fun _ hq => hq)
     (cpsBranchWithin_mono_nSteps (by omega) hchain)
 
-#print axioms bansf_nonceStationCont476_spec
 
 /-- Continuation at `B + 468`: spill the tuple cursor/end, then decode its
     index and value and capture the nonce. -/
@@ -240,7 +238,6 @@ theorem bansf_nonceStationCont468_spec (aB newSp oB : Word)
       (fun _ hq => hq) (fun _ hq => hq) hc)
   exact cpsBranchWithin_mono_nSteps (by omega) hfull
 
-#print axioms bansf_nonceStationCont468_spec
 
 /-- A rejected tuple `walk_init` carries enough untouched frame to establish
     the shared nonce-station rejection assertion. -/
@@ -289,7 +286,6 @@ theorem nonceTupleInitReject_to_stationRej (aB newSp oB n4 v19 v20 s64 s72 : Wor
   unfold nonceStationRej
   xperm_hyp hq3
 
-#print axioms nonceTupleInitReject_to_stationRej
 
 /-- Reframe a successful tuple `walk_init` as the existential precondition
     consumed by the continuation at `B + 468`. -/
@@ -369,7 +365,6 @@ theorem nonceTupleInitOk_to_cont468Pre (aB newSp oB n4 v19 v20 s64 s72 : Word)
   refine ⟨cOff, (sepConj_pure_right h).2 ⟨?_, hok⟩⟩
   xperm_hyp hconv2
 
-#print axioms nonceTupleInitOk_to_cont468Pre
 
 /-- Ownership-facing wrapper for the nonce loop-exit moves. -/
 theorem bansf_nonceLoopExitMove113_own_spec (v19 v20 : Word) :
@@ -385,7 +380,6 @@ theorem bansf_nonceLoopExitMove113_own_spec (v19 v20 : Word) :
   exact cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp)
     (fun h hq => by xperm_hyp hq) hmL
 
-#print axioms bansf_nonceLoopExitMove113_own_spec
 
 /-- Continuation at `B + 452`: initialize the last nonce tuple and run its
     index/value/capture chain. -/
@@ -527,7 +521,6 @@ theorem bansf_nonceStationCont452_spec (aB newSp oB : Word)
     (fun _ hq => hq) (fun _ hq => hq)
     (cpsBranchWithin_mono_nSteps (by omega) hfull)
 
-#print axioms bansf_nonceStationCont452_spec
 
 /-- Reframe the nonce find-last loop's reject exit as the shared station
     rejection assertion. -/
@@ -568,7 +561,6 @@ theorem nonceLoopReject_to_stationRej (aB newSp oB n4 : Word)
   unfold nonceStationRej
   xperm_hyp hq3
 
-#print axioms nonceLoopReject_to_stationRej
 
 /-- Reframe the clean find-last loop exit as the existential precondition of
     the continuation at `B + 452`. -/
@@ -662,7 +654,6 @@ theorem nonceLoopExit_to_cont452Pre (aB newSp oB n4 : Word)
   change R h
   exact (congrFun heq h).mp hL
 
-#print axioms nonceLoopExit_to_cont452Pre
 
 /-- Continuation at the nonce find-last loop header `B + 408`. -/
 theorem bansf_nonceStationCont408_spec (aB newSp oB : Word)
@@ -718,7 +709,6 @@ theorem bansf_nonceStationCont408_spec (aB newSp oB : Word)
     (fun _ hq => hq) (fun _ hq => hq) hc452
   exact cpsBranchWithin_chain_snd hloopW hc452'
 
-#print axioms bansf_nonceStationCont408_spec
 
 /-- Reframe the taken empty-list arm at `B + 540` as the genuine empty
     disjunct of the nonce station postcondition. -/
@@ -773,7 +763,6 @@ theorem nonceEmpty_to_stationPost (aB newSp oB : Word)
     xperm_hyp hq3
   · exact FieldFinal.empty b hb (hcontent.trans hempty)
 
-#print axioms nonceEmpty_to_stationPost
 
 /-- Turn the two slot-100/101 spills into the station-2 find-last invariant. -/
 theorem nonceLoopEntry_to_flInv (aB newSp : Word) (acctBytes : List (BitVec 8))
@@ -838,7 +827,6 @@ theorem nonceLoopEntry_to_flInv (aB newSp : Word) (acctBytes : List (BitVec 8))
     (sepConj_pure_right h).2 ⟨?_, rfl, Nat.le_refl _, hcle, Or.inl rfl⟩⟩
   xperm_hyp hpOwn
 
-#print axioms nonceLoopEntry_to_flInv
 
 /-- Continuation at `B + 396`: split an initialized nonce field into the empty
     result or the station-2 find-last loop. -/
@@ -1007,7 +995,6 @@ theorem bansf_nonceStationCont396_spec (aB newSp oB : Word)
       (fun _ x => x) (fun _ x => x)
       (cpsBranchWithin_mono_nSteps (by omega) hfull)
 
-#print axioms bansf_nonceStationCont396_spec
 
 end BalAccountNonstorageFinalsSpec
 end EvmAsm.Codegen

--- a/EvmAsm/Codegen/Programs/BalAccountNonstorageFinalsChainH.lean
+++ b/EvmAsm/Codegen/Programs/BalAccountNonstorageFinalsChainH.lean
@@ -362,7 +362,6 @@ theorem bansf_nonceFieldInit97_spec (aB : Word) (aLen fOff : Nat) (fSpanW : Word
       bv_omega
 
 
-#print axioms bansf_nonceFieldInit97_spec
 theorem bansf_item4_spec (aB newSp : Word) (aLen off : Nat)
     (acctBytes : List (BitVec 8))
     (v5 v6 v7 v10 v11 v12 v28 v29 v30 v31 vRa : Word) (F : Assertion)
@@ -784,7 +783,6 @@ theorem bansf_item4_spec (aB newSp : Word) (aLen off : Nat)
       xperm_hyp hR
     exact (sepConj_pure_right h).2 ⟨hflat, by decide⟩
 
-#print axioms bansf_item4_spec
 
 /-- Reframe an outer item-4 parse failure as the nonce station reject post,
     preserving the earlier balance footprint and all untouched out cells. -/
@@ -821,7 +819,6 @@ theorem item4Reject_to_nonceStationRej (aB newSp oB : Word) (aLen : Nat)
   unfold nonceStationRej
   xperm_hyp hqOwn
 
-#print axioms item4Reject_to_nonceStationRej
 
 /-- Expose a successful outer item-4 decode as the exact slot-92 span-capture
     precondition, retaining the decode derivation for station bounds. -/
@@ -878,7 +875,6 @@ theorem item4Ok_to_nonceSpanPre (aB newSp oB : Word) (aLen off : Nat)
   refine ⟨n4, l4, (sepConj_pure_right h).2 ⟨?_, hdec⟩⟩
   xperm_hyp hat
 
-#print axioms item4Ok_to_nonceSpanPre
 
 /-- Reframe a nonce-field `rlp_walk_init` failure as the station reject post. -/
 theorem nonceFieldInitReject_to_stationRej (aB newSp oB n4 v19 v20 : Word)
@@ -921,7 +917,6 @@ theorem nonceFieldInitReject_to_stationRej (aB newSp oB n4 v19 v20 : Word)
   unfold nonceStationRej
   xperm_hyp hqOwn
 
-#print axioms nonceFieldInitReject_to_stationRej
 
 /-- Untouched nonce-station state framed around the field initializer. -/
 def nonceFieldFrame (aB newSp oB n4 v19 v20 : Word) (aLen : Nat)
@@ -993,7 +988,6 @@ theorem nonceFieldInitOk_to_cont396Pre (aB newSp oB n4 v19 v20 : Word)
   refine ⟨cOff, (sepConj_pure_right h).2 ⟨?_, hok⟩⟩
   xperm_hyp hatOwn
 
-#print axioms nonceFieldInitOk_to_cont396Pre
 
 /-- Successful outer-item continuation (`B + 372`): capture its field span,
     initialize the field window, and run the complete nonce parser. -/
@@ -1084,7 +1078,6 @@ theorem bansf_nonceStationCont372_spec (aB newSp oB : Word)
     (fun _ x => x) (fun _ x => x)
     (cpsBranchWithin_mono_nSteps (by omega) hfull)
 
-#print axioms bansf_nonceStationCont372_spec
 
 /-- Successful outer nonce-station result, retaining the item-4 decode that
     identifies the field window consumed by `nonceStationPost`. -/
@@ -1238,7 +1231,6 @@ theorem bansf_nonceStation_spec (aB newSp oB : Word) (aLen off : Nat)
     (fun _ x => x) (fun _ x => x)
     (cpsBranchWithin_mono_nSteps (by omega) hfull)
 
-#print axioms bansf_nonceStation_spec
 
 
 end BalAccountNonstorageFinalsSpec

--- a/EvmAsm/Codegen/Programs/BalAccountNonstorageFinalsChainI.lean
+++ b/EvmAsm/Codegen/Programs/BalAccountNonstorageFinalsChainI.lean
@@ -52,7 +52,6 @@ theorem bansf_codeFieldInitSuccess144_spec (aB : Word)
     (fun h' hp' => ((sepConj_pure_right h').1 hp').1)) h hq
   xperm_hyp hq'
 
-#print axioms bansf_codeFieldInitSuccess144_spec
 
 /-- Slot 144, nonzero-status arm (`B + 576 → B + 736`): branch through the
     shared reject stub and release the code field-init registers. -/
@@ -114,7 +113,6 @@ theorem bansf_codeFieldInitFailure144_spec (aB cur endW k : Word)
       (sepConj_mono (regIs_implies_regOwn .x1) (fun _ x => x))) h hq'
   xperm_hyp hqOwn
 
-#print axioms bansf_codeFieldInitFailure144_spec
 theorem bansf_codeFieldInit143_spec (aB : Word) (aLen fOff : Nat) (fSpanW : Word)
     (acctBytes : List (BitVec 8))
     (v5 v6 v7 v12 v28 v29 v30 v31 vRa : Word) (F : Assertion)
@@ -464,7 +462,6 @@ theorem bansf_codeFieldInit143_spec (aB : Word) (aLen fOff : Nat) (fSpanW : Word
       bv_omega
 
 
-#print axioms bansf_codeFieldInit143_spec
 
 /-- Slot 145, taken arm (`B + 580 → B + 724`): an empty code field skips
     directly to the success stub. -/
@@ -491,7 +488,6 @@ theorem bansf_codeEmptyTaken145_spec (aB : Word) (cOff fEnd : Nat)
     (fun h hq => sepConj_mono_right
       (fun h' hp' => ((sepConj_pure_right h').1 hp').1) h hq) h
 
-#print axioms bansf_codeEmptyTaken145_spec
 
 /-- Slot 145, fall-through arm (`B + 580 → B + 584`): a nonempty code
     window enters the station-3 find-last loop. -/
@@ -523,7 +519,6 @@ theorem bansf_codeEmptyFall145_spec (aB : Word) (aLen cOff fEnd : Nat)
     (fun h hq => sepConj_mono_right
       (fun h' hp' => ((sepConj_pure_right h').1 hp').1) h hq) h
 
-#print axioms bansf_codeEmptyFall145_spec
 
 /-- Slots 146–147 (`B + 584 → B + 592`): spill the nonempty code window
     cursor and end for station-3's find-last loop. -/
@@ -559,7 +554,6 @@ theorem bansf_codeLoopEntry146_spec (aB newSp : Word) (cOff fEnd : Nat) :
   exact cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp)
     (fun h hq => by xperm_hyp hq) hchain
 
-#print axioms bansf_codeLoopEntry146_spec
 
 /-- Shared reject boundary for the code station. `G` is the already-complete
     balance/nonce footprint and remains untouched. -/
@@ -644,7 +638,6 @@ theorem codeLoopReject_to_stationRej (aB newSp oB n5 : Word) (aLen : Nat)
   unfold codeStationRej
   xperm_hyp hqOwn
 
-#print axioms codeLoopReject_to_stationRej
 
 /-- Slots 175–180 (`B + 700 → B + 724`): materialize the selected code
     value as the relative `(offset,length)` window and set `has_code`. -/
@@ -728,7 +721,6 @@ theorem bansf_codeMaterialize175_spec (aB oB vNext vLen v29 v5 : Word) :
   exact cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp)
     (fun h hq => by xperm_hyp hq) c5
 
-#print axioms bansf_codeMaterialize175_spec
 
 /-- Slots 170–172 (`B + 680 → B + 692`): load the tuple value cursor/end
     and move the cursor into `a0` for `rlp_walk_next`. -/
@@ -767,7 +759,6 @@ theorem bansf_codeValueArgs170_spec (newSp cursor endW v28 v11 v10 : Word) :
   exact cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp)
     (fun h hq => by xperm_hyp hq) c2
 
-#print axioms bansf_codeValueArgs170_spec
 
 /-- Status-zero continuation for the code tuple value (`B + 696 → B + 724`):
     fall through the gate and materialize its relative window. -/
@@ -813,7 +804,6 @@ theorem bansf_codeValueSuccess174_spec
   exact cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp)
     (fun h hq => by xperm_hyp hq) hchain
 
-#print axioms bansf_codeValueSuccess174_spec
 
 /-- Nonzero-status continuation for the code tuple value (`B + 696 → B + 736`). -/
 theorem bansf_codeValueFailure174_spec (aB newSp cur k : Word)
@@ -887,7 +877,6 @@ theorem bansf_codeValueFailure174_spec (aB newSp cur k : Word)
           (sepConj_mono memIs_implies_memOwn (fun _ x => x))))) h hq'
   xperm_hyp hqOwn
 
-#print axioms bansf_codeValueFailure174_spec
 theorem bansf_codeTupleItem1_spec (aB newSp : Word) (aLen tEnd off : Nat)
     (acctBytes : List (BitVec 8))
     (v5 v6 v7 v10 v11 v12 v28 v29 v30 v31 vRa : Word) (F : Assertion)
@@ -1266,7 +1255,6 @@ theorem bansf_codeTupleItem1_spec (aB newSp : Word) (aLen tEnd off : Nat)
       xperm_hyp hR
     exact (sepConj_pure_right h).2 ⟨hflat, by decide⟩
 
-#print axioms bansf_codeTupleItem1_spec
 
 /-- Reframe a successful code tuple value decode as the materialization-tail
     precondition, retaining its decode derivation. -/
@@ -1319,7 +1307,6 @@ theorem codeTupleValOk_to_materializePre
     xperm_hyp hpV
   exact ⟨vNext, vLen, hp'⟩
 
-#print axioms codeTupleValOk_to_materializePre
 
 /-- Reframe the materialized code window as the found arm of the code station. -/
 theorem codeMaterialized_to_stationPost
@@ -1369,7 +1356,6 @@ theorem codeMaterialized_to_stationPost
   rw [h_off, h_len]
   xperm_hyp hpOwn
 
-#print axioms codeMaterialized_to_stationPost
 
 
 

--- a/EvmAsm/Codegen/Programs/BalAccountNonstorageFinalsChainJ.lean
+++ b/EvmAsm/Codegen/Programs/BalAccountNonstorageFinalsChainJ.lean
@@ -83,7 +83,6 @@ theorem bansf_codeStationCont700_spec
       exact codeMaterialized_to_stationPost aB newSp oB n5 vNext vLen aLen
         fOff fSpanN acctBytes G F (hFF vNext vLen hdec) h hsp) hmF
 
-#print axioms bansf_codeStationCont700_spec
 
 /-- A rejected code value item carries the untouched station frame needed for
     the shared code-station reject boundary. -/
@@ -123,7 +122,6 @@ theorem codeTupleReject_to_stationRej (aB newSp oB n5 : Word)
   unfold codeStationRej
   xperm_hyp hq3
 
-#print axioms codeTupleReject_to_stationRej
 
 /-- Slots 163–164 (`B + 652 → B + 660`): spill the code tuple cursor and
     end before decoding its index item. -/
@@ -164,7 +162,6 @@ theorem bansf_codeTupleSpill163_spec (newSp v10 v11 : Word) :
   exact cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp)
     (fun h hq => by xperm_hyp hq) hchain
 
-#print axioms bansf_codeTupleSpill163_spec
 
 
 theorem bansf_codeTupleItem0_spec (aB newSp : Word) (aLen off : Nat)
@@ -602,7 +599,6 @@ theorem bansf_codeTupleItem0_spec (aB newSp : Word) (aLen off : Nat)
         bytesRegion aB acctBytes ** F)) h := by
       xperm_hyp hR
     exact (sepConj_pure_right h).2 ⟨hflat, by decide⟩
-#print axioms bansf_codeTupleItem0_spec
 
 
 
@@ -694,7 +690,6 @@ theorem codeTupleOk_to_cont680Pre (aB newSp oB n5 : Word)
   change R h
   exact (congrFun heq h).mp hL
 
-#print axioms codeTupleOk_to_cont680Pre
 
 /-- Continuation at `B + 680`: decode the code tuple's value item and
     materialize its selected byte window. -/
@@ -774,7 +769,6 @@ theorem bansf_codeStationCont680_spec (aB newSp oB : Word)
     (fun _ hq => hq) (fun _ hq => hq)
     (cpsBranchWithin_mono_nSteps (by omega) hchain)
 
-#print axioms bansf_codeStationCont680_spec
 
 /-- Continuation at `B + 660`: decode the code tuple's index item, then its
     value item, and materialize the selected window. -/
@@ -846,7 +840,6 @@ theorem bansf_codeStationCont660_spec (aB newSp oB : Word)
     (fun _ hq => hq) (fun _ hq => hq)
     (cpsBranchWithin_mono_nSteps (by omega) hchain)
 
-#print axioms bansf_codeStationCont660_spec
 
 /-- Continuation at `B + 652`: spill the code tuple cursor/end, then decode
     its index and value items. -/
@@ -905,7 +898,6 @@ theorem bansf_codeStationCont652_spec (aB newSp oB : Word)
       (fun _ hq => hq) (fun _ hq => hq) hc)
   exact cpsBranchWithin_mono_nSteps (by omega) hfull
 
-#print axioms bansf_codeStationCont652_spec
 
 
 theorem bansf_codeTupleInit161_spec (aB : Word) (aLen fOff : Nat) (fSpanW : Word)
@@ -1354,7 +1346,6 @@ theorem bansf_codeTupleInit161_spec (aB : Word) (aLen fOff : Nat) (fSpanW : Word
       bv_omega
 
 
-#print axioms bansf_codeTupleInit161_spec
 
 /-- Normalize a rejected code tuple `walk_init` to the shared station reject boundary. -/
 theorem codeTupleInitReject_to_stationRej
@@ -1401,7 +1392,6 @@ theorem codeTupleInitReject_to_stationRej
   unfold codeStationRej
   xperm_hyp hq3
 
-#print axioms codeTupleInitReject_to_stationRej
 
 end BalAccountNonstorageFinalsSpec
 end EvmAsm.Codegen

--- a/EvmAsm/Codegen/Programs/BalAccountNonstorageFinalsChainK.lean
+++ b/EvmAsm/Codegen/Programs/BalAccountNonstorageFinalsChainK.lean
@@ -84,7 +84,6 @@ theorem codeTupleInitOk_to_cont652Pre
   refine ⟨cOff, (sepConj_pure_right h).2 ⟨?_, hok⟩⟩
   xperm_hyp hconv2
 
-#print axioms codeTupleInitOk_to_cont652Pre
 
 /-- Slots 159–160 (`B + 636 → B + 644`): move the last code tuple span into
     the tuple `rlp_walk_init` arguments, accepting owned destination regs. -/
@@ -119,7 +118,6 @@ theorem bansf_codeLoopExitMove159_own_spec (v19 v20 : Word) :
   exact cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp)
     (fun h hq => by xperm_hyp hq) hc
 
-#print axioms bansf_codeLoopExitMove159_own_spec
 
 
 theorem bansf_codeStationCont636_spec (aB newSp oB : Word)
@@ -260,7 +258,6 @@ theorem bansf_codeStationCont636_spec (aB newSp oB : Word)
     (fun _ hq => hq) (fun _ hq => hq)
     (cpsBranchWithin_mono_nSteps (by omega) hfull)
 
-#print axioms bansf_codeStationCont636_spec
 
 
 
@@ -354,7 +351,6 @@ theorem codeLoopExit_to_cont636Pre (aB newSp oB n5 : Word)
   change R h
   exact (congrFun heq h).mp hL
 
-#print axioms codeLoopExit_to_cont636Pre
 
 
 
@@ -411,7 +407,6 @@ theorem bansf_codeStationCont592_spec (aB newSp oB : Word)
     (fun _ hq => hq) (fun _ hq => hq) hc452
   exact cpsBranchWithin_chain_snd hloopW hc452'
 
-#print axioms bansf_codeStationCont592_spec
 
 
 
@@ -466,7 +461,6 @@ theorem codeEmpty_to_stationPost (aB newSp oB : Word)
     xperm_hyp hq3
   · exact FieldFinal.empty b hb (hcontent.trans hempty)
 
-#print axioms codeEmpty_to_stationPost
 
 
 
@@ -637,7 +631,6 @@ theorem bansf_codeStationCont580_spec (aB newSp oB : Word)
       (fun _ x => x) (fun _ x => x)
       (cpsBranchWithin_mono_nSteps (by omega) hfull)
 
-#print axioms bansf_codeStationCont580_spec
 
 
 
@@ -681,7 +674,6 @@ theorem codeFieldInitReject_to_stationRej (aB newSp oB n5 v19 v20 : Word)
   unfold codeStationRej
   xperm_hyp hqOwn
 
-#print axioms codeFieldInitReject_to_stationRej
 
 
 
@@ -755,7 +747,6 @@ theorem codeFieldInitOk_to_cont580Pre (aB newSp oB n5 v19 v20 : Word)
   refine ⟨cOff, (sepConj_pure_right h).2 ⟨?_, hok⟩⟩
   xperm_hyp hatOwn
 
-#print axioms codeFieldInitOk_to_cont580Pre
 /-- Successful outer code-item continuation: capture its field span,
     initialize the field window, and run the complete code selector. -/
 theorem bansf_codeStationCont556_spec (aB newSp oB : Word)
@@ -844,7 +835,6 @@ theorem bansf_codeStationCont556_spec (aB newSp oB : Word)
     (fun _ x => x) (fun _ x => x)
     (cpsBranchWithin_mono_nSteps (by omega) hfull)
 
-#print axioms bansf_codeStationCont556_spec
 
 
 end BalAccountNonstorageFinalsSpec

--- a/EvmAsm/Codegen/Programs/BalAccountNonstorageFinalsChainL.lean
+++ b/EvmAsm/Codegen/Programs/BalAccountNonstorageFinalsChainL.lean
@@ -45,7 +45,6 @@ theorem bansf_codeItemArgs135_spec (newSp cursor endW v10 v11 : Word) :
   exact cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp)
     (fun h hq => by xperm_hyp hq) hc
 
-#print axioms bansf_codeItemArgs135_spec
 
 /-- Concrete code witness for the final outer-item status gate at slot 138. -/
 theorem bansf_codeItemStatus138_code :
@@ -59,7 +58,6 @@ theorem bansf_codeItemStatus138_code :
       (by decide +kernel) (by decide +kernel) (by decide +kernel)
       (by decide +kernel) a i h)
 
-#print axioms bansf_codeItemStatus138_code
 
 /-- Status-zero arm of the final outer code item (`B + 552 → B + 556`). -/
 theorem bansf_codeItemSuccess138_spec
@@ -86,7 +84,6 @@ theorem bansf_codeItemSuccess138_spec
         (fun h' hp' => ((sepConj_pure_right h').1 hp').1)) h hq
       xperm_hyp hq') hfallF
 
-#print axioms bansf_codeItemSuccess138_spec
 
 
 /-- Nonzero-status continuation for the final outer code item
@@ -162,7 +159,6 @@ theorem bansf_codeItemFailure138_spec (aB newSp cur k : Word)
           (sepConj_mono memIs_implies_memOwn (fun _ x => x))))) h hq'
   xperm_hyp hqOwn
 
-#print axioms bansf_codeItemFailure138_spec
 
 /-- Reframe final-item success for `B + 556`, keeping cursor and spill distinct. -/
 theorem codeItemSuccess_to_cont556Pre
@@ -197,7 +193,6 @@ theorem codeItemSuccess_to_cont556Pre
   intro h hp
   xperm_hyp hp
 
-#print axioms codeItemSuccess_to_cont556Pre
 
 /-- Successful final outer-item decode, with spill 48 unchanged. -/
 def codeItemFinalOk (aB newSp spill5 : Word) (aLen off : Nat)
@@ -248,7 +243,6 @@ theorem codeItemFinalOk_to_cont556Pre
   refine ⟨next, len, ?_⟩
   xperm_hyp hpL
 
-#print axioms codeItemFinalOk_to_cont556Pre
 
 
 theorem bansf_codeItem5_spec (aB newSp : Word) (aLen off : Nat)
@@ -623,7 +617,6 @@ theorem bansf_codeItem5_spec (aB newSp : Word) (aLen off : Nat)
       xperm_hyp hR
     exact (sepConj_pure_right h).2 ⟨hflat, by decide⟩
 
-#print axioms bansf_codeItem5_spec
 
 /-- Reframe final outer-item failure as the code-station reject post. -/
 theorem item5Reject_to_codeStationRej (aB newSp oB : Word) (aLen : Nat)
@@ -658,7 +651,6 @@ theorem item5Reject_to_codeStationRej (aB newSp oB : Word) (aLen : Nat)
   unfold codeStationRej
   xperm_hyp hqOwn
 
-#print axioms item5Reject_to_codeStationRej
 
 
 def codeStationOuterPost (aB newSp oB : Word) (aLen off : Nat)
@@ -816,7 +808,6 @@ theorem bansf_codeStation_spec (aB newSp oB : Word) (aLen off : Nat)
     (fun _ x => x) (fun _ x => x)
     (cpsBranchWithin_mono_nSteps (by omega) hfull)
 
-#print axioms bansf_codeStation_spec
 
 
 end BalAccountNonstorageFinalsSpec

--- a/EvmAsm/Codegen/Programs/BalAccountNonstorageFinalsChainM.lean
+++ b/EvmAsm/Codegen/Programs/BalAccountNonstorageFinalsChainM.lean
@@ -49,7 +49,6 @@ theorem balStationPost_to_resultFrame
     refine sepConj_mono_left (fun h' hp' => Or.inr ⟨vNext, vLen, hp'⟩) h ?_
     xperm_hyp hp
 
-#print axioms balStationPost_to_resultFrame
 
 /-- Persistent balance+nonce result carried unchanged through code station. -/
 def nonceResult (aB oB : Word) (fOff fSpanN : Nat)
@@ -91,7 +90,6 @@ theorem nonceStationPost_to_resultFrame
     refine sepConj_mono_left (fun h' hp' => Or.inr ⟨vNext, vLen, hp'⟩) h ?_
     xperm_pure hp
 
-#print axioms nonceStationPost_to_resultFrame
 
 /-- Persistent balance+nonce+code result carried into the verdict tail. -/
 def codeResult (aB oB : Word) (fOff fSpanN : Nat)
@@ -131,7 +129,6 @@ theorem codeStationPost_to_resultFrame
     refine sepConj_mono_left (fun h' hp' => Or.inr ⟨vNext, vLen, hp'⟩) h ?_
     xperm_pure hp
 
-#print axioms codeStationPost_to_resultFrame
 
 /-- The abstract result represented by three optional final value windows. -/
 def finalsOutOf (acctBytes : List (BitVec 8)) (aB : Word)
@@ -201,7 +198,6 @@ theorem fieldFinals_to_finalsDerivation
         exact Or.inr ⟨rfl, vNext, vLen, hcode, rfl, rfl⟩
   · cases code <;> simp [finalsOutOf]
 
-#print axioms fieldFinals_to_finalsDerivation
 
 /-- Expose the optional balance window encoded by `balResult`, while retaining
     the complete owned balance footprint. -/
@@ -226,7 +222,6 @@ theorem balResult_attachFinal
       rcases heq with ⟨rfl, rfl⟩
       exact ((sepConj_pure_right h).1 hp).2.2⟩
 
-#print axioms balResult_attachFinal
 
 /-- Pure semantic witnesses accumulated after balance and nonce stations. -/
 def balNonceFinals (acctBytes : List (BitVec 8)) (aB : Word)
@@ -277,7 +272,6 @@ theorem nonceResult_attachFinals
     rcases heq with ⟨rfl, rfl⟩
     exact hNonce.2
 
-#print axioms nonceResult_attachFinals
 
 /-- Pure semantic witnesses accumulated after all three value stations. -/
 def allFieldFinals (acctBytes : List (BitVec 8)) (aB : Word)
@@ -324,7 +318,6 @@ theorem codeResult_attachFinals
     refine ⟨bal, nonce, some (vNext, vLen),
       (sepConj_pure_right h).2 ⟨hpKeep, hBNFacts, hCode⟩⟩
 
-#print axioms codeResult_attachFinals
 
 /-- The complete six-item outer AccountChanges decode chain. -/
 def outerDecodes (acctBytes : List (BitVec 8)) (aB : Word) (aLen : Nat)
@@ -363,7 +356,6 @@ theorem outerAndFieldFinals_to_derivation
     n0 l0 n1 l1 n2 l2 n3 l3 n4 l4 n5 l5 bal nonce code
     h0 hd0 hd1 hd2 hd3 hd4 hd5 hbal hnonce hcode hbalBound hnonceBound
 
-#print axioms outerAndFieldFinals_to_derivation
 
 /-- Reframe the successful outer nonce item as a persistent nonce result,
     reusable code-station frame, and its retained outer decode. -/
@@ -394,7 +386,6 @@ theorem nonceStationOuterPost_to_resultFrame
   exact nonceStationPost_to_resultFrame aB newSp oB n4 aLen
     (n4 - l4 - aB).toNat l4.toNat acctBytes G F h hStation
 
-#print axioms nonceStationOuterPost_to_resultFrame
 
 /-- Reframe the successful outer code item as the complete persistent result,
     verdict frame, and its retained outer decode. -/
@@ -426,7 +417,6 @@ theorem codeStationOuterPost_to_resultFrame
     acctBytes G F h hStation
   exact hResult
 
-#print axioms codeStationOuterPost_to_resultFrame
 
 /-- Existential code-station entry obtained from a successful nonce station;
     the item-4 decode is retained in the ambient assertion. -/
@@ -461,7 +451,6 @@ theorem nonceStationOuterPost_to_codePre
   rw [← hrep]
   xperm_hyp hp
 
-#print axioms nonceStationOuterPost_to_codePre
 
 /-- The persistent balance result owns only memory and pure facts. -/
 theorem balResult_pcFree (aB oB : Word) (fOff fSpanN : Nat)
@@ -474,7 +463,6 @@ theorem balResult_pcFree (aB oB : Word) (fOff fSpanN : Nat)
   · obtain ⟨vNext, vLen, hp⟩ := hp
     exact (inferInstance : Assertion.PCFree _).proof h hp
 
-#print axioms balResult_pcFree
 
 /-- The persistent nonce result is PC-free when its preserved footprint is. -/
 theorem nonceResult_pcFree (aB oB : Word) (fOff fSpanN : Nat)
@@ -488,7 +476,6 @@ theorem nonceResult_pcFree (aB oB : Word) (fOff fSpanN : Nat)
   · obtain ⟨vNext, vLen, hp⟩ := hp
     exact (inferInstance : Assertion.PCFree _).proof h hp
 
-#print axioms nonceResult_pcFree
 
 /-- The complete persistent code result is PC-free when its preserved
     balance+nonce footprint is. -/
@@ -503,7 +490,6 @@ theorem codeResult_pcFree (aB oB : Word) (fOff fSpanN : Nat)
   · obtain ⟨vNext, vLen, hp⟩ := hp
     exact (inferInstance : Assertion.PCFree _).proof h hp
 
-#print axioms codeResult_pcFree
 
 /-- Reject result after entering code from a successful nonce station. -/
 def nonceCodeRej (aB newSp oB : Word) (aLen off : Nat)
@@ -555,7 +541,6 @@ theorem bansf_codeStation_from_noncePost
     (fun h hp => ⟨n4, l4, (sepConj_pure_right h).2 ⟨hp, hdec4⟩⟩)
     (fun h hp => ⟨n4, l4, (sepConj_pure_right h).2 ⟨hp, hdec4⟩⟩) hs
 
-#print axioms bansf_codeStation_from_noncePost
 
 /-- Unified reject assertion for the nonce→code station chain. -/
 def nonceCodeChainRej (aB newSp oB : Word) (aLen off : Nat)
@@ -594,7 +579,6 @@ theorem bansf_nonceCodeStations_spec
     hc (fun _ hp => Or.inl hp) (fun _ hp => Or.inr hp)
   exact cpsBranchWithin_mono_nSteps (by omega) hcomp
 
-#print axioms bansf_nonceCodeStations_spec
 
 /-- Pre-zeroed nonce and code output cells carried ambiently through balance. -/
 def laterFieldZeros (oB : Word) (F : Assertion) : Assertion :=
@@ -646,7 +630,6 @@ theorem balStationPost_to_noncePre
   rw [← hrep]
   xperm_hyp hpFrame
 
-#print axioms balStationPost_to_noncePre
 
 /-- The pre-zeroed later-field footprint is PC-free whenever its ambient
     assertion is PC-free. -/
@@ -656,7 +639,6 @@ theorem laterFieldZeros_pcFree (oB : Word) (F : Assertion) (hF : F.pcFree) :
   unfold laterFieldZeros
   exact (inferInstance : Assertion.PCFree _).proof
 
-#print axioms laterFieldZeros_pcFree
 
 /-- Unified reject assertion for the balance→nonce→code value-station chain. -/
 def valueStationsRej (aB newSp oB n3 l3 : Word) (aLen : Nat)
@@ -719,7 +701,6 @@ theorem bansf_valueStations_spec
       (n3 - l3 - aB).toNat l3.toNat acctBytes F)
     hnc (fun _ hp => Or.inl hp) (fun _ hp => Or.inr hp)
 
-#print axioms bansf_valueStations_spec
 
 /-- Concrete AccountChanges with one final tuple in each value field:
     balance `1`, nonce `2`, and one-byte code `0x03`. -/
@@ -772,7 +753,6 @@ theorem finalsDerivation_nonAbsent_witness :
     hbal hnonce hcode (by simp) (by simp)
   simpa [nonAbsentWitnessOut, finalsOutOf, nonAbsentWitnessBytes] using hderiv
 
-#print axioms finalsDerivation_nonAbsent_witness
 
 /-- Balance output cells indexed by the optional final value window. -/
 def balOutCells (acctBytes : List (BitVec 8)) (aB oB : Word) :
@@ -803,7 +783,6 @@ theorem balResult_to_indexed
     refine ⟨some (vNext, vLen), ?_⟩
     simpa [balOutCells] using hp
 
-#print axioms balResult_to_indexed
 
 /-- Nonce output cells indexed by the optional final value window. -/
 def nonceOutCells (acctBytes : List (BitVec 8)) (aB oB : Word) :
@@ -853,7 +832,6 @@ theorem nonceResult_to_indexed
       rcases heq with ⟨rfl, rfl⟩
       exact hNonceFinal.2
 
-#print axioms nonceResult_to_indexed
 
 /-- Code output cells indexed by the optional final value window. -/
 def codeOutCells (aB oB : Word) : Option (Word × Word) → Assertion
@@ -901,7 +879,6 @@ theorem codeResult_to_indexed
     exact ⟨hBN, hCode, hd, hu, hBNCells,
       by simpa [codeOutCells] using hCodeCells⟩
 
-#print axioms codeResult_to_indexed
 
 /-- Exact output-block ownership indexed by the abstract `FinalsOut`. -/
 def finalOutBlock (acctBytes : List (BitVec 8)) (aB oB : Word)
@@ -989,7 +966,6 @@ theorem nonceCodePost_to_successPost
   refine ⟨hResult, hFrame, hd, hu, ?_, hFrameOwn⟩
   exact ⟨bal, nonce, code, (sepConj_pure_right hResult).2 ⟨hCells, rfl⟩⟩
 
-#print axioms nonceCodePost_to_successPost
 
 /-- Success-state remainder after factoring the verdict register `a0`. -/
 def bansfSuccessRest (aB newSp oB : Word) (aLen : Nat)
@@ -1022,7 +998,6 @@ theorem bansfSuccessPost_to_a0Rest
   exact sepConj_mono_right (fun h' hp' => ⟨out, spill, hp'⟩) h (by
     xperm_hyp hp)
 
-#print axioms bansfSuccessPost_to_a0Rest
 
 /-- The exact output-block assertion owns memory and pure equality only. -/
 theorem finalOutBlock_pcFree (acctBytes : List (BitVec 8)) (aB oB : Word)
@@ -1037,7 +1012,6 @@ theorem finalOutBlock_pcFree (acctBytes : List (BitVec 8)) (aB oB : Word)
     simp only [balOutCells, nonceOutCells, codeOutCells] at hCells ⊢ <;>
     exact (inferInstance : Assertion.PCFree _).proof h hCells
 
-#print axioms finalOutBlock_pcFree
 
 /-- The semantic success remainder is PC-free when its ambient assertion is. -/
 theorem bansfSuccessRest_pcFree
@@ -1053,7 +1027,6 @@ theorem bansfSuccessRest_pcFree
     ⟨finalOutBlock_pcFree acctBytes aB oB out⟩
   exact (inferInstance : Assertion.PCFree _).proof h hCore
 
-#print axioms bansfSuccessRest_pcFree
 
 /-- Success verdict stub over existential ownership of the incoming `a0`. -/
 theorem bansf_successTail_own :
@@ -1066,7 +1039,6 @@ theorem bansf_successTail_own :
     unfold bansfCR
     exact CodeReq.union_mono_left a i hi)
 
-#print axioms bansf_successTail_own
 
 /-- Semantic success post with the success verdict pinned in `a0`. -/
 def bansfSuccessVerdictPost (aB newSp oB : Word) (aLen : Nat)
@@ -1089,7 +1061,6 @@ theorem bansf_successTail_semantic
     (bansfSuccessPost_to_a0Rest aB newSp oB aLen acctBytes F)
     (fun _ hp => hp) ht
 
-#print axioms bansf_successTail_semantic
 
 /-- A bounded branch whose two arms reach the same PC is a triple with the
     disjunction of the two postconditions. -/
@@ -1108,7 +1079,6 @@ theorem cpsBranchWithin_same_exit_to_triple
     obtain ⟨hp, hcompat, hq⟩ := hQ2
     exact ⟨hp, hcompat, sepConj_mono_left (fun _ hx => Or.inr hx) hp hq⟩
 
-#print axioms cpsBranchWithin_same_exit_to_triple
 
 /-- Unified B+736 post after all value stations and the success verdict stub. -/
 def valueStationsVerdictPost (aB newSp oB n3 l3 : Word) (aLen : Nat)
@@ -1173,7 +1143,6 @@ theorem bansf_valueStationsVerdict_spec
     hs (fun _ hp => hp)
   exact cpsBranchWithin_same_exit_to_triple hbr
 
-#print axioms bansf_valueStationsVerdict_spec
 
 end BalAccountNonstorageFinalsSpec
 end EvmAsm.Codegen

--- a/EvmAsm/Codegen/Programs/BalAccountNonstorageFinalsChainN.lean
+++ b/EvmAsm/Codegen/Programs/BalAccountNonstorageFinalsChainN.lean
@@ -26,7 +26,6 @@ theorem valueEntryAmbient_pcFree
   unfold valueEntryAmbient
   exact (inferInstance : Assertion.PCFree _).proof
 
-#print axioms valueEntryAmbient_pcFree
 
 /-- Value-station entry with the two callee-saved temporaries existentially
     owned, as exposed by the outer item walk. -/
@@ -78,7 +77,6 @@ theorem bansf_valueStationsVerdict_own1920
     hslack hover hvalid hovout hovalid hoff3 hPrefix
   exact cpsTripleWithin_weaken (by xsimp) (fun _ hp => hp) ht
 
-#print axioms bansf_valueStationsVerdict_own1920
 
 /-- Unified verdict post after entering the value stations from the existential
     item-3 accumulator produced by SEG-B. -/
@@ -160,7 +158,6 @@ theorem bansf_valueStations_from_acc3
     unfold valueEntryAmbient valueStationsEntryOwn laterFieldZeros
     xsimp) (fun _ hp => ⟨n3, l3, hp⟩) ht
 
-#print axioms bansf_valueStations_from_acc3
 
 /-- Common B+736 post after outer items 0--3 and all value stations. -/
 def itemsVerdictPost (aB newSp oB : Word) (aLen off0 : Nat)
@@ -216,7 +213,6 @@ theorem bansf_itemsVerdict_spec
   exact cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp) (fun _ hp => hp)
     (cpsBranchWithin_same_exit_to_triple hbr)
 
-#print axioms bansf_itemsVerdict_spec
 
 /-- Verdict post after eliminating the existential outer-header offset carried
     by `chainMidB`. -/
@@ -277,7 +273,6 @@ theorem bansf_chainMidVerdict_spec
     unfold valueEntryAmbient
     xperm_hyp hpp) (fun _ hp => ⟨off0, hp⟩) ht
 
-#print axioms bansf_chainMidVerdict_spec
 
 /-- Common verdict after the outer-init chain, including its early reject. -/
 def chainAVerdictPost (aB newSp oB : Word) (aLen : Nat)
@@ -335,7 +330,6 @@ theorem bansf_chainAVerdict_spec
   exact cpsTripleWithin_weaken (fun _ hp => hp) (fun _ hp => hp)
     (cpsBranchWithin_same_exit_to_triple hbr)
 
-#print axioms bansf_chainAVerdict_spec
 
 /-- ABI-friendly body entry: the incoming saved-register values of `x19` and
     `x20` are concrete, while every other body resource is grouped ambiently. -/
@@ -388,7 +382,6 @@ theorem bansf_chainAVerdict_concrete1920
         (regIs_implies_regOwn .x20)) (fun _ hx => hx) h hp
     xperm_hyp hpOwn) (fun _ hp => hp) ht
 
-#print axioms bansf_chainAVerdict_concrete1920
 
 end BalAccountNonstorageFinalsSpec
 end EvmAsm.Codegen

--- a/EvmAsm/Codegen/Programs/BalAccountNonstorageFinalsChainO.lean
+++ b/EvmAsm/Codegen/Programs/BalAccountNonstorageFinalsChainO.lean
@@ -90,7 +90,6 @@ theorem chainRejB_to_abiReject
   simp only [regsOwnAt, bansfFrame, List.foldr, sepConj_emp_right']
   xperm_hyp hq'
 
-#print axioms chainRejB_to_abiReject
 
 /-- An item-walk reject carries the same ABI anchors and conservative result;
     the successful outer-header fact is irrelevant once rejection is chosen. -/
@@ -139,7 +138,6 @@ theorem itemRejAmbient_to_abiReject
   simp only [regsOwnAt, bansfFrame, List.foldr, sepConj_emp_right']
   xperm_hyp hq'
 
-#print axioms itemRejAmbient_to_abiReject
 
 private def lateZeroBlock (oB : Word) : Assertion :=
   ((oB + 40) ↦ₘ (0 : Word)) ** ((oB + 48) ↦ₘ (0 : Word)) **
@@ -200,7 +198,6 @@ theorem balStationRej_to_abiReject
   simp only [regsOwnAt, bansfFrame, List.foldr, sepConj_emp_right']
   xperm_hyp hq'
 
-#print axioms balStationRej_to_abiReject
 
 private def balOwnBlock (oB : Word) : Assertion :=
   memOwn oB ** memOwn (oB + 8) ** memOwn (oB + 16) **
@@ -256,7 +253,6 @@ theorem bytesRegion32_to_memOwnU256 (base : Word) (bs : List (BitVec 8))
     (sepConj_mono memIs_implies_memOwn
       (sepConj_mono memIs_implies_memOwn memIs_implies_memOwn)) h hp
 
-#print axioms bytesRegion32_to_memOwnU256
 
 /-- Either semantic balance result owns exactly the five balance output cells,
     independently of whether the field was absent or materialized. -/
@@ -288,7 +284,6 @@ theorem balResult_to_balOwnBlock
     unfold balOwnBlock
     exact hOwned
 
-#print axioms balResult_to_balOwnBlock
 
 /-- Either semantic nonce result extends an owned balance footprint with the
     two owned nonce output cells. -/
@@ -315,7 +310,6 @@ theorem nonceResult_to_balanceNonceOwnBlock
     unfold balanceNonceOwnBlock
     xperm_hyp hOwned
 
-#print axioms nonceResult_to_balanceNonceOwnBlock
 
 /-- A code-station reject normalizes to the common ABI reject result whenever
     the already-materialized balance and nonce footprint owns its cells. -/
@@ -357,7 +351,6 @@ theorem codeStationRej_to_abiReject
   simp only [regsOwnAt, bansfFrame, List.foldr, sepConj_emp_right']
   xperm_hyp hq'
 
-#print axioms codeStationRej_to_abiReject
 
 /-- A nonce-station reject normalizes to the common ABI reject result whenever
     the already-materialized balance footprint owns its output cells. -/
@@ -407,7 +400,6 @@ theorem nonceStationRej_to_abiReject
   simp only [regsOwnAt, bansfFrame, List.foldr, sepConj_emp_right']
   xperm_hyp hq'
 
-#print axioms nonceStationRej_to_abiReject
 
 /-- The existential code reject reached after a successful nonce station also
     normalizes to the common ABI reject result. -/
@@ -427,7 +419,6 @@ theorem nonceCodeRej_to_abiReject
     (nonceResult_to_balanceNonceOwnBlock aB oB
       (n4 - l4 - aB).toNat l4.toNat acctBytes G hG) h hRej
 
-#print axioms nonceCodeRej_to_abiReject
 
 /-- Semantic success result after factoring out the stack pointer and the
     callee-saved registers consumed by `abiFrame_spec_own`. -/
@@ -487,7 +478,6 @@ theorem bansfSuccessVerdict_to_abiSuccess
   simp only [regsOwnAt, bansfFrame, List.foldr, sepConj_emp_right']
   xperm_hyp hq'
 
-#print axioms bansfSuccessVerdict_to_abiSuccess
 
 /-- Observable result of the body: exact rejection status, or exact success
     status together with the window-anchored semantic derivation. -/
@@ -548,7 +538,6 @@ theorem chainAVerdictPost_to_abiVerdict
       · exact success (bansfSuccessVerdict_to_abiSuccess aB newSp oB aLen
           acctBytes F h hp)
 
-#print axioms chainAVerdictPost_to_abiVerdict
 
 /-- Pull an ambient assertion out of either observable verdict arm. -/
 theorem bansfVerdictResult_frame_out
@@ -568,7 +557,6 @@ theorem bansfVerdictResult_frame_out
     refine sepConj_mono_right (fun _ hp' => ⟨out, spill, hp'⟩) h ?_
     xperm_hyp hp
 
-#print axioms bansfVerdictResult_frame_out
 
 /-- Caller-owned resources used by the body, excluding the ABI frame itself. -/
 def bansfCallerPre (aB newSp oB : Word) (aLen : Nat)
@@ -647,7 +635,6 @@ theorem bansf_body_spec
       (bansfVerdictResult_frame_out aB newSp oB aLen acctBytes FS F)) h hpAbi
     simpa only [newSp, FS] using hpOut) ht
 
-#print axioms bansf_body_spec
 
 /-- The caller-owned body footprint is PC-free when its ambient frame is. -/
 theorem bansfCallerPre_pcFree
@@ -658,7 +645,6 @@ theorem bansfCallerPre_pcFree
   unfold bansfCallerPre
   exact (inferInstance : Assertion.PCFree _).proof
 
-#print axioms bansfCallerPre_pcFree
 
 /-- Both exact verdict arms are PC-free when the ambient assertion is. -/
 theorem bansfVerdictResult_pcFree
@@ -677,7 +663,6 @@ theorem bansfVerdictResult_pcFree
       ⟨finalOutBlock_pcFree acctBytes aB oB out⟩
     exact (inferInstance : Assertion.PCFree _).proof h hp
 
-#print axioms bansfVerdictResult_pcFree
 
 /-- Static account/output geometry required by the verified memory model.
     It contains no decode result or branch outcome. -/
@@ -754,7 +739,6 @@ theorem bansf_spec_within
   · simpa only [bansfFrame, List.length_cons, List.length_nil, hBodyLen,
       Nat.reduceAdd, Nat.reduceMul] using hbody
 
-#print axioms bansf_spec_within
 
 end BalAccountNonstorageFinalsSpec
 end EvmAsm.Codegen

--- a/EvmAsm/Codegen/Programs/BalAccountNonstorageFinalsLoop.lean
+++ b/EvmAsm/Codegen/Programs/BalAccountNonstorageFinalsLoop.lean
@@ -176,7 +176,6 @@ theorem fl_failArm (aB newSp cursor v19 v20 raOld k : Word)
     h hq
   xperm_hyp hq2
 
-#print axioms fl_failArm
 
 /-! ## §3  The accept arm: spill the advanced cursor, capture the span -/
 
@@ -312,7 +311,6 @@ theorem fl_okArm (aB newSp cursorOld v19 v20 next len raVal : Word)
   exact cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp)
     (fun h hq => by xperm_hyp hq) c4
 
-#print axioms fl_okArm
 
 /-! ## §4  The loop head: reload the spills, test for the window end -/
 
@@ -421,8 +419,6 @@ theorem fl_headFall (newSp cursor endW : Word) (hne : cursor ≠ endW) :
     (fun h' hp' => ((sepConj_pure_right h').1 hp').1)) h hq
   xperm_hyp hq2
 
-#print axioms fl_headExit
-#print axioms fl_headFall
 
 /-! ## §5  The call block: `mv a0/a1`, `jal rlp_walk_next` -/
 
@@ -566,7 +562,6 @@ theorem fl_callBlock (aB newSp : Word) (acctBytes : List (BitVec 8))
   have c2 := cpsTripleWithin_seq_perm_same_cr (fun h hp => by xperm_hyp hp) c1 hcallF
   exact cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp) (fun _ hq => hq) c2
 
-#print axioms fl_callBlock
 
 /-! ## §6  The dispatch: consume the six-outcome post -/
 
@@ -712,8 +707,6 @@ private theorem fl_dispatchOk (aB newSp : Word) (acctBytes : List (BitVec 8))
         BitVec.toNat_ofNat] at this
       omega
 
-#print axioms fl_dispatchFail
-#print axioms fl_dispatchOk
 
 /-! ## §7  The round: one full pass from the header -/
 
@@ -861,7 +854,6 @@ theorem fl_round (aB newSp : Word) (acctBytes : List (BitVec 8))
     · exact Or.inr (Or.inr (Or.inr (Or.inr (Or.inr
         ⟨h1, h2, hd, hu, ⟨h3, h4, hd2, hu2, hCF, a6⟩, hEx⟩))))
 
-#print axioms fl_round
 
 /-! ## §8  The folded loop -/
 
@@ -888,7 +880,6 @@ theorem bansf_findLastLoop1_spec (aB newSp : Word) (acctBytes : List (BitVec 8))
       (fun j' => fl_round aB newSp acctBytes off0 endOff F hF hsalign hslack
         hover hvalid hoff0 j') j)
 
-#print axioms bansf_findLastLoop1_spec
 
 end BalAccountNonstorageFinalsSpec
 end EvmAsm.Codegen

--- a/EvmAsm/Codegen/Programs/BalAccountNonstorageFinalsLoop2.lean
+++ b/EvmAsm/Codegen/Programs/BalAccountNonstorageFinalsLoop2.lean
@@ -105,7 +105,6 @@ theorem fl2_failArm (aB newSp cursor v19 v20 raOld k : Word)
     h hq
   xperm_hyp hq2
 
-#print axioms fl2_failArm
 
 /-! ## §3  The accept arm: spill the advanced cursor, capture the span -/
 
@@ -241,7 +240,6 @@ theorem fl2_okArm (aB newSp cursorOld v19 v20 next len raVal : Word)
   exact cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp)
     (fun h hq => by xperm_hyp hq) c4
 
-#print axioms fl2_okArm
 
 /-! ## §4  The loop head: reload the spills, test for the window end -/
 
@@ -350,8 +348,6 @@ theorem fl2_headFall (newSp cursor endW : Word) (hne : cursor ≠ endW) :
     (fun h' hp' => ((sepConj_pure_right h').1 hp').1)) h hq
   xperm_hyp hq2
 
-#print axioms fl2_headExit
-#print axioms fl2_headFall
 
 /-! ## §5  The call block: `mv a0/a1`, `jal rlp_walk_next` -/
 
@@ -495,7 +491,6 @@ theorem fl2_callBlock (aB newSp : Word) (acctBytes : List (BitVec 8))
   have c2 := cpsTripleWithin_seq_perm_same_cr (fun h hp => by xperm_hyp hp) c1 hcallF
   exact cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp) (fun _ hq => hq) c2
 
-#print axioms fl2_callBlock
 
 /-! ## §6  The dispatch: consume the six-outcome post -/
 
@@ -641,8 +636,6 @@ private theorem fl2_dispatchOk (aB newSp : Word) (acctBytes : List (BitVec 8))
         BitVec.toNat_ofNat] at this
       omega
 
-#print axioms fl2_dispatchFail
-#print axioms fl2_dispatchOk
 
 /-! ## §7  The round: one full pass from the header -/
 
@@ -790,7 +783,6 @@ theorem fl2_round (aB newSp : Word) (acctBytes : List (BitVec 8))
     · exact Or.inr (Or.inr (Or.inr (Or.inr (Or.inr
         ⟨h1, h2, hd, hu, ⟨h3, h4, hd2, hu2, hCF, a6⟩, hEx⟩))))
 
-#print axioms fl2_round
 
 /-! ## §8  The folded loop -/
 
@@ -817,7 +809,6 @@ theorem bansf_findLastLoop2_spec (aB newSp : Word) (acctBytes : List (BitVec 8))
       (fun j' => fl2_round aB newSp acctBytes off0 endOff F hF hsalign hslack
         hover hvalid hoff0 j') j)
 
-#print axioms bansf_findLastLoop2_spec
 
 end BalAccountNonstorageFinalsSpec
 end EvmAsm.Codegen

--- a/EvmAsm/Codegen/Programs/BalAccountNonstorageFinalsLoop3.lean
+++ b/EvmAsm/Codegen/Programs/BalAccountNonstorageFinalsLoop3.lean
@@ -105,7 +105,6 @@ theorem fl3_failArm (aB newSp cursor v19 v20 raOld k : Word)
     h hq
   xperm_hyp hq2
 
-#print axioms fl3_failArm
 
 /-! ## §3  The accept arm: spill the advanced cursor, capture the span -/
 
@@ -241,7 +240,6 @@ theorem fl3_okArm (aB newSp cursorOld v19 v20 next len raVal : Word)
   exact cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp)
     (fun h hq => by xperm_hyp hq) c4
 
-#print axioms fl3_okArm
 
 /-! ## §4  The loop head: reload the spills, test for the window end -/
 
@@ -350,8 +348,6 @@ theorem fl3_headFall (newSp cursor endW : Word) (hne : cursor ≠ endW) :
     (fun h' hp' => ((sepConj_pure_right h').1 hp').1)) h hq
   xperm_hyp hq2
 
-#print axioms fl3_headExit
-#print axioms fl3_headFall
 
 /-! ## §5  The call block: `mv a0/a1`, `jal rlp_walk_next` -/
 
@@ -495,7 +491,6 @@ theorem fl3_callBlock (aB newSp : Word) (acctBytes : List (BitVec 8))
   have c2 := cpsTripleWithin_seq_perm_same_cr (fun h hp => by xperm_hyp hp) c1 hcallF
   exact cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp) (fun _ hq => hq) c2
 
-#print axioms fl3_callBlock
 
 /-! ## §6  The dispatch: consume the six-outcome post -/
 
@@ -641,8 +636,6 @@ private theorem fl3_dispatchOk (aB newSp : Word) (acctBytes : List (BitVec 8))
         BitVec.toNat_ofNat] at this
       omega
 
-#print axioms fl3_dispatchFail
-#print axioms fl3_dispatchOk
 
 /-! ## §7  The round: one full pass from the header -/
 
@@ -790,7 +783,6 @@ theorem fl3_round (aB newSp : Word) (acctBytes : List (BitVec 8))
     · exact Or.inr (Or.inr (Or.inr (Or.inr (Or.inr
         ⟨h1, h2, hd, hu, ⟨h3, h4, hd2, hu2, hCF, a6⟩, hEx⟩))))
 
-#print axioms fl3_round
 
 /-! ## §8  The folded loop -/
 
@@ -817,7 +809,6 @@ theorem bansf_findLastLoop3_spec (aB newSp : Word) (acctBytes : List (BitVec 8))
       (fun j' => fl3_round aB newSp acctBytes off0 endOff F hF hsalign hslack
         hover hvalid hoff0 j') j)
 
-#print axioms bansf_findLastLoop3_spec
 
 end BalAccountNonstorageFinalsSpec
 end EvmAsm.Codegen

--- a/EvmAsm/Codegen/Programs/BalAccountNonstorageFinalsSpec.lean
+++ b/EvmAsm/Codegen/Programs/BalAccountNonstorageFinalsSpec.lean
@@ -410,7 +410,6 @@ theorem finalsDerivation_witness :
       rw [h1, h2]
       exact FieldFinal.empty 0xc0 rfl (by decide)⟩
 
-#print axioms finalsDerivation_witness
 
 /-! ## §3  The verdict stubs
 
@@ -456,8 +455,6 @@ theorem bansf_rejectTail_spec (base vOld : Word)
   rw [show base + 732 + 4 = base + 736 from by bv_omega] at hli
   exact hli
 
-#print axioms bansf_successTail_spec
-#print axioms bansf_rejectTail_spec
 
 /-! ## §4  Concrete linkage: code requirement, call-site adapters
 
@@ -556,7 +553,6 @@ theorem bansf_callSite22_walk_init {n : Nat} {Prest Q : Assertion} (vRa : Word)
   · exact CodeReq.mono_union_right bansf_prog_disj_walkInit
       (fun a i h => CodeReq.union_mono_left a i h) a i h
 
-#print axioms bansf_callSite22_walk_init
 
 /-- Call-site adapter for the `jal rlp_walk_next` at slot 28 (`B + 112`). -/
 theorem bansf_callSite28_walk_next {n : Nat} {Prest Q : Assertion} (vRa : Word)
@@ -582,7 +578,6 @@ theorem bansf_callSite28_walk_next {n : Nat} {Prest Q : Assertion} (vRa : Word)
       (fun a i h => CodeReq.mono_union_right bansf_walkInit_disj_walkNext
         (fun a i h => CodeReq.union_mono_left a i h) a i h) a i h
 
-#print axioms bansf_callSite28_walk_next
 
 /-- Call-site adapter for the `jal rlp_walk_next` at slot 33 (`B + 132`). -/
 theorem bansf_callSite33_walk_next {n : Nat} {Prest Q : Assertion} (vRa : Word)
@@ -608,7 +603,6 @@ theorem bansf_callSite33_walk_next {n : Nat} {Prest Q : Assertion} (vRa : Word)
       (fun a i h => CodeReq.mono_union_right bansf_walkInit_disj_walkNext
         (fun a i h => CodeReq.union_mono_left a i h) a i h) a i h
 
-#print axioms bansf_callSite33_walk_next
 
 /-- Call-site adapter for the `jal rlp_walk_next` at slot 38 (`B + 152`). -/
 theorem bansf_callSite38_walk_next {n : Nat} {Prest Q : Assertion} (vRa : Word)
@@ -634,7 +628,6 @@ theorem bansf_callSite38_walk_next {n : Nat} {Prest Q : Assertion} (vRa : Word)
       (fun a i h => CodeReq.mono_union_right bansf_walkInit_disj_walkNext
         (fun a i h => CodeReq.union_mono_left a i h) a i h) a i h
 
-#print axioms bansf_callSite38_walk_next
 
 /-- Call-site adapter for the `jal rlp_walk_next` at slot 43 (`B + 172`). -/
 theorem bansf_callSite43_walk_next {n : Nat} {Prest Q : Assertion} (vRa : Word)
@@ -660,7 +653,6 @@ theorem bansf_callSite43_walk_next {n : Nat} {Prest Q : Assertion} (vRa : Word)
       (fun a i h => CodeReq.mono_union_right bansf_walkInit_disj_walkNext
         (fun a i h => CodeReq.union_mono_left a i h) a i h) a i h
 
-#print axioms bansf_callSite43_walk_next
 
 /-- Call-site adapter for the `jal rlp_walk_init` at slot 50 (`B + 200`). -/
 theorem bansf_callSite50_walk_init {n : Nat} {Prest Q : Assertion} (vRa : Word)
@@ -685,7 +677,6 @@ theorem bansf_callSite50_walk_init {n : Nat} {Prest Q : Assertion} (vRa : Word)
   · exact CodeReq.mono_union_right bansf_prog_disj_walkInit
       (fun a i h => CodeReq.union_mono_left a i h) a i h
 
-#print axioms bansf_callSite50_walk_init
 
 /-- Call-site adapter for the `jal rlp_walk_next` at slot 60 (`B + 240`). -/
 theorem bansf_callSite60_walk_next {n : Nat} {Prest Q : Assertion} (vRa : Word)
@@ -711,7 +702,6 @@ theorem bansf_callSite60_walk_next {n : Nat} {Prest Q : Assertion} (vRa : Word)
       (fun a i h => CodeReq.mono_union_right bansf_walkInit_disj_walkNext
         (fun a i h => CodeReq.union_mono_left a i h) a i h) a i h
 
-#print axioms bansf_callSite60_walk_next
 
 /-- Call-site adapter for the `jal rlp_walk_init` at slot 68 (`B + 272`). -/
 theorem bansf_callSite68_walk_init {n : Nat} {Prest Q : Assertion} (vRa : Word)
@@ -736,7 +726,6 @@ theorem bansf_callSite68_walk_init {n : Nat} {Prest Q : Assertion} (vRa : Word)
   · exact CodeReq.mono_union_right bansf_prog_disj_walkInit
       (fun a i h => CodeReq.union_mono_left a i h) a i h
 
-#print axioms bansf_callSite68_walk_init
 
 /-- Call-site adapter for the `jal rlp_walk_next` at slot 74 (`B + 296`). -/
 theorem bansf_callSite74_walk_next {n : Nat} {Prest Q : Assertion} (vRa : Word)
@@ -762,7 +751,6 @@ theorem bansf_callSite74_walk_next {n : Nat} {Prest Q : Assertion} (vRa : Word)
       (fun a i h => CodeReq.mono_union_right bansf_walkInit_disj_walkNext
         (fun a i h => CodeReq.union_mono_left a i h) a i h) a i h
 
-#print axioms bansf_callSite74_walk_next
 
 /-- Call-site adapter for the `jal rlp_walk_next` at slot 79 (`B + 316`). -/
 theorem bansf_callSite79_walk_next {n : Nat} {Prest Q : Assertion} (vRa : Word)
@@ -788,7 +776,6 @@ theorem bansf_callSite79_walk_next {n : Nat} {Prest Q : Assertion} (vRa : Word)
       (fun a i h => CodeReq.mono_union_right bansf_walkInit_disj_walkNext
         (fun a i h => CodeReq.union_mono_left a i h) a i h) a i h
 
-#print axioms bansf_callSite79_walk_next
 
 /-- Call-site adapter for the `jal rlp_content_to_u256_be` at slot 84 (`B + 336`). -/
 theorem bansf_callSite84_content_to_u256_be {n : Nat} {Prest Q : Assertion} (vRa : Word)
@@ -816,7 +803,6 @@ theorem bansf_callSite84_content_to_u256_be {n : Nat} {Prest Q : Assertion} (vRa
           (fun a i h => CodeReq.mono_union_right bansf_ctu64_disj_ctu256
             (fun _ _ hh => hh) a i h) a i h) a i h) a i h
 
-#print axioms bansf_callSite84_content_to_u256_be
 
 /-- Call-site adapter for the `jal rlp_walk_next` at slot 90 (`B + 360`). -/
 theorem bansf_callSite90_walk_next {n : Nat} {Prest Q : Assertion} (vRa : Word)
@@ -842,7 +828,6 @@ theorem bansf_callSite90_walk_next {n : Nat} {Prest Q : Assertion} (vRa : Word)
       (fun a i h => CodeReq.mono_union_right bansf_walkInit_disj_walkNext
         (fun a i h => CodeReq.union_mono_left a i h) a i h) a i h
 
-#print axioms bansf_callSite90_walk_next
 
 /-- Call-site adapter for the `jal rlp_walk_init` at slot 97 (`B + 388`). -/
 theorem bansf_callSite97_walk_init {n : Nat} {Prest Q : Assertion} (vRa : Word)
@@ -867,7 +852,6 @@ theorem bansf_callSite97_walk_init {n : Nat} {Prest Q : Assertion} (vRa : Word)
   · exact CodeReq.mono_union_right bansf_prog_disj_walkInit
       (fun a i h => CodeReq.union_mono_left a i h) a i h
 
-#print axioms bansf_callSite97_walk_init
 
 /-- Call-site adapter for the `jal rlp_walk_next` at slot 107 (`B + 428`). -/
 theorem bansf_callSite107_walk_next {n : Nat} {Prest Q : Assertion} (vRa : Word)
@@ -893,7 +877,6 @@ theorem bansf_callSite107_walk_next {n : Nat} {Prest Q : Assertion} (vRa : Word)
       (fun a i h => CodeReq.mono_union_right bansf_walkInit_disj_walkNext
         (fun a i h => CodeReq.union_mono_left a i h) a i h) a i h
 
-#print axioms bansf_callSite107_walk_next
 
 /-- Call-site adapter for the `jal rlp_walk_init` at slot 115 (`B + 460`). -/
 theorem bansf_callSite115_walk_init {n : Nat} {Prest Q : Assertion} (vRa : Word)
@@ -918,7 +901,6 @@ theorem bansf_callSite115_walk_init {n : Nat} {Prest Q : Assertion} (vRa : Word)
   · exact CodeReq.mono_union_right bansf_prog_disj_walkInit
       (fun a i h => CodeReq.union_mono_left a i h) a i h
 
-#print axioms bansf_callSite115_walk_init
 
 /-- Call-site adapter for the `jal rlp_walk_next` at slot 121 (`B + 484`). -/
 theorem bansf_callSite121_walk_next {n : Nat} {Prest Q : Assertion} (vRa : Word)
@@ -944,7 +926,6 @@ theorem bansf_callSite121_walk_next {n : Nat} {Prest Q : Assertion} (vRa : Word)
       (fun a i h => CodeReq.mono_union_right bansf_walkInit_disj_walkNext
         (fun a i h => CodeReq.union_mono_left a i h) a i h) a i h
 
-#print axioms bansf_callSite121_walk_next
 
 /-- Call-site adapter for the `jal rlp_walk_next` at slot 126 (`B + 504`). -/
 theorem bansf_callSite126_walk_next {n : Nat} {Prest Q : Assertion} (vRa : Word)
@@ -970,7 +951,6 @@ theorem bansf_callSite126_walk_next {n : Nat} {Prest Q : Assertion} (vRa : Word)
       (fun a i h => CodeReq.mono_union_right bansf_walkInit_disj_walkNext
         (fun a i h => CodeReq.union_mono_left a i h) a i h) a i h
 
-#print axioms bansf_callSite126_walk_next
 
 /-- Call-site adapter for the `jal rlp_content_to_u64` at slot 130 (`B + 520`). -/
 theorem bansf_callSite130_content_to_u64 {n : Nat} {Prest Q : Assertion} (vRa : Word)
@@ -997,7 +977,6 @@ theorem bansf_callSite130_content_to_u64 {n : Nat} {Prest Q : Assertion} (vRa : 
         (fun a i h => CodeReq.mono_union_right bansf_walkNext_disj_ctu64
           (fun a i h => CodeReq.union_mono_left a i h) a i h) a i h) a i h
 
-#print axioms bansf_callSite130_content_to_u64
 
 /-- Call-site adapter for the `jal rlp_walk_next` at slot 137 (`B + 548`). -/
 theorem bansf_callSite137_walk_next {n : Nat} {Prest Q : Assertion} (vRa : Word)
@@ -1023,7 +1002,6 @@ theorem bansf_callSite137_walk_next {n : Nat} {Prest Q : Assertion} (vRa : Word)
       (fun a i h => CodeReq.mono_union_right bansf_walkInit_disj_walkNext
         (fun a i h => CodeReq.union_mono_left a i h) a i h) a i h
 
-#print axioms bansf_callSite137_walk_next
 
 /-- Call-site adapter for the `jal rlp_walk_init` at slot 143 (`B + 572`). -/
 theorem bansf_callSite143_walk_init {n : Nat} {Prest Q : Assertion} (vRa : Word)
@@ -1048,7 +1026,6 @@ theorem bansf_callSite143_walk_init {n : Nat} {Prest Q : Assertion} (vRa : Word)
   · exact CodeReq.mono_union_right bansf_prog_disj_walkInit
       (fun a i h => CodeReq.union_mono_left a i h) a i h
 
-#print axioms bansf_callSite143_walk_init
 
 /-- Call-site adapter for the `jal rlp_walk_next` at slot 153 (`B + 612`). -/
 theorem bansf_callSite153_walk_next {n : Nat} {Prest Q : Assertion} (vRa : Word)
@@ -1074,7 +1051,6 @@ theorem bansf_callSite153_walk_next {n : Nat} {Prest Q : Assertion} (vRa : Word)
       (fun a i h => CodeReq.mono_union_right bansf_walkInit_disj_walkNext
         (fun a i h => CodeReq.union_mono_left a i h) a i h) a i h
 
-#print axioms bansf_callSite153_walk_next
 
 /-- Call-site adapter for the `jal rlp_walk_init` at slot 161 (`B + 644`). -/
 theorem bansf_callSite161_walk_init {n : Nat} {Prest Q : Assertion} (vRa : Word)
@@ -1099,7 +1075,6 @@ theorem bansf_callSite161_walk_init {n : Nat} {Prest Q : Assertion} (vRa : Word)
   · exact CodeReq.mono_union_right bansf_prog_disj_walkInit
       (fun a i h => CodeReq.union_mono_left a i h) a i h
 
-#print axioms bansf_callSite161_walk_init
 
 /-- Call-site adapter for the `jal rlp_walk_next` at slot 167 (`B + 668`). -/
 theorem bansf_callSite167_walk_next {n : Nat} {Prest Q : Assertion} (vRa : Word)
@@ -1125,7 +1100,6 @@ theorem bansf_callSite167_walk_next {n : Nat} {Prest Q : Assertion} (vRa : Word)
       (fun a i h => CodeReq.mono_union_right bansf_walkInit_disj_walkNext
         (fun a i h => CodeReq.union_mono_left a i h) a i h) a i h
 
-#print axioms bansf_callSite167_walk_next
 
 /-- Call-site adapter for the `jal rlp_walk_next` at slot 173 (`B + 692`). -/
 theorem bansf_callSite173_walk_next {n : Nat} {Prest Q : Assertion} (vRa : Word)
@@ -1151,7 +1125,6 @@ theorem bansf_callSite173_walk_next {n : Nat} {Prest Q : Assertion} (vRa : Word)
       (fun a i h => CodeReq.mono_union_right bansf_walkInit_disj_walkNext
         (fun a i h => CodeReq.union_mono_left a i h) a i h) a i h
 
-#print axioms bansf_callSite173_walk_next
 
 end BalAccountNonstorageFinalsSpec
 end EvmAsm.Codegen

--- a/EvmAsm/Codegen/Programs/BalAccountNonstorageFinalsWalk.lean
+++ b/EvmAsm/Codegen/Programs/BalAccountNonstorageFinalsWalk.lean
@@ -117,7 +117,6 @@ theorem rlpItemDecode_advance {bytes : List (BitVec 8)} {base : Word}
     rw [reassoc_longlist] at hnext
     exact advance_longform hhdr1 hhdr9 hfit1 hfit2 hnext hoffle hover
 
-#print axioms rlpItemDecode_advance
 
 /-- Word rotation for the long-list span shape: `h + l + 1 = (h + 1) + l`. -/
 private theorem add_rot (h l : Word) : h + l + 1 = (h + 1) + l := by
@@ -254,7 +253,6 @@ theorem rlpItemDecode_spanStart {bytes : List (BitVec 8)} {base : Word}
       exact hfit2
     exact spanStart_longlist hhdr1 hhdr9 hfit1' hfit2' hnext hlen hoffle hover
 
-#print axioms rlpItemDecode_spanStart
 
 
 /-! ## §2  The walked-so-far chain -/
@@ -300,8 +298,6 @@ theorem WalkPrefix.toLastItemAt {bytes : List (BitVec 8)} {base endPtr : Word}
   | cons o o' n l n' l' hi hne hrest ih =>
       exact .step o n l n' l' hi hne (ih hend)
 
-#print axioms WalkPrefix.snoc
-#print axioms WalkPrefix.toLastItemAt
 
 end BalAccountNonstorageFinalsSpec
 end EvmAsm.Codegen

--- a/EvmAsm/Codegen/Programs/BalStorageReadsExecLogScan.lean
+++ b/EvmAsm/Codegen/Programs/BalStorageReadsExecLogScan.lean
@@ -209,7 +209,6 @@ private theorem bsre_stationBr_spec {CR : CodeReq} (A : Word) (boff : BitVec 13)
   · exact fun h hq => by xperm_hyp hq
   · exact fun h hq => by xperm_hyp hq
 
-#print axioms bsre_stationBr_spec
 
 /-- `breakStation_spec` instantiated at the station lemma's exact post
     shapes: the taken (mismatch) arm runs a return-tail triple, the
@@ -355,7 +354,6 @@ private theorem bsre_scanNextIter_spec (base logBase addrPtr krevBase : Word)
     (cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) hmvF hstation)
   exact fun h hp => by unfold scanRegs at hp; xperm_hyp hp
 
-#print axioms bsre_scanNextIter_spec
 
 /-- Scan-next, last round (`j + 1 = count`, cursor at the log base): the
     `BNE x28, x29` back-edge FALLS THROUGH and slot 96's `JAL` exits to the
@@ -488,7 +486,6 @@ private theorem bsre_scanNextLast_spec (base logBase addrPtr krevBase : Word)
     (cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) hmvF hstation)
   exact fun h hp => by unfold scanRegs at hp; xperm_hyp hp
 
-#print axioms bsre_scanNextLast_spec
 
 /-! ### §5.4  The 8-station compare cascade (slots 69–93) -/
 
@@ -575,8 +572,6 @@ private theorem bsre_stationK_spec {CR : CodeReq}
   · exact fun h hq => by unfold scanRegs; xperm_hyp hq
   · exact fun h hq => by unfold scanRegs; xperm_hyp hq
 
-#print axioms bsre_stationA_spec
-#print axioms bsre_stationK_spec
 
 /-- **The compare cascade** from the first station (`base + 276`, slot 69),
     generic in the scan-next continuation `hnext` (invoked at `base + 376`
@@ -837,7 +832,6 @@ private theorem bsre_cascade_spec (base logBase addrPtr krevBase : Word)
   exact cpsBranchWithin_mono_nSteps (by omega)
     (cpsTripleWithin_as_cpsBranchWithin_right ret Q hfound)
 
-#print axioms bsre_cascade_spec
 
 /-! ### §5.5  One full round from the loop head, and the whole loop -/
 
@@ -914,7 +908,6 @@ theorem bsre_scanIter_spec (base logBase addrPtr krevBase : Word)
     (cpsBranchWithin_pure_pre hmain)
   exact fun h hp => by unfold scanInv at hp; xperm_hyp hp
 
-#print axioms bsre_scanIter_spec
 
 /-- **The last scan round** (`j + 1 = count`, the cursor about to reach the
     log base): the round either exits FOUND at `base + 388` or falls out to
@@ -988,7 +981,6 @@ theorem bsre_scanLast_spec (base logBase addrPtr krevBase : Word)
     (cpsBranchWithin_pure_pre hmain)
   exact fun h hp => by unfold scanInv at hp; xperm_hyp hp
 
-#print axioms bsre_scanLast_spec
 
 /-- **The whole exec-log scan loop** (`count - 1` full rounds then the last
     round): from the loop head with nothing refuted yet, exit FOUND at
@@ -1015,7 +1007,6 @@ theorem bsre_scanLoop_spec (base logBase addrPtr krevBase : Word)
     (bsre_scanLast_spec base logBase addrPtr krevBase logBytes addrBytes key32
       count F hF hlog haddr hkey hcnt hbound (count - 1) (by omega))
 
-#print axioms bsre_scanLoop_spec
 
 /-! ### §5.6  The dword↔byte-slice bridge (spec-side)
 
@@ -1084,7 +1075,6 @@ theorem entryMatchesD_iff_slices (logBytes addrBytes key32 : List (BitVec 8))
       rw [show 8 * (16 * t + (4 + k)) = 128 * t + 32 + 8 * k from by omega]
       exact hd.symm
 
-#print axioms entryMatchesD_iff_slices
 
 /-! ## §6  Concrete linkage: code requirement, call-site adapters, `la` pairs
 
@@ -1144,7 +1134,6 @@ theorem bsre_callSite15_walk_init {n : Nat} {Prest Q : Assertion} (vRa : Word)
   · exact CodeReq.mono_union_right bsre_prog_disj_walkInit
       (fun a i h => CodeReq.union_mono_left a i h) a i h
 
-#print axioms bsre_callSite15_walk_init
 
 /-- Call-site adapter for the `jal rlp_walk_next` at slot 18 (`B + 72`). -/
 theorem bsre_callSite18_walk_next {n : Nat} {Prest Q : Assertion} (vRa : Word)
@@ -1170,7 +1159,6 @@ theorem bsre_callSite18_walk_next {n : Nat} {Prest Q : Assertion} (vRa : Word)
       (fun a i h => CodeReq.mono_union_right bsre_walkInit_disj_walkNext
         (fun _ _ hh => hh) a i h) a i h
 
-#print axioms bsre_callSite18_walk_next
 
 /-- Call-site adapter for the `jal rlp_walk_next` at slot 21 (`B + 84`). -/
 theorem bsre_callSite21_walk_next {n : Nat} {Prest Q : Assertion} (vRa : Word)
@@ -1196,7 +1184,6 @@ theorem bsre_callSite21_walk_next {n : Nat} {Prest Q : Assertion} (vRa : Word)
       (fun a i h => CodeReq.mono_union_right bsre_walkInit_disj_walkNext
         (fun _ _ hh => hh) a i h) a i h
 
-#print axioms bsre_callSite21_walk_next
 
 /-- Call-site adapter for the `jal rlp_walk_next` at slot 24 (`B + 96`). -/
 theorem bsre_callSite24_walk_next {n : Nat} {Prest Q : Assertion} (vRa : Word)
@@ -1222,7 +1209,6 @@ theorem bsre_callSite24_walk_next {n : Nat} {Prest Q : Assertion} (vRa : Word)
       (fun a i h => CodeReq.mono_union_right bsre_walkInit_disj_walkNext
         (fun _ _ hh => hh) a i h) a i h
 
-#print axioms bsre_callSite24_walk_next
 
 /-- Call-site adapter for the `jal rlp_walk_init` at slot 28 (`B + 112`). -/
 theorem bsre_callSite28_walk_init {n : Nat} {Prest Q : Assertion} (vRa : Word)
@@ -1247,7 +1233,6 @@ theorem bsre_callSite28_walk_init {n : Nat} {Prest Q : Assertion} (vRa : Word)
   · exact CodeReq.mono_union_right bsre_prog_disj_walkInit
       (fun a i h => CodeReq.union_mono_left a i h) a i h
 
-#print axioms bsre_callSite28_walk_init
 
 /-- Call-site adapter for the `jal rlp_walk_next` at slot 35 (`B + 140`). -/
 theorem bsre_callSite35_walk_next {n : Nat} {Prest Q : Assertion} (vRa : Word)
@@ -1273,7 +1258,6 @@ theorem bsre_callSite35_walk_next {n : Nat} {Prest Q : Assertion} (vRa : Word)
       (fun a i h => CodeReq.mono_union_right bsre_walkInit_disj_walkNext
         (fun _ _ hh => hh) a i h) a i h
 
-#print axioms bsre_callSite35_walk_next
 
 /-- The `la t0, bsr_krev` pair at slots 45–46: AUIPC+ADDI resolve
     to the linked scratch address. -/
@@ -1310,7 +1294,6 @@ theorem bsre_la_krev1_spec (vOld : Word) :
         = (GuestAddrs.bsr_krev : Word) from by decide] at haddi
   exact cpsTripleWithin_seq_same_cr hau haddi
 
-#print axioms bsre_la_krev1_spec
 
 /-- The `la x31, bsr_krev` pair at slots 66–67: AUIPC+ADDI resolve
     to the linked scratch address. -/
@@ -1347,7 +1330,6 @@ theorem bsre_la_krev2_spec (vOld : Word) :
         = (GuestAddrs.bsr_krev : Word) from by decide] at haddi
   exact cpsTripleWithin_seq_same_cr hau haddi
 
-#print axioms bsre_la_krev2_spec
 
 
 end BalStorageReadsExecLogSpec

--- a/EvmAsm/Codegen/Programs/BalStorageReadsExecLogSpec.lean
+++ b/EvmAsm/Codegen/Programs/BalStorageReadsExecLogSpec.lean
@@ -255,8 +255,6 @@ theorem bsre_rejectTail_spec (base vOld : Word)
   rw [show base + 400 + 4 = base + 404 from by bv_omega] at hli
   exact hli
 
-#print axioms bsre_matchTail_spec
-#print axioms bsre_rejectTail_spec
 
 /-! ## §4  The byte-reverse loop (slots 55–61)
 
@@ -653,7 +651,6 @@ theorem bsre_revIter_spec (base acctBase krevBase : Word)
       (fun _ => cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
         (fun _ hq => hq) hbody))
 
-#print axioms bsre_revIter_spec
 
 /-! ### §4.4  Exhaustion (header BEQ taken at `i = klen`) and the whole loop -/
 
@@ -767,7 +764,6 @@ theorem bsre_revExh_spec (base acctBase krevBase : Word)
       (fun _ => htaken)
       (fun hc => absurd hctr0 hc))
 
-#print axioms bsre_revExh_spec
 
 /-- **The whole byte-reverse loop** (header entry to post-loop station):
     `klen` iterations then the taken exit, materialising `keyRev32` of the
@@ -804,7 +800,6 @@ theorem bsre_revLoop_spec (base acctBase krevBase : Word)
     (bsre_revExh_spec base acctBase krevBase acctBytes contentOff klen F
       hF hklen hcw hbound)
 
-#print axioms bsre_revLoop_spec
 
 /-! ## §5  The exec-log scan loop (slots 68–95)
 

--- a/EvmAsm/Codegen/Programs/BalValueReverseSAsm.lean
+++ b/EvmAsm/Codegen/Programs/BalValueReverseSAsm.lean
@@ -597,7 +597,6 @@ theorem balValueReverseFn_spec (p c r : Word) (w : List (BitVec 8))
     subst i
     exact ⟨hx5, hx6, by rw [hA, reverseLoopWin_16_eq_reverse w]⟩
 
-#print axioms balValueReverseFn_spec
 
 end BalValueReverseSAsm
 


### PR DESCRIPTION
Removes 267 redundant `#print axioms` commands across 27 `Bal*` files in `Codegen/Programs` (BalAccountNonstorageFinalsChain/Loop/Spec/Walk, BalStorageReadsExecLog*, BalValueReverse).

`check-axioms.sh` audits the 88 witnesses in `Progress.lean` independently, so these in-source commands are pure build noise. Verified: `lake build` green, `check-axioms.sh` reports 88 witnesses unchanged.

No merge label.