### PR TITLE
chore: remove redundant in-source #print axioms in AccountIsEip161Empty routines

### DIFF
--- a/EvmAsm/Codegen/Programs/AccountIsEip161EmptyClose.lean
+++ b/EvmAsm/Codegen/Programs/AccountIsEip161EmptyClose.lean
@@ -54,7 +54,6 @@ theorem aie_disjoint : aieCode.Disjoint RlpListNthItemSAsm.code := by
   · right
     rw [RlpListNthItemSAsm.total_length]; decide
 
-#print axioms aie_disjoint
 
 /-- K20's linked code is subsumed by the AIE full closure. -/
 theorem k20_mono :
@@ -159,7 +158,6 @@ theorem aieChunkA (sp0 spA raIn c8 c9 c18 q0 q1 q2 q3 : Word)
   refine cpsTripleWithin_weaken (fun _ hp => by unfold aieSlots at hp; xperm_chunked hp)
     (fun _ hq => by unfold aieSlots; xperm_chunked hq) s04
 
-#print axioms aieChunkA
 
 /-! ## Prologue chunk B — argument moves and output-cell zeroing ([5]-[8]) -/
 
@@ -204,7 +202,6 @@ theorem aieChunkB (accBase lenW outPtr c8 c9 c18 oldOut : Word) :
   refine cpsTripleWithin_weaken (fun _ hp => by xperm_chunked hp)
     (fun _ hq => by xperm_chunked hq) s58
 
-#print axioms aieChunkB
 
 /-! ## Prologue chunk C — call-argument setup ([9]-[15]) -/
 
@@ -272,7 +269,6 @@ theorem aieChunkC (accBase lenW outPtr old13 old14 : Word) :
   refine cpsTripleWithin_weaken (fun _ hp => by xperm_chunked hp)
     (fun _ hq => by xperm_chunked hq) s915
 
-#print axioms aieChunkC
 
 /-! ## Prologue — full caller footprint and composition ([0]-[15]) -/
 
@@ -334,7 +330,6 @@ theorem aieHead (sp0 spA newSp raIn accBase lenW outPtr c8 c9 c18 q0 q1 q2 q3
       unfold aiePre at hp; xperm_chunked hp) (fun _ hq => by
       unfold aieCalleePre entryRest mkSaved; xperm_chunked hq) hframed
 
-#print axioms aieHead
 
 /-! ## Field-0 (nonce) RLP call adapter — prologue ;; jal ;; K20 ([0]-[16]+callee) -/
 
@@ -403,7 +398,6 @@ theorem aieCall0 (sp0 spA newSp raIn accBase lenW outPtr c8 c9 c18 q0 q1 q2 q3
   have hhj := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_chunked hp) hhead hjalF
   exact cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_chunked hp) hhj hcallee
 
-#print axioms aieCall0
 
 /-! ## Mid-call (fields 1/3) RLP call adapters
 
@@ -550,7 +544,6 @@ theorem aieCall1 (spA newSp accBase lenW outPtr raIn c8 c9 c18 v1 v10 v11 v12 v1
     (fun _ hq => hq)
     (cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_chunked hp) hsj hcallee)
 
-#print axioms aieCall1
 
 set_option maxRecDepth 8000 in
 /-- Field-3 (code_hash) call adapter: setup [60]-[66] ;; `jal` [67] ;; K20 (index 3),
@@ -673,7 +666,6 @@ theorem aieCall3 (spA newSp accBase lenW outPtr raIn c8 c9 c18 v1 v10 v11 v12 v1
     (fun _ hq => hq)
     (cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_chunked hp) hsj hcallee)
 
-#print axioms aieCall3
 
 /-! ## Epilogue ([102]-[107]) -/
 
@@ -755,6 +747,5 @@ theorem aieEpi (sp0 spA raIn c8 c9 c18 w1 w8 w9 w18 : Word) (G : Assertion)
   exact cpsTripleWithin_weaken (fun _ hp => by xperm_chunked hp)
     (fun _ hq => by xperm_chunked hq) hframed
 
-#print axioms aieEpi
 
 end EvmAsm.Codegen.AccountIsEip161EmptySpec

--- a/EvmAsm/Codegen/Programs/AccountIsEip161EmptyClose2.lean
+++ b/EvmAsm/Codegen/Programs/AccountIsEip161EmptyClose2.lean
@@ -85,7 +85,6 @@ theorem aieSpanBound (bytes : List (BitVec 8)) (accBase : Word) (listLen index :
   rw [hoff]
   exact hbound off next len hoffle hdec
 
-#print axioms aieSpanBound
 
 /-! ## Code-membership macro into the full closure -/
 
@@ -138,7 +137,6 @@ theorem aieVerdictNotEmpty (outPtr v10 oldout : Word) :
     (cpsTripleWithin_weaken (fun _ hp => by xperm_chunked hp)
       (fun _ hq => by xperm_chunked hq) s2)
 
-#print axioms aieVerdictNotEmpty
 
 set_option maxRecDepth 8000 in
 /-- Parse-fail verdict tail ([99]-[100], `AB+396 → AB+408`): set `a0 = 1`. -/
@@ -161,7 +159,6 @@ theorem aieVerdictFail (v10 : Word) :
     (cpsTripleWithin_weaken (fun _ hp => by xperm_chunked hp)
       (fun _ hq => by xperm_chunked hq) s1)
 
-#print axioms aieVerdictFail
 
 set_option maxRecDepth 8000 in
 /-- Size-fail verdict tail ([101], `AB+404 → AB+408`): set `a0 = 2`, fall through
@@ -175,7 +172,6 @@ theorem aieVerdictSizeFail (v10 : Word) :
   rw [show (AB + 404 : Word) + 4 = AB + 408 from by bv_omega] at h101
   exact cpsTripleWithin_extend_code (aieFC 101, (AB + 404), (.LI .x10 (2 : Word))) h101
 
-#print axioms aieVerdictSizeFail
 
 set_option maxRecDepth 8000 in
 /-- Empty verdict tail ([87]-[95], `AB+348 → AB+408`): 5 NOPs, then store `1`
@@ -252,7 +248,6 @@ theorem aieVerdictEmpty (outPtr v5 v10 oldout : Word) :
     (cpsTripleWithin_weaken (fun _ hp => by xperm_chunked hp)
       (fun _ hq => by xperm_chunked hq) s8)
 
-#print axioms aieVerdictEmpty
 
 /-! ## Verdict → return bridges (verdict tail ;; epilogue, all landing on `raIn`)
 
@@ -285,7 +280,6 @@ theorem aieRetNotEmpty (sp0 spA raIn c8 c9 c18 w1 w8 w9 outPtr v10 oldout : Word
     (cpsTripleWithin_weaken (fun _ hp => by xperm_chunked hp)
       (fun _ hq => by xperm_chunked hq) s)
 
-#print axioms aieRetNotEmpty
 
 set_option maxRecDepth 8000 in
 /-- Parse-fail return bridge (`AB+396 → raIn`): a0 := 1, output cell untouched. -/
@@ -309,7 +303,6 @@ theorem aieRetFail (sp0 spA raIn c8 c9 c18 w1 w8 w9 w18 v10 : Word)
     (cpsTripleWithin_weaken (fun _ hp => by xperm_chunked hp)
       (fun _ hq => by xperm_chunked hq) s)
 
-#print axioms aieRetFail
 
 set_option maxRecDepth 8000 in
 /-- Size-fail return bridge (`AB+404 → raIn`): a0 := 2, output cell untouched. -/
@@ -333,7 +326,6 @@ theorem aieRetSizeFail (sp0 spA raIn c8 c9 c18 w1 w8 w9 w18 v10 : Word)
     (cpsTripleWithin_weaken (fun _ hp => by xperm_chunked hp)
       (fun _ hq => by xperm_chunked hq) s)
 
-#print axioms aieRetSizeFail
 
 set_option maxRecDepth 8000 in
 /-- Empty return bridge (`AB+348 → raIn`): out := 1, a0 := 0. -/
@@ -360,6 +352,5 @@ theorem aieRetEmpty (sp0 spA raIn c8 c9 c18 w1 w8 w9 outPtr v5 v10 oldout : Word
     (cpsTripleWithin_weaken (fun _ hp => by xperm_chunked hp)
       (fun _ hq => by xperm_chunked hq) s)
 
-#print axioms aieRetEmpty
 
 end EvmAsm.Codegen.AccountIsEip161EmptySpec

--- a/EvmAsm/Codegen/Programs/AccountIsEip161EmptyClose3.lean
+++ b/EvmAsm/Codegen/Programs/AccountIsEip161EmptyClose3.lean
@@ -138,7 +138,6 @@ theorem aieReturn_to_result
   simp only [mkSaved]
   xperm_pure hp
 
-#print axioms aieReturn_to_result
 
 /-- `aieCallCore` with the dispatch registers `x10`/`x0` removed — the frame the
     `bne a0, zero` step carries. -/
@@ -184,7 +183,6 @@ theorem aieResult_cases (spA newSp accBase lenW outPtr raIn c8 c9 c18 retA s3 s4
   | fail h_fail =>
     exact Or.inr ⟨v11, v12, (sepConj_pure_right h).2 ⟨hcore, h_fail⟩⟩
 
-#print axioms aieResult_cases
 
 set_option maxRecDepth 8000 in
 /-- On K20 success, `bne a0, zero` is not taken; the field body follows. -/
@@ -233,7 +231,6 @@ theorem aieBranchSelected (entry : Word) (foff : BitVec 13)
   unfold aieCallCore
   xperm_pure hstate
 
-#print axioms aieBranchSelected
 
 set_option maxRecDepth 8000 in
 /-- On K20 failure, `bne a0, zero` is taken to the parse-fail verdict. -/
@@ -280,7 +277,6 @@ theorem aieBranchFailed (entry : Word) (foff : BitVec 13)
   unfold aieCallCore
   xperm_pure hstate
 
-#print axioms aieBranchFailed
 
 set_option maxRecDepth 8000 in
 /-- **Unified `bne a0, zero` dispatch** over the K20 return existential: parse
@@ -311,7 +307,6 @@ theorem aieResultBranch (entry : Word) (foff : BitVec 13)
       s3 s4 s5 bytes outv oldOff oldLen listLen index h hp)
     (fun _ hq => hq) (fun _ hq => hq) hor
 
-#print axioms aieResultBranch
 
 /-! ## Per-field dispatch instantiations
 
@@ -338,7 +333,6 @@ theorem aieDispatch0 (spA newSp accBase lenW outPtr raIn c8 c9 c18 s3 s4 s5 : Wo
   rw [show (AB + 68 : Word) + 4 = AB + 72 from by bv_omega] at h
   exact h
 
-#print axioms aieDispatch0
 
 /-- Field-1 (balance) dispatch `[44]` at `AB+176`: fail → `AB+396`, ok → `AB+180`. -/
 theorem aieDispatch1 (spA newSp accBase lenW outPtr raIn c8 c9 c18 s3 s4 s5 : Word)
@@ -359,7 +353,6 @@ theorem aieDispatch1 (spA newSp accBase lenW outPtr raIn c8 c9 c18 s3 s4 s5 : Wo
   rw [show (AB + 176 : Word) + 4 = AB + 180 from by bv_omega] at h
   exact h
 
-#print axioms aieDispatch1
 
 /-- Field-3 (code_hash) dispatch `[68]` at `AB+272`: fail → `AB+396`, ok → `AB+276`. -/
 theorem aieDispatch3 (spA newSp accBase lenW outPtr raIn c8 c9 c18 s3 s4 s5 : Word)
@@ -380,7 +373,6 @@ theorem aieDispatch3 (spA newSp accBase lenW outPtr raIn c8 c9 c18 s3 s4 s5 : Wo
   rw [show (AB + 272 : Word) + 4 = AB + 276 from by bv_omega] at h
   exact h
 
-#print axioms aieDispatch3
 
 /-! ## Parse-fail return bridge (`aieFailed` at `AB+396` → `raIn`)
 
@@ -441,6 +433,5 @@ theorem aieFailToRet (sp0 spA newSp accBase lenW outPtr raIn c8 c9 c18 retA s3 s
   · intro h hq
     exact ⟨v11, v12, hq⟩
 
-#print axioms aieFailToRet
 
 end EvmAsm.Codegen.AccountIsEip161EmptySpec

--- a/EvmAsm/Codegen/Programs/AccountIsEip161EmptyClose4.lean
+++ b/EvmAsm/Codegen/Programs/AccountIsEip161EmptyClose4.lean
@@ -190,7 +190,6 @@ theorem aieField3SizeHead (v5 v6 v7 len3 : Word) :
     (cpsBranchWithin_weaken (fun _ hp => by xperm_chunked hp)
       (fun _ hp => by xperm_chunked hp) (fun _ hp => by xperm_chunked hp) hbr)
 
-#print axioms aieField3SizeHead
 
 /-! ## Field-3 content-pointer setup ([74]-[79], `AB+296 → AB+320`)
 
@@ -253,6 +252,5 @@ theorem aieField3PtrSetup (v5 accBase v28 v31 offset3 : Word) :
     (cpsTripleWithin_weaken (fun _ hp => by xperm_chunked hp)
       (fun _ hq => by xperm_chunked hq) s3)
 
-#print axioms aieField3PtrSetup
 
 end EvmAsm.Codegen.AccountIsEip161EmptySpec

--- a/EvmAsm/Codegen/Programs/AccountIsEip161EmptyClose5.lean
+++ b/EvmAsm/Codegen/Programs/AccountIsEip161EmptyClose5.lean
@@ -613,7 +613,6 @@ theorem aieField3ContentCont
         (fun h hq => aieNotEmptyPost_to_aiePost sp0 spA raIn c8 c9 c18 newSp accBase outPtr
           bytes listLen h hq) hfull)
 
-#print axioms aieField3ContentCont
 
 /-- Peel a leading existential out of the left operand of a separating
     conjunction (local copy of the Close3 helper). -/
@@ -707,7 +706,6 @@ theorem aieField3OK
   obtain ⟨v12, hp⟩ := aieSepConj_exists_left' h hp
   exact ⟨offset, len, v11, v12, hp⟩
 
-#print axioms aieField3OK
 
 /-! ## Parse-fail continuation folded into the abstract post (`AB+396 → raIn`) -/
 
@@ -807,7 +805,6 @@ theorem aieFailCont (sp0 spA newSp raIn accBase lenW outPtr c8 c9 c18 retA s3 s4
     (sepConj_mono_right (sepConj_mono_right (sepConj_mono_right
       (aieFailG_to_junk _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _))))))) h hq2
 
-#print axioms aieFailCont
 
 /-! ## Field-3 call + dispatch continuation (`AB+240 → raIn`) -/
 
@@ -859,6 +856,5 @@ theorem aieField3Cont
     o0 l0 o1 l1 hspA hret halign hover hvalid hoverL hbound hS0 hl0 hz0 hS1 hl1 hz1
   exact cpsBranchWithin_merge_same_cr hbranch (cpsTripleWithin_mono_nSteps (by omega) hfc) hok
 
-#print axioms aieField3Cont
 
 end EvmAsm.Codegen.AccountIsEip161EmptySpec

--- a/EvmAsm/Codegen/Programs/AccountIsEip161EmptyClose6.lean
+++ b/EvmAsm/Codegen/Programs/AccountIsEip161EmptyClose6.lean
@@ -116,7 +116,6 @@ theorem aieField1SizeHead (v5 v6 v7 len : Word) :
     (cpsBranchWithin_weaken (fun _ hp => by xperm_chunked hp)
       (fun _ hp => by xperm_chunked hp) (fun _ hp => by xperm_chunked hp) hbr)
 
-#print axioms aieField1SizeHead
 
 /-! ## Field-1 (balance) content-pointer setup ([50]-[53], `AB+200 → AB+216`) -/
 
@@ -156,7 +155,6 @@ theorem aieField1PtrSetup (v5 accBase v28 offset : Word) :
     (cpsTripleWithin_weaken (fun _ hp => by xperm_chunked hp)
       (fun _ hq => by xperm_chunked hq) s2)
 
-#print axioms aieField1PtrSetup
 
 /-! ## Generic field body frame + a0=1 size-fail continuation -/
 
@@ -207,7 +205,6 @@ theorem aieSizeFail1Cont
   · exact aiePost_intro sp0 spA raIn c8 c9 c18 newSp accBase outPtr bytes listLen 1 0
       (Or.inr (Or.inr (Or.inl ⟨rfl, rfl⟩))) h hq
 
-#print axioms aieSizeFail1Cont
 
 set_option maxRecDepth 8000 in
 /-- Downgrade the saved-frame cells to the owned frame slots (`frameSlotsOwn`),
@@ -229,7 +226,6 @@ theorem savedFrame_to_frameSlotsOwn (newSp : Word) (saved : Saved) : ∀ h,
   rw [sepConj_emp_right']
   exact h2
 
-#print axioms savedFrame_to_frameSlotsOwn
 
 /-- The K20-call footprint (`aieMidPre`) residual as it emerges from the previous
     field's all-zero loop exit: `x5`/`x6`/`x7` still `regIs`, the frame still
@@ -284,7 +280,6 @@ theorem aieMidResidual_to_aieMidPre (spA newSp accBase lenW outPtr raIn c8 c9 c1
   refine sepConj_mono (fun _ h => h) ?_
   exact fun _ h => h
 
-#print axioms aieMidResidual_to_aieMidPre
 
 /-! ## Field-1 (balance) content continuation (`AB+200 → raIn`) -/
 
@@ -444,7 +439,6 @@ theorem aieField1ContentCont
           bytes listLen h hq) hfull)
     omega
 
-#print axioms aieField1ContentCont
 
 /-! ## Field-1 (balance) OK path (`AB+180 → raIn`) -/
 
@@ -530,7 +524,6 @@ theorem aieField1OK
   obtain ⟨v12, hp⟩ := aieSepConj_exists_left' h hp
   exact ⟨offset, len, v11, v12, hp⟩
 
-#print axioms aieField1OK
 
 /-! ## Field-1 call + dispatch continuation (`AB+144 → raIn`) -/
 
@@ -579,7 +572,6 @@ theorem aieField1Cont
     o0 l0 hspA hret hnewSp hlistLenW halign hslack hover hvalid hoverL hbound hS0 hl0 hz0
   exact cpsBranchWithin_merge_same_cr hbranch (cpsTripleWithin_mono_nSteps (by omega) hfc) hok
 
-#print axioms aieField1Cont
 
 /-! ## Field-0 (nonce) size-check head ([18]-[22], `AB+72 → {AB+396, AB+92}`) -/
 
@@ -631,7 +623,6 @@ theorem aieField0SizeHead (v5 v6 v7 len : Word) :
     (cpsBranchWithin_weaken (fun _ hp => by xperm_chunked hp)
       (fun _ hp => by xperm_chunked hp) (fun _ hp => by xperm_chunked hp) hbr)
 
-#print axioms aieField0SizeHead
 
 /-! ## Field-0 (nonce) content-pointer setup ([23]-[27], `AB+92 → AB+112`) -/
 
@@ -675,7 +666,6 @@ theorem aieField0PtrSetup (v5 accBase v28 v7 offset : Word) :
     (cpsTripleWithin_weaken (fun _ hp => by xperm_chunked hp)
       (fun _ hq => by xperm_chunked hq) s3)
 
-#print axioms aieField0PtrSetup
 
 /-! ## Field-0 (nonce) content continuation (`AB+92 → raIn`) -/
 
@@ -862,7 +852,6 @@ theorem aieField0ContentCont
           bytes listLen h hq) hfull)
     omega
 
-#print axioms aieField0ContentCont
 
 /-! ## Field-0 (nonce) OK path (`AB+72 → raIn`) -/
 
@@ -945,7 +934,6 @@ theorem aieField0OK
   obtain ⟨v12, hp⟩ := aieSepConj_exists_left' h hp
   exact ⟨offset, len, v11, v12, hp⟩
 
-#print axioms aieField0OK
 
 /-! ## Top-level whole-program caller contract (`AB → raIn`) -/
 
@@ -1000,6 +988,5 @@ theorem account_is_eip161_empty_spec_within
     hspA hret hnewSp hlistLenW halign hslack hover hvalid hoverL hbound
   exact cpsBranchWithin_merge_same_cr hbranch (cpsTripleWithin_mono_nSteps (by omega) hfc) hok
 
-#print axioms account_is_eip161_empty_spec_within
 
 end EvmAsm.Codegen.AccountIsEip161EmptySpec

--- a/EvmAsm/Codegen/Programs/AccountIsEip161EmptyLoop.lean
+++ b/EvmAsm/Codegen/Programs/AccountIsEip161EmptyLoop.lean
@@ -269,7 +269,6 @@ theorem aieNonceLoop (accBase : Word) (bytes : List (BitVec 8))
           simp only [show i + 1 + k = i + (k + 1) from by omega] at hq
           xperm_chunked hq) sfull)
 
-#print axioms aieNonceLoop
 
 /-! ## Balance all-zero scan loop ([54]-[59], `AB+216 → {AB+240, AB+384}`)
 
@@ -447,7 +446,6 @@ theorem aieBalAllZero (accBase : Word) (bytes : List (BitVec 8))
       (cpsTripleWithin_weaken (fun _ hp => by xperm_chunked hp)
         (fun _ hq => by xperm_chunked hq) sfull)
 
-#print axioms aieBalAllZero
 
 /-- **Balance loop, nonzero-break exit** ([54]-[59], `AB+216 → AB+384`): when
     the first `j` content bytes are zero and byte `j` is nonzero, the loop
@@ -604,7 +602,6 @@ theorem aieBalNonEmpty (accBase : Word) (bytes : List (BitVec 8))
       (cpsTripleWithin_weaken (fun _ hp => by xperm_chunked hp)
         (fun _ hq => by xperm_chunked hq) sfull)
 
-#print axioms aieBalNonEmpty
 
 /-! ## Code-hash byte-compare loop ([80]-[86], `AB+320 → {AB+348, AB+384}`)
 
@@ -838,7 +835,6 @@ theorem aieCHAllMatch (accBase ecBase : Word) (bytes : List (BitVec 8))
         (cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
           (fun _ hq => by xperm_hyp hq) sfull)
 
-#print axioms aieCHAllMatch
 
 set_option maxRecDepth 40000 in
 /-- **Code-hash loop, mismatch exit** ([80]-[86], `AB+320 → AB+384`): when the
@@ -1050,6 +1046,5 @@ theorem aieCHMismatch (accBase ecBase : Word) (bytes : List (BitVec 8))
       (cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
         (fun _ hq => by xperm_hyp hq) sfull)
 
-#print axioms aieCHMismatch
 
 end EvmAsm.Codegen.AccountIsEip161EmptySpec


### PR DESCRIPTION
Removes 51 redundant `#print axioms` commands across 7 `AccountIsEip161Empty*` files (Close, Close2-6, Loop) in `Codegen/Programs`.

`check-axioms.sh` audits the 88 witnesses in `Progress.lean` independently, so these in-source commands are pure build noise. Verified: `lake build` green, `check-axioms.sh` reports 88 witnesses unchanged.

No merge label.