### PR TITLE
chore: batch-merge #10380 #10381 #10382

### DIFF
--- a/EvmAsm/Codegen/Programs/Bls12Fq12EqSAsm.lean
+++ b/EvmAsm/Codegen/Programs/Bls12Fq12EqSAsm.lean
@@ -57,7 +57,6 @@ theorem blqEq_spec (ptr1 ptr2 ret : Word) (bs1 bs2 : List (BitVec 8))
       72).flatten (GuestAddrs.blq_eq : Word) = blqEq_prog from rfl] at h
   exact h
 
-#print axioms blqEq_spec
 
 end Bls12Fq12EqSAsm
 end EvmAsm.Codegen

--- a/EvmAsm/Codegen/Programs/Bls12G1Eq48SAsm.lean
+++ b/EvmAsm/Codegen/Programs/Bls12G1Eq48SAsm.lean
@@ -542,7 +542,6 @@ theorem blsgEq48Fn_spec (ptr1 ptr2 : Word) (bs1 bs2 : List (BitVec 8))
       rw [hx10rf, if_pos heq]
 
 
-#print axioms blsgEq48Fn_spec
 
 end Bls12G1Eq48SAsm
 

--- a/EvmAsm/Codegen/Programs/Bls12G1IsZeroNSAsm.lean
+++ b/EvmAsm/Codegen/Programs/Bls12G1IsZeroNSAsm.lean
@@ -261,7 +261,6 @@ theorem blsgIsZeroNFn_spec (ptr : Word) (bs : List (BitVec 8)) (len : Nat)
       refine ⟨?_, hlen, hptr⟩
       rw [hx10rf, isZeroNResult, if_pos heq]
 
-#print axioms blsgIsZeroNFn_spec
 
 end Bls12G1IsZeroNSAsm
 end EvmAsm.Codegen

--- a/EvmAsm/Codegen/Programs/Bls12G1LeToBeSAsm.lean
+++ b/EvmAsm/Codegen/Programs/Bls12G1LeToBeSAsm.lean
@@ -863,7 +863,6 @@ theorem blsgLeToBeFn_spec (src dst : Word) (inBytes orig : List (BitVec 8))
     exact outer_step_engine src dst inBytes rf₀ ws₀ A₀ rf2 ws' A' (i + 1) (by omega)
       hs5 hs28 hws0len hlimbs hInv
 
-#print axioms blsgLeToBeFn_spec
 
 end Bls12G1LeToBeSAsm
 

--- a/EvmAsm/Codegen/Programs/Bls12G1LtPSAsm.lean
+++ b/EvmAsm/Codegen/Programs/Bls12G1LtPSAsm.lean
@@ -834,7 +834,6 @@ theorem blsgLtP_spec (inPtr ret : Word) (xs : List (BitVec 8))
     (fun h hq => by unfold ltPost at hq; exact hq)
     (cpsTripleWithin_mono_nSteps (by omega) hc3)
 
-#print axioms blsgLtP_spec
 
 end Bls12G1LtPSAsm
 

--- a/EvmAsm/Codegen/Programs/Bls12G2EncodeSAsm.lean
+++ b/EvmAsm/Codegen/Programs/Bls12G2EncodeSAsm.lean
@@ -815,8 +815,6 @@ theorem blsg2Encode_spec (sp0 ret src dst arb8 arb9 arb18 : Word)
     xperm_hyp hq2
   abi_frame (40 : BitVec 12) halign hbody
 
-#print axioms blsg2Encode_spec
-#print axioms blsgLeToBeFlat_spec
 
 end Bls12G2EncodeSAsm
 

--- a/EvmAsm/Codegen/Programs/Bls12G2EqNSAsm.lean
+++ b/EvmAsm/Codegen/Programs/Bls12G2EqNSAsm.lean
@@ -535,7 +535,6 @@ theorem blsg2EqNFn_spec (ptr1 ptr2 : Word) (bs1 bs2 : List (BitVec 8)) (n : Nat)
       rw [hx10rf, if_pos heq]
 
 
-#print axioms blsg2EqNFn_spec
 
 /-! ## The byte-transparent whole-routine spec (genuine byte-equality post)
 
@@ -684,7 +683,6 @@ theorem blsg2EqN_spec (ptr1 ptr2 ret : Word) (bs1 bs2 : List (BitVec 8))
     (fun h hq => by xperm_hyp hq)
     (cpsTripleWithin_mono_nSteps (by omega) hc3)
 
-#print axioms blsg2EqN_spec
 
 end Bls12G2EqNSAsm
 

--- a/EvmAsm/Codegen/Programs/Bls12KzgG2WireSAsm.lean
+++ b/EvmAsm/Codegen/Programs/Bls12KzgG2WireSAsm.lean
@@ -1062,8 +1062,6 @@ theorem blskG2Wire_spec (sp0 ret src dst arb8 arb9 arb18 : Word)
     xperm_hyp hq2
   abi_frame (32 : BitVec 12) halign hbody
 
-#print axioms blskG2Wire_spec
-#print axioms blsgLeToBeWireFlat_spec
 
 end Bls12KzgG2WireSAsm
 

--- a/EvmAsm/Codegen/Programs/Bls12KzgLtBeSAsm.lean
+++ b/EvmAsm/Codegen/Programs/Bls12KzgLtBeSAsm.lean
@@ -810,7 +810,6 @@ theorem blskLtBe_spec (aPtr bPtr ret : Word) (len : Nat) (xs bs : List (BitVec 8
     (fun h hq => by unfold ltPost at hq; exact hq)
     (cpsTripleWithin_mono_nSteps (by omega) hc3)
 
-#print axioms blskLtBe_spec
 
 end Bls12KzgLtBeSAsm
 

--- a/EvmAsm/Codegen/Programs/Bls12PtCopySAsm.lean
+++ b/EvmAsm/Codegen/Programs/Bls12PtCopySAsm.lean
@@ -354,7 +354,6 @@ theorem blqPtCopyFn_spec (src dst : Word) (srcBytes orig : List (BitVec 8))
     rw [hws, copyWin1728_216_eq srcBytes orig hs ho]
     rfl
 
-#print axioms blqPtCopyFn_spec
 
 end Bls12PtCopySAsm
 

--- a/EvmAsm/Codegen/Programs/Bn254CallAllotmentSAsm.lean
+++ b/EvmAsm/Codegen/Programs/Bn254CallAllotmentSAsm.lean
@@ -533,7 +533,6 @@ theorem bn254CallAllotment_spec (gp sp ret : Word) (w0 w1 w2 w3 rem : Word)
     (fun h hq => by rw [hPOST] at hq; xperm_hyp hq)
     (cpsTripleWithin_mono_nSteps (by omega) hc8)
 
-#print axioms bn254CallAllotment_spec
 
 end Bn254CallAllotmentSAsm
 

--- a/EvmAsm/Codegen/Programs/Bn254CurveIsInfSAsm.lean
+++ b/EvmAsm/Codegen/Programs/Bn254CurveIsInfSAsm.lean
@@ -303,7 +303,6 @@ theorem bncIsInf64Fn_spec (ptr : Word) (bs : List (BitVec 8))
       refine ⟨?_, hle, hpl⟩
       rw [hx10rf, if_pos heq]
 
-#print axioms bncIsInf64Fn_spec
 
 end Bn254CurveIsInfSAsm
 

--- a/EvmAsm/Codegen/Programs/Bn254FieldAddModPSAsm.lean
+++ b/EvmAsm/Codegen/Programs/Bn254FieldAddModPSAsm.lean
@@ -734,10 +734,6 @@ theorem bnfAddModP_spec (sp0 aPtr bPtr outPtr ret v8 v9 : Word)
     (hsub := by code_mem)
     (hbody := hbody)
 
-#print axioms bnfBeToLeFlat_spec
-#print axioms bnfLeToBeFlat_spec
-#print axioms csrsStep_spec
-#print axioms bnfAddModP_spec
 
 end Bn254FieldAddModPSAsm
 

--- a/EvmAsm/Codegen/Programs/Bn254FieldLtPSAsm.lean
+++ b/EvmAsm/Codegen/Programs/Bn254FieldLtPSAsm.lean
@@ -832,7 +832,6 @@ theorem bnfLtP_spec (inPtr ret : Word) (xs : List (BitVec 8))
     (fun h hq => by unfold ltPost at hq; exact hq)
     (cpsTripleWithin_mono_nSteps (by omega) hc3)
 
-#print axioms bnfLtP_spec
 
 end Bn254FieldLtPSAsm
 

--- a/EvmAsm/Codegen/Programs/Bn254FieldMulModPSAsm.lean
+++ b/EvmAsm/Codegen/Programs/Bn254FieldMulModPSAsm.lean
@@ -733,10 +733,6 @@ theorem bnfMulModP_spec (sp0 aPtr bPtr outPtr ret v8 v9 : Word)
     (hsub := by code_mem)
     (hbody := hbody)
 
-#print axioms bnfBeToLeFlat_spec
-#print axioms bnfLeToBeFlat_spec
-#print axioms csrsStep_spec
-#print axioms bnfMulModP_spec
 
 end Bn254FieldMulModPSAsm
 

--- a/EvmAsm/Codegen/Programs/Bn254Fp2EqSAsm.lean
+++ b/EvmAsm/Codegen/Programs/Bn254Fp2EqSAsm.lean
@@ -55,7 +55,6 @@ theorem bnpFp2Eq_spec (ptr1 ptr2 ret : Word) (bs1 bs2 : List (BitVec 8))
       8).flatten (GuestAddrs.bnp_fp2_eq : Word) = bnpFp2Eq_prog from rfl] at h
   exact h
 
-#print axioms bnpFp2Eq_spec
 
 end Bn254Fp2EqSAsm
 end EvmAsm.Codegen

--- a/EvmAsm/Codegen/Programs/Bn254Fq12EqSAsm.lean
+++ b/EvmAsm/Codegen/Programs/Bn254Fq12EqSAsm.lean
@@ -57,7 +57,6 @@ theorem bnqEq_spec (ptr1 ptr2 ret : Word) (bs1 bs2 : List (BitVec 8))
       48).flatten (GuestAddrs.bnq_eq : Word) = bnqEq_prog from rfl] at h
   exact h
 
-#print axioms bnqEq_spec
 
 end Bn254Fq12EqSAsm
 end EvmAsm.Codegen

--- a/EvmAsm/Codegen/Programs/Bn254Fq12SetOneSAsm.lean
+++ b/EvmAsm/Codegen/Programs/Bn254Fq12SetOneSAsm.lean
@@ -391,8 +391,6 @@ theorem bnqSetOneFrame_spec (sp0 ret dst arb8 v5 v7 : Word) (vs : List Word)
     xperm_hyp hq2
   abi_frame (16 : BitVec 12) halign hbody
 
-#print axioms bnqZeroFlat_spec
-#print axioms bnqSetOneFrame_spec
 
 end Bn254Fq12SetOneSAsm
 

--- a/EvmAsm/Codegen/Programs/Bn254PtCopySAsm.lean
+++ b/EvmAsm/Codegen/Programs/Bn254PtCopySAsm.lean
@@ -354,7 +354,6 @@ theorem bnqPtCopyFn_spec (src dst : Word) (srcBytes orig : List (BitVec 8))
     rw [hws, copyWin1152_144_eq srcBytes orig hs ho]
     rfl
 
-#print axioms bnqPtCopyFn_spec
 
 end Bn254PtCopySAsm
 

--- a/EvmAsm/Codegen/Programs/HeaderExtractLogsBloomSpec.lean
+++ b/EvmAsm/Codegen/Programs/HeaderExtractLogsBloomSpec.lean
@@ -134,7 +134,6 @@ theorem headerExtractLogsBloom_call_spec_within
     helbCalleeMem
   exact h
 
-#print axioms headerExtractLogsBloom_call_spec_within
 
 /-! ## `la` materialize helpers (address-specific AUIPC hi/lo) -/
 
@@ -332,7 +331,6 @@ theorem helbPrologue
       unfold callEntryRest entryRest savedRegTail
       xperm_chunked hq) call)
 
-#print axioms helbPrologue
 
 /-! ## The shared return postcondition
 
@@ -448,7 +446,6 @@ theorem helbEpilogue (newSp a0v v1 v8 v9 v18 : Word) (fsaved : HeaderFieldsSpec.
   exact cpsTripleWithin_mono_nSteps (by omega)
     (cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp) (fun _ hp => by xperm_hyp hp) s2)
 
-#print axioms helbEpilogue
 
 /-! ## Copy-loop helpers -/
 
@@ -1420,6 +1417,5 @@ theorem headerExtractLogsBloom_spec_within
   have c2 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_chunked hp) c1 hpost
   exact c2
 
-#print axioms headerExtractLogsBloom_spec_within
 
 end EvmAsm.Codegen.HeaderExtractLogsBloomSpec

--- a/EvmAsm/Codegen/Programs/HeaderExtractNumberSpec.lean
+++ b/EvmAsm/Codegen/Programs/HeaderExtractNumberSpec.lean
@@ -57,7 +57,6 @@ theorem hdr_disjoint :
     · rw [rlp_content_to_u64_prog_length]; decide
     · rw [hdr_length, rlp_content_to_u64_prog_length]; decide
 
-#print axioms hdr_disjoint
 
 /-- K34's linked code is subsumed by the wrapper's full closure. -/
 theorem k34_mono :
@@ -213,7 +212,6 @@ theorem hdrPrologue
       unfold flatPre wholeRest
       xperm_hyp hq) hall
 
-#print axioms hdrPrologue
 
 /-! ## Epilogue core (instructions 5--7) -/
 
@@ -267,7 +265,6 @@ theorem epiCore (sp0 spH raIn : Word) (G : Assertion) (hG : G.pcFree)
   exact cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
     (fun _ hq => by xperm_hyp hq) hframed
 
-#print axioms epiCore
 
 /-! ## Epilogue over K34's result post (instructions 5--7) -/
 
@@ -364,7 +361,6 @@ theorem hdrEpilogue
             bytes listLen 8 h'')) h') => sepConj_or_split h' hh) h hp
   exact sepConj_or_split h hinner
 
-#print axioms hdrEpilogue
 
 /-! ## Whole-program caller contract -/
 
@@ -447,6 +443,5 @@ theorem header_extract_number_spec_within
     hpro hcall'
   exact cpsTripleWithin_seq_perm_same_cr (fun _ hp => hp) h01 hepi
 
-#print axioms header_extract_number_spec_within
 
 end EvmAsm.Codegen.HeaderExtractNumberSpec

--- a/EvmAsm/Codegen/Programs/HeaderFieldsGenericBlocks.lean
+++ b/EvmAsm/Codegen/Programs/HeaderFieldsGenericBlocks.lean
@@ -406,10 +406,5 @@ theorem hfMarshalNextBundled {code : CodeReq}
     (fun h hp => by unfold hfWalkAmbient hesrAmbRegs hesrSpill at hp; xperm_chunked hp)
     (fun h hq => by unfold hfWalkAmbient hesrAmbRegs hesrSpill; xperm_chunked hq) hmF
 
-#print axioms hfEpilogue
-#print axioms hfStatus1Bundled
-#print axioms hfStatus2Return
-#print axioms hfSuccessFinish
-#print axioms hfMarshalNextBundled
 
 end EvmAsm.Codegen.HeaderFieldsSpec

--- a/EvmAsm/Codegen/Programs/HeaderFieldsGenericDispatch.lean
+++ b/EvmAsm/Codegen/Programs/HeaderFieldsGenericDispatch.lean
@@ -319,7 +319,6 @@ theorem hfStageRec {code : CodeReq} {nCont : Nat}
       (fun _ h => h) (cpsTripleWithin_or_pre hOK hFAIL)
   exact cpsTripleWithin_seq_same_cr hwalk' hdisp
 
-#print axioms hfStageRec
 
 set_option maxRecDepth 8000 in
 /-- Generic selecting walk stage (the final field walk).  Walk-call at `entryPC`,
@@ -562,6 +561,5 @@ theorem hfStageSel {code : CodeReq} {nTail : Nat}
       (fun _ h => h) (cpsTripleWithin_or_pre hOK hFAIL)
   exact cpsTripleWithin_seq_same_cr hwalk' hdisp
 
-#print axioms hfStageSel
 
 end EvmAsm.Codegen.HeaderFieldsSpec

--- a/EvmAsm/Codegen/Programs/HeaderFieldsGenericInit.lean
+++ b/EvmAsm/Codegen/Programs/HeaderFieldsGenericInit.lean
@@ -568,9 +568,5 @@ theorem hfInitDispatch {code : CodeReq} {nStage1 : Nat}
   unfold hfScratchConst
   xperm_chunked hq
 
-#print axioms hfPrologue
-#print axioms hfInitStep
-#print axioms hfMarshalInitBundled
-#print axioms hfInitDispatch
 
 end EvmAsm.Codegen.HeaderFieldsSpec

--- a/EvmAsm/Codegen/Programs/HeaderFieldsSpec.lean
+++ b/EvmAsm/Codegen/Programs/HeaderFieldsSpec.lean
@@ -108,6 +108,5 @@ theorem header_extract_state_root_fnspec
     (fun h hq => by unfold hesrAmbient; xperm_chunked hq) hproF hdisp
   exact cpsTripleWithin_weaken (fun h hp => by xperm_chunked hp) (fun _ h => h) hcomp
 
-#print axioms header_extract_state_root_fnspec
 
 end EvmAsm.Codegen.HeaderFieldsSpec

--- a/EvmAsm/Codegen/Programs/HeaderFieldsSpecBlocks.lean
+++ b/EvmAsm/Codegen/Programs/HeaderFieldsSpecBlocks.lean
@@ -537,10 +537,5 @@ theorem hesrSuccessFinish (newSp a0old v1 v8 v9 v18 : Word) (saved : Saved)
   refine cpsTripleWithin_mono_nSteps (by omega)
     (cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp) (fun _ hp => by xperm_hyp hp) s2)
 
-#print axioms hesrInitStep
-#print axioms hesrEpilogue
-#print axioms hesrStatus1Return
-#print axioms hesrStatus2Return
-#print axioms hesrSuccessFinish
 
 end EvmAsm.Codegen.HeaderFieldsSpec

--- a/EvmAsm/Codegen/Programs/HeaderFieldsSpecBlocksTail.lean
+++ b/EvmAsm/Codegen/Programs/HeaderFieldsSpecBlocksTail.lean
@@ -963,14 +963,5 @@ theorem hesrSuccessTailBundled
     · exact Or.inl ⟨ha0, hsucc, hlen, hfin⟩
     · exact Or.inr (Or.inl ⟨ha0, hsucc, hlen, hfin⟩)
 
-#print axioms hesrSuccessTail
-#print axioms hesrLenDispatch
-#print axioms hesrSuccessContinue
-#print axioms hesrCopyThenFinish
-#print axioms hesrLenLoad
-#print axioms hesrOffsetLoadAdd
-#print axioms hesrOffsetStore
-#print axioms hesrCopyLoop
-#print axioms hesrSuccessTailBundled
 
 end EvmAsm.Codegen.HeaderFieldsSpec

--- a/EvmAsm/Codegen/Programs/HeaderFieldsSpecCommon.lean
+++ b/EvmAsm/Codegen/Programs/HeaderFieldsSpecCommon.lean
@@ -262,8 +262,6 @@ theorem hesrNextOutcome_to_norm (listBase endPtr : Word) (bytes : List (BitVec 8
     refine sepConj_mono_right (sepConj_mono_right (sepConj_mono_right ?_)) h hb6
     exact fun h' ⟨he, hP⟩ => ⟨he, by decide, Or.inr hP⟩
 
-#print axioms cpsTripleWithin_or_pre
-#print axioms hesrNextOutcome_to_norm
 
 /-! ## Stage 4 — the selected item (`next4`, `BNE[32]` @+128 → ret)
 
@@ -365,7 +363,6 @@ theorem cpsTripleWithin_of_forall_memIs_to_memOwn2
     ⟨hp, hcompat, h1, h2, hd, hu,
       ⟨g0, g1, d1, u1, hP, g2, g3, d2, u2, hv1, hv2⟩, hRb⟩ hpc
 
-#print axioms hesrNextStep
 /-! ## Stages 1-3 — walk-and-recurse dispatch around a non-selected item
 
     Each of the first three `rlp_walk_next` calls decodes the zero-based child
@@ -386,7 +383,6 @@ theorem pcFree_hesrSpill (newSp cursor endPtr : Word) :
   unfold hesrSpill
   exact pcFree_sepConj pcFree_memIs pcFree_memIs
 
-#print axioms hesrSpill
 /-- Peel seven owned scratch registers at once (local mirror of the committed
     `cpsTripleWithin_of_forall_regIs_to_regOwn7`). -/
 theorem cpsTripleWithin_of_forall_regIs_to_regOwn7

--- a/EvmAsm/Codegen/Programs/HeaderFieldsSpecDispatch.lean
+++ b/EvmAsm/Codegen/Programs/HeaderFieldsSpecDispatch.lean
@@ -329,8 +329,6 @@ private theorem hesrStage4
   rw [show (hesrBase + 124 : Word) + 4 = hesrBase + 128 from by bv_omega] at hwalk'
   exact cpsTripleWithin_seq_same_cr hwalk' hdisp
 
-#print axioms hesrMarshalNext
-#print axioms hesrStage4
 /-- Bundled-entry wrapper for the inter-call marshalling: the ambient registers
     and the two spill cells stay folded (`hesrWalkAmbient`/`hesrSpill`) so the
     stage feeds it over few atoms.  Internally it unfolds them, frames the
@@ -363,7 +361,6 @@ theorem hesrMarshalNextBundled
     (fun h hp => by unfold hesrWalkAmbient hesrAmbRegs hesrSpill at hp; xperm_chunked hp)
     (fun h hq => by unfold hesrWalkAmbient hesrAmbRegs hesrSpill; xperm_chunked hq) hmF
 
-#print axioms hesrMarshalNextBundled
 set_option maxRecDepth 8000 in
 theorem hesrStage3
     (listBase endPtr outPtr newSp : Word) (offPrev listLen cursorOff : Nat)
@@ -681,6 +678,5 @@ theorem hesrStage3
   rw [show (hesrBase + 104 : Word) + 4 = hesrBase + 108 from by bv_omega] at hwalk'
   exact cpsTripleWithin_seq_same_cr hwalk' hdisp
 
-#print axioms hesrStage3
 
 end EvmAsm.Codegen.HeaderFieldsSpec

--- a/EvmAsm/Codegen/Programs/HeaderFieldsSpecDispatch2.lean
+++ b/EvmAsm/Codegen/Programs/HeaderFieldsSpecDispatch2.lean
@@ -80,7 +80,6 @@ private theorem hesrMarshalInit (cursor endPtr newSp : Word) :
   have s3 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) s2 f15
   exact cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp) (fun _ hp => by xperm_hyp hp) s3
 
-#print axioms hesrMarshalInit
 set_option maxRecDepth 8000 in
 private theorem hesrStage2
     (listBase endPtr outPtr newSp : Word) (offPrev listLen cursorOff : Nat)
@@ -392,7 +391,6 @@ private theorem hesrStage2
   rw [show (hesrBase + 84 : Word) + 4 = hesrBase + 88 from by bv_omega] at hwalk'
   exact cpsTripleWithin_seq_same_cr hwalk' hdisp
 
-#print axioms hesrStage2
 set_option maxRecDepth 8000 in
 private theorem hesrStage1
     (listBase endPtr outPtr newSp : Word) (offPrev listLen cursorOff : Nat)
@@ -705,7 +703,6 @@ private theorem hesrStage1
   rw [show (hesrBase + 64 : Word) + 4 = hesrBase + 68 from by bv_omega] at hwalk'
   exact cpsTripleWithin_seq_same_cr hwalk' hdisp
 
-#print axioms hesrStage1
 /-! ## The init-call dispatch and the whole-program caller contract
 
     The init phase in front of `hesrStage1`: the `rlp_walk_init` call at [10]
@@ -755,7 +752,6 @@ private theorem hesrMarshalInitBundled
     (fun h hq => by
       unfold hesrWalkAmbient hesrAmbRegs hesrAmbConst hesrSpill; xperm_chunked hq) hmF
 
-#print axioms hesrMarshalInitBundled
 set_option maxRecDepth 8000 in
 theorem hesrInitDispatch
     (listBase outPtr newSp oldRa v5 v6 v7 v28 v29 v30 v31 : Word)
@@ -1041,6 +1037,5 @@ theorem hesrInitDispatch
   unfold hesrScratchConst
   xperm_chunked hq
 
-#print axioms hesrInitDispatch
 
 end EvmAsm.Codegen.HeaderFieldsSpec

--- a/EvmAsm/Codegen/Programs/HeaderReceiptsRootSpec.lean
+++ b/EvmAsm/Codegen/Programs/HeaderReceiptsRootSpec.lean
@@ -388,6 +388,5 @@ theorem header_extract_receipts_root_fnspec
     (fun h hq => by unfold hfAmbient; xperm_chunked hq) hproF hdisp
   exact cpsTripleWithin_weaken (fun h hp => by xperm_chunked hp) (fun _ h => h) hcomp
 
-#print axioms header_extract_receipts_root_fnspec
 
 end EvmAsm.Codegen.HeaderReceiptsRootSpec

--- a/EvmAsm/Codegen/Programs/HeaderReceiptsRootTail.lean
+++ b/EvmAsm/Codegen/Programs/HeaderReceiptsRootTail.lean
@@ -905,6 +905,5 @@ theorem herrSuccessTailBundled
     · exact Or.inl ⟨ha0, hsucc, hlen, hfin⟩
     · exact Or.inr (Or.inl ⟨ha0, hsucc, hlen, hfin⟩)
 
-#print axioms herrSuccessTailBundled
 
 end EvmAsm.Codegen.HeaderReceiptsRootSpec

--- a/EvmAsm/Codegen/Programs/HeaderValidateExtraDataLengthSpec.lean
+++ b/EvmAsm/Codegen/Programs/HeaderValidateExtraDataLengthSpec.lean
@@ -59,7 +59,6 @@ theorem hved_disjoint :
   · right
     rw [EvmAsm.Codegen.RlpListNthItemSAsm.total_length]; decide
 
-#print axioms hved_disjoint
 
 /-- K20's linked code is subsumed by the wrapper's full closure. -/
 theorem k20_mono :
@@ -299,7 +298,6 @@ theorem hvedHead
       unfold hvedPre at hp; xperm_hyp hp) (fun h hq => by
       unfold calleePre entryRest; xperm_hyp hq) hframed
 
-#print axioms hvedHead
 
 /-! ## Call (instruction 7): jal + K20 selector -/
 
@@ -368,7 +366,6 @@ theorem hvedCall
     hhead hjalF
   exact cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) hhj hcallee
 
-#print axioms hvedCall
 
 /-! ## Epilogue (instructions 19--21) -/
 
@@ -422,7 +419,6 @@ theorem hvedEpi (sp0 spH raIn : Word) (G : Assertion) (hG : G.pcFree)
   exact cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
     (fun _ hq => by xperm_hyp hq) hframed
 
-#print axioms hvedEpi
 
 /-! ## Length load + compare dispatch (instructions 9--15/16--17, then epilogue) -/
 
@@ -628,7 +624,6 @@ theorem hvedDispatch
   exact cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp) (fun _ hq => hq)
     (cpsBranchWithin_merge_same_cr hbranch hrej hsucc)
 
-#print axioms hvedDispatch
 
 set_option maxRecDepth 8000 in
 /-- `hvedDispatch` with `x5/x6` presented as owned (their pre-values are
@@ -662,7 +657,6 @@ theorem hvedDispatchOwned
     (hvedDispatch sp0 spH newSp raIn listBase oldOffset oldLen offset len v5 v6 saved
       bytes listLen hspH hret hResult)
 
-#print axioms hvedDispatchOwned
 
 /-! ## Status dispatch + full rest (instruction 8 onward) -/
 
@@ -828,7 +822,6 @@ theorem hvedRest
   refine cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp) (fun _ hq => hq)
     (cpsBranchWithin_merge_same_cr hbneF h_t h_f)
 
-#print axioms hvedRest
 
 /-! ## Whole-program caller contract -/
 
@@ -864,6 +857,5 @@ theorem header_validate_extra_data_length_spec_within
     listLen hspH hret hraSaved
   exact cpsTripleWithin_seq_same_cr hcall hrest
 
-#print axioms header_validate_extra_data_length_spec_within
 
 end EvmAsm.Codegen.HeaderValidateExtraDataLengthSpec

--- a/EvmAsm/Codegen/Programs/HeaderWithdrawalsRootChain.lean
+++ b/EvmAsm/Codegen/Programs/HeaderWithdrawalsRootChain.lean
@@ -146,7 +146,6 @@ theorem hewrStage16Chain
           h_src_align h_dst_align hb' h_dst_bound h_src_over h_dst_over h_src_valid h_dst_valid
           ⟨c0, listBase + BitVec.ofNat 64 listLenN, n', hpay', hnth, hoffeq⟩)))
 
-#print axioms hewrStage16Chain
 
 /-- Stage 15 (`hfStageRec`, count 15) at `hewrBase+364`. -/
 theorem hewrStage15Chain

--- a/EvmAsm/Codegen/Programs/HeaderWithdrawalsRootSpec.lean
+++ b/EvmAsm/Codegen/Programs/HeaderWithdrawalsRootSpec.lean
@@ -151,6 +151,5 @@ theorem header_extract_withdrawals_root_fnspec
     (fun h hq => by unfold hfAmbient; xperm_chunked hq) hproF hdisp
   exact cpsTripleWithin_weaken (fun h hp => by xperm_chunked hp) (fun _ h => h) hcomp
 
-#print axioms header_extract_withdrawals_root_fnspec
 
 end EvmAsm.Codegen.HeaderWithdrawalsRootSpec

--- a/EvmAsm/Codegen/Programs/HeaderWithdrawalsRootTail.lean
+++ b/EvmAsm/Codegen/Programs/HeaderWithdrawalsRootTail.lean
@@ -909,6 +909,5 @@ theorem hewrSuccessTailBundled
     · exact Or.inl ⟨ha0, hsucc, hlen, hfin⟩
     · exact Or.inr (Or.inl ⟨ha0, hsucc, hlen, hfin⟩)
 
-#print axioms hewrSuccessTailBundled
 
 end EvmAsm.Codegen.HeaderWithdrawalsRootSpec

--- a/EvmAsm/Codegen/Programs/P256Eq32SAsm.lean
+++ b/EvmAsm/Codegen/Programs/P256Eq32SAsm.lean
@@ -58,7 +58,6 @@ theorem p256Eq32Fn_spec (ptr1 ptr2 : Word) (bs1 bs2 : List (BitVec 8))
   simpa [p256Eq32Fn, p256Eq32Body, Secp256k1FieldEq32SAsm.secfEq32Fn] using
     Secp256k1FieldEq32SAsm.secfEq32Fn_spec ptr1 ptr2 bs1 bs2 hwf1 hwf2 base
 
-#print axioms p256Eq32Fn_spec
 
 end P256Eq32SAsm
 end EvmAsm.Codegen

--- a/EvmAsm/Codegen/Programs/P256IsZeroNSAsm.lean
+++ b/EvmAsm/Codegen/Programs/P256IsZeroNSAsm.lean
@@ -261,7 +261,6 @@ theorem p256IsZeroNFn_spec (ptr : Word) (bs : List (BitVec 8)) (len : Nat)
       refine ⟨?_, hlen, hptr⟩
       rw [hx10rf, isZeroNResult, if_pos heq]
 
-#print axioms p256IsZeroNFn_spec
 
 end P256IsZeroNSAsm
 end EvmAsm.Codegen

--- a/EvmAsm/Codegen/Programs/P256LtBeSAsm.lean
+++ b/EvmAsm/Codegen/Programs/P256LtBeSAsm.lean
@@ -795,7 +795,6 @@ theorem p256LtBe_spec (aPtr bPtr ret : Word) (xs bs : List (BitVec 8))
     (fun h hq => by unfold ltPost at hq; exact hq)
     (cpsTripleWithin_mono_nSteps (by omega) hc3)
 
-#print axioms p256LtBe_spec
 
 end P256LtBeSAsm
 

--- a/EvmAsm/Codegen/Programs/RlpBytesEncodedSizeSAsm.lean
+++ b/EvmAsm/Codegen/Programs/RlpBytesEncodedSizeSAsm.lean
@@ -814,7 +814,6 @@ theorem rlpBytesEncodedSize_spec
 
 end Routine
 
-#print axioms rlpBytesEncodedSize_spec
 
 end RlpBytesEncodedSizeSAsm
 

--- a/EvmAsm/Codegen/Programs/RlpContentToU256BeCallSAsm.lean
+++ b/EvmAsm/Codegen/Programs/RlpContentToU256BeCallSAsm.lean
@@ -76,7 +76,6 @@ theorem rlpContentToU256Be_call_spec_within
   · unfold flatPost
     xperm_hyp hp
 
-#print axioms rlpContentToU256Be_call_spec_within
 
 end RlpContentToU256BeCallSAsm
 end EvmAsm.Codegen

--- a/EvmAsm/Codegen/Programs/RlpContentToU64CallSAsm.lean
+++ b/EvmAsm/Codegen/Programs/RlpContentToU64CallSAsm.lean
@@ -66,7 +66,6 @@ theorem rlpContentToU64_call_spec_within
   · unfold flatPost
     xperm_hyp hp
 
-#print axioms rlpContentToU64_call_spec_within
 
 end RlpContentToU64CallSAsm
 end EvmAsm.Codegen

--- a/EvmAsm/Codegen/Programs/RlpFieldToU256BeComposeSAsm.lean
+++ b/EvmAsm/Codegen/Programs/RlpFieldToU256BeComposeSAsm.lean
@@ -255,6 +255,5 @@ theorem fitToSuccessDone
       xperm_hyp hcombined)
     (fun _ hp => hp) hs
 
-#print axioms fitToSuccessDone
 
 end EvmAsm.Codegen.RlpFieldToU256BeSAsm

--- a/EvmAsm/Codegen/Programs/RlpFieldToU256BeFinishSAsm.lean
+++ b/EvmAsm/Codegen/Programs/RlpFieldToU256BeFinishSAsm.lean
@@ -123,7 +123,6 @@ theorem listResultBranch
       listBase offsetPtr lenPtr oldOffset oldLen saved bytes listLen index h hp)
     (fun _ hp => hp) (fun _ hp => hp) hor
 
-#print axioms listResultBranch
 
 /-- Reload the selected length and comparison bound (instructions 16--19). -/
 theorem selectedLengthExact
@@ -173,7 +172,6 @@ theorem selectedLengthExact
   exact cpsTripleWithin_frameR F hF
     (cpsTripleWithin_extend_code (fun a i hi => wrapperCode_mono a i hi) hs')
 
-#print axioms selectedLengthExact
 
 def selectedPathCarry (sp0 listBase : Word) (saved : ListSaved)
     (bytes : List (BitVec 8)) (v11 v12 : Word) : Assertion :=
@@ -261,7 +259,6 @@ theorem selectedLength
       rw [hs0] at hp
       xperm_pure hp) (fun _ hp => hp) howned
 
-#print axioms selectedLength
 
 def lengthRest (sp0 listBase offset len : Word) (saved : ListSaved)
     (bytes : List (BitVec 8)) (listLen index : Nat) (v11 v12 : Word) :
@@ -350,7 +347,6 @@ theorem lengthBranch
       xperm_hyp hp) (fun _ hp => hp) (fun _ hp => hp)
     (lengthBranchCase sp0 listBase offset len v11 v12 saved bytes listLen index)
 
-#print axioms lengthBranch
 
 /-- Materialize the selected source cursor and right-aligned destination cursor
     (instructions 21--26). -/
@@ -449,7 +445,6 @@ theorem cursorSetupExact
   exact cpsTripleWithin_frameR F hF
     (cpsTripleWithin_extend_code (fun a i hi => wrapperCode_mono a i hi) hs)
 
-#print axioms cursorSetupExact
 
 /-- Success status and jump to the common restore join (34--35). -/
 theorem successStatusTail (old10 : Word) (F : Assertion) (hF : F.pcFree) :
@@ -515,9 +510,6 @@ theorem failureStatusTail (old10 : Word) (F : Assertion) (hF : F.pcFree) :
   exact cpsTripleWithin_frameR F hF
     (cpsTripleWithin_extend_code (fun a i hi => wrapperCode_mono a i hi) h0')
 
-#print axioms successStatusTail
-#print axioms tooLongStatusTail
-#print axioms failureStatusTail
 
 /-- Restore K35's saved `ra/s0/s1`, deallocate its 32-byte frame, and return
     (instructions 39--43). -/
@@ -590,6 +582,5 @@ theorem restoreTail
     (fun h hp => by rw [regsAt_frame]; xperm_hyp hp) h123
   exact cpsTripleWithin_extend_code (fun a i hi => wrapperCode_mono a i hi) hlocal
 
-#print axioms restoreTail
 
 end EvmAsm.Codegen.RlpFieldToU256BeSAsm

--- a/EvmAsm/Codegen/Programs/RlpFieldToU256BeFlatSAsm.lean
+++ b/EvmAsm/Codegen/Programs/RlpFieldToU256BeFlatSAsm.lean
@@ -157,6 +157,5 @@ theorem rlpFieldToU256Be_flat_spec_within
           (fun _ hp => ⟨v11, v12, hp⟩) h hfixed
       exact sepConj_mono_right (fun _ hp => Or.inr (Or.inr hp)) h hflat
 
-#print axioms rlpFieldToU256Be_flat_spec_within
 
 end EvmAsm.Codegen.RlpFieldToU256BeSAsm

--- a/EvmAsm/Codegen/Programs/RlpFieldToU256BeLoopSAsm.lean
+++ b/EvmAsm/Codegen/Programs/RlpFieldToU256BeLoopSAsm.lean
@@ -319,7 +319,6 @@ theorem copyFn_spec (listBase outputPtr : Word) (bytes : List (BitVec 8))
     change ws = List.replicate (32 - len) 0 ++ (bytes.drop offset).take len
     rw [hwin, copyWin_done bytes offset len hfit hbound]
 
-#print axioms copyFn_spec
 
 /-! ## Partial-register bridge for the inline caller composition -/
 
@@ -437,7 +436,6 @@ theorem copyBody_spec_within
     (cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
       (fun _ hp => by xperm_hyp hp) sall)
 
-#print axioms copyBody_spec_within
 
 /-- Exact bounded closure of K35's top-tested copy loop (instructions 27--33).
     The post exposes the genuine right-aligned byte window. -/
@@ -640,6 +638,5 @@ theorem copyLoop_spec_within
   rw [hdone] at h0
   simpa only [Nat.zero_add, show 32 - len + len = 32 by omega] using h0
 
-#print axioms copyLoop_spec_within
 
 end EvmAsm.Codegen.RlpFieldToU256BeSAsm

--- a/EvmAsm/Codegen/Programs/RlpFieldToU256BeOutcomeSAsm.lean
+++ b/EvmAsm/Codegen/Programs/RlpFieldToU256BeOutcomeSAsm.lean
@@ -68,7 +68,6 @@ theorem successDoneToOutcome
     xperm_hyp hp), ?_⟩
   exact .success offset len hsem.1 hsem.2
 
-#print axioms successDoneToOutcome
 
 def statusCarry (sp0 listBase : Word) (saved : ListSaved)
     (bytes : List (BitVec 8)) (v11 v12 status : Word) : Assertion :=
@@ -157,7 +156,6 @@ theorem tooLongToOutcome
     xperm_hyp hp), ?_⟩
   exact .tooLong offset len hsem.1 hsem.2
 
-#print axioms tooLongToOutcome
 
 def failureOutcome (sp0 listBase outputPtr oldOffset oldLen : Word)
     (saved : ListSaved) (bytes : List (BitVec 8))
@@ -221,7 +219,6 @@ theorem failureToOutcome
     xperm_hyp hp), ?_⟩
   exact .listFailure h_fail
 
-#print axioms failureToOutcome
 
 def joinedOutcome (sp0 listBase outputPtr oldOffset oldLen : Word)
     (saved : ListSaved) (bytes : List (BitVec 8))
@@ -275,7 +272,6 @@ theorem selectedToJoined
   simpa only [Nat.add_assoc] using
     cpsTripleWithin_seq_perm_same_cr (fun h hp => by xperm_hyp hp) hl hm
 
-#print axioms selectedToJoined
 
 theorem listDispatchToJoined
     (sp0 listBase outputPtr oldOffset oldLen : Word) (saved : ListSaved)
@@ -315,6 +311,5 @@ theorem listDispatchToJoined
   have hm := cpsBranchWithin_merge_same_cr hb hf hs
   exact cpsTripleWithin_weaken (fun _ hp => hp) (fun _ hp => hp) hm
 
-#print axioms listDispatchToJoined
 
 end EvmAsm.Codegen.RlpFieldToU256BeSAsm

--- a/EvmAsm/Codegen/Programs/RlpFieldToU256BeRestoreSAsm.lean
+++ b/EvmAsm/Codegen/Programs/RlpFieldToU256BeRestoreSAsm.lean
@@ -39,7 +39,6 @@ theorem restoreTailExact
       xperm_hyp hp1)
     (fun _ hp => hp) ht
 
-#print axioms restoreTailExact
 
 def successPayload (newSp listBase outputPtr offset len v11 v12 : Word)
     (saved : ListSaved) (bytes : List (BitVec 8))
@@ -113,7 +112,6 @@ theorem restoreSuccess
   unfold successReturned
   exact ⟨offset, len, v11, v12, hp⟩
 
-#print axioms restoreSuccess
 
 def tooLongPayload (newSp listBase outputPtr offset len v11 v12 : Word)
     (saved : ListSaved) (bytes : List (BitVec 8))
@@ -185,7 +183,6 @@ theorem restoreTooLong
   unfold tooLongReturned
   exact ⟨offset, len, v11, v12, hp⟩
 
-#print axioms restoreTooLong
 
 def failurePayload (newSp listBase outputPtr oldOffset oldLen v11 v12 : Word)
     (saved : ListSaved) (bytes : List (BitVec 8))
@@ -255,7 +252,6 @@ theorem restoreFailure
   unfold failureReturned
   exact ⟨v11, v12, hp⟩
 
-#print axioms restoreFailure
 
 def returnedOutcome
     (spOuter newSp listBase outputPtr oldOffset oldLen : Word) (outer : Saved)
@@ -311,6 +307,5 @@ theorem restoreJoined
           ⟨g1, g2, gd, gu, ⟨ha, hb, hd, hu, hra, hf⟩, hsf⟩))
     (fun _ hp => hp) hor
 
-#print axioms restoreJoined
 
 end EvmAsm.Codegen.RlpFieldToU256BeSAsm

--- a/EvmAsm/Codegen/Programs/RlpFieldToU256BeSAsm.lean
+++ b/EvmAsm/Codegen/Programs/RlpFieldToU256BeSAsm.lean
@@ -172,6 +172,5 @@ theorem callListNth
   dsimp [saved] at hcall
   exact hcall
 
-#print axioms callListNth
 
 end EvmAsm.Codegen.RlpFieldToU256BeSAsm

--- a/EvmAsm/Codegen/Programs/RlpFieldToU256BeSetupSAsm.lean
+++ b/EvmAsm/Codegen/Programs/RlpFieldToU256BeSetupSAsm.lean
@@ -52,7 +52,6 @@ theorem setupPrologue
   exact cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
     (fun h hp => by rw [frameSlotsSaved_frame] at hp; xperm_hyp hp) hseq
 
-#print axioms setupPrologue
 
 /-- Save the input/output pointers (instructions 4--5). -/
 theorem setupMoves
@@ -81,7 +80,6 @@ theorem setupMoves
     (cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
       (fun _ hp => by xperm_hyp hp) hs)
 
-#print axioms setupMoves
 
 private theorem getByteAt_dword0 (j : Nat) (hj : j < 8) :
     getByteAt (dwordBytes (0 : Word)) j = 0 := by
@@ -164,7 +162,6 @@ theorem zeroOutput (outputPtr : Word) (orig : List (BitVec 8))
   rw [zeroFold orig hlen] at h0123
   simpa using h0123
 
-#print axioms zeroOutput
 
 /-- Materialize K20's offset and length result cells (instructions 10--13). -/
 theorem setupGlobals (old13 old14 : Word) (F : Assertion) (hF : F.pcFree) :
@@ -201,6 +198,5 @@ theorem setupGlobals (old13 old14 : Word) (F : Assertion) (hF : F.pcFree) :
   exact cpsTripleWithin_frameR F hF
     (cpsTripleWithin_extend_code (fun a i hi => wrapperCode_mono a i hi) hs')
 
-#print axioms setupGlobals
 
 end EvmAsm.Codegen.RlpFieldToU256BeSAsm

--- a/EvmAsm/Codegen/Programs/RlpFieldToU256BeWholeSAsm.lean
+++ b/EvmAsm/Codegen/Programs/RlpFieldToU256BeWholeSAsm.lean
@@ -48,7 +48,6 @@ theorem dispatchAndRestore
     saved bytes listLen index hs0 hs1 hnewSp hret
   exact cpsTripleWithin_seq_same_cr hd' hr
 
-#print axioms dispatchAndRestore
 
 @[irreducible] def wholeRest
     (listBase listLenW indexW outputPtr oldOffset oldLen old14 : Word)
@@ -163,7 +162,6 @@ theorem setupAndCall
       simpa only [sepConj_assoc', sepConj_comm', sepConj_left_comm'] using hp') hall
   simpa only [Nat.add_assoc] using hall'
 
-#print axioms setupAndCall
 
 theorem rlpFieldToU256Be_spec_within
     (spOuter newSp listBase listLenW indexW outputPtr oldOffset oldLen old14 : Word)
@@ -208,6 +206,5 @@ theorem rlpFieldToU256Be_spec_within
     hover hoover hvalid houtvalid hnewSp hret
   exact cpsTripleWithin_seq_perm_same_cr (fun h hp => by xperm_hyp hp) hs ht
 
-#print axioms rlpFieldToU256Be_spec_within
 
 end EvmAsm.Codegen.RlpFieldToU256BeSAsm

--- a/EvmAsm/Codegen/Programs/RlpFieldToU64FinishSAsm.lean
+++ b/EvmAsm/Codegen/Programs/RlpFieldToU64FinishSAsm.lean
@@ -89,7 +89,6 @@ theorem contentDone_to_scalarResult
     · exact h_ok
   · exact h_scalar
 
-#print axioms contentDone_to_scalarResult
 
 def scalarFrame
     (sp0 listBase offset len v12 value : Word)
@@ -197,7 +196,6 @@ private theorem scalarBranchCase
     unfold scalarCore
     xperm_hyp hp
 
-#print axioms scalarBranchCase
 
 theorem scalarBranch
     (sp0 listBase : Word)
@@ -218,7 +216,6 @@ theorem scalarBranch
   exact scalarBranchCase sp0 listBase offset len v12 value status saved bytes
     listLen index h_ok h_out
 
-#print axioms scalarBranch
 
 /-- Store a successfully decoded scalar, materialize wrapper status zero, and
     jump to the shared restore join (instructions 22--24). -/
@@ -271,7 +268,6 @@ theorem successMachineTail
     unfold code
     exact CodeReq.union_mono_left a i hi) h012
 
-#print axioms successMachineTail
 
 /-- Scalar status two is preserved as wrapper status two
     (instructions 25, 26, 31). -/
@@ -325,7 +321,6 @@ theorem tooLongMachineTail
     unfold code
     exact CodeReq.union_mono_left a i hi) h012
 
-#print axioms tooLongMachineTail
 
 /-- Scalar status three (leading-zero rejection) maps to wrapper status one
     (instructions 25--28). -/
@@ -396,7 +391,6 @@ theorem noncanonicalMachineTail
     unfold code
     exact CodeReq.union_mono_left a i hi) h0123
 
-#print axioms noncanonicalMachineTail
 
 theorem scalarOutcome_result
     {bytes : List (BitVec 8)} {listBase offset len value status : Word}
@@ -420,7 +414,6 @@ theorem scalarOutcome_result
   | success h_pos h_fit h_nz =>
       exact ⟨0, .success offset len h_ok h_pos h_fit h_nz, Or.inl ⟨rfl, rfl⟩⟩
 
-#print axioms scalarOutcome_result
 
 def stableRest
     (ra sp0 listBase offset len v12 : Word)
@@ -496,7 +489,6 @@ private theorem successSemanticTail
     xperm_hyp hp
   · exact h_result
 
-#print axioms successSemanticTail
 
 private theorem tooLongSemanticTail
     (sp0 listBase offset len v12 x5 : Word)
@@ -528,7 +520,6 @@ private theorem tooLongSemanticTail
     xperm_hyp hp
   · exact h_result
 
-#print axioms tooLongSemanticTail
 
 private theorem noncanonicalSemanticTail
     (sp0 listBase offset len v12 x5 : Word)
@@ -560,7 +551,6 @@ private theorem noncanonicalSemanticTail
     xperm_hyp hp
   · exact h_result
 
-#print axioms noncanonicalSemanticTail
 
 def scalarNo5
     (sp0 listBase offset len v12 value status : Word)
@@ -652,9 +642,6 @@ private theorem noncanonicalSemanticOwned
       unfold P scalarNo5
       xperm_hyp hp) (fun _ hp => hp) howned
 
-#print axioms successSemanticOwned
-#print axioms tooLongSemanticOwned
-#print axioms noncanonicalSemanticOwned
 
 def fallReady
     (sp0 listBase : Word)
@@ -715,7 +702,6 @@ theorem fallSemanticTail
       exact successSemanticOwned sp0 listBase offset len v12 _ saved bytes
         listLen index (.success offset len h_ok h_pos h_fit h_nz)
 
-#print axioms fallSemanticTail
 
 theorem takenSemanticTail
     (sp0 listBase : Word)
@@ -753,7 +739,6 @@ theorem takenSemanticTail
       exact noncanonicalSemanticOwned sp0 listBase offset len v12 saved bytes
         listLen index (.noncanonical offset len h_ok h_pos h_fit h_zero)
 
-#print axioms takenSemanticTail
 
 theorem scalarTaken_framed_to_ready
     (sp0 listBase : Word)
@@ -816,9 +801,6 @@ theorem scalarBranchWithOutput
     (scalarTaken_framed_to_ready sp0 listBase saved bytes listLen index)
     (scalarFall_framed_to_ready sp0 listBase saved bytes listLen index) hbF
 
-#print axioms scalarTaken_framed_to_ready
-#print axioms scalarFall_framed_to_ready
-#print axioms scalarBranchWithOutput
 
 theorem scalarDispatch
     (sp0 listBase : Word)
@@ -848,8 +830,6 @@ theorem contentDone_framed_to_scalarResult
   sepConj_mono_left
     (contentDone_to_scalarResult sp0 listBase saved bytes listLen index)
 
-#print axioms scalarDispatch
-#print axioms contentDone_framed_to_scalarResult
 
 theorem callContentWithOutput
     (sp0 listBase vOld : Word)
@@ -905,8 +885,6 @@ theorem selectedToJoin
   have hd := scalarDispatch sp0 listBase saved bytes listLen index
   exact cpsTripleWithin_seq_same_cr hsc' hd
 
-#print axioms callContentWithOutput
-#print axioms selectedToJoin
 
 def failureResultAtJoin
     (sp0 listBase oldOffset oldLen : Word)
@@ -973,8 +951,6 @@ theorem failureToAllJoin
   · xperm_hyp hp
   · exact .listFailure h_fail
 
-#print axioms selectedToAllJoin
-#print axioms failureToAllJoin
 
 theorem listDispatchToJoin
     (sp0 listBase oldOffset oldLen : Word)
@@ -1031,7 +1007,6 @@ theorem listDispatchToJoin
       simpa only [sepConj_assoc', sepConj_comm', sepConj_left_comm'] using hp)
     (fun _ hp => hp) hm
 
-#print axioms listDispatchToJoin
 
 def successPayload
     (sp0 listBase offset len v12 x5 scalarStatus wrapperStatus outputValue : Word)
@@ -1104,7 +1079,6 @@ theorem joinedResult_to_restoreReady
   have hcombined' := sepConj_mono_left (sepConj_mono_right himpl) h hcombined
   xperm_hyp hcombined'
 
-#print axioms joinedResult_to_restoreReady
 
 def failurePayload
     (sp0 listBase oldOffset oldLen v11 v12 : Word)
@@ -1188,7 +1162,6 @@ theorem failureResult_to_restoreReady
   have hcombined' := sepConj_mono_left (sepConj_mono_right himpl) h hcombined
   xperm_hyp hcombined'
 
-#print axioms failureResult_to_restoreReady
 
 def successReturned
     (spOuter newSp listBase : Word) (outer : Saved)
@@ -1262,7 +1235,6 @@ theorem restoreSuccess
   unfold successReturned
   exact ⟨offset, len, v12, x5, scalarStatus, wrapperStatus, outputValue, hp⟩
 
-#print axioms restoreSuccess
 
 theorem restoreFailure
     (spOuter newSp listBase oldOffset oldLen : Word) (outer : Saved)
@@ -1308,6 +1280,5 @@ theorem restoreAll
     (restoreFailure spOuter newSp listBase oldOffset oldLen outer saved bytes
       listLen index hnewSp hret)
 
-#print axioms restoreAll
 
 end EvmAsm.Codegen.RlpFieldToU64SAsm

--- a/EvmAsm/Codegen/Programs/RlpFieldToU64FlatSAsm.lean
+++ b/EvmAsm/Codegen/Programs/RlpFieldToU64FlatSAsm.lean
@@ -137,6 +137,5 @@ theorem rlpFieldToU64_flat_spec_within
       unfold flatPost
       exact sepConj_mono_right (fun _ hp => Or.inr hp) h hflat
 
-#print axioms rlpFieldToU64_flat_spec_within
 
 end EvmAsm.Codegen.RlpFieldToU64SAsm

--- a/EvmAsm/Codegen/Programs/RlpFieldToU64SAsm.lean
+++ b/EvmAsm/Codegen/Programs/RlpFieldToU64SAsm.lean
@@ -179,7 +179,6 @@ theorem listResult_cases
   | ok offset len h_ok => exact Or.inl ⟨rfl, h_ok⟩
   | fail h_fail => exact Or.inr ⟨rfl, rfl, rfl, h_fail⟩
 
-#print axioms listResult_cases
 
 def listSelected
     (sp0 listBase offsetPtr lenPtr : Word)
@@ -222,7 +221,6 @@ theorem listCallResult_cases
     unfold listFailed
     exact ⟨v11, v12, (sepConj_pure_right h).2 ⟨hcore, h_fail⟩⟩
 
-#print axioms listCallResult_cases
 
 theorem pcFree_listCallRest sp0 listBase offsetPtr lenPtr saved bytes offset len
     v11 v12 : (listCallRest sp0 listBase offsetPtr lenPtr saved bytes offset len
@@ -281,7 +279,6 @@ theorem branchSelected
   unfold listCallCore
   xperm_pure hstate
 
-#print axioms branchSelected
 
 /-- On a strict K20 failure, instruction 12's `bne a0, zero` is necessarily
     taken and preserves the exact unchanged offset/length cells. -/
@@ -334,7 +331,6 @@ theorem branchFailed
   unfold listCallCore
   xperm_pure hstate
 
-#print axioms branchFailed
 
 /-- Unified semantic dispatch for instruction 12, directly over K20's
     existential result post. -/
@@ -360,7 +356,6 @@ theorem listResultBranch
       oldLen saved bytes listLen index h hp)
     (fun _ hq => hq) (fun _ hq => hq) hor
 
-#print axioms listResultBranch
 
 /-- Peel K20's restored `ra` out of its flat post, yielding the exact
     `(ra ** P) -> (ra ** Q)` contract expected by `callWithin_spec`. -/
@@ -413,7 +408,6 @@ theorem listCalleeCallContract
   unfold listCallResult
   exact ⟨status, offset, len, v11, v12, hrest⟩
 
-#print axioms listCalleeCallContract
 
 /-- The real `jal` at wrapper instruction 11 composed with strict K20. -/
 theorem callListNth
@@ -473,7 +467,6 @@ theorem callListNth
   dsimp [saved] at hcall
   exact hcall
 
-#print axioms callListNth
 
 /-! ## Three-register ABI frame -/
 
@@ -582,7 +575,6 @@ theorem setupPrologue
     unfold code
     exact CodeReq.union_mono_left a i hi) hlocal
 
-#print axioms setupPrologue
 
 /-- Save the input/output pointers and zero the caller-visible output cell
     (instructions 4--6), before either strict callee can fail. -/
@@ -638,7 +630,6 @@ theorem setupMovesZero
     exact CodeReq.union_mono_left a i hi) hframed
   exact hall
 
-#print axioms setupMovesZero
 
 /-- Materialize `rfu_offset` and `rfu_length` in `a3/a4`
     (instructions 7--10), with both addresses proved by `la_resolve`. -/
@@ -678,7 +669,6 @@ theorem setupGlobals (old13 old14 : Word) (F : Assertion) (hF : F.pcFree) :
     unfold code
     exact CodeReq.union_mono_left a i hi) hframed
 
-#print axioms setupGlobals
 
 theorem frameRegs_implies_owned (s0 s1 : Word) : ∀ h,
     (regOwn .x1 ** (.x8 ↦ᵣ s0) ** (.x9 ↦ᵣ s1)) h →
@@ -760,7 +750,6 @@ theorem restoreTail (sp0 newSp : Word) (saved : Saved)
     unfold code
     exact CodeReq.union_mono_left a i hi) hlocal
 
-#print axioms restoreTail
 
 /-- Failure-status materialization and jump to the shared restore tail
     (instructions 29--30). -/
@@ -827,7 +816,6 @@ theorem failureJoin
   unfold listCallCore
   xperm_pure hq
 
-#print axioms failureJoin
 
 /-- Selected-item address setup (instructions 13--19): reload K20's exact
     offset/length cells and form the content pointer for the scalar callee. -/
@@ -915,7 +903,6 @@ theorem selectedSetupExact
     unfold code
     exact CodeReq.union_mono_left a i hi) hframed
 
-#print axioms selectedSetupExact
 
 def selectedCarry
     (sp0 listBase : Word)
@@ -997,7 +984,6 @@ theorem selectedSetup
       rw [hs0] at hp
       xperm_pure hp) (fun _ hq => hq) howned
 
-#print axioms selectedSetup
 
 theorem strictNthItem_last_decode
     {bytes : List (BitVec 8)} {base : Word} {endOff index off : Nat}
@@ -1038,8 +1024,6 @@ theorem success_content_bounds
   · omega
   · omega
 
-#print axioms strictNthItem_last_decode
-#print axioms success_content_bounds
 
 def contentOutcome (srcBytes : List (BitVec 8)) (srcOff len : Nat) : Assertion :=
   fun h =>
@@ -1090,7 +1074,6 @@ theorem contentOutcome_semantic (bytes : List (BitVec 8)) (offset len : Nat) : �
     exact ⟨_, 0, (sepConj_pure_right h).2
       ⟨(by xperm_hyp hstate), .success h_sem.1 h_sem.2.1 h_sem.2.2⟩⟩
 
-#print axioms contentOutcome_semantic
 
 def contentCallPost (srcBase : Word) (srcBytes : List (BitVec 8))
     (srcOff len : Nat) : Assertion :=
@@ -1158,7 +1141,6 @@ theorem callContentExact
   unfold contentRawPost
   exact hcall
 
-#print axioms callContentExact
 
 def contentCarry
     (sp0 listBase offset len v12 : Word)
@@ -1217,7 +1199,6 @@ theorem callContentFramedExact
   exact cpsTripleWithin_weaken (fun h hp => by xperm_pure hp)
     (fun h hq => by xperm_pure hq) hcf
 
-#print axioms callContentFramedExact
 
 def contentDone
     (sp0 listBase : Word)
@@ -1344,7 +1325,6 @@ theorem callContentOwned
       unfold P6 contentCarry listOtherSaved
       xperm_pure hp) (fun _ hq => hq) h6
 
-#print axioms callContentOwned
 
 theorem callContent
     (sp0 listBase vOld : Word)
@@ -1368,9 +1348,6 @@ theorem callContent
     ⟨offset, len, v12, hready⟩⟩ := hp
   exact ⟨offset, len, v12, hRa, hReady, hd, hu, hra, hready⟩
 
-#print axioms callContent
 
-#print axioms Result.status_cases
-#print axioms frameRegs_implies_owned
 
 end EvmAsm.Codegen.RlpFieldToU64SAsm

--- a/EvmAsm/Codegen/Programs/RlpFieldToU64WholeSAsm.lean
+++ b/EvmAsm/Codegen/Programs/RlpFieldToU64WholeSAsm.lean
@@ -24,7 +24,6 @@ theorem allJoinedResult_to_restoreReady
     exact failureResult_to_restoreReady newSp newSp listBase oldOffset oldLen outer
       saved bytes listLen index h ⟨h1, h2, hd, hu, hf, hsf⟩
 
-#print axioms allJoinedResult_to_restoreReady
 
 theorem dispatchAndRestore
     (spOuter newSp listBase oldOffset oldLen : Word) (outer : Saved)
@@ -58,7 +57,6 @@ theorem dispatchAndRestore
     listLen index hnewSp hret
   exact cpsTripleWithin_seq_perm_same_cr (fun _ hp => hp) hd' hr
 
-#print axioms dispatchAndRestore
 
 @[irreducible] def wholeRest
     (listBase listLenW indexW outputPtr oldOut oldOffset oldLen old14 : Word)
@@ -108,7 +106,6 @@ theorem prologueAndMoves
     unfold wholeRest F at *
     xperm_hyp hp') hpm
 
-#print axioms prologueAndMoves
 
 theorem setupAndCall
     (spOuter newSp listBase listLenW indexW outputPtr oldOut oldOffset oldLen old14 : Word)
@@ -180,7 +177,6 @@ theorem setupAndCall
   have hpgc' := cpsTripleWithin_weaken (fun _ hp => hp) hpost hpgc
   simpa only [show 7 + 4 = 11 by decide] using hpgc'
 
-#print axioms setupAndCall
 
 theorem rlpFieldToU64_spec_within
     (spOuter newSp listBase listLenW indexW outputPtr oldOut oldOffset oldLen old14 : Word)
@@ -219,6 +215,5 @@ theorem rlpFieldToU64_spec_within
     saved bytes listLen index (by rfl) hsalign hslack hover hvalid hnewSp hret
   exact cpsTripleWithin_seq_perm_same_cr (fun h hp => by xperm_hyp hp) hs ht
 
-#print axioms rlpFieldToU64_spec_within
 
 end EvmAsm.Codegen.RlpFieldToU64SAsm

--- a/EvmAsm/Codegen/Programs/RlpListCountItemsFlatSAsm.lean
+++ b/EvmAsm/Codegen/Programs/RlpListCountItemsFlatSAsm.lean
@@ -143,7 +143,6 @@ theorem rlpListCountItems_flat_spec_within
     simp only [stackFree_succ, stackFree_zero, sepConj_emp_right']
     xperm_hyp hq1
 
-#print axioms rlpListCountItems_flat_spec_within
 
 #guard rlpListCountItems_prog.length = 186
 

--- a/EvmAsm/Codegen/Programs/RlpListCountItemsSAsm.lean
+++ b/EvmAsm/Codegen/Programs/RlpListCountItemsSAsm.lean
@@ -154,9 +154,5 @@ theorem rlp_list_count_items_spec_within
     unfold initStable
     xperm_hyp hp0) hp hb
 
-#print axioms initializedToJoin
-#print axioms bodyToFinal
-#print axioms bodyToFinalOwned
-#print axioms rlp_list_count_items_spec_within
 
 end EvmAsm.Codegen.RlpListCountItemsSAsm

--- a/EvmAsm/Codegen/Programs/RlpListCountItemsSAsmBase.lean
+++ b/EvmAsm/Codegen/Programs/RlpListCountItemsSAsmBase.lean
@@ -116,8 +116,5 @@ theorem LoopInvariant.toFailure
   refine .walk cursorOff count off endPtr h_inv.h_list h_inv.h_prefix ?_
   simpa [h_inv.h_cursor] using h_fail
 
-#print axioms LoopInvariant.step
-#print axioms LoopInvariant.toSuccess
-#print axioms LoopInvariant.toFailure
 
 end EvmAsm.Codegen.RlpListCountItemsSAsm

--- a/EvmAsm/Codegen/Programs/RlpListCountItemsSAsmCode.lean
+++ b/EvmAsm/Codegen/Programs/RlpListCountItemsSAsmCode.lean
@@ -84,8 +84,5 @@ theorem callWalkNext {n : Nat} {Prest Q : Assertion} (oldRa : Word)
       (by rfl) (by rw [total_length]; norm_num) (by rw [total_length]; norm_num)
       a i h_code) walkNext_sub) h_call
 
-#print axioms reemit_byte_tie
-#print axioms callWalkInit
-#print axioms callWalkNext
 
 end EvmAsm.Codegen.RlpListCountItemsSAsm

--- a/EvmAsm/Codegen/Programs/RlpListCountItemsSAsmFrame.lean
+++ b/EvmAsm/Codegen/Programs/RlpListCountItemsSAsmFrame.lean
@@ -138,7 +138,5 @@ theorem wrapperPrologue (sp0 newSp listBase listLenW outPtr oldCount : Word)
   exact cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
     (fun _ hp => by unfold setupPost entryRest; xperm_hyp hp) h012
 
-#print axioms setupMoves
-#print axioms wrapperPrologue
 
 end EvmAsm.Codegen.RlpListCountItemsSAsm

--- a/EvmAsm/Codegen/Programs/RlpListCountItemsSAsmInit.lean
+++ b/EvmAsm/Codegen/Programs/RlpListCountItemsSAsmInit.lean
@@ -112,8 +112,5 @@ theorem initCallExact (listBase : Word) (bytes : List (BitVec 8))
   have hc := callWalkInit oldRa (by unfold Prest; pcf) hwi'
   simpa [Prest, Q] using hc
 
-#print axioms nthFailure_to_countFailure
-#print axioms initOutcome_to_normalized
-#print axioms initCallExact
 
 end EvmAsm.Codegen.RlpListCountItemsSAsm

--- a/EvmAsm/Codegen/Programs/RlpListCountItemsSAsmLoop.lean
+++ b/EvmAsm/Codegen/Programs/RlpListCountItemsSAsmLoop.lean
@@ -298,9 +298,5 @@ theorem initCallDispatchExact
       xperm_hyp hp) hcallN
       (initNormalizedDispatch newSp listBase outPtr oldCount saved bytes listLen))
 
-#print axioms initRejectBranch
-#print axioms initSuccessBranch
-#print axioms initNormalizedDispatch
-#print axioms initCallDispatchExact
 
 end EvmAsm.Codegen.RlpListCountItemsSAsm

--- a/EvmAsm/Codegen/Programs/RlpListCountItemsSAsmNext.lean
+++ b/EvmAsm/Codegen/Programs/RlpListCountItemsSAsmNext.lean
@@ -202,11 +202,5 @@ theorem incrementBack (count : Nat) (F : Assertion) (h_F : F.pcFree) :
   rw [sepConj_emp_left'] at hjF
   exact cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) haF hjF
 
-#print axioms nextCallBlock
-#print axioms headerDone
-#print axioms headerContinue
-#print axioms statusReject
-#print axioms statusOk
-#print axioms incrementBack
 
 end EvmAsm.Codegen.RlpListCountItemsSAsm

--- a/EvmAsm/Codegen/Programs/RlpListCountItemsSAsmRound.lean
+++ b/EvmAsm/Codegen/Programs/RlpListCountItemsSAsmRound.lean
@@ -471,16 +471,5 @@ theorem scanFromInit (newSp listBase outPtr oldCount : Word)
     unfold remaining
     omega) hloop
 
-#print axioms failureRegs_mono
-#print axioms nextOutcome_to_normalized
-#print axioms nextCallNormalized
-#print axioms dispatchDone
-#print axioms dispatchFailure
-#print axioms dispatchSuccess
-#print axioms cpsNBranchWithin_pre_or
-#print axioms afterCall
-#print axioms loopRound
-#print axioms strictCountLoop
-#print axioms scanFromInit
 
 end EvmAsm.Codegen.RlpListCountItemsSAsm

--- a/EvmAsm/Codegen/Programs/RlpListCountItemsSAsmTail.lean
+++ b/EvmAsm/Codegen/Programs/RlpListCountItemsSAsmTail.lean
@@ -407,13 +407,5 @@ theorem joinToFinal (sp0 newSp listBase outPtr : Word) (saved : Saved)
     unfold F at hp
     xperm_hyp hp) he
 
-#print axioms scratchExact_implies_owned
-#print axioms successTail
-#print axioms failureTailConcrete
-#print axioms failureTail
-#print axioms selectedTail
-#print axioms scanAndTails
-#print axioms epilogueOwned
-#print axioms joinToFinal
 
 end EvmAsm.Codegen.RlpListCountItemsSAsm

--- a/EvmAsm/Codegen/Programs/RlpListEncodedSizeSAsm.lean
+++ b/EvmAsm/Codegen/Programs/RlpListEncodedSizeSAsm.lean
@@ -535,9 +535,6 @@ theorem rlpListEncodedSize_spec
 
 end Routine
 
-#print axioms u64ByteLen_shift_zero
-#print axioms u64ByteLen_shift_ne
-#print axioms rlpListEncodedSize_spec
 
 end RlpListEncodedSizeSAsm
 

--- a/EvmAsm/Codegen/Programs/RlpListNthItemCallSAsm.lean
+++ b/EvmAsm/Codegen/Programs/RlpListNthItemCallSAsm.lean
@@ -148,6 +148,5 @@ theorem rlpListNthItem_call_spec_within
       calleeSaved bytes) hk''
   exact cpsTripleWithin_frameR F hF hcall
 
-#print axioms rlpListNthItem_call_spec_within
 
 end EvmAsm.Codegen.RlpListNthItemSAsm

--- a/EvmAsm/Codegen/Programs/RlpListNthItemSAsm.lean
+++ b/EvmAsm/Codegen/Programs/RlpListNthItemSAsm.lean
@@ -69,7 +69,6 @@ theorem initAndScanExact
       exact Or.inr hp
     · exact absurd hf List.not_mem_nil)
 
-#print axioms initAndScanExact
 
 /-- Concrete success tail (wrapper slots 22--27): compute the content offset,
     update both ABI output cells, set status zero, and jump to the restore join. -/
@@ -118,7 +117,6 @@ theorem selectedTailCore (listBase next len offsetPtr lenPtr oldOffset oldLen v5
       (by rw [total_length]; norm_num)) h5
   runBlock h0' h1' h2' h3' h4' h5'
 
-#print axioms selectedTailCore
 
 /-- Concrete failure tail (wrapper slot 28): set the ABI status to one. -/
 theorem rejectedTailCore (oldA0 : Word) :
@@ -130,7 +128,6 @@ theorem rejectedTailCore (oldA0 : Word) :
       (.LI .x10 (1 : Word)) (by bv_omega) (by rw [total_length]; norm_num) rfl
       (by rw [total_length]; norm_num)) h0
 
-#print axioms rejectedTailCore
 
 /-- Shared ABI epilogue (slots 29--37), parameterized by arbitrary current
     values of the seven restored registers and an arbitrary framed result. -/
@@ -192,7 +189,6 @@ theorem epilogueOwned (sp0 newSp : Word) (saved : Saved)
     rw [regsAt_listNthFrame]
     xperm_hyp hp) h123
 
-#print axioms epilogueOwned
 
 def joinResult (newSp listBase _indexW offsetPtr lenPtr oldOffset oldLen : Word)
     (saved : Saved) (bytes : List (BitVec 8)) (listLen index : Nat) : Assertion :=
@@ -354,7 +350,6 @@ theorem selectedToJoin
         xperm_hyp hallOwned
       · exact Result.ok _ _ ⟨cursorOff, endPtr, next, hlist, hnth, rfl⟩) hcF
 
-#print axioms selectedToJoin
 
 theorem scanRejected_implies_failure
     (newSp listBase indexW offsetPtr lenPtr oldOffset oldLen : Word)
@@ -372,7 +367,6 @@ theorem scanRejected_implies_failure
   exact .walk cursorOff count off endPtr hpure.2.2.1 hpure.2.1
     hpure.2.2.2.1 hpure.2.2.2.2
 
-#print axioms scanRejected_implies_failure
 
 theorem initRejected_implies_failure
     (newSp listBase indexW offsetPtr lenPtr oldOffset oldLen : Word)
@@ -398,8 +392,6 @@ theorem preTailRejected_implies_failure
   · exact initRejected_implies_failure newSp listBase indexW offsetPtr lenPtr
       oldOffset oldLen saved bytes listLen index h hp
 
-#print axioms initRejected_implies_failure
-#print axioms preTailRejected_implies_failure
 
 theorem preTailRejected_implies_result
     (newSp listBase indexW offsetPtr lenPtr oldOffset oldLen : Word)
@@ -411,7 +403,6 @@ theorem preTailRejected_implies_result
   exact .fail (preTailRejected_implies_failure newSp listBase indexW offsetPtr
     lenPtr oldOffset oldLen saved bytes listLen index h hp)
 
-#print axioms preTailRejected_implies_result
 
 def rejectedExpanded (newSp listBase indexW offsetPtr lenPtr oldOffset oldLen : Word)
     (saved : Saved) (bytes : List (BitVec 8)) (listLen index : Nat) : Assertion :=
@@ -497,7 +488,6 @@ theorem preTailRejected_to_expanded
     unfold R at howned
     xperm_hyp howned
 
-#print axioms preTailRejected_to_expanded
 
 /-- Run the one-instruction failure tail and fold its status into `Result.fail`. -/
 theorem rejectedExpandedToJoin
@@ -562,7 +552,6 @@ theorem rejectedExpandedToJoin
         (sepConj_pure_right h).2 ⟨?_, .fail hfailure⟩⟩
       xperm_hyp howned) ht
 
-#print axioms rejectedExpandedToJoin
 
 theorem rejectedToJoin
     (newSp listBase indexW offsetPtr lenPtr oldOffset oldLen : Word)
@@ -579,7 +568,6 @@ theorem rejectedToJoin
     (rejectedExpandedToJoin newSp listBase indexW offsetPtr lenPtr oldOffset oldLen
       saved bytes listLen index)
 
-#print axioms rejectedToJoin
 
 /-- Initialization, strict child scan, and both semantic tails reconverge at
     the single ABI restore join. -/
@@ -621,7 +609,6 @@ theorem initScanToJoinExact
     (selectedToJoin newSp listBase indexW offsetPtr lenPtr oldOffset oldLen saved
       bytes listLen index) hrejected
 
-#print axioms initScanToJoinExact
 
 def returnResult (sp0 newSp listBase _indexW offsetPtr lenPtr oldOffset oldLen : Word)
     (saved : Saved) (bytes : List (BitVec 8)) (listLen index : Nat) : Assertion :=
@@ -672,7 +659,6 @@ theorem joinToReturn
       (sepConj_pure_right h).2 ⟨?_, hresult⟩⟩
     xperm_hyp hp) he
 
-#print axioms joinToReturn
 
 theorem cpsTripleWithin_of_forall_regIs_to_regOwn7
     {n : Nat} {entry exit_ : Word} {cr : CodeReq}
@@ -740,7 +726,6 @@ theorem setupToJoin
     unfold P initStable
     xperm_hyp hp) (fun _ hq => hq) howned
 
-#print axioms setupToJoin
 
 /-- Unified whole-routine contract for the strict, spec-aligned K20 replacement.
     Preconditions are entirely static; success, parse rejection, and OOB are
@@ -775,7 +760,6 @@ theorem rlpListNthItem_spec_within
     saved bytes listLen index hnewSp hret
   exact cpsTripleWithin_seq_same_cr (cpsTripleWithin_seq_same_cr hp hc) he
 
-#print axioms rlpListNthItem_spec_within
 
 /-! ## Call-site adapter -/
 
@@ -978,6 +962,5 @@ theorem rlpListNthItem_flat_spec_within
     simp only [stackFree_succ, stackFree_zero, sepConj_emp_right']
     xperm_hyp hq1
 
-#print axioms rlpListNthItem_flat_spec_within
 
 end EvmAsm.Codegen.RlpListNthItemSAsm

--- a/EvmAsm/Codegen/Programs/RlpListNthItemSAsmBase.lean
+++ b/EvmAsm/Codegen/Programs/RlpListNthItemSAsmBase.lean
@@ -602,8 +602,6 @@ theorem callWalkNext {n : Nat} {Prest Q : Assertion} (oldRa : Word)
         (by rw [total_length]; norm_num) (by rw [total_length]; norm_num) a i hc)
     walkNext_sub) hcall
 
-#print axioms callWalkInit
-#print axioms callWalkNext
 
 /-! ## Indexed wrapper-loop assertions -/
 
@@ -794,8 +792,6 @@ theorem wrapperPrologue (sp0 newSp listBase listLenW indexW offsetPtr lenPtr
   exact cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
     (fun _ hp => by unfold setupPost entryRest; xperm_hyp hp) h012
 
-#print axioms setupMoves
-#print axioms wrapperPrologue
 
 def initStable (newSp listBase indexW offsetPtr lenPtr oldOffset oldLen : Word)
     (saved : Saved) : Assertion :=
@@ -953,7 +949,6 @@ theorem initCallExact (listBase : Word) (bytes : List (BitVec 8))
   have hc := callWalkInit oldRa (by unfold Prest; pcf) hwi'
   simpa [Prest, Q] using hc
 
-#print axioms initCallExact
 
 def initNormalized (listBase : Word) (bytes : List (BitVec 8))
     (listLen index : Nat) : Assertion := fun h =>
@@ -1101,7 +1096,6 @@ theorem initOutcome_to_normalized (listBase : Word) (bytes : List (BitVec 8))
     exact Or.inl ⟨cursorOff, listBase + BitVec.ofNat 64 listLen, by
       exact threeRegs_pure_mono (fun _ => hlist) h hl⟩
 
-#print axioms initOutcome_to_normalized
 
 def initRejected (newSp listBase indexW offsetPtr lenPtr oldOffset oldLen : Word)
     (saved : Saved) (bytes : List (BitVec 8)) (listLen index : Nat) : Assertion :=
@@ -1165,7 +1159,6 @@ theorem initRejectBranch (newSp listBase indexW offsetPtr lenPtr oldOffset oldLe
     unfold initCommon at hp' ⊢
     xperm_hyp hp') htF
 
-#print axioms initRejectBranch
 
 /-- Stable resources other than `s4`; `x20` is separated because slot 16 reads
     it while preparing the WalkNext call. -/
@@ -1340,7 +1333,6 @@ theorem initSuccessBranch (newSp listBase indexW offsetPtr lenPtr oldOffset oldL
       exact (sepConj_pure_right g).2 ⟨hg,
         ⟨by omega, by omega, hlist.cursor_le, StrictPrefix.zero⟩⟩) h hbase) h012
 
-#print axioms initSuccessBranch
 
 theorem cpsNBranchWithin_pre_or_init {n : Nat} {entry : Word} {cr : CodeReq}
     {P1 P2 : Assertion} {exits : List (Word × Assertion)}

--- a/EvmAsm/Codegen/Programs/RlpListNthItemSAsmScan.lean
+++ b/EvmAsm/Codegen/Programs/RlpListNthItemSAsmScan.lean
@@ -122,7 +122,6 @@ theorem initNormalizedDispatch (newSp listBase indexW offsetPtr lenPtr oldOffset
       xperm_hyp hall'
     ) harms
 
-#print axioms initNormalizedDispatch
 
 /-- The embedded strict initializer followed by its local status dispatch. -/
 theorem initCallDispatchExact
@@ -170,7 +169,6 @@ theorem initCallDispatchExact
     (cpsTripleWithin_seq_cpsNBranchWithin_perm_same_cr (fun h hp => by
       xperm_hyp hp) hcallN hdispatch)
 
-#print axioms initCallDispatchExact
 
 /-- Loop success station (`B+88`), before the two output stores. -/
 def loopSelected (newSp listBase indexW offsetPtr lenPtr endPtr oldOffset oldLen : Word)
@@ -327,7 +325,6 @@ theorem nextCallBlock (listBase endPtr : Word) (bytes : List (BitVec 8))
   exact cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp)
     (fun _ hq => by unfold nextCommon; exact hq) hc
 
-#print axioms nextCallBlock
 
 /-! ## Wrapper dispatch instructions -/
 
@@ -441,11 +438,6 @@ theorem incrementBack (count : Nat) (F : Assertion) (hF : F.pcFree)
   rw [sepConj_emp_left'] at hjF
   exact cpsTripleWithin_seq_perm_same_cr (fun h hp => by xperm_hyp hp) haF hjF
 
-#print axioms statusReject
-#print axioms statusOk
-#print axioms indexSelected
-#print axioms indexContinue
-#print axioms incrementBack
 
 /-! ## Semantic dispatch adapters -/
 
@@ -486,7 +478,6 @@ theorem dispatchFailure
     unfold nextScratchOwned at hq'
     xperm_hyp hq'
 
-#print axioms dispatchFailure
 
 theorem dispatchSuccess
     (newSp listBase indexW offsetPtr lenPtr endPtr oldOffset oldLen : Word)
@@ -583,7 +574,6 @@ theorem dispatchSuccess
     unfold nextScratchOwned at hq'
     xperm_hyp hq'
 
-#print axioms dispatchSuccess
 
 theorem cpsNBranchWithin_pre_or {n : Nat} {entry : Word} {cr : CodeReq}
     {P1 P2 : Assertion} {exits : List (Word × Assertion)}
@@ -596,7 +586,6 @@ theorem cpsNBranchWithin_pre_or {n : Nat} {entry : Word} {cr : CodeReq}
   · exact h1 R hR s hcr ⟨hp, hcompat, ha, hb, hd, hu, hP, hRb⟩ hpc
   · exact h2 R hR s hcr ⟨hp, hcompat, ha, hb, hd, hu, hP, hRb⟩ hpc
 
-#print axioms cpsNBranchWithin_pre_or
 
 /-! ## One complete loop round and the measure fold -/
 
@@ -674,8 +663,6 @@ theorem callFail_shape
   unfold nextScratch stableFrame
   xperm_hyp hp'
 
-#print axioms callOk_shape
-#print axioms callFail_shape
 
 theorem failureRegs_mono (listBase endPtr : Word) (bytes : List (BitVec 8))
     (off : Nat) (status : Word) (P : Prop)
@@ -864,7 +851,6 @@ theorem loopRound
       unfold stableRest savedFrame at hp ⊢
       xperm_hyp hp) hseq)
 
-#print axioms loopRound
 
 /-- The strict list scan folded over the remaining-index measure. -/
 theorem listNthLoop
@@ -895,7 +881,6 @@ theorem listNthLoop
         oldLen saved bytes listLen index cursorOff hindexW hindex hlist hsalign
         hslack hover hvalid j') j)
 
-#print axioms listNthLoop
 
 def scanSelected (newSp listBase indexW offsetPtr lenPtr oldOffset oldLen : Word)
     (saved : Saved) (bytes : List (BitVec 8)) (listLen index : Nat) : Assertion :=
@@ -970,6 +955,5 @@ theorem scanFromInit
     unfold F
     xperm_hyp hp) hn'
 
-#print axioms scanFromInit
 
 end EvmAsm.Codegen.RlpListNthItemSAsm

--- a/EvmAsm/Codegen/Programs/RlpWalkCallSAsm.lean
+++ b/EvmAsm/Codegen/Programs/RlpWalkCallSAsm.lean
@@ -220,12 +220,5 @@ theorem walk_init_next_13
   have h₁₂ := cpsTripleWithin_seq_same_cr h₁₁ h_next₁₂
   exact cpsTripleWithin_seq_same_cr h₁₂ h_next₁₃
 
-#print axioms rlp_walk_init_call_within
-#print axioms rlp_walk_next_call_within
-#print axioms walk_call_seq
-#print axioms walk_init_next_4
-#print axioms walk_init_next_6
-#print axioms walk_init_next_17
-#print axioms walk_init_next_13
 
 end EvmAsm.Codegen.RlpWalkCallSAsm

--- a/EvmAsm/Codegen/Programs/RlpWalkInitFlatSAsm.lean
+++ b/EvmAsm/Codegen/Programs/RlpWalkInitFlatSAsm.lean
@@ -53,6 +53,5 @@ theorem rlp_walk_init_flat_spec_within
       t3Old t4Old t5Old t6Old listBytes listOff hsalign hoff hover hvalid hll_len
       hll_over hll_valid)
 
-#print axioms rlp_walk_init_flat_spec_within
 
 end EvmAsm.Codegen.RlpWalkInitFlatSAsm

--- a/EvmAsm/Codegen/Programs/RlpWalkNextFlatSAsm.lean
+++ b/EvmAsm/Codegen/Programs/RlpWalkNextFlatSAsm.lean
@@ -55,6 +55,5 @@ theorem rlp_walk_next_flat_spec_within
     (rlp_walk_next_spec_within base srcBase endPtr raVal a2Old t0Old t1Old t2Old
       t3Old t4Old t5Old t6Old srcBytes srcOff hsalign hoff hover hvalid hss hls hll)
 
-#print axioms rlp_walk_next_flat_spec_within
 
 end EvmAsm.Codegen.RlpWalkNextFlatSAsm

--- a/EvmAsm/Codegen/Programs/Secp256k1FieldCmpPSAsm.lean
+++ b/EvmAsm/Codegen/Programs/Secp256k1FieldCmpPSAsm.lean
@@ -935,7 +935,6 @@ theorem secfCmpP_spec (inPtr outPtr ret : Word) (xs : List (BitVec 8))
     (fun h hq => by unfold cmpPost at hq; exact hq)
     (cpsTripleWithin_mono_nSteps (by omega) hc3)
 
-#print axioms secfCmpP_spec
 
 end Secp256k1FieldCmpPSAsm
 

--- a/EvmAsm/Codegen/Programs/Secp256k1FieldMulModPSAsm.lean
+++ b/EvmAsm/Codegen/Programs/Secp256k1FieldMulModPSAsm.lean
@@ -734,10 +734,6 @@ theorem secfMulModP_spec (sp0 aPtr bPtr outPtr ret v8 v9 : Word)
     (hsub := by code_mem)
     (hbody := hbody)
 
-#print axioms secfBeToLeFlat_spec
-#print axioms secfLeToBeFlat_spec
-#print axioms csrsStep_spec
-#print axioms secfMulModP_spec
 
 end Secp256k1FieldMulModPSAsm
 

--- a/EvmAsm/Codegen/Programs/Secp256k1FieldReduceOnceNSAsm.lean
+++ b/EvmAsm/Codegen/Programs/Secp256k1FieldReduceOnceNSAsm.lean
@@ -515,7 +515,6 @@ theorem secfReduceOnceNFrame_spec (sp0 ret src dst s0 s1 v12 : Word)
       rw [hnewSp]
       xperm_hyp hq) h1234
 
-#print axioms secfReduceOnceNFrame_spec
 
 end Secp256k1FieldReduceOnceNSAsm
 

--- a/EvmAsm/Codegen/Programs/Secp256k1FieldReduceOnceSAsm.lean
+++ b/EvmAsm/Codegen/Programs/Secp256k1FieldReduceOnceSAsm.lean
@@ -513,7 +513,6 @@ theorem secfReduceOnceFrame_spec (sp0 ret src dst s0 s1 v12 : Word)
       rw [hnewSp]
       xperm_hyp hq) h1234
 
-#print axioms secfReduceOnceFrame_spec
 
 end Secp256k1FieldReduceOnceSAsm
 

--- a/EvmAsm/Codegen/Programs/Secp256k1FieldSubModPSAsm.lean
+++ b/EvmAsm/Codegen/Programs/Secp256k1FieldSubModPSAsm.lean
@@ -1232,7 +1232,6 @@ theorem secfSubModP_spec
   exact cpsTripleWithin_weaken (fun _ hp => by rw [hnewSp]; xperm_hyp hp)
     (fun _ hq => by rw [hnewSp]; xperm_hyp hq) h1234
 
-#print axioms secfSubModP_spec
 
 end Secp256k1FieldSubModPSAsm
 

--- a/EvmAsm/Codegen/Programs/Secp256k1PointDoubleSAsm.lean
+++ b/EvmAsm/Codegen/Programs/Secp256k1PointDoubleSAsm.lean
@@ -604,13 +604,6 @@ theorem pointDouble_spec (sp0 inPtr outPtr ret v8 v9 : Word)
         xBE yBE oX oY ws hxlen hylen hoXlen hoYlen hwslen hwfX hwfY
         hoal hoov hovalid harval hdIn hdOut hxlt hylt hy0)
 
-#print axioms pointDouble_spec
-#print axioms pointDoubleRegBody_spec
-#print axioms curveStep_spec
-#print axioms secfBeToLeFlat_spec
-#print axioms secfLeToBeFlat_spec
-#print axioms secfIsZero32Flat_spec
-#print axioms secfZero32Flat_spec
 
 end Secp256k1PointDoubleSAsm
 


### PR DESCRIPTION
Batch-merge of #10380 #10381 #10382 (all author pirapira).

Verified locally: `lake build` (4694/4694 jobs) + all `scripts/check-*.sh` gates green (no layout drift — these only remove in-source `#print axioms` doc-comments, no code/proof changes).

Combines these three independent PRs into a single integration branch to amortize CI cost. Merged with real merge commits (no squash) to preserve per-PR commit attribution.