### PR TITLE
chore: gitignore completeness audit (OS cruft, editor backups, agent scratch dirs)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,22 @@ docs/agents/phase*-bootstrap.md
 docs/agents/rollout-complete.md
 build.log
 log.txt
+
+# OS cruft (macOS Finder / Windows)
+.DS_Store
+Thumbs.db
+
+# Editor swap / backup files
+*.swp
+*.swo
+*~
+*.bak
+*.orig
+*.rej
+
+# AI agent local scratch dirs (analogous to .claude/ .codex/ .opencode/;
+# .opencode/ is added separately in #10379)
+.gemini/
+.cursor/
+.aider*
+.continue/


### PR DESCRIPTION
Add genuinely-missing preventive ignore patterns (low-risk hygiene; no tracked file is newly affected — verified via `git check-ignore`):

- **OS cruft**: `.DS_Store`, `Thumbs.db` (macOS Finder / Windows)
- **Editor swap/backup**: `*.swp`, `*.swo`, `*~`, `*.bak`, `*.orig`, `*.rej`
- **AI agent scratch dirs** (analogous to the existing `.claude/` `.codex/` entries): `.gemini/`, `.cursor/`, `.aider*`, `.continue/`

`.opencode/` is added separately in #10379 (kept apart to avoid a .gitignore edit-conflict between the two PRs).