### PR TITLE
chore: remove redundant in-source #print axioms in misc leaf routines

### DIFF
--- a/EvmAsm/Codegen/Programs/BloomEqSAsm.lean
+++ b/EvmAsm/Codegen/Programs/BloomEqSAsm.lean
@@ -693,7 +693,6 @@ theorem bloomEq_spec (aPtr bPtr outPtr ret : Word) (bsA bsB : List (BitVec 8))
     (fun h hq => by unfold bePost at hq; exact hq)
     (cpsTripleWithin_mono_nSteps (by omega) hc4)
 
-#print axioms bloomEq_spec
 
 end BloomEqSAsm
 

--- a/EvmAsm/Codegen/Programs/BytesToNibblesSAsm.lean
+++ b/EvmAsm/Codegen/Programs/BytesToNibblesSAsm.lean
@@ -413,7 +413,6 @@ theorem bytesToNibblesFn_spec (src dst : Word) (len : Nat)
     · rw [RegFile.get_set_self _ _ _ (by decide), hx31]
     · rw [hwin, nibbleWin_len srcBytes orig i hlenOrig]
 
-#print axioms bytesToNibblesFn_spec
 
 end BytesToNibblesSAsm
 

--- a/EvmAsm/Codegen/Programs/CalcExcessBlobGasFnSAsm.lean
+++ b/EvmAsm/Codegen/Programs/CalcExcessBlobGasFnSAsm.lean
@@ -78,7 +78,6 @@ theorem calcExcessBlobGasFn_spec (parentExcess blobGasUsed target base : Word) :
       intro hge
       simp_all
 
-#print axioms calcExcessBlobGasFn_spec
 
 end CalcExcessBlobGasFnSAsm
 end EvmAsm.Codegen

--- a/EvmAsm/Codegen/Programs/CallExtraGasSAsm.lean
+++ b/EvmAsm/Codegen/Programs/CallExtraGasSAsm.lean
@@ -84,7 +84,6 @@ theorem callExtraGasFn_spec (isCold valueNonzero : Word) (base : Word) :
         simp_all [Cond.holds, execInstrRF, aluSem]
         try decide
 
-#print axioms callExtraGasFn_spec
 
 end CallExtraGasSAsm
 end EvmAsm.Codegen

--- a/EvmAsm/Codegen/Programs/CallFrameBaseSAsm.lean
+++ b/EvmAsm/Codegen/Programs/CallFrameBaseSAsm.lean
@@ -330,7 +330,6 @@ theorem frameBase_spec (depth ret : Word)
     have hq2 := sepConj_mono_right (regAtomsOf_to_regOwns _ fbRest) h hq1
     xperm_hyp hq2
 
-#print axioms frameBase_spec
 
 end CallFrameBaseSAsm
 end EvmAsm.Codegen

--- a/EvmAsm/Codegen/Programs/CheckGasLimitSAsm.lean
+++ b/EvmAsm/Codegen/Programs/CheckGasLimitSAsm.lean
@@ -398,7 +398,6 @@ theorem checkGasLimit_spec (nl pl ret : Word)
     (cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
       (fun _ hq => hq) hc2)
 
-#print axioms checkGasLimit_spec
 
 end CheckGasLimitSAsm
 

--- a/EvmAsm/Codegen/Programs/CopyWordGasSAsm.lean
+++ b/EvmAsm/Codegen/Programs/CopyWordGasSAsm.lean
@@ -47,7 +47,6 @@ theorem copyWordGasFn_spec (size base : Word) :
     · congr 1
     · exact hA
 
-#print axioms copyWordGasFn_spec
 
 end CopyWordGasSAsm
 end EvmAsm.Codegen

--- a/EvmAsm/Codegen/Programs/CreateDeployedCodeValidSAsm.lean
+++ b/EvmAsm/Codegen/Programs/CreateDeployedCodeValidSAsm.lean
@@ -259,9 +259,6 @@ theorem cdcvJoin_spec (base ret codePtr len v5old v6old dwordAddr wordVal : Word
   rw [hPtail] at hq
   xperm_hyp hq
 
-#print axioms cdcvJoin_spec
-#print axioms EvmAsm.Rv64.SAsm.retJoinStation_spec
-#print axioms EvmAsm.Rv64.SAsm.sharedRetTail_spec
 
 end CreateDeployedCodeValidSAsm
 end EvmAsm.Codegen

--- a/EvmAsm/Codegen/Programs/CreateInitcodeSizeValidSAsm.lean
+++ b/EvmAsm/Codegen/Programs/CreateInitcodeSizeValidSAsm.lean
@@ -95,7 +95,6 @@ theorem cisvJoin_spec (base ret len v5old : Word)
   rw [hPtail] at hq
   xperm_hyp hq
 
-#print axioms cisvJoin_spec
 
 end CreateInitcodeSizeValidSAsm
 end EvmAsm.Codegen

--- a/EvmAsm/Codegen/Programs/DispatcherCaptureExecStateGasSAsm.lean
+++ b/EvmAsm/Codegen/Programs/DispatcherCaptureExecStateGasSAsm.lean
@@ -153,7 +153,6 @@ theorem dispatcherCaptureExecStateGas_spec
   exact cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
     (fun _ hq => by xperm_hyp hq) hall
 
-#print axioms dispatcherCaptureExecStateGas_spec
 
 end DispatcherCaptureExecStateGasSAsm
 end EvmAsm.Codegen

--- a/EvmAsm/Codegen/Programs/EphU32leSAsm.lean
+++ b/EvmAsm/Codegen/Programs/EphU32leSAsm.lean
@@ -37,7 +37,6 @@ theorem ephU32leFn_spec (p : Word) (bs : List (BitVec 8))
   simpa [ephU32leFn, SgLoadU32leSAsm.sgLoadU32leFn] using
     SgLoadU32leSAsm.sgLoadU32leFn_spec p bs hwf base
 
-#print axioms ephU32leFn_spec
 
 end EphU32leSAsm
 end EvmAsm.Codegen

--- a/EvmAsm/Codegen/Programs/FrameDepthPopSAsm.lean
+++ b/EvmAsm/Codegen/Programs/FrameDepthPopSAsm.lean
@@ -87,6 +87,5 @@ theorem frameDepthPop_spec (depth old5 old10 ret : Word)
   exact cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
     (fun _ hq => by xperm_hyp hq) h12345
 
-#print axioms frameDepthPop_spec
 end FrameDepthPopSAsm
 end EvmAsm.Codegen

--- a/EvmAsm/Codegen/Programs/FrameDepthPushSAsm.lean
+++ b/EvmAsm/Codegen/Programs/FrameDepthPushSAsm.lean
@@ -85,6 +85,5 @@ theorem frameDepthPush_spec (depth old5 old10 ret : Word)
   exact cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
     (fun _ hq => by xperm_hyp hq) h12345
 
-#print axioms frameDepthPush_spec
 end FrameDepthPushSAsm
 end EvmAsm.Codegen

--- a/EvmAsm/Codegen/Programs/FrameLoadRegsSAsm.lean
+++ b/EvmAsm/Codegen/Programs/FrameLoadRegsSAsm.lean
@@ -104,6 +104,5 @@ theorem frameLoadRegs_spec (depth old5 old6 old11 pcVal codeBase ret : Word)
   exact cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
     (fun _ hq => by xperm_hyp hq) hall
 
-#print axioms frameLoadRegs_spec
 end FrameLoadRegsSAsm
 end EvmAsm.Codegen

--- a/EvmAsm/Codegen/Programs/FrameSaveRegsSAsm.lean
+++ b/EvmAsm/Codegen/Programs/FrameSaveRegsSAsm.lean
@@ -109,6 +109,5 @@ theorem frameSaveRegs_spec (depth pcVal codeBase old5 old6 oldPc oldCode ret : W
   exact cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
     (fun _ hq => by xperm_hyp hq) hall
 
-#print axioms frameSaveRegs_spec
 end FrameSaveRegsSAsm
 end EvmAsm.Codegen

--- a/EvmAsm/Codegen/Programs/HpDecodeNibblesSAsmPaths.lean
+++ b/EvmAsm/Codegen/Programs/HpDecodeNibblesSAsmPaths.lean
@@ -1268,8 +1268,6 @@ theorem hp_decode_nibbles_spec (base sp0 ret : Word) (vals : Reg → Word)
       src dst cnt isl srcBytes bufOrig v5 v6 v7 v28 v29 v30 v31 oldCnt oldIsl
       hsalign hsover hsvalid hbuf hdalign hdover hdvalid)
 
-#print axioms hp_decode_nibbles_spec
-#print axioms hdnRes_hpEncode
 
 end HpDecodeNibblesSAsm
 

--- a/EvmAsm/Codegen/Programs/HpEncodeNibblesSAsm.lean
+++ b/EvmAsm/Codegen/Programs/HpEncodeNibblesSAsm.lean
@@ -876,7 +876,6 @@ theorem hpEncodeNibblesFn_spec (src dst : Word) (len : Nat) (isLeaf : Word)
       bv_omega
     · rw [hwin, hpWin_done srcBytes orig len isLeaf hlenOrig]
 
-#print axioms hpEncodeNibblesFn_spec
 
 end HpEncodeNibblesSAsm
 

--- a/EvmAsm/Codegen/Programs/InitCodeCostSAsm.lean
+++ b/EvmAsm/Codegen/Programs/InitCodeCostSAsm.lean
@@ -80,7 +80,6 @@ theorem initCodeCostFn_spec (initCodeLength gasPerWord outPtr base : Word)
       setBytes_zero_dword_eq orig _ horig, hA]
     norm_num
 
-#print axioms initCodeCostFn_spec
 
 end InitCodeCostSAsm
 end EvmAsm.Codegen

--- a/EvmAsm/Codegen/Programs/Keccak256WordGasSAsm.lean
+++ b/EvmAsm/Codegen/Programs/Keccak256WordGasSAsm.lean
@@ -46,7 +46,6 @@ theorem keccak256WordGasFn_spec (size base : Word) :
     · congr 1
     · exact hA
 
-#print axioms keccak256WordGasFn_spec
 
 end Keccak256WordGasSAsm
 end EvmAsm.Codegen

--- a/EvmAsm/Codegen/Programs/KeccakReverseSAsm.lean
+++ b/EvmAsm/Codegen/Programs/KeccakReverseSAsm.lean
@@ -1252,7 +1252,6 @@ theorem byteReverse32Fn_spec (p pc aux1 aux3 : Word) (w : List (BitVec 8))
     · rw [hA, hx12, sepConj_comm',
         show ([b0, b1, b2, b3, b4, b5, b6, b7, b8, b9, b10, b11, b12, b13, b14, b15, b16, b17, b18, b19, b20, b21, b22, b23, b24, b25, b26, b27, b28, b29, b30, b31] : List (BitVec 8)).reverse = [b31, b30, b29, b28, b27, b26, b25, b24, b23, b22, b21, b20, b19, b18, b17, b16, b15, b14, b13, b12, b11, b10, b9, b8, b7, b6, b5, b4, b3, b2, b1, b0] from rfl]
 
-#print axioms byteReverse32Fn_spec
 
 end KeccakReverseSAsm
 

--- a/EvmAsm/Codegen/Programs/LogDataGasSAsm.lean
+++ b/EvmAsm/Codegen/Programs/LogDataGasSAsm.lean
@@ -47,7 +47,6 @@ theorem logDataGasFn_spec (numTopics dataBytes base : Word) :
       ne_eq, reduceCtorEq, not_false_eq_true, hx10, hx11]
     constructor <;> trivial
 
-#print axioms logDataGasFn_spec
 
 end LogDataGasSAsm
 end EvmAsm.Codegen

--- a/EvmAsm/Codegen/Programs/MessageCallGasSAsm.lean
+++ b/EvmAsm/Codegen/Programs/MessageCallGasSAsm.lean
@@ -1395,8 +1395,6 @@ theorem messageCallGas_spec (base ret v r g m e : Word)
     (fun _ hq => hq)
     (cpsTripleWithin_mono_nSteps (by omega) hall)
 
-#print axioms multiRegRetTail_spec
-#print axioms messageCallGas_spec
 
 end MessageCallGasSAsm
 

--- a/EvmAsm/Codegen/Programs/MptEarlyRetShape.lean
+++ b/EvmAsm/Codegen/Programs/MptEarlyRetShape.lean
@@ -147,7 +147,6 @@ theorem mptSetAcc_failTail_spec {m : Nat} (base ret : Word) {F Q : Assertion}
     sepConj_emp_right']
   exact hp
 
-#print axioms mptSetAcc_failTail_spec
 
 /-- `mpt_insert_acc`'s mid-loop "function return": the fail stub at `+2748`
     joins the shared epilogue at `+2696`. -/
@@ -184,7 +183,6 @@ theorem mptInsertAcc_failTail_spec {m : Nat} (base ret : Word) {F Q : Assertion}
     sepConj_emp_right']
   exact hp
 
-#print axioms mptInsertAcc_failTail_spec
 
 end MptEarlyRetShape
 

--- a/EvmAsm/Codegen/Programs/MptResolveCacheResetSAsm.lean
+++ b/EvmAsm/Codegen/Programs/MptResolveCacheResetSAsm.lean
@@ -330,8 +330,6 @@ theorem mptResolveCacheReset_spec (old5 retAddr : Word) (orig : List (BitVec 8))
     (fun _ hp => by xperm_hyp hp) hlaF htail
   exact hall
 
-#print axioms cacheResetFn_spec
-#print axioms mptResolveCacheReset_spec
 
 end MptResolveCacheResetSAsm
 end EvmAsm.Codegen

--- a/EvmAsm/Codegen/Programs/NibblesCommonPrefixLenSAsm.lean
+++ b/EvmAsm/Codegen/Programs/NibblesCommonPrefixLenSAsm.lean
@@ -682,7 +682,6 @@ theorem nibblesCommonPrefixLenFn_spec (ptrA ptrB outPtr : Word)
       simpa only [execBlock_cons, execBlock_nil, execInstrRF_nil, aluSem] using hwsEmpty
     · rw [hAeq, hx14Focus, hsdwsOut, hrest, hx5]
 
-#print axioms nibblesCommonPrefixLenFn_spec
 
 end NibblesCommonPrefixLenSAsm
 

--- a/EvmAsm/Codegen/Programs/ReceiptExtractLogsBloomCallSAsm.lean
+++ b/EvmAsm/Codegen/Programs/ReceiptExtractLogsBloomCallSAsm.lean
@@ -97,6 +97,5 @@ theorem receiptExtractLogsBloom_call_spec_within
     hcalleeMem
   simpa [B, K20B] using h
 
-#print axioms receiptExtractLogsBloom_call_spec_within
 
 end EvmAsm.Codegen.ReceiptExtractLogsBloomCallSAsm

--- a/EvmAsm/Codegen/Programs/ReceiptExtractLogsBloomSpec.lean
+++ b/EvmAsm/Codegen/Programs/ReceiptExtractLogsBloomSpec.lean
@@ -271,7 +271,6 @@ theorem relbPrologue
       unfold callEntryRest entryRest savedRegTail
       xperm_chunked hq) call)
 
-#print axioms relbPrologue
 
 /-! ## The shared return postcondition
 
@@ -387,7 +386,6 @@ theorem relbEpilogue (newSp a0v v1 v8 v9 v18 : Word) (fsaved : HeaderFieldsSpec.
   exact cpsTripleWithin_mono_nSteps (by omega)
     (cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp) (fun _ hp => by xperm_hyp hp) s2)
 
-#print axioms relbEpilogue
 
 /-! ## Copy-loop helpers -/
 
@@ -1360,6 +1358,5 @@ theorem receiptExtractLogsBloom_spec_within
   have c2 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_chunked hp) c1 hpost
   exact c2
 
-#print axioms receiptExtractLogsBloom_spec_within
 
 end EvmAsm.Codegen.ReceiptExtractLogsBloomSpec

--- a/EvmAsm/Codegen/Programs/SgLoadU32leSAsm.lean
+++ b/EvmAsm/Codegen/Programs/SgLoadU32leSAsm.lean
@@ -133,7 +133,6 @@ theorem sgLoadU32leFn_spec (p : Word) (bs : List (BitVec 8))
     exact sgLoadU32le_engine (sgLoadU32leFn p bs).region
       (sgLoadU32leFn p bs).rw.base rf₀ hx10
 
-#print axioms sgLoadU32leFn_spec
 
 end SgLoadU32leSAsm
 

--- a/EvmAsm/Codegen/Programs/SgMemcpySAsm.lean
+++ b/EvmAsm/Codegen/Programs/SgMemcpySAsm.lean
@@ -339,7 +339,6 @@ theorem sgMemcpyFn_spec (src dst : Word) (len : Nat) (bs orig : List (BitVec 8))
     show ws = bs.take i
     rw [hwin, copyWin_len_eq bs orig i hol hlb]
 
-#print axioms sgMemcpyFn_spec
 
 end SgMemcpySAsm
 

--- a/EvmAsm/Codegen/Programs/SwdWriteBe32U64SAsm.lean
+++ b/EvmAsm/Codegen/Programs/SwdWriteBe32U64SAsm.lean
@@ -402,7 +402,6 @@ theorem swdWriteBe32U64Fn_spec (v dst : Word) (orig : List (BitVec 8))
     subst hi8
     exact beWin32_8_eq v
 
-#print axioms swdWriteBe32U64Fn_spec
 
 end SwdWriteBe32U64SAsm
 

--- a/EvmAsm/Codegen/Programs/SwdWriteBe8SAsm.lean
+++ b/EvmAsm/Codegen/Programs/SwdWriteBe8SAsm.lean
@@ -261,7 +261,6 @@ theorem swdWriteBe8Fn_spec (v dst : Word) (orig : List (BitVec 8))
     subst hi8
     exact writeBe8Win_8_eq v orig hlen
 
-#print axioms swdWriteBe8Fn_spec
 
 end SwdWriteBe8SAsm
 

--- a/EvmAsm/Codegen/Programs/TxValidateAgainstBlockSAsm.lean
+++ b/EvmAsm/Codegen/Programs/TxValidateAgainstBlockSAsm.lean
@@ -204,7 +204,6 @@ theorem txvabJoin_spec
         hstation2))
   exact hq
 
-#print axioms txvabJoin_spec
 
 end TxValidateAgainstBlockSAsm
 

--- a/EvmAsm/Codegen/Programs/U256AddBeSAsm.lean
+++ b/EvmAsm/Codegen/Programs/U256AddBeSAsm.lean
@@ -1081,8 +1081,6 @@ theorem u256AddBeInPlace_spec (aPtr bPtr : Word)
     intro rf ws A h
     exact u256AddBeInPlace_retVal_post aPtr bPtr aBytes bBytes rf ws A h
 
-#print axioms u256AddBe_spec
-#print axioms u256AddBeInPlace_spec
 
 end U256AddBeSAsm
 

--- a/EvmAsm/Codegen/Programs/U256EqSAsm.lean
+++ b/EvmAsm/Codegen/Programs/U256EqSAsm.lean
@@ -433,7 +433,6 @@ theorem u256Eq_spec (ptr1 ptr2 base ret : Word) (bs1 bs2 : List (BitVec 8))
   exact cpsTripleWithin_weaken (fun _ hp => hp)
     (sepConj_mono_right (asrtM_mono (u256Eq_sp_post ptr1 ptr2 bs1 bs2))) hsound
 
-#print axioms u256Eq_spec
 
 -- Byte-identity to the existing emitted `u256_eq` program.
 #guard (u256EqBody 0 0 [] []).flatten 0 = u256Eq_prog

--- a/EvmAsm/Codegen/Programs/U256LtBeSAsm.lean
+++ b/EvmAsm/Codegen/Programs/U256LtBeSAsm.lean
@@ -857,7 +857,6 @@ theorem u256LtBe_spec (aPtr bPtr outPtr ret : Word) (as bs : List (BitVec 8))
     (fun h hq => by unfold ltPost at hq; exact hq)
     (cpsTripleWithin_mono_nSteps (by omega) hc3)
 
-#print axioms u256LtBe_spec
 
 end U256LtBeSAsm
 

--- a/EvmAsm/Codegen/Programs/U256MinSAsm.lean
+++ b/EvmAsm/Codegen/Programs/U256MinSAsm.lean
@@ -927,7 +927,6 @@ theorem u256Min_spec (aPtr bPtr outPtr ret : Word) (as bs os : List (BitVec 8))
   unfold minSel at hq
   xperm_hyp hq
 
-#print axioms u256Min_spec
 
 end U256MinSAsm
 


### PR DESCRIPTION
Removes 45 redundant `#print axioms` commands across 36 files in `Codegen/Programs` — the remaining leaf routines: Frame* (DepthPush/Pop, Load/SaveRegs), U256* (AddBe/Eq/LtBe/Min), gas routines (Keccak256WordGas, LogDataGas, CopyWordGas, CallExtraGas, CheckGasLimit, InitCodeCost, MessageCallGas, DispatcherCaptureExecStateGas), Swd*/Sg*, Hp*/Nibbles*, Mpt (EarlyRetShape, ResolveCacheReset), Create-valid, Receipt/Extract, BloomEq, BytesToNibbles, EphU32le, TxValidateAgainstBlock, CalcExcessBlobGas.

`check-axioms.sh` audits the 88 witnesses in `Progress.lean` independently, so these in-source commands are pure build noise. Verified: `lake build` green, `check-axioms.sh` reports 88 witnesses unchanged.

No merge label.