### PR TITLE
proof(withdrawal): withdrawalDecode caller Fn.Spec (pkljc-unblocked, multi-field decoder)

### DIFF
--- a/EvmAsm/Codegen/Programs/Imports.lean
+++ b/EvmAsm/Codegen/Programs/Imports.lean
@@ -306,6 +306,7 @@ import EvmAsm.Codegen.Programs.HeadersKeccak
 import EvmAsm.Codegen.Programs.HeaderU64
 import EvmAsm.Codegen.Programs.HeaderExtractNumberSpec
 import EvmAsm.Codegen.Programs.WithdrawalDecodeSpec
+import EvmAsm.Codegen.Programs.WithdrawalDecodeClose
 import EvmAsm.Codegen.Programs.Receipt
 import EvmAsm.Codegen.Programs.State
 import EvmAsm.Codegen.Programs.StateCompose

--- a/EvmAsm/Codegen/Programs/Imports.lean
+++ b/EvmAsm/Codegen/Programs/Imports.lean
@@ -309,6 +309,7 @@ import EvmAsm.Codegen.Programs.WithdrawalDecodeSpec
 import EvmAsm.Codegen.Programs.WithdrawalDecodeLoop
 import EvmAsm.Codegen.Programs.WithdrawalDecodeClose
 import EvmAsm.Codegen.Programs.WithdrawalDecodeClose2
+import EvmAsm.Codegen.Programs.WithdrawalDecodeClose3
 import EvmAsm.Codegen.Programs.Receipt
 import EvmAsm.Codegen.Programs.State
 import EvmAsm.Codegen.Programs.StateCompose

--- a/EvmAsm/Codegen/Programs/Imports.lean
+++ b/EvmAsm/Codegen/Programs/Imports.lean
@@ -310,6 +310,7 @@ import EvmAsm.Codegen.Programs.WithdrawalDecodeLoop
 import EvmAsm.Codegen.Programs.WithdrawalDecodeClose
 import EvmAsm.Codegen.Programs.WithdrawalDecodeClose2
 import EvmAsm.Codegen.Programs.WithdrawalDecodeClose3
+import EvmAsm.Codegen.Programs.WithdrawalDecodeClose4
 import EvmAsm.Codegen.Programs.Receipt
 import EvmAsm.Codegen.Programs.State
 import EvmAsm.Codegen.Programs.StateCompose

--- a/EvmAsm/Codegen/Programs/Imports.lean
+++ b/EvmAsm/Codegen/Programs/Imports.lean
@@ -308,6 +308,7 @@ import EvmAsm.Codegen.Programs.HeaderExtractNumberSpec
 import EvmAsm.Codegen.Programs.WithdrawalDecodeSpec
 import EvmAsm.Codegen.Programs.WithdrawalDecodeLoop
 import EvmAsm.Codegen.Programs.WithdrawalDecodeClose
+import EvmAsm.Codegen.Programs.WithdrawalDecodeClose2
 import EvmAsm.Codegen.Programs.Receipt
 import EvmAsm.Codegen.Programs.State
 import EvmAsm.Codegen.Programs.StateCompose

--- a/EvmAsm/Codegen/Programs/Imports.lean
+++ b/EvmAsm/Codegen/Programs/Imports.lean
@@ -306,6 +306,7 @@ import EvmAsm.Codegen.Programs.HeadersKeccak
 import EvmAsm.Codegen.Programs.HeaderU64
 import EvmAsm.Codegen.Programs.HeaderExtractNumberSpec
 import EvmAsm.Codegen.Programs.WithdrawalDecodeSpec
+import EvmAsm.Codegen.Programs.WithdrawalDecodeLoop
 import EvmAsm.Codegen.Programs.WithdrawalDecodeClose
 import EvmAsm.Codegen.Programs.Receipt
 import EvmAsm.Codegen.Programs.State

--- a/EvmAsm/Codegen/Programs/Imports.lean
+++ b/EvmAsm/Codegen/Programs/Imports.lean
@@ -311,6 +311,7 @@ import EvmAsm.Codegen.Programs.WithdrawalDecodeClose
 import EvmAsm.Codegen.Programs.WithdrawalDecodeClose2
 import EvmAsm.Codegen.Programs.WithdrawalDecodeClose3
 import EvmAsm.Codegen.Programs.WithdrawalDecodeClose4
+import EvmAsm.Codegen.Programs.WithdrawalDecodeClose5
 import EvmAsm.Codegen.Programs.Receipt
 import EvmAsm.Codegen.Programs.State
 import EvmAsm.Codegen.Programs.StateCompose

--- a/EvmAsm/Codegen/Programs/Imports.lean
+++ b/EvmAsm/Codegen/Programs/Imports.lean
@@ -305,6 +305,7 @@ import EvmAsm.Codegen.Programs.BlockHashPredicates
 import EvmAsm.Codegen.Programs.HeadersKeccak
 import EvmAsm.Codegen.Programs.HeaderU64
 import EvmAsm.Codegen.Programs.HeaderExtractNumberSpec
+import EvmAsm.Codegen.Programs.WithdrawalDecodeSpec
 import EvmAsm.Codegen.Programs.Receipt
 import EvmAsm.Codegen.Programs.State
 import EvmAsm.Codegen.Programs.StateCompose

--- a/EvmAsm/Codegen/Programs/WithdrawalDecodeClose.lean
+++ b/EvmAsm/Codegen/Programs/WithdrawalDecodeClose.lean
@@ -288,4 +288,52 @@ theorem wdEpiCore
 
 #print axioms wdEpiCore
 
+/-! ## Status-return tails ([51]-[52] success, [53] failure) -/
+
+set_option maxRecDepth 8000 in
+/-- Success tail [51]-[52]: set `a0 := 0` and jump over the failure store to the
+    epilogue entry (`WB+216`).  Generic over the untouched frame `G`. -/
+theorem wdSuccessTail (v10old : Word) (G : Assertion) (hG : G.pcFree) :
+    cpsTripleWithin 2 (WB + 204) (WB + 216) fullCode
+      (((.x10 : Reg) ↦ᵣ v10old) ** G)
+      (((.x10 : Reg) ↦ᵣ (0 : Word)) ** G) := by
+  -- [51] LI x10 0
+  have h0 := li_spec_gen_within .x10 v10old (0 : Word) (WB + 204) (by decide)
+  have h0' := cpsTripleWithin_extend_code wd_mono
+    (cpsTripleWithin_extend_code (cr' := wdCode)
+      (CodeReq.ofProg_mem_at WB (WB + 204) withdrawalDecode_prog 51
+        (.LI .x10 (0 : Word)) (by bv_omega) (by rw [wd_length]; decide) rfl
+        (by rw [wd_length]; decide)) h0)
+  -- [52] JAL x0 8 : jump to WB+216 (preserves the whole footprint)
+  have h1 := jal0_spec_pcFree (P := ((.x10 : Reg) ↦ᵣ (0 : Word)) ** G) (8 : BitVec 21)
+    (WB + 208) (pcFree_sepConj pcFree_regIs hG)
+  rw [show WB + 208 + signExtend21 (8 : BitVec 21) = WB + 216 from by decide] at h1
+  have h1' := cpsTripleWithin_extend_code wd_mono
+    (cpsTripleWithin_extend_code (cr' := wdCode)
+      (CodeReq.ofProg_mem_at WB (WB + 208) withdrawalDecode_prog 52
+        (.JAL .x0 (8 : BitVec 21)) (by bv_omega) (by rw [wd_length]; decide) rfl
+        (by rw [wd_length]; decide)) h1)
+  have f0 := cpsTripleWithin_frameR G hG h0'
+  exact cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) f0 h1'
+
+#print axioms wdSuccessTail
+
+set_option maxRecDepth 8000 in
+/-- Failure tail [53]: set `a0 := 1` and fall through to the epilogue entry
+    (`WB+216`).  Generic over the untouched frame `G`. -/
+theorem wdFailTail (v10old : Word) (G : Assertion) (hG : G.pcFree) :
+    cpsTripleWithin 1 (WB + 212) (WB + 216) fullCode
+      (((.x10 : Reg) ↦ᵣ v10old) ** G)
+      (((.x10 : Reg) ↦ᵣ (1 : Word)) ** G) := by
+  have h0 := li_spec_gen_within .x10 v10old (1 : Word) (WB + 212) (by decide)
+  rw [show (WB + 212 : Word) + 4 = WB + 216 from by bv_omega] at h0
+  have h0' := cpsTripleWithin_extend_code wd_mono
+    (cpsTripleWithin_extend_code (cr' := wdCode)
+      (CodeReq.ofProg_mem_at WB (WB + 212) withdrawalDecode_prog 53
+        (.LI .x10 (1 : Word)) (by bv_omega) (by rw [wd_length]; decide) rfl
+        (by rw [wd_length]; decide)) h0)
+  exact cpsTripleWithin_frameR G hG h0'
+
+#print axioms wdFailTail
+
 end EvmAsm.Codegen.WithdrawalDecodeSpec

--- a/EvmAsm/Codegen/Programs/WithdrawalDecodeClose.lean
+++ b/EvmAsm/Codegen/Programs/WithdrawalDecodeClose.lean
@@ -168,4 +168,124 @@ theorem wdPrologue
 
 #print axioms wdPrologue
 
+/-! ## Epilogue core (instructions [54]-[59]) -/
+
+set_option maxRecDepth 8000 in
+/-- Restore `ra/s0/s1/s2` from the four stack slots, deallocate the 32-byte
+    frame, and return.  Generic over the callee result footprint `G`. -/
+theorem wdEpiCore
+    (sp0 spW raIn s0Old s1Old s2Old x1old x8old x9old x18old : Word)
+    (G : Assertion) (hG : G.pcFree)
+    (hspW : spW = sp0 + signExtend12 (-32 : BitVec 12))
+    (hret : raIn &&& ~~~(1 : Word) = raIn) :
+    cpsTripleWithin 6 (WB + 216) raIn fullCode
+      (((.x2 ↦ᵣ spW) ** (.x1 ↦ᵣ x1old) ** (.x8 ↦ᵣ x8old) ** (.x9 ↦ᵣ x9old) **
+        (.x18 ↦ᵣ x18old) ** (spW ↦ₘ raIn) ** ((spW + 8) ↦ₘ s0Old) **
+        ((spW + 16) ↦ₘ s1Old) ** ((spW + 24) ↦ₘ s2Old)) ** G)
+      (((.x2 ↦ᵣ sp0) ** (.x1 ↦ᵣ raIn) ** (.x8 ↦ᵣ s0Old) ** (.x9 ↦ᵣ s1Old) **
+        (.x18 ↦ᵣ s2Old) ** (spW ↦ₘ raIn) ** ((spW + 8) ↦ₘ s0Old) **
+        ((spW + 16) ↦ₘ s1Old) ** ((spW + 24) ↦ₘ s2Old)) ** G) := by
+  have hz0 : signExtend12 (0 : BitVec 12) = (0 : Word) := by decide
+  have hz8 : signExtend12 (8 : BitVec 12) = (8 : Word) := by decide
+  have hz16 : signExtend12 (16 : BitVec 12) = (16 : Word) := by decide
+  have hz24 : signExtend12 (24 : BitVec 12) = (24 : Word) := by decide
+  -- [54] LD x1 x2 0 : restore ra
+  have h0 := ld_spec_gen_within .x1 .x2 spW x1old raIn (0 : BitVec 12) (WB + 216)
+    (by decide)
+  rw [hz0, show spW + (0 : Word) = spW from by bv_omega] at h0
+  have h0' := cpsTripleWithin_extend_code wd_mono
+    (cpsTripleWithin_extend_code (cr' := wdCode)
+      (CodeReq.ofProg_mem_at WB (WB + 216) withdrawalDecode_prog 54
+        (.LD .x1 .x2 (0 : BitVec 12)) (by bv_omega) (by rw [wd_length]; decide)
+        rfl (by rw [wd_length]; decide)) h0)
+  -- [55] LD x8 x2 8 : restore s0
+  have h1 := ld_spec_gen_within .x8 .x2 spW x8old s0Old (8 : BitVec 12) (WB + 220)
+    (by decide)
+  rw [hz8] at h1
+  have h1' := cpsTripleWithin_extend_code wd_mono
+    (cpsTripleWithin_extend_code (cr' := wdCode)
+      (CodeReq.ofProg_mem_at WB (WB + 220) withdrawalDecode_prog 55
+        (.LD .x8 .x2 (8 : BitVec 12)) (by bv_omega) (by rw [wd_length]; decide)
+        rfl (by rw [wd_length]; decide)) h1)
+  -- [56] LD x9 x2 16 : restore s1
+  have h2 := ld_spec_gen_within .x9 .x2 spW x9old s1Old (16 : BitVec 12) (WB + 224)
+    (by decide)
+  rw [hz16] at h2
+  have h2' := cpsTripleWithin_extend_code wd_mono
+    (cpsTripleWithin_extend_code (cr' := wdCode)
+      (CodeReq.ofProg_mem_at WB (WB + 224) withdrawalDecode_prog 56
+        (.LD .x9 .x2 (16 : BitVec 12)) (by bv_omega) (by rw [wd_length]; decide)
+        rfl (by rw [wd_length]; decide)) h2)
+  -- [57] LD x18 x2 24 : restore s2
+  have h3 := ld_spec_gen_within .x18 .x2 spW x18old s2Old (24 : BitVec 12) (WB + 228)
+    (by decide)
+  rw [hz24] at h3
+  have h3' := cpsTripleWithin_extend_code wd_mono
+    (cpsTripleWithin_extend_code (cr' := wdCode)
+      (CodeReq.ofProg_mem_at WB (WB + 228) withdrawalDecode_prog 57
+        (.LD .x18 .x2 (24 : BitVec 12)) (by bv_omega) (by rw [wd_length]; decide)
+        rfl (by rw [wd_length]; decide)) h3)
+  -- [58] ADDI x2 x2 32 : deallocate
+  have h4 := addi_spec_gen_same_within .x2 spW (32 : BitVec 12) (WB + 232) (by decide)
+  rw [show spW + signExtend12 (32 : BitVec 12) = sp0 from by
+    rw [hspW]; exact sext_frameRestore sp0 (-32 : BitVec 12) (32 : BitVec 12)
+      (by decide)] at h4
+  have h4' := cpsTripleWithin_extend_code wd_mono
+    (cpsTripleWithin_extend_code (cr' := wdCode)
+      (CodeReq.ofProg_mem_at WB (WB + 232) withdrawalDecode_prog 58
+        (.ADDI .x2 .x2 (32 : BitVec 12)) (by bv_omega) (by rw [wd_length]; decide)
+        rfl (by rw [wd_length]; decide)) h4)
+  -- [59] JALR x0 x1 0 : return
+  have h5 := EvmAsm.Evm64.ret_spec_within' (WB + 236) raIn
+  rw [hret] at h5
+  have h5' := cpsTripleWithin_extend_code wd_mono
+    (cpsTripleWithin_extend_code (cr' := wdCode)
+      (CodeReq.ofProg_mem_at WB (WB + 236) withdrawalDecode_prog 59
+        (.JALR .x0 .x1 (0 : BitVec 12)) (by bv_omega) (by rw [wd_length]; decide)
+        rfl (by rw [wd_length]; decide)) h5)
+  -- Frame each instruction over the untouched local cells.
+  have f0 := cpsTripleWithin_frameR
+    ((.x8 ↦ᵣ x8old) ** (.x9 ↦ᵣ x9old) ** (.x18 ↦ᵣ x18old) **
+     ((spW + 8) ↦ₘ s0Old) ** ((spW + 16) ↦ₘ s1Old) ** ((spW + 24) ↦ₘ s2Old))
+    (by pcf) h0'
+  have f1 := cpsTripleWithin_frameR
+    ((.x1 ↦ᵣ raIn) ** (.x9 ↦ᵣ x9old) ** (.x18 ↦ᵣ x18old) **
+     (spW ↦ₘ raIn) ** ((spW + 16) ↦ₘ s1Old) ** ((spW + 24) ↦ₘ s2Old))
+    (by pcf) h1'
+  have f2 := cpsTripleWithin_frameR
+    ((.x1 ↦ᵣ raIn) ** (.x8 ↦ᵣ s0Old) ** (.x18 ↦ᵣ x18old) **
+     (spW ↦ₘ raIn) ** ((spW + 8) ↦ₘ s0Old) ** ((spW + 24) ↦ₘ s2Old))
+    (by pcf) h2'
+  have f3 := cpsTripleWithin_frameR
+    ((.x1 ↦ᵣ raIn) ** (.x8 ↦ᵣ s0Old) ** (.x9 ↦ᵣ s1Old) **
+     (spW ↦ₘ raIn) ** ((spW + 8) ↦ₘ s0Old) ** ((spW + 16) ↦ₘ s1Old))
+    (by pcf) h3'
+  have f4 := cpsTripleWithin_frameR
+    ((.x1 ↦ᵣ raIn) ** (.x8 ↦ᵣ s0Old) ** (.x9 ↦ᵣ s1Old) ** (.x18 ↦ᵣ s2Old) **
+     (spW ↦ₘ raIn) ** ((spW + 8) ↦ₘ s0Old) ** ((spW + 16) ↦ₘ s1Old) **
+     ((spW + 24) ↦ₘ s2Old)) (by pcf) h4'
+  have f5 := cpsTripleWithin_frameR
+    ((.x2 ↦ᵣ sp0) ** (.x8 ↦ᵣ s0Old) ** (.x9 ↦ᵣ s1Old) ** (.x18 ↦ᵣ s2Old) **
+     (spW ↦ₘ raIn) ** ((spW + 8) ↦ₘ s0Old) ** ((spW + 16) ↦ₘ s1Old) **
+     ((spW + 24) ↦ₘ s2Old)) (by pcf) h5'
+  have c01 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) f0 f1
+  have c012 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) c01 f2
+  have c0123 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) c012 f3
+  have c04 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) c0123 f4
+  have c05 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) c04 f5
+  have hlocal : cpsTripleWithin 6 (WB + 216) raIn fullCode
+      ((.x2 ↦ᵣ spW) ** (.x1 ↦ᵣ x1old) ** (.x8 ↦ᵣ x8old) ** (.x9 ↦ᵣ x9old) **
+        (.x18 ↦ᵣ x18old) ** (spW ↦ₘ raIn) ** ((spW + 8) ↦ₘ s0Old) **
+        ((spW + 16) ↦ₘ s1Old) ** ((spW + 24) ↦ₘ s2Old))
+      ((.x2 ↦ᵣ sp0) ** (.x1 ↦ᵣ raIn) ** (.x8 ↦ᵣ s0Old) ** (.x9 ↦ᵣ s1Old) **
+        (.x18 ↦ᵣ s2Old) ** (spW ↦ₘ raIn) ** ((spW + 8) ↦ₘ s0Old) **
+        ((spW + 16) ↦ₘ s1Old) ** ((spW + 24) ↦ₘ s2Old)) :=
+    cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
+      (fun _ hq => by xperm_hyp hq) c05
+  have hframed := cpsTripleWithin_frameR G hG hlocal
+  exact cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
+    (fun _ hq => by xperm_hyp hq) hframed
+
+#print axioms wdEpiCore
+
 end EvmAsm.Codegen.WithdrawalDecodeSpec

--- a/EvmAsm/Codegen/Programs/WithdrawalDecodeClose.lean
+++ b/EvmAsm/Codegen/Programs/WithdrawalDecodeClose.lean
@@ -1,0 +1,171 @@
+/-
+  `withdrawalDecode_prog` caller-contract composition (in progress).
+
+  This module hosts the straight-line block lemmas of the 60-instruction
+  accessor that bookend the four field decodes:
+
+    * `wdPrologue`  — instructions [0]-[7]: allocate the 32-byte frame, save
+      `ra/s0/s1/s2`, and load `s0/s1/s2 := a0/a1/a2` (list ptr / len / output).
+    * `wdEpiCore`   — instructions [54]-[59]: restore `ra/s0/s1/s2`, deallocate,
+      and return, generic over the callee result footprint `G`.
+
+  Both are stated generic over an untouched frame `G`, exactly like
+  `HeaderExtractNumberSpec.epiCore`, so the eventual four-field compose can
+  thread its live footprint through them.
+
+  No `sorry`/`admit`/`native_decide`/`bv_decide`; classical-3 axioms only.
+-/
+
+import EvmAsm.Codegen.Programs.WithdrawalDecodeSpec
+
+namespace EvmAsm.Codegen.WithdrawalDecodeSpec
+
+open EvmAsm.Rv64 EvmAsm.Rv64.SAsm
+
+/-! ## Prologue (instructions [0]-[7]) -/
+
+set_option maxRecDepth 8000 in
+/-- Allocate the 32-byte frame, save `ra/s0/s1/s2` into the four stack slots,
+    and copy the three ABI arguments into the callee-saved registers
+    (`s0 := a0 = list ptr`, `s1 := a1 = len`, `s2 := a2 = output ptr`), leaving
+    `a0/a1/a2` intact.  Generic over the untouched frame `G`. -/
+theorem wdPrologue
+    (sp0 spW raIn s0Old s1Old s2Old listBase listLen outBase : Word)
+    (G : Assertion) (hG : G.pcFree)
+    (hspW : spW = sp0 + signExtend12 (-32 : BitVec 12)) :
+    cpsTripleWithin 8 WB (WB + 32) fullCode
+      (((.x2 ↦ᵣ sp0) ** (.x1 ↦ᵣ raIn) ** (.x8 ↦ᵣ s0Old) ** (.x9 ↦ᵣ s1Old) **
+        (.x18 ↦ᵣ s2Old) ** (.x10 ↦ᵣ listBase) ** (.x11 ↦ᵣ listLen) **
+        (.x12 ↦ᵣ outBase) ** memOwn spW ** memOwn (spW + 8) **
+        memOwn (spW + 16) ** memOwn (spW + 24)) ** G)
+      (((.x2 ↦ᵣ spW) ** (.x1 ↦ᵣ raIn) ** (.x8 ↦ᵣ listBase) ** (.x9 ↦ᵣ listLen) **
+        (.x18 ↦ᵣ outBase) ** (.x10 ↦ᵣ listBase) ** (.x11 ↦ᵣ listLen) **
+        (.x12 ↦ᵣ outBase) ** (spW ↦ₘ raIn) ** ((spW + 8) ↦ₘ s0Old) **
+        ((spW + 16) ↦ₘ s1Old) ** ((spW + 24) ↦ₘ s2Old)) ** G) := by
+  have hz0 : signExtend12 (0 : BitVec 12) = (0 : Word) := by decide
+  have hz8 : signExtend12 (8 : BitVec 12) = (8 : Word) := by decide
+  have hz16 : signExtend12 (16 : BitVec 12) = (16 : Word) := by decide
+  have hz24 : signExtend12 (24 : BitVec 12) = (24 : Word) := by decide
+  -- [0] ADDI x2 x2 -32 : sp0 → spW
+  have h0 := addi_spec_gen_same_within .x2 sp0 (-32 : BitVec 12) WB (by decide)
+  rw [← hspW] at h0
+  have h0' := cpsTripleWithin_extend_code wd_mono
+    (cpsTripleWithin_extend_code (cr' := wdCode)
+      (CodeReq.ofProg_mem_at WB WB withdrawalDecode_prog 0
+        (.ADDI .x2 .x2 (-32 : BitVec 12)) (by decide) (by rw [wd_length]; decide)
+        rfl (by rw [wd_length]; decide)) h0)
+  -- [1] SD x2 x1 0 : store raIn at spW
+  have h1 := sd_spec_gen_own_within .x2 .x1 spW raIn (0 : BitVec 12) (WB + 4)
+  rw [hz0, show spW + (0 : Word) = spW from by bv_omega] at h1
+  have h1' := cpsTripleWithin_extend_code wd_mono
+    (cpsTripleWithin_extend_code (cr' := wdCode)
+      (CodeReq.ofProg_mem_at WB (WB + 4) withdrawalDecode_prog 1
+        (.SD .x2 .x1 (0 : BitVec 12)) (by bv_omega) (by rw [wd_length]; decide)
+        rfl (by rw [wd_length]; decide)) h1)
+  -- [2] SD x2 x8 8 : store s0Old at spW+8
+  have h2 := sd_spec_gen_own_within .x2 .x8 spW s0Old (8 : BitVec 12) (WB + 8)
+  rw [hz8] at h2
+  have h2' := cpsTripleWithin_extend_code wd_mono
+    (cpsTripleWithin_extend_code (cr' := wdCode)
+      (CodeReq.ofProg_mem_at WB (WB + 8) withdrawalDecode_prog 2
+        (.SD .x2 .x8 (8 : BitVec 12)) (by bv_omega) (by rw [wd_length]; decide)
+        rfl (by rw [wd_length]; decide)) h2)
+  -- [3] SD x2 x9 16 : store s1Old at spW+16
+  have h3 := sd_spec_gen_own_within .x2 .x9 spW s1Old (16 : BitVec 12) (WB + 12)
+  rw [hz16] at h3
+  have h3' := cpsTripleWithin_extend_code wd_mono
+    (cpsTripleWithin_extend_code (cr' := wdCode)
+      (CodeReq.ofProg_mem_at WB (WB + 12) withdrawalDecode_prog 3
+        (.SD .x2 .x9 (16 : BitVec 12)) (by bv_omega) (by rw [wd_length]; decide)
+        rfl (by rw [wd_length]; decide)) h3)
+  -- [4] SD x2 x18 24 : store s2Old at spW+24
+  have h4 := sd_spec_gen_own_within .x2 .x18 spW s2Old (24 : BitVec 12) (WB + 16)
+  rw [hz24] at h4
+  have h4' := cpsTripleWithin_extend_code wd_mono
+    (cpsTripleWithin_extend_code (cr' := wdCode)
+      (CodeReq.ofProg_mem_at WB (WB + 16) withdrawalDecode_prog 4
+        (.SD .x2 .x18 (24 : BitVec 12)) (by bv_omega) (by rw [wd_length]; decide)
+        rfl (by rw [wd_length]; decide)) h4)
+  -- [5] MV x8 x10 : x8 := listBase
+  have h5 := mv_spec_gen_within .x8 .x10 listBase s0Old (WB + 20) (by decide)
+  have h5' := cpsTripleWithin_extend_code wd_mono
+    (cpsTripleWithin_extend_code (cr' := wdCode)
+      (CodeReq.ofProg_mem_at WB (WB + 20) withdrawalDecode_prog 5 (.MV .x8 .x10)
+        (by bv_omega) (by rw [wd_length]; decide) rfl
+        (by rw [wd_length]; decide)) h5)
+  -- [6] MV x9 x11 : x9 := listLen
+  have h6 := mv_spec_gen_within .x9 .x11 listLen s1Old (WB + 24) (by decide)
+  have h6' := cpsTripleWithin_extend_code wd_mono
+    (cpsTripleWithin_extend_code (cr' := wdCode)
+      (CodeReq.ofProg_mem_at WB (WB + 24) withdrawalDecode_prog 6 (.MV .x9 .x11)
+        (by bv_omega) (by rw [wd_length]; decide) rfl
+        (by rw [wd_length]; decide)) h6)
+  -- [7] MV x18 x12 : x18 := outBase
+  have h7 := mv_spec_gen_within .x18 .x12 outBase s2Old (WB + 28) (by decide)
+  have h7' := cpsTripleWithin_extend_code wd_mono
+    (cpsTripleWithin_extend_code (cr' := wdCode)
+      (CodeReq.ofProg_mem_at WB (WB + 28) withdrawalDecode_prog 7 (.MV .x18 .x12)
+        (by bv_omega) (by rw [wd_length]; decide) rfl
+        (by rw [wd_length]; decide)) h7)
+  -- Frame each instruction over the untouched local cells.
+  have f0 := cpsTripleWithin_frameR
+    ((.x1 ↦ᵣ raIn) ** (.x8 ↦ᵣ s0Old) ** (.x9 ↦ᵣ s1Old) ** (.x18 ↦ᵣ s2Old) **
+     (.x10 ↦ᵣ listBase) ** (.x11 ↦ᵣ listLen) ** (.x12 ↦ᵣ outBase) **
+     memOwn spW ** memOwn (spW + 8) ** memOwn (spW + 16) ** memOwn (spW + 24))
+    (by pcf) h0'
+  have f1 := cpsTripleWithin_frameR
+    ((.x8 ↦ᵣ s0Old) ** (.x9 ↦ᵣ s1Old) ** (.x18 ↦ᵣ s2Old) **
+     (.x10 ↦ᵣ listBase) ** (.x11 ↦ᵣ listLen) ** (.x12 ↦ᵣ outBase) **
+     memOwn (spW + 8) ** memOwn (spW + 16) ** memOwn (spW + 24)) (by pcf) h1'
+  have f2 := cpsTripleWithin_frameR
+    ((.x1 ↦ᵣ raIn) ** (.x9 ↦ᵣ s1Old) ** (.x18 ↦ᵣ s2Old) **
+     (.x10 ↦ᵣ listBase) ** (.x11 ↦ᵣ listLen) ** (.x12 ↦ᵣ outBase) **
+     (spW ↦ₘ raIn) ** memOwn (spW + 16) ** memOwn (spW + 24)) (by pcf) h2'
+  have f3 := cpsTripleWithin_frameR
+    ((.x1 ↦ᵣ raIn) ** (.x8 ↦ᵣ s0Old) ** (.x18 ↦ᵣ s2Old) **
+     (.x10 ↦ᵣ listBase) ** (.x11 ↦ᵣ listLen) ** (.x12 ↦ᵣ outBase) **
+     (spW ↦ₘ raIn) ** ((spW + 8) ↦ₘ s0Old) ** memOwn (spW + 24)) (by pcf) h3'
+  have f4 := cpsTripleWithin_frameR
+    ((.x1 ↦ᵣ raIn) ** (.x8 ↦ᵣ s0Old) ** (.x9 ↦ᵣ s1Old) **
+     (.x10 ↦ᵣ listBase) ** (.x11 ↦ᵣ listLen) ** (.x12 ↦ᵣ outBase) **
+     (spW ↦ₘ raIn) ** ((spW + 8) ↦ₘ s0Old) ** ((spW + 16) ↦ₘ s1Old)) (by pcf) h4'
+  have f5 := cpsTripleWithin_frameR
+    ((.x2 ↦ᵣ spW) ** (.x1 ↦ᵣ raIn) ** (.x9 ↦ᵣ s1Old) ** (.x18 ↦ᵣ s2Old) **
+     (.x11 ↦ᵣ listLen) ** (.x12 ↦ᵣ outBase) **
+     (spW ↦ₘ raIn) ** ((spW + 8) ↦ₘ s0Old) ** ((spW + 16) ↦ₘ s1Old) **
+     ((spW + 24) ↦ₘ s2Old)) (by pcf) h5'
+  have f6 := cpsTripleWithin_frameR
+    ((.x2 ↦ᵣ spW) ** (.x1 ↦ᵣ raIn) ** (.x8 ↦ᵣ listBase) ** (.x18 ↦ᵣ s2Old) **
+     (.x10 ↦ᵣ listBase) ** (.x12 ↦ᵣ outBase) **
+     (spW ↦ₘ raIn) ** ((spW + 8) ↦ₘ s0Old) ** ((spW + 16) ↦ₘ s1Old) **
+     ((spW + 24) ↦ₘ s2Old)) (by pcf) h6'
+  have f7 := cpsTripleWithin_frameR
+    ((.x2 ↦ᵣ spW) ** (.x1 ↦ᵣ raIn) ** (.x8 ↦ᵣ listBase) ** (.x9 ↦ᵣ listLen) **
+     (.x10 ↦ᵣ listBase) ** (.x11 ↦ᵣ listLen) **
+     (spW ↦ₘ raIn) ** ((spW + 8) ↦ₘ s0Old) ** ((spW + 16) ↦ₘ s1Old) **
+     ((spW + 24) ↦ₘ s2Old)) (by pcf) h7'
+  have c01 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) f0 f1
+  have c012 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) c01 f2
+  have c0123 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) c012 f3
+  have c04 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) c0123 f4
+  have c05 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) c04 f5
+  have c06 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) c05 f6
+  have c07 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) c06 f7
+  have hlocal : cpsTripleWithin 8 WB (WB + 32) fullCode
+      ((.x2 ↦ᵣ sp0) ** (.x1 ↦ᵣ raIn) ** (.x8 ↦ᵣ s0Old) ** (.x9 ↦ᵣ s1Old) **
+        (.x18 ↦ᵣ s2Old) ** (.x10 ↦ᵣ listBase) ** (.x11 ↦ᵣ listLen) **
+        (.x12 ↦ᵣ outBase) ** memOwn spW ** memOwn (spW + 8) **
+        memOwn (spW + 16) ** memOwn (spW + 24))
+      ((.x2 ↦ᵣ spW) ** (.x1 ↦ᵣ raIn) ** (.x8 ↦ᵣ listBase) ** (.x9 ↦ᵣ listLen) **
+        (.x18 ↦ᵣ outBase) ** (.x10 ↦ᵣ listBase) ** (.x11 ↦ᵣ listLen) **
+        (.x12 ↦ᵣ outBase) ** (spW ↦ₘ raIn) ** ((spW + 8) ↦ₘ s0Old) **
+        ((spW + 16) ↦ₘ s1Old) ** ((spW + 24) ↦ₘ s2Old)) :=
+    cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
+      (fun _ hq => by xperm_hyp hq) c07
+  have hframed := cpsTripleWithin_frameR G hG hlocal
+  exact cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
+    (fun _ hq => by xperm_hyp hq) hframed
+
+#print axioms wdPrologue
+
+end EvmAsm.Codegen.WithdrawalDecodeSpec

--- a/EvmAsm/Codegen/Programs/WithdrawalDecodeClose2.lean
+++ b/EvmAsm/Codegen/Programs/WithdrawalDecodeClose2.lean
@@ -1,0 +1,216 @@
+/-
+  `withdrawalDecode_prog` caller-contract composition, part 2.
+
+  This module hosts the middle straight-line/branch blocks of the 60-instruction
+  accessor:
+
+    * `wdCopySetup`  — instructions [34]-[38]: `la x5, wd_offset`, load the
+      selected content offset, compute the source cursor `x28 = listBase +
+      offset` and the destination cursor `x29 = outBase + 16`.
+    * `wdLenCheck`   — instructions [29]-[33]: `la x5, wd_length`, load the
+      selected length, and branch on `len ≠ 20` to the failure tail (`WB+212`)
+      or fall through to the copy setup (`WB+136`).
+
+  No `sorry`/`admit`/`native_decide`/`bv_decide`; classical-3 axioms only.
+-/
+
+import EvmAsm.Codegen.Programs.WithdrawalDecodeClose
+import EvmAsm.Codegen.Programs.WithdrawalDecodeLoop
+import EvmAsm.Rv64.LaResolve
+
+namespace EvmAsm.Codegen.WithdrawalDecodeSpec
+
+open EvmAsm.Rv64 EvmAsm.Rv64.SAsm
+
+/-! ## Guest data-section cells written by the field-2 `rlp_list_nth_item` call -/
+
+/-- The `wd_offset` data cell (holds the selected content's relative offset). -/
+abbrev wdOffsetAddr : Word := (GuestAddrs.wd_offset : Word)
+/-- The `wd_length` data cell (holds the selected content's length). -/
+abbrev wdLengthAddr : Word := (GuestAddrs.wd_length : Word)
+
+/-! ## `la` materialize helpers -/
+
+/-- `la x5, wd_length` at [29]-[30] (`WB+116 → WB+124`). -/
+theorem wdLaLen116 (v : Word) :
+    cpsTripleWithin 2 (WB + 116) (WB + 124) fullCode
+      (.x5 ↦ᵣ v) (.x5 ↦ᵣ wdLengthAddr) := by
+  have hau : ∀ a i, CodeReq.singleton (WB + 116)
+      (.AUIPC .x5 (Codegen.laHi GuestAddrs.wd_length (GuestAddrs.withdrawal_decode + 116)))
+        a = some i → fullCode a = some i := fun a i hi => wd_mono a i
+    (CodeReq.ofProg_mem_at WB (WB + 116) withdrawalDecode_prog 29
+      (.AUIPC .x5 (Codegen.laHi GuestAddrs.wd_length (GuestAddrs.withdrawal_decode + 116)))
+      (by bv_omega) (by rw [wd_length]; decide) rfl (by rw [wd_length]; decide) a i hi)
+  have had : ∀ a i, CodeReq.singleton (WB + 120)
+      (.ADDI .x5 .x5 (Codegen.laLo GuestAddrs.wd_length (GuestAddrs.withdrawal_decode + 116)))
+        a = some i → fullCode a = some i := fun a i hi => wd_mono a i
+    (CodeReq.ofProg_mem_at WB (WB + 120) withdrawalDecode_prog 30
+      (.ADDI .x5 .x5 (Codegen.laLo GuestAddrs.wd_length (GuestAddrs.withdrawal_decode + 116)))
+      (by bv_omega) (by rw [wd_length]; decide) rfl (by rw [wd_length]; decide) a i hi)
+  have h := la_materialize_within .x5 v (WB + 116) wdLengthAddr (by decide) (by decide) hau had
+  rw [show (WB + 116 : Word) + 8 = WB + 124 from by bv_omega] at h
+  exact h
+
+/-- `la x5, wd_offset` at [34]-[35] (`WB+136 → WB+144`). -/
+theorem wdLaOff136 (v : Word) :
+    cpsTripleWithin 2 (WB + 136) (WB + 144) fullCode
+      (.x5 ↦ᵣ v) (.x5 ↦ᵣ wdOffsetAddr) := by
+  have hau : ∀ a i, CodeReq.singleton (WB + 136)
+      (.AUIPC .x5 (Codegen.laHi GuestAddrs.wd_offset (GuestAddrs.withdrawal_decode + 136)))
+        a = some i → fullCode a = some i := fun a i hi => wd_mono a i
+    (CodeReq.ofProg_mem_at WB (WB + 136) withdrawalDecode_prog 34
+      (.AUIPC .x5 (Codegen.laHi GuestAddrs.wd_offset (GuestAddrs.withdrawal_decode + 136)))
+      (by bv_omega) (by rw [wd_length]; decide) rfl (by rw [wd_length]; decide) a i hi)
+  have had : ∀ a i, CodeReq.singleton (WB + 140)
+      (.ADDI .x5 .x5 (Codegen.laLo GuestAddrs.wd_offset (GuestAddrs.withdrawal_decode + 136)))
+        a = some i → fullCode a = some i := fun a i hi => wd_mono a i
+    (CodeReq.ofProg_mem_at WB (WB + 140) withdrawalDecode_prog 35
+      (.ADDI .x5 .x5 (Codegen.laLo GuestAddrs.wd_offset (GuestAddrs.withdrawal_decode + 136)))
+      (by bv_omega) (by rw [wd_length]; decide) rfl (by rw [wd_length]; decide) a i hi)
+  have h := la_materialize_within .x5 v (WB + 136) wdOffsetAddr (by decide) (by decide) hau had
+  rw [show (WB + 136 : Word) + 8 = WB + 144 from by bv_omega] at h
+  exact h
+
+/-! ## Copy setup (instructions [34]-[38]) -/
+
+set_option maxRecDepth 8000 in
+/-- Copy setup: `la x5, wd_offset` ([34]-[35]), load the selected content offset
+    from the `wd_offset` cell ([36]), compute the source cursor
+    `x28 = listBase + offset` ([37]) and the destination cursor
+    `x29 = outBase + 16` ([38]). -/
+theorem wdCopySetup (v5old v28old v29old listBase outBase offset : Word) :
+    cpsTripleWithin 5 (WB + 136) (WB + 156) fullCode
+      (((.x5 : Reg) ↦ᵣ v5old) ** ((.x28 : Reg) ↦ᵣ v28old) **
+       ((.x29 : Reg) ↦ᵣ v29old) ** ((.x8 : Reg) ↦ᵣ listBase) **
+       ((.x18 : Reg) ↦ᵣ outBase) ** (wdOffsetAddr ↦ₘ offset))
+      (((.x5 : Reg) ↦ᵣ wdOffsetAddr) ** ((.x28 : Reg) ↦ᵣ (listBase + offset)) **
+       ((.x29 : Reg) ↦ᵣ (outBase + 16)) ** ((.x8 : Reg) ↦ᵣ listBase) **
+       ((.x18 : Reg) ↦ᵣ outBase) ** (wdOffsetAddr ↦ₘ offset)) := by
+  -- [34]-[35] la x5, wd_offset
+  have hla := wdLaOff136 v5old
+  have hlaf := cpsTripleWithin_frameR
+    (((.x28 : Reg) ↦ᵣ v28old) ** ((.x29 : Reg) ↦ᵣ v29old) **
+     ((.x8 : Reg) ↦ᵣ listBase) ** ((.x18 : Reg) ↦ᵣ outBase) **
+     (wdOffsetAddr ↦ₘ offset))
+    (by repeat' first | exact pcFree_regIs | exact pcFree_memIs | apply pcFree_sepConj) hla
+  -- [36] LD x28 x5 0 : x28 := *wd_offset = offset
+  have hld := ld_spec_gen_within .x28 .x5 wdOffsetAddr v28old offset (0 : BitVec 12)
+    (WB + 144) (by decide)
+  rw [show wdOffsetAddr + signExtend12 (0 : BitVec 12) = wdOffsetAddr from by
+    rw [show signExtend12 (0 : BitVec 12) = (0 : Word) from by decide]; bv_omega,
+    show (WB + 144 : Word) + 4 = WB + 148 from by bv_omega] at hld
+  have hlde := cpsTripleWithin_extend_code wd_mono
+    (cpsTripleWithin_extend_code (cr' := wdCode)
+      (CodeReq.ofProg_mem_at WB (WB + 144) withdrawalDecode_prog 36
+        (.LD .x28 .x5 (0 : BitVec 12)) (by bv_omega) (by rw [wd_length]; decide)
+        rfl (by rw [wd_length]; decide)) hld)
+  have hldf := cpsTripleWithin_frameR
+    (((.x29 : Reg) ↦ᵣ v29old) ** ((.x8 : Reg) ↦ᵣ listBase) **
+     ((.x18 : Reg) ↦ᵣ outBase))
+    (by repeat' first | exact pcFree_regIs | exact pcFree_memIs | apply pcFree_sepConj) hlde
+  -- [37] ADD x28 x8 x28 : x28 := listBase + offset
+  have hadd := add_spec_gen_rd_eq_rs2_within .x28 .x8 listBase offset (WB + 148) (by decide)
+  rw [show (WB + 148 : Word) + 4 = WB + 152 from by bv_omega] at hadd
+  have hadde := cpsTripleWithin_extend_code wd_mono
+    (cpsTripleWithin_extend_code (cr' := wdCode)
+      (CodeReq.ofProg_mem_at WB (WB + 148) withdrawalDecode_prog 37
+        (.ADD .x28 .x8 .x28) (by bv_omega) (by rw [wd_length]; decide)
+        rfl (by rw [wd_length]; decide)) hadd)
+  have haddf := cpsTripleWithin_frameR
+    (((.x5 : Reg) ↦ᵣ wdOffsetAddr) ** ((.x29 : Reg) ↦ᵣ v29old) **
+     ((.x18 : Reg) ↦ᵣ outBase) ** (wdOffsetAddr ↦ₘ offset))
+    (by repeat' first | exact pcFree_regIs | exact pcFree_memIs | apply pcFree_sepConj) hadde
+  -- [38] ADDI x29 x18 16 : x29 := outBase + 16
+  have haddi := addi_spec_gen_within .x29 .x18 v29old outBase (16 : BitVec 12) (WB + 152)
+    (by decide)
+  rw [show outBase + signExtend12 (16 : BitVec 12) = outBase + 16 from by
+    rw [show signExtend12 (16 : BitVec 12) = (16 : Word) from by decide],
+    show (WB + 152 : Word) + 4 = WB + 156 from by bv_omega] at haddi
+  have haddie := cpsTripleWithin_extend_code wd_mono
+    (cpsTripleWithin_extend_code (cr' := wdCode)
+      (CodeReq.ofProg_mem_at WB (WB + 152) withdrawalDecode_prog 38
+        (.ADDI .x29 .x18 (16 : BitVec 12)) (by bv_omega) (by rw [wd_length]; decide)
+        rfl (by rw [wd_length]; decide)) haddi)
+  have haddif := cpsTripleWithin_frameR
+    (((.x5 : Reg) ↦ᵣ wdOffsetAddr) ** ((.x28 : Reg) ↦ᵣ (listBase + offset)) **
+     ((.x8 : Reg) ↦ᵣ listBase) ** (wdOffsetAddr ↦ₘ offset))
+    (by repeat' first | exact pcFree_regIs | exact pcFree_memIs | apply pcFree_sepConj) haddie
+  have s1 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) hlaf hldf
+  have s2 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) s1 haddf
+  have s3 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) s2 haddif
+  exact cpsTripleWithin_mono_nSteps (by omega)
+    (cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
+      (fun _ hq => by xperm_hyp hq) s3)
+
+#print axioms wdCopySetup
+
+/-! ## Length check (instructions [29]-[33]) -/
+
+set_option maxRecDepth 8000 in
+/-- Length check: `la x5, wd_length` ([29]-[30]), load the selected length into
+    `x6` ([31]), `li x7, 20` ([32]), then `bne x6, x7` at [33] branches to the
+    failure tail (`WB+212`, `len ≠ 20`) or falls through to the copy setup
+    (`WB+136`, `len = 20`). -/
+theorem wdLenCheck (v5old v6old v7old len : Word) :
+    cpsBranchWithin 5 (WB + 116) fullCode
+      (((.x5 : Reg) ↦ᵣ v5old) ** ((.x6 : Reg) ↦ᵣ v6old) **
+       ((.x7 : Reg) ↦ᵣ v7old) ** (wdLengthAddr ↦ₘ len))
+      (WB + 212)
+        ((((.x6 : Reg) ↦ᵣ len) ** ((.x7 : Reg) ↦ᵣ (20 : Word)) ** ⌜len ≠ (20 : Word)⌝) **
+         ((.x5 : Reg) ↦ᵣ wdLengthAddr) ** (wdLengthAddr ↦ₘ len))
+      (WB + 136)
+        ((((.x6 : Reg) ↦ᵣ len) ** ((.x7 : Reg) ↦ᵣ (20 : Word)) ** ⌜len = (20 : Word)⌝) **
+         ((.x5 : Reg) ↦ᵣ wdLengthAddr) ** (wdLengthAddr ↦ₘ len)) := by
+  -- [29]-[30] la x5, wd_length
+  have hla := wdLaLen116 v5old
+  have hlaf := cpsTripleWithin_frameR
+    (((.x6 : Reg) ↦ᵣ v6old) ** ((.x7 : Reg) ↦ᵣ v7old) ** (wdLengthAddr ↦ₘ len))
+    (by repeat' first | exact pcFree_regIs | exact pcFree_memIs | apply pcFree_sepConj) hla
+  -- [31] LD x6 x5 0 : x6 := *wd_length = len
+  have hld := ld_spec_gen_within .x6 .x5 wdLengthAddr v6old len (0 : BitVec 12)
+    (WB + 124) (by decide)
+  rw [show wdLengthAddr + signExtend12 (0 : BitVec 12) = wdLengthAddr from by
+    rw [show signExtend12 (0 : BitVec 12) = (0 : Word) from by decide]; bv_omega,
+    show (WB + 124 : Word) + 4 = WB + 128 from by bv_omega] at hld
+  have hlde := cpsTripleWithin_extend_code wd_mono
+    (cpsTripleWithin_extend_code (cr' := wdCode)
+      (CodeReq.ofProg_mem_at WB (WB + 124) withdrawalDecode_prog 31
+        (.LD .x6 .x5 (0 : BitVec 12)) (by bv_omega) (by rw [wd_length]; decide)
+        rfl (by rw [wd_length]; decide)) hld)
+  have hldf := cpsTripleWithin_frameR
+    (((.x7 : Reg) ↦ᵣ v7old)) pcFree_regIs hlde
+  -- [32] LI x7 20
+  have hli := li_spec_gen_within .x7 v7old (20 : Word) (WB + 128) (by decide)
+  rw [show (WB + 128 : Word) + 4 = WB + 132 from by bv_omega] at hli
+  have hlie := cpsTripleWithin_extend_code wd_mono
+    (cpsTripleWithin_extend_code (cr' := wdCode)
+      (CodeReq.ofProg_mem_at WB (WB + 128) withdrawalDecode_prog 32
+        (.LI .x7 (20 : Word)) (by bv_omega) (by rw [wd_length]; decide)
+        rfl (by rw [wd_length]; decide)) hli)
+  have hlif := cpsTripleWithin_frameR
+    (((.x5 : Reg) ↦ᵣ wdLengthAddr) ** ((.x6 : Reg) ↦ᵣ len) ** (wdLengthAddr ↦ₘ len))
+    (by repeat' first | exact pcFree_regIs | exact pcFree_memIs | apply pcFree_sepConj) hlie
+  -- straight-line [29]-[32] : WB+116 → WB+132
+  have s1 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) hlaf hldf
+  have sStraight := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) s1 hlif
+  -- [33] BNE x6 x7 80 : taken (len ≠ 20) → WB+212, else → WB+136
+  have hbne := bne_spec_gen_within .x6 .x7 (80 : BitVec 13) len (20 : Word) (WB + 132)
+  rw [show (WB + 132 : Word) + signExtend13 (80 : BitVec 13) = WB + 212 from by
+    rw [show signExtend13 (80 : BitVec 13) = (80 : Word) from by decide]; bv_omega,
+    show (WB + 132 : Word) + 4 = WB + 136 from by bv_omega] at hbne
+  have hbnee := cpsBranchWithin_extend_code wd_mono
+    (cpsBranchWithin_extend_code (cr' := wdCode)
+      (CodeReq.ofProg_mem_at WB (WB + 132) withdrawalDecode_prog 33
+        (.BNE .x6 .x7 (80 : BitVec 13)) (by bv_omega) (by rw [wd_length]; decide)
+        rfl (by rw [wd_length]; decide)) hbne)
+  have hbnef := cpsBranchWithin_frameR
+    (((.x5 : Reg) ↦ᵣ wdLengthAddr) ** (wdLengthAddr ↦ₘ len))
+    (by repeat' first | exact pcFree_regIs | exact pcFree_memIs | apply pcFree_sepConj) hbnee
+  -- compose straight ;; branch, permuting the midpoint
+  have hcomposed := cpsTripleWithin_seq_cpsBranchWithin_perm_same_cr
+    (fun _ hp => by xperm_hyp hp) sStraight hbnef
+  exact cpsBranchWithin_mono_nSteps (by omega) hcomposed
+
+#print axioms wdLenCheck
+
+end EvmAsm.Codegen.WithdrawalDecodeSpec

--- a/EvmAsm/Codegen/Programs/WithdrawalDecodeClose2.lean
+++ b/EvmAsm/Codegen/Programs/WithdrawalDecodeClose2.lean
@@ -213,4 +213,280 @@ theorem wdLenCheck (v5old v6old v7old len : Word) :
 
 #print axioms wdLenCheck
 
+/-! ## Per-field argument shuffles (call setups) -/
+
+set_option maxRecDepth 8000 in
+/-- Field-0 call setup [8]-[11] (`WB+32 → WB+48`): `mv a0,s0 ; mv a1,s1 ;
+    li a2,0 ; mv a3,s2` — arrange `rlp_field_to_u64(listBase, len, 0, outBase)`. -/
+theorem wdField0Setup (v10 v11 v12 v13 listBase len outBase : Word) :
+    cpsTripleWithin 4 (WB + 32) (WB + 48) fullCode
+      (((.x10 : Reg) ↦ᵣ v10) ** ((.x11 : Reg) ↦ᵣ v11) ** ((.x12 : Reg) ↦ᵣ v12) **
+       ((.x13 : Reg) ↦ᵣ v13) ** ((.x8 : Reg) ↦ᵣ listBase) **
+       ((.x9 : Reg) ↦ᵣ len) ** ((.x18 : Reg) ↦ᵣ outBase))
+      (((.x10 : Reg) ↦ᵣ listBase) ** ((.x11 : Reg) ↦ᵣ len) **
+       ((.x12 : Reg) ↦ᵣ (0 : Word)) ** ((.x13 : Reg) ↦ᵣ outBase) **
+       ((.x8 : Reg) ↦ᵣ listBase) ** ((.x9 : Reg) ↦ᵣ len) **
+       ((.x18 : Reg) ↦ᵣ outBase)) := by
+  have h8 := mv_spec_gen_within .x10 .x8 listBase v10 (WB + 32) (by decide)
+  have h8e := cpsTripleWithin_extend_code wd_mono
+    (cpsTripleWithin_extend_code (cr' := wdCode)
+      (CodeReq.ofProg_mem_at WB (WB + 32) withdrawalDecode_prog 8 (.MV .x10 .x8)
+        (by bv_omega) (by rw [wd_length]; decide) rfl (by rw [wd_length]; decide)) h8)
+  have h9 := mv_spec_gen_within .x11 .x9 len v11 (WB + 36) (by decide)
+  have h9e := cpsTripleWithin_extend_code wd_mono
+    (cpsTripleWithin_extend_code (cr' := wdCode)
+      (CodeReq.ofProg_mem_at WB (WB + 36) withdrawalDecode_prog 9 (.MV .x11 .x9)
+        (by bv_omega) (by rw [wd_length]; decide) rfl (by rw [wd_length]; decide)) h9)
+  have h10 := li_spec_gen_within .x12 v12 (0 : Word) (WB + 40) (by decide)
+  have h10e := cpsTripleWithin_extend_code wd_mono
+    (cpsTripleWithin_extend_code (cr' := wdCode)
+      (CodeReq.ofProg_mem_at WB (WB + 40) withdrawalDecode_prog 10 (.LI .x12 (0 : Word))
+        (by bv_omega) (by rw [wd_length]; decide) rfl (by rw [wd_length]; decide)) h10)
+  have h11 := mv_spec_gen_within .x13 .x18 outBase v13 (WB + 44) (by decide)
+  have h11e := cpsTripleWithin_extend_code wd_mono
+    (cpsTripleWithin_extend_code (cr' := wdCode)
+      (CodeReq.ofProg_mem_at WB (WB + 44) withdrawalDecode_prog 11 (.MV .x13 .x18)
+        (by bv_omega) (by rw [wd_length]; decide) rfl (by rw [wd_length]; decide)) h11)
+  have f8 := cpsTripleWithin_frameR
+    (((.x11 : Reg) ↦ᵣ v11) ** ((.x12 : Reg) ↦ᵣ v12) ** ((.x13 : Reg) ↦ᵣ v13) **
+     ((.x9 : Reg) ↦ᵣ len) ** ((.x18 : Reg) ↦ᵣ outBase))
+    (by repeat' first | exact pcFree_regIs | apply pcFree_sepConj) h8e
+  have f9 := cpsTripleWithin_frameR
+    (((.x10 : Reg) ↦ᵣ listBase) ** ((.x12 : Reg) ↦ᵣ v12) ** ((.x13 : Reg) ↦ᵣ v13) **
+     ((.x8 : Reg) ↦ᵣ listBase) ** ((.x18 : Reg) ↦ᵣ outBase))
+    (by repeat' first | exact pcFree_regIs | apply pcFree_sepConj) h9e
+  have f10 := cpsTripleWithin_frameR
+    (((.x10 : Reg) ↦ᵣ listBase) ** ((.x11 : Reg) ↦ᵣ len) ** ((.x13 : Reg) ↦ᵣ v13) **
+     ((.x8 : Reg) ↦ᵣ listBase) ** ((.x9 : Reg) ↦ᵣ len) ** ((.x18 : Reg) ↦ᵣ outBase))
+    (by repeat' first | exact pcFree_regIs | apply pcFree_sepConj) h10e
+  have f11 := cpsTripleWithin_frameR
+    (((.x10 : Reg) ↦ᵣ listBase) ** ((.x11 : Reg) ↦ᵣ len) ** ((.x12 : Reg) ↦ᵣ (0 : Word)) **
+     ((.x8 : Reg) ↦ᵣ listBase) ** ((.x9 : Reg) ↦ᵣ len))
+    (by repeat' first | exact pcFree_regIs | apply pcFree_sepConj) h11e
+  have s1 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) f8 f9
+  have s2 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) s1 f10
+  have s3 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) s2 f11
+  exact cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
+    (fun _ hq => by xperm_hyp hq) s3
+
+#print axioms wdField0Setup
+
+set_option maxRecDepth 8000 in
+/-- Field-1 call setup [14]-[17] (`WB+56 → WB+72`): `mv a0,s0 ; mv a1,s1 ;
+    li a2,1 ; addi a3,s2,8` — `rlp_field_to_u64(listBase, len, 1, outBase+8)`. -/
+theorem wdField1Setup (v10 v11 v12 v13 listBase len outBase : Word) :
+    cpsTripleWithin 4 (WB + 56) (WB + 72) fullCode
+      (((.x10 : Reg) ↦ᵣ v10) ** ((.x11 : Reg) ↦ᵣ v11) ** ((.x12 : Reg) ↦ᵣ v12) **
+       ((.x13 : Reg) ↦ᵣ v13) ** ((.x8 : Reg) ↦ᵣ listBase) **
+       ((.x9 : Reg) ↦ᵣ len) ** ((.x18 : Reg) ↦ᵣ outBase))
+      (((.x10 : Reg) ↦ᵣ listBase) ** ((.x11 : Reg) ↦ᵣ len) **
+       ((.x12 : Reg) ↦ᵣ (1 : Word)) ** ((.x13 : Reg) ↦ᵣ (outBase + 8)) **
+       ((.x8 : Reg) ↦ᵣ listBase) ** ((.x9 : Reg) ↦ᵣ len) **
+       ((.x18 : Reg) ↦ᵣ outBase)) := by
+  have h14 := mv_spec_gen_within .x10 .x8 listBase v10 (WB + 56) (by decide)
+  have h14e := cpsTripleWithin_extend_code wd_mono
+    (cpsTripleWithin_extend_code (cr' := wdCode)
+      (CodeReq.ofProg_mem_at WB (WB + 56) withdrawalDecode_prog 14 (.MV .x10 .x8)
+        (by bv_omega) (by rw [wd_length]; decide) rfl (by rw [wd_length]; decide)) h14)
+  have h15 := mv_spec_gen_within .x11 .x9 len v11 (WB + 60) (by decide)
+  have h15e := cpsTripleWithin_extend_code wd_mono
+    (cpsTripleWithin_extend_code (cr' := wdCode)
+      (CodeReq.ofProg_mem_at WB (WB + 60) withdrawalDecode_prog 15 (.MV .x11 .x9)
+        (by bv_omega) (by rw [wd_length]; decide) rfl (by rw [wd_length]; decide)) h15)
+  have h16 := li_spec_gen_within .x12 v12 (1 : Word) (WB + 64) (by decide)
+  have h16e := cpsTripleWithin_extend_code wd_mono
+    (cpsTripleWithin_extend_code (cr' := wdCode)
+      (CodeReq.ofProg_mem_at WB (WB + 64) withdrawalDecode_prog 16 (.LI .x12 (1 : Word))
+        (by bv_omega) (by rw [wd_length]; decide) rfl (by rw [wd_length]; decide)) h16)
+  have h17 := addi_spec_gen_within .x13 .x18 v13 outBase (8 : BitVec 12) (WB + 68) (by decide)
+  rw [show outBase + signExtend12 (8 : BitVec 12) = outBase + 8 from by
+    rw [show signExtend12 (8 : BitVec 12) = (8 : Word) from by decide]] at h17
+  have h17e := cpsTripleWithin_extend_code wd_mono
+    (cpsTripleWithin_extend_code (cr' := wdCode)
+      (CodeReq.ofProg_mem_at WB (WB + 68) withdrawalDecode_prog 17
+        (.ADDI .x13 .x18 (8 : BitVec 12)) (by bv_omega) (by rw [wd_length]; decide)
+        rfl (by rw [wd_length]; decide)) h17)
+  have f14 := cpsTripleWithin_frameR
+    (((.x11 : Reg) ↦ᵣ v11) ** ((.x12 : Reg) ↦ᵣ v12) ** ((.x13 : Reg) ↦ᵣ v13) **
+     ((.x9 : Reg) ↦ᵣ len) ** ((.x18 : Reg) ↦ᵣ outBase))
+    (by repeat' first | exact pcFree_regIs | apply pcFree_sepConj) h14e
+  have f15 := cpsTripleWithin_frameR
+    (((.x10 : Reg) ↦ᵣ listBase) ** ((.x12 : Reg) ↦ᵣ v12) ** ((.x13 : Reg) ↦ᵣ v13) **
+     ((.x8 : Reg) ↦ᵣ listBase) ** ((.x18 : Reg) ↦ᵣ outBase))
+    (by repeat' first | exact pcFree_regIs | apply pcFree_sepConj) h15e
+  have f16 := cpsTripleWithin_frameR
+    (((.x10 : Reg) ↦ᵣ listBase) ** ((.x11 : Reg) ↦ᵣ len) ** ((.x13 : Reg) ↦ᵣ v13) **
+     ((.x8 : Reg) ↦ᵣ listBase) ** ((.x9 : Reg) ↦ᵣ len) ** ((.x18 : Reg) ↦ᵣ outBase))
+    (by repeat' first | exact pcFree_regIs | apply pcFree_sepConj) h16e
+  have f17 := cpsTripleWithin_frameR
+    (((.x10 : Reg) ↦ᵣ listBase) ** ((.x11 : Reg) ↦ᵣ len) ** ((.x12 : Reg) ↦ᵣ (1 : Word)) **
+     ((.x8 : Reg) ↦ᵣ listBase) ** ((.x9 : Reg) ↦ᵣ len))
+    (by repeat' first | exact pcFree_regIs | apply pcFree_sepConj) h17e
+  have s1 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) f14 f15
+  have s2 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) s1 f16
+  have s3 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) s2 f17
+  exact cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
+    (fun _ hq => by xperm_hyp hq) s3
+
+#print axioms wdField1Setup
+
+set_option maxRecDepth 8000 in
+/-- Field-3 call setup [45]-[48] (`WB+180 → WB+196`): `mv a0,s0 ; mv a1,s1 ;
+    li a2,3 ; addi a3,s2,40` — `rlp_field_to_u64(listBase, len, 3, outBase+40)`. -/
+theorem wdField3Setup (v10 v11 v12 v13 listBase len outBase : Word) :
+    cpsTripleWithin 4 (WB + 180) (WB + 196) fullCode
+      (((.x10 : Reg) ↦ᵣ v10) ** ((.x11 : Reg) ↦ᵣ v11) ** ((.x12 : Reg) ↦ᵣ v12) **
+       ((.x13 : Reg) ↦ᵣ v13) ** ((.x8 : Reg) ↦ᵣ listBase) **
+       ((.x9 : Reg) ↦ᵣ len) ** ((.x18 : Reg) ↦ᵣ outBase))
+      (((.x10 : Reg) ↦ᵣ listBase) ** ((.x11 : Reg) ↦ᵣ len) **
+       ((.x12 : Reg) ↦ᵣ (3 : Word)) ** ((.x13 : Reg) ↦ᵣ (outBase + 40)) **
+       ((.x8 : Reg) ↦ᵣ listBase) ** ((.x9 : Reg) ↦ᵣ len) **
+       ((.x18 : Reg) ↦ᵣ outBase)) := by
+  have h45 := mv_spec_gen_within .x10 .x8 listBase v10 (WB + 180) (by decide)
+  have h45e := cpsTripleWithin_extend_code wd_mono
+    (cpsTripleWithin_extend_code (cr' := wdCode)
+      (CodeReq.ofProg_mem_at WB (WB + 180) withdrawalDecode_prog 45 (.MV .x10 .x8)
+        (by bv_omega) (by rw [wd_length]; decide) rfl (by rw [wd_length]; decide)) h45)
+  have h46 := mv_spec_gen_within .x11 .x9 len v11 (WB + 184) (by decide)
+  have h46e := cpsTripleWithin_extend_code wd_mono
+    (cpsTripleWithin_extend_code (cr' := wdCode)
+      (CodeReq.ofProg_mem_at WB (WB + 184) withdrawalDecode_prog 46 (.MV .x11 .x9)
+        (by bv_omega) (by rw [wd_length]; decide) rfl (by rw [wd_length]; decide)) h46)
+  have h47 := li_spec_gen_within .x12 v12 (3 : Word) (WB + 188) (by decide)
+  have h47e := cpsTripleWithin_extend_code wd_mono
+    (cpsTripleWithin_extend_code (cr' := wdCode)
+      (CodeReq.ofProg_mem_at WB (WB + 188) withdrawalDecode_prog 47 (.LI .x12 (3 : Word))
+        (by bv_omega) (by rw [wd_length]; decide) rfl (by rw [wd_length]; decide)) h47)
+  have h48 := addi_spec_gen_within .x13 .x18 v13 outBase (40 : BitVec 12) (WB + 192) (by decide)
+  rw [show outBase + signExtend12 (40 : BitVec 12) = outBase + 40 from by
+    rw [show signExtend12 (40 : BitVec 12) = (40 : Word) from by decide]] at h48
+  have h48e := cpsTripleWithin_extend_code wd_mono
+    (cpsTripleWithin_extend_code (cr' := wdCode)
+      (CodeReq.ofProg_mem_at WB (WB + 192) withdrawalDecode_prog 48
+        (.ADDI .x13 .x18 (40 : BitVec 12)) (by bv_omega) (by rw [wd_length]; decide)
+        rfl (by rw [wd_length]; decide)) h48)
+  have f45 := cpsTripleWithin_frameR
+    (((.x11 : Reg) ↦ᵣ v11) ** ((.x12 : Reg) ↦ᵣ v12) ** ((.x13 : Reg) ↦ᵣ v13) **
+     ((.x9 : Reg) ↦ᵣ len) ** ((.x18 : Reg) ↦ᵣ outBase))
+    (by repeat' first | exact pcFree_regIs | apply pcFree_sepConj) h45e
+  have f46 := cpsTripleWithin_frameR
+    (((.x10 : Reg) ↦ᵣ listBase) ** ((.x12 : Reg) ↦ᵣ v12) ** ((.x13 : Reg) ↦ᵣ v13) **
+     ((.x8 : Reg) ↦ᵣ listBase) ** ((.x18 : Reg) ↦ᵣ outBase))
+    (by repeat' first | exact pcFree_regIs | apply pcFree_sepConj) h46e
+  have f47 := cpsTripleWithin_frameR
+    (((.x10 : Reg) ↦ᵣ listBase) ** ((.x11 : Reg) ↦ᵣ len) ** ((.x13 : Reg) ↦ᵣ v13) **
+     ((.x8 : Reg) ↦ᵣ listBase) ** ((.x9 : Reg) ↦ᵣ len) ** ((.x18 : Reg) ↦ᵣ outBase))
+    (by repeat' first | exact pcFree_regIs | apply pcFree_sepConj) h47e
+  have f48 := cpsTripleWithin_frameR
+    (((.x10 : Reg) ↦ᵣ listBase) ** ((.x11 : Reg) ↦ᵣ len) ** ((.x12 : Reg) ↦ᵣ (3 : Word)) **
+     ((.x8 : Reg) ↦ᵣ listBase) ** ((.x9 : Reg) ↦ᵣ len))
+    (by repeat' first | exact pcFree_regIs | apply pcFree_sepConj) h48e
+  have s1 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) f45 f46
+  have s2 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) s1 f47
+  have s3 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) s2 f48
+  exact cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
+    (fun _ hq => by xperm_hyp hq) s3
+
+#print axioms wdField3Setup
+
+/-- `la x13, wd_offset` at [23]-[24] (`WB+92 → WB+100`). -/
+theorem wdLaOff92 (v : Word) :
+    cpsTripleWithin 2 (WB + 92) (WB + 100) fullCode
+      (.x13 ↦ᵣ v) (.x13 ↦ᵣ wdOffsetAddr) := by
+  have hau : ∀ a i, CodeReq.singleton (WB + 92)
+      (.AUIPC .x13 (Codegen.laHi GuestAddrs.wd_offset (GuestAddrs.withdrawal_decode + 92)))
+        a = some i → fullCode a = some i := fun a i hi => wd_mono a i
+    (CodeReq.ofProg_mem_at WB (WB + 92) withdrawalDecode_prog 23
+      (.AUIPC .x13 (Codegen.laHi GuestAddrs.wd_offset (GuestAddrs.withdrawal_decode + 92)))
+      (by bv_omega) (by rw [wd_length]; decide) rfl (by rw [wd_length]; decide) a i hi)
+  have had : ∀ a i, CodeReq.singleton (WB + 96)
+      (.ADDI .x13 .x13 (Codegen.laLo GuestAddrs.wd_offset (GuestAddrs.withdrawal_decode + 92)))
+        a = some i → fullCode a = some i := fun a i hi => wd_mono a i
+    (CodeReq.ofProg_mem_at WB (WB + 96) withdrawalDecode_prog 24
+      (.ADDI .x13 .x13 (Codegen.laLo GuestAddrs.wd_offset (GuestAddrs.withdrawal_decode + 92)))
+      (by bv_omega) (by rw [wd_length]; decide) rfl (by rw [wd_length]; decide) a i hi)
+  have h := la_materialize_within .x13 v (WB + 92) wdOffsetAddr (by decide) (by decide) hau had
+  rw [show (WB + 92 : Word) + 8 = WB + 100 from by bv_omega] at h
+  exact h
+
+/-- `la x14, wd_length` at [25]-[26] (`WB+100 → WB+108`). -/
+theorem wdLaLen100 (v : Word) :
+    cpsTripleWithin 2 (WB + 100) (WB + 108) fullCode
+      (.x14 ↦ᵣ v) (.x14 ↦ᵣ wdLengthAddr) := by
+  have hau : ∀ a i, CodeReq.singleton (WB + 100)
+      (.AUIPC .x14 (Codegen.laHi GuestAddrs.wd_length (GuestAddrs.withdrawal_decode + 100)))
+        a = some i → fullCode a = some i := fun a i hi => wd_mono a i
+    (CodeReq.ofProg_mem_at WB (WB + 100) withdrawalDecode_prog 25
+      (.AUIPC .x14 (Codegen.laHi GuestAddrs.wd_length (GuestAddrs.withdrawal_decode + 100)))
+      (by bv_omega) (by rw [wd_length]; decide) rfl (by rw [wd_length]; decide) a i hi)
+  have had : ∀ a i, CodeReq.singleton (WB + 104)
+      (.ADDI .x14 .x14 (Codegen.laLo GuestAddrs.wd_length (GuestAddrs.withdrawal_decode + 100)))
+        a = some i → fullCode a = some i := fun a i hi => wd_mono a i
+    (CodeReq.ofProg_mem_at WB (WB + 104) withdrawalDecode_prog 26
+      (.ADDI .x14 .x14 (Codegen.laLo GuestAddrs.wd_length (GuestAddrs.withdrawal_decode + 100)))
+      (by bv_omega) (by rw [wd_length]; decide) rfl (by rw [wd_length]; decide) a i hi)
+  have h := la_materialize_within .x14 v (WB + 100) wdLengthAddr (by decide) (by decide) hau had
+  rw [show (WB + 100 : Word) + 8 = WB + 108 from by bv_omega] at h
+  exact h
+
+set_option maxRecDepth 8000 in
+/-- Field-2 call setup [20]-[26] (`WB+80 → WB+108`): `mv a0,s0 ; mv a1,s1 ;
+    li a2,2 ; la a3,wd_offset ; la a4,wd_length` — arrange
+    `rlp_list_nth_item(listBase, len, 2, &wd_offset, &wd_length)`. -/
+theorem wdField2Setup (v10 v11 v12 v13 v14 listBase len : Word) :
+    cpsTripleWithin 7 (WB + 80) (WB + 108) fullCode
+      (((.x10 : Reg) ↦ᵣ v10) ** ((.x11 : Reg) ↦ᵣ v11) ** ((.x12 : Reg) ↦ᵣ v12) **
+       ((.x13 : Reg) ↦ᵣ v13) ** ((.x14 : Reg) ↦ᵣ v14) ** ((.x8 : Reg) ↦ᵣ listBase) **
+       ((.x9 : Reg) ↦ᵣ len))
+      (((.x10 : Reg) ↦ᵣ listBase) ** ((.x11 : Reg) ↦ᵣ len) **
+       ((.x12 : Reg) ↦ᵣ (2 : Word)) ** ((.x13 : Reg) ↦ᵣ wdOffsetAddr) **
+       ((.x14 : Reg) ↦ᵣ wdLengthAddr) ** ((.x8 : Reg) ↦ᵣ listBase) **
+       ((.x9 : Reg) ↦ᵣ len)) := by
+  have h20 := mv_spec_gen_within .x10 .x8 listBase v10 (WB + 80) (by decide)
+  have h20e := cpsTripleWithin_extend_code wd_mono
+    (cpsTripleWithin_extend_code (cr' := wdCode)
+      (CodeReq.ofProg_mem_at WB (WB + 80) withdrawalDecode_prog 20 (.MV .x10 .x8)
+        (by bv_omega) (by rw [wd_length]; decide) rfl (by rw [wd_length]; decide)) h20)
+  have h21 := mv_spec_gen_within .x11 .x9 len v11 (WB + 84) (by decide)
+  have h21e := cpsTripleWithin_extend_code wd_mono
+    (cpsTripleWithin_extend_code (cr' := wdCode)
+      (CodeReq.ofProg_mem_at WB (WB + 84) withdrawalDecode_prog 21 (.MV .x11 .x9)
+        (by bv_omega) (by rw [wd_length]; decide) rfl (by rw [wd_length]; decide)) h21)
+  have h22 := li_spec_gen_within .x12 v12 (2 : Word) (WB + 88) (by decide)
+  have h22e := cpsTripleWithin_extend_code wd_mono
+    (cpsTripleWithin_extend_code (cr' := wdCode)
+      (CodeReq.ofProg_mem_at WB (WB + 88) withdrawalDecode_prog 22 (.LI .x12 (2 : Word))
+        (by bv_omega) (by rw [wd_length]; decide) rfl (by rw [wd_length]; decide)) h22)
+  have h23 := wdLaOff92 v13
+  have h25 := wdLaLen100 v14
+  have f20 := cpsTripleWithin_frameR
+    (((.x11 : Reg) ↦ᵣ v11) ** ((.x12 : Reg) ↦ᵣ v12) ** ((.x13 : Reg) ↦ᵣ v13) **
+     ((.x14 : Reg) ↦ᵣ v14) ** ((.x9 : Reg) ↦ᵣ len))
+    (by repeat' first | exact pcFree_regIs | apply pcFree_sepConj) h20e
+  have f21 := cpsTripleWithin_frameR
+    (((.x10 : Reg) ↦ᵣ listBase) ** ((.x12 : Reg) ↦ᵣ v12) ** ((.x13 : Reg) ↦ᵣ v13) **
+     ((.x14 : Reg) ↦ᵣ v14) ** ((.x8 : Reg) ↦ᵣ listBase))
+    (by repeat' first | exact pcFree_regIs | apply pcFree_sepConj) h21e
+  have f22 := cpsTripleWithin_frameR
+    (((.x10 : Reg) ↦ᵣ listBase) ** ((.x11 : Reg) ↦ᵣ len) ** ((.x13 : Reg) ↦ᵣ v13) **
+     ((.x14 : Reg) ↦ᵣ v14) ** ((.x8 : Reg) ↦ᵣ listBase) ** ((.x9 : Reg) ↦ᵣ len))
+    (by repeat' first | exact pcFree_regIs | apply pcFree_sepConj) h22e
+  have f23 := cpsTripleWithin_frameR
+    (((.x10 : Reg) ↦ᵣ listBase) ** ((.x11 : Reg) ↦ᵣ len) ** ((.x12 : Reg) ↦ᵣ (2 : Word)) **
+     ((.x14 : Reg) ↦ᵣ v14) ** ((.x8 : Reg) ↦ᵣ listBase) ** ((.x9 : Reg) ↦ᵣ len))
+    (by repeat' first | exact pcFree_regIs | apply pcFree_sepConj) h23
+  have f25 := cpsTripleWithin_frameR
+    (((.x10 : Reg) ↦ᵣ listBase) ** ((.x11 : Reg) ↦ᵣ len) ** ((.x12 : Reg) ↦ᵣ (2 : Word)) **
+     ((.x13 : Reg) ↦ᵣ wdOffsetAddr) ** ((.x8 : Reg) ↦ᵣ listBase) ** ((.x9 : Reg) ↦ᵣ len))
+    (by repeat' first | exact pcFree_regIs | apply pcFree_sepConj) h25
+  have s1 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) f20 f21
+  have s2 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) s1 f22
+  have s3 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) s2 f23
+  have s4 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) s3 f25
+  exact cpsTripleWithin_mono_nSteps (by omega)
+    (cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
+      (fun _ hq => by xperm_hyp hq) s4)
+
+#print axioms wdField2Setup
+
 end EvmAsm.Codegen.WithdrawalDecodeSpec

--- a/EvmAsm/Codegen/Programs/WithdrawalDecodeClose2.lean
+++ b/EvmAsm/Codegen/Programs/WithdrawalDecodeClose2.lean
@@ -571,4 +571,158 @@ theorem wdField0Call
 
 #print axioms wdField0Call
 
+/-! ## Field-1 call adapter [14]-[18] + K34 -/
+
+open EvmAsm.Codegen.RlpFieldToU64SAsm in
+set_option maxRecDepth 8000 in
+/-- Field-1 RLP call adapter [14]-[18] + `rlp_field_to_u64` (index 1, output
+    `outBase+8`), `ra := WB+76`. -/
+theorem wdField1Call
+    (spW newSp raIn listBase len outBase oldOut oldOffset oldLen old14
+      s3 s4 s5 v10 v11 v12 v13 : Word)
+    (bytes : List (BitVec 8)) (listLen : Nat)
+    (hnewSp : newSp = spW + signExtend12 (-32 : BitVec 12))
+    (hlenW : len = BitVec.ofNat 64 listLen)
+    (hsalign : listBase.toNat % 8 = 0)
+    (hslack : listLen + 9 ≤ bytes.length)
+    (hover : listBase.toNat + bytes.length < 2 ^ 64)
+    (hvalid : ∀ k, k < bytes.length →
+      isValidByteAccess (listBase + BitVec.ofNat 64 k) = true) :
+    let outer : Saved := { ra := WB + 76, s0 := listBase, s1 := len }
+    let saved : EvmAsm.Codegen.RlpListNthItemSAsm.Saved :=
+      { ra := B + 48, s0 := listBase, s1 := outBase + 8, s2 := outBase, s3 := s3,
+        s4 := s4, s5 := s5 }
+    let callSteps := 1 + ((12 + ((85 + 93 * (1 + 2)) + 6)) + 9)
+    let tailSteps := (7 + (1 + (7 * (2 ^ 64 - 1) + 11))) + 5
+    let n34 := (7 + 4 + callSteps) + ((1 + tailSteps) + 5)
+    cpsTripleWithin (4 + (1 + n34)) (WB + 56) (WB + 76) fullCode
+      (((.x1 : Reg) ↦ᵣ raIn) ** (.x2 ↦ᵣ spW) ** (.x8 ↦ᵣ listBase) ** (.x9 ↦ᵣ len) **
+        (.x18 ↦ᵣ outBase) ** (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ v11) ** (.x12 ↦ᵣ v12) **
+        (.x13 ↦ᵣ v13) ** (.x14 ↦ᵣ old14) ** frameSlotsOwn frame newSp **
+        stackFree newSp 8 ** regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+        (.x19 ↦ᵣ s3) ** (.x20 ↦ᵣ s4) ** (.x21 ↦ᵣ s5) ** regOwn .x28 ** regOwn .x29 **
+        regOwn .x30 ** regOwn .x31 ** (.x0 ↦ᵣ (0 : Word)) ** bytesRegion listBase bytes **
+        ((outBase + 8) ↦ₘ oldOut) ** (offsetCell ↦ₘ oldOffset) ** (lengthCell ↦ₘ oldLen))
+      (((.x1 : Reg) ↦ᵣ (WB + 76)) **
+        flatPost spW newSp listBase oldOffset oldLen outer saved bytes listLen 1) := by
+  intro outer saved callSteps tailSteps n34
+  have hsetup := wdField1Setup v10 v11 v12 v13 listBase len outBase
+  have hsetupF := cpsTripleWithin_frameR
+    ((.x1 ↦ᵣ raIn) ** (.x2 ↦ᵣ spW) ** (.x14 ↦ᵣ old14) ** frameSlotsOwn frame newSp **
+     stackFree newSp 8 ** regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+     (.x19 ↦ᵣ s3) ** (.x20 ↦ᵣ s4) ** (.x21 ↦ᵣ s5) ** regOwn .x28 ** regOwn .x29 **
+     regOwn .x30 ** regOwn .x31 ** (.x0 ↦ᵣ (0 : Word)) ** bytesRegion listBase bytes **
+     ((outBase + 8) ↦ₘ oldOut) ** (offsetCell ↦ₘ oldOffset) ** (lengthCell ↦ₘ oldLen))
+    (by repeat' first
+        | exact pcFree_regIs | exact pcFree_memIs | exact bytesRegion_pcFree _ _
+        | exact pcFree_regOwn | exact pcFree_frameSlotsOwn _ _ | exact pcFree_stackFree _ _
+        | apply pcFree_sepConj) hsetup
+  have hhead : cpsTripleWithin 4 (WB + 56) (WB + 72) fullCode
+      (((.x1 : Reg) ↦ᵣ raIn) ** (.x2 ↦ᵣ spW) ** (.x8 ↦ᵣ listBase) ** (.x9 ↦ᵣ len) **
+        (.x18 ↦ᵣ outBase) ** (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ v11) ** (.x12 ↦ᵣ v12) **
+        (.x13 ↦ᵣ v13) ** (.x14 ↦ᵣ old14) ** frameSlotsOwn frame newSp **
+        stackFree newSp 8 ** regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+        (.x19 ↦ᵣ s3) ** (.x20 ↦ᵣ s4) ** (.x21 ↦ᵣ s5) ** regOwn .x28 ** regOwn .x29 **
+        regOwn .x30 ** regOwn .x31 ** (.x0 ↦ᵣ (0 : Word)) ** bytesRegion listBase bytes **
+        ((outBase + 8) ↦ₘ oldOut) ** (offsetCell ↦ₘ oldOffset) ** (lengthCell ↦ₘ oldLen))
+      ((.x1 ↦ᵣ raIn) **
+       flatPre spW newSp listBase len (1 : Word) (outBase + 8) oldOut oldOffset oldLen
+         old14 outer outBase s3 s4 s5 bytes) :=
+    cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
+      (fun _ hq => by unfold flatPre wholeRest outer; xperm_hyp hq) hsetupF
+  have hflat := rlpFieldToU64_flat_spec_within spW newSp listBase len (1 : Word) (outBase + 8)
+    oldOut oldOffset oldLen old14 outer outBase s3 s4 s5 bytes listLen 1 hnewSp hlenW
+    (by decide) (by decide) hsalign hslack hover hvalid
+    (by show (WB + 76) &&& ~~~(1 : Word) = WB + 76; decide)
+  have hflatC := cpsTripleWithin_extend_code k34_mono hflat
+  have hcall := callWithin_spec (WB + 72) B raIn
+    (jalOff GuestAddrs.rlp_field_to_u64 (GuestAddrs.withdrawal_decode + 72))
+    n34 (by show (WB + 72) + signExtend21 _ = B; decide)
+    (fun a i hi => wd_mono a i
+      (CodeReq.ofProg_mem_at WB (WB + 72) withdrawalDecode_prog 18
+        (.JAL .x1 (jalOff GuestAddrs.rlp_field_to_u64 (GuestAddrs.withdrawal_decode + 72)))
+        (by bv_omega) (by rw [wd_length]; decide) rfl (by rw [wd_length]; decide) a i hi))
+    (by unfold flatPre wholeRest; pcf) hflatC
+  rw [show (WB + 72 + 4 : Word) = WB + 76 from by bv_omega] at hcall
+  exact cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) hhead hcall
+
+#print axioms wdField1Call
+
+/-! ## Field-3 call adapter [45]-[49] + K34 -/
+
+open EvmAsm.Codegen.RlpFieldToU64SAsm in
+set_option maxRecDepth 8000 in
+/-- Field-3 RLP call adapter [45]-[49] + `rlp_field_to_u64` (index 3, output
+    `outBase+40`), `ra := WB+200`. -/
+theorem wdField3Call
+    (spW newSp raIn listBase len outBase oldOut oldOffset oldLen old14
+      s3 s4 s5 v10 v11 v12 v13 : Word)
+    (bytes : List (BitVec 8)) (listLen : Nat)
+    (hnewSp : newSp = spW + signExtend12 (-32 : BitVec 12))
+    (hlenW : len = BitVec.ofNat 64 listLen)
+    (hsalign : listBase.toNat % 8 = 0)
+    (hslack : listLen + 9 ≤ bytes.length)
+    (hover : listBase.toNat + bytes.length < 2 ^ 64)
+    (hvalid : ∀ k, k < bytes.length →
+      isValidByteAccess (listBase + BitVec.ofNat 64 k) = true) :
+    let outer : Saved := { ra := WB + 200, s0 := listBase, s1 := len }
+    let saved : EvmAsm.Codegen.RlpListNthItemSAsm.Saved :=
+      { ra := B + 48, s0 := listBase, s1 := outBase + 40, s2 := outBase, s3 := s3,
+        s4 := s4, s5 := s5 }
+    let callSteps := 1 + ((12 + ((85 + 93 * (3 + 2)) + 6)) + 9)
+    let tailSteps := (7 + (1 + (7 * (2 ^ 64 - 1) + 11))) + 5
+    let n34 := (7 + 4 + callSteps) + ((1 + tailSteps) + 5)
+    cpsTripleWithin (4 + (1 + n34)) (WB + 180) (WB + 200) fullCode
+      (((.x1 : Reg) ↦ᵣ raIn) ** (.x2 ↦ᵣ spW) ** (.x8 ↦ᵣ listBase) ** (.x9 ↦ᵣ len) **
+        (.x18 ↦ᵣ outBase) ** (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ v11) ** (.x12 ↦ᵣ v12) **
+        (.x13 ↦ᵣ v13) ** (.x14 ↦ᵣ old14) ** frameSlotsOwn frame newSp **
+        stackFree newSp 8 ** regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+        (.x19 ↦ᵣ s3) ** (.x20 ↦ᵣ s4) ** (.x21 ↦ᵣ s5) ** regOwn .x28 ** regOwn .x29 **
+        regOwn .x30 ** regOwn .x31 ** (.x0 ↦ᵣ (0 : Word)) ** bytesRegion listBase bytes **
+        ((outBase + 40) ↦ₘ oldOut) ** (offsetCell ↦ₘ oldOffset) ** (lengthCell ↦ₘ oldLen))
+      (((.x1 : Reg) ↦ᵣ (WB + 200)) **
+        flatPost spW newSp listBase oldOffset oldLen outer saved bytes listLen 3) := by
+  intro outer saved callSteps tailSteps n34
+  have hsetup := wdField3Setup v10 v11 v12 v13 listBase len outBase
+  have hsetupF := cpsTripleWithin_frameR
+    ((.x1 ↦ᵣ raIn) ** (.x2 ↦ᵣ spW) ** (.x14 ↦ᵣ old14) ** frameSlotsOwn frame newSp **
+     stackFree newSp 8 ** regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+     (.x19 ↦ᵣ s3) ** (.x20 ↦ᵣ s4) ** (.x21 ↦ᵣ s5) ** regOwn .x28 ** regOwn .x29 **
+     regOwn .x30 ** regOwn .x31 ** (.x0 ↦ᵣ (0 : Word)) ** bytesRegion listBase bytes **
+     ((outBase + 40) ↦ₘ oldOut) ** (offsetCell ↦ₘ oldOffset) ** (lengthCell ↦ₘ oldLen))
+    (by repeat' first
+        | exact pcFree_regIs | exact pcFree_memIs | exact bytesRegion_pcFree _ _
+        | exact pcFree_regOwn | exact pcFree_frameSlotsOwn _ _ | exact pcFree_stackFree _ _
+        | apply pcFree_sepConj) hsetup
+  have hhead : cpsTripleWithin 4 (WB + 180) (WB + 196) fullCode
+      (((.x1 : Reg) ↦ᵣ raIn) ** (.x2 ↦ᵣ spW) ** (.x8 ↦ᵣ listBase) ** (.x9 ↦ᵣ len) **
+        (.x18 ↦ᵣ outBase) ** (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ v11) ** (.x12 ↦ᵣ v12) **
+        (.x13 ↦ᵣ v13) ** (.x14 ↦ᵣ old14) ** frameSlotsOwn frame newSp **
+        stackFree newSp 8 ** regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+        (.x19 ↦ᵣ s3) ** (.x20 ↦ᵣ s4) ** (.x21 ↦ᵣ s5) ** regOwn .x28 ** regOwn .x29 **
+        regOwn .x30 ** regOwn .x31 ** (.x0 ↦ᵣ (0 : Word)) ** bytesRegion listBase bytes **
+        ((outBase + 40) ↦ₘ oldOut) ** (offsetCell ↦ₘ oldOffset) ** (lengthCell ↦ₘ oldLen))
+      ((.x1 ↦ᵣ raIn) **
+       flatPre spW newSp listBase len (3 : Word) (outBase + 40) oldOut oldOffset oldLen
+         old14 outer outBase s3 s4 s5 bytes) :=
+    cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
+      (fun _ hq => by unfold flatPre wholeRest outer; xperm_hyp hq) hsetupF
+  have hflat := rlpFieldToU64_flat_spec_within spW newSp listBase len (3 : Word) (outBase + 40)
+    oldOut oldOffset oldLen old14 outer outBase s3 s4 s5 bytes listLen 3 hnewSp hlenW
+    (by decide) (by decide) hsalign hslack hover hvalid
+    (by show (WB + 200) &&& ~~~(1 : Word) = WB + 200; decide)
+  have hflatC := cpsTripleWithin_extend_code k34_mono hflat
+  have hcall := callWithin_spec (WB + 196) B raIn
+    (jalOff GuestAddrs.rlp_field_to_u64 (GuestAddrs.withdrawal_decode + 196))
+    n34 (by show (WB + 196) + signExtend21 _ = B; decide)
+    (fun a i hi => wd_mono a i
+      (CodeReq.ofProg_mem_at WB (WB + 196) withdrawalDecode_prog 49
+        (.JAL .x1 (jalOff GuestAddrs.rlp_field_to_u64 (GuestAddrs.withdrawal_decode + 196)))
+        (by bv_omega) (by rw [wd_length]; decide) rfl (by rw [wd_length]; decide) a i hi))
+    (by unfold flatPre wholeRest; pcf) hflatC
+  rw [show (WB + 196 + 4 : Word) = WB + 200 from by bv_omega] at hcall
+  exact cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) hhead hcall
+
+#print axioms wdField3Call
+
 end EvmAsm.Codegen.WithdrawalDecodeSpec

--- a/EvmAsm/Codegen/Programs/WithdrawalDecodeClose2.lean
+++ b/EvmAsm/Codegen/Programs/WithdrawalDecodeClose2.lean
@@ -725,4 +725,102 @@ theorem wdField3Call
 
 #print axioms wdField3Call
 
+/-! ## Field-2 call adapter [20]-[27] + strict K20 selector -/
+
+open EvmAsm.Codegen.RlpListNthItemSAsm in
+set_option maxRecDepth 8000 in
+/-- Field-2 RLP call adapter [20]-[27] + the strict `rlp_list_nth_item` selector
+    (index 2, outputs `wd_offset`/`wd_length`), `ra := WB+112`.  The post is
+    K20's `flatReturnResult` (its offset/length cells written, its `Result`
+    pinned). -/
+theorem wdField2Call
+    (spW raIn listBase len s2v s3 s4 s5 oldOffset oldLen v10 v11 v12 v13 v14 : Word)
+    (bytes : List (BitVec 8)) (listLen : Nat)
+    (hlenW : len = BitVec.ofNat 64 listLen)
+    (hsalign : listBase.toNat % 8 = 0)
+    (hslack : listLen + 9 ≤ bytes.length)
+    (hover : listBase.toNat + bytes.length < 2 ^ 64)
+    (hvalid : ∀ k, k < bytes.length →
+      isValidByteAccess (listBase + BitVec.ofNat 64 k) = true) :
+    let saved : Saved :=
+      { ra := WB + 112, s0 := listBase, s1 := len, s2 := s2v, s3 := s3, s4 := s4,
+        s5 := s5 }
+    let n20 := (12 + ((85 + 93 * (2 + 2)) + 6)) + 9
+    cpsTripleWithin (7 + (1 + n20)) (WB + 80) (WB + 112) fullCode
+      (((.x1 : Reg) ↦ᵣ raIn) ** (.x2 ↦ᵣ spW) ** (.x8 ↦ᵣ listBase) ** (.x9 ↦ᵣ len) **
+        (.x18 ↦ᵣ s2v) ** (.x19 ↦ᵣ s3) ** (.x20 ↦ᵣ s4) ** (.x21 ↦ᵣ s5) **
+        (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ v11) ** (.x12 ↦ᵣ v12) ** (.x13 ↦ᵣ v13) **
+        (.x14 ↦ᵣ v14) ** stackFree spW 8 ** regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+        regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+        (.x0 ↦ᵣ (0 : Word)) ** bytesRegion listBase bytes **
+        (wdOffsetAddr ↦ₘ oldOffset) ** (wdLengthAddr ↦ₘ oldLen))
+      (flatReturnResult spW listBase (2 : Word) wdOffsetAddr wdLengthAddr oldOffset
+        oldLen saved bytes listLen 2) := by
+  intro saved n20
+  -- [20]-[26] arg shuffle
+  have hsetup := wdField2Setup v10 v11 v12 v13 v14 listBase len
+  have hsetupF := cpsTripleWithin_frameR
+    ((.x1 ↦ᵣ raIn) ** (.x2 ↦ᵣ spW) ** (.x18 ↦ᵣ s2v) ** (.x19 ↦ᵣ s3) **
+     (.x20 ↦ᵣ s4) ** (.x21 ↦ᵣ s5) ** stackFree spW 8 ** regOwn .x5 ** regOwn .x6 **
+     regOwn .x7 ** regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+     (.x0 ↦ᵣ (0 : Word)) ** bytesRegion listBase bytes **
+     (wdOffsetAddr ↦ₘ oldOffset) ** (wdLengthAddr ↦ₘ oldLen))
+    (by repeat' first
+        | exact pcFree_regIs | exact pcFree_memIs | exact bytesRegion_pcFree _ _
+        | exact pcFree_regOwn | exact pcFree_stackFree _ _ | apply pcFree_sepConj) hsetup
+  have hhead : cpsTripleWithin 7 (WB + 80) (WB + 108) fullCode
+      (((.x1 : Reg) ↦ᵣ raIn) ** (.x2 ↦ᵣ spW) ** (.x8 ↦ᵣ listBase) ** (.x9 ↦ᵣ len) **
+        (.x18 ↦ᵣ s2v) ** (.x19 ↦ᵣ s3) ** (.x20 ↦ᵣ s4) ** (.x21 ↦ᵣ s5) **
+        (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ v11) ** (.x12 ↦ᵣ v12) ** (.x13 ↦ᵣ v13) **
+        (.x14 ↦ᵣ v14) ** stackFree spW 8 ** regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+        regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+        (.x0 ↦ᵣ (0 : Word)) ** bytesRegion listBase bytes **
+        (wdOffsetAddr ↦ₘ oldOffset) ** (wdLengthAddr ↦ₘ oldLen))
+      ((.x1 ↦ᵣ raIn) ** (.x2 ↦ᵣ spW) ** (.x8 ↦ᵣ listBase) ** (.x9 ↦ᵣ len) **
+       (.x18 ↦ᵣ s2v) ** (.x19 ↦ᵣ s3) ** (.x20 ↦ᵣ s4) ** (.x21 ↦ᵣ s5) **
+       stackFree spW 8 **
+       entryRest listBase len (2 : Word) wdOffsetAddr wdLengthAddr oldOffset oldLen bytes) :=
+    cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
+      (fun _ hq => by unfold entryRest; xperm_hyp hq) hsetupF
+  -- [27] jal rlp_list_nth_item : ra := WB+112, enter K20
+  have hjal := jal_link_spec_within
+    (jalOff GuestAddrs.rlp_list_nth_item (GuestAddrs.withdrawal_decode + 108)) (WB + 108) raIn
+  rw [show (WB + 108) + signExtend21 (jalOff GuestAddrs.rlp_list_nth_item
+      (GuestAddrs.withdrawal_decode + 108)) = B from by decide,
+    show (WB + 108 + 4 : Word) = WB + 112 from by bv_omega] at hjal
+  have hjale := cpsTripleWithin_extend_code wd_mono
+    (cpsTripleWithin_extend_code (cr' := wdCode)
+      (CodeReq.ofProg_mem_at WB (WB + 108) withdrawalDecode_prog 27
+        (.JAL .x1 (jalOff GuestAddrs.rlp_list_nth_item (GuestAddrs.withdrawal_decode + 108)))
+        (by bv_omega) (by rw [wd_length]; decide) rfl (by rw [wd_length]; decide)) hjal)
+  have hjalF := cpsTripleWithin_frameR
+    ((.x2 ↦ᵣ spW) ** (.x8 ↦ᵣ listBase) ** (.x9 ↦ᵣ len) ** (.x18 ↦ᵣ s2v) **
+     (.x19 ↦ᵣ s3) ** (.x20 ↦ᵣ s4) ** (.x21 ↦ᵣ s5) ** stackFree spW 8 **
+     entryRest listBase len (2 : Word) wdOffsetAddr wdLengthAddr oldOffset oldLen bytes)
+    (by repeat' first
+        | exact pcFree_regIs | exact pcFree_stackFree _ _
+        | exact (by unfold entryRest; repeat' first
+            | exact pcFree_regIs | exact pcFree_memIs | exact bytesRegion_pcFree _ _
+            | exact pcFree_regOwn | apply pcFree_sepConj : (entryRest listBase len (2 : Word)
+              wdOffsetAddr wdLengthAddr oldOffset oldLen bytes).pcFree)
+        | apply pcFree_sepConj) hjale
+  -- K20 flat selector.
+  have hk20 := rlpListNthItem_flat_spec_within spW listBase len (2 : Word) wdOffsetAddr
+    wdLengthAddr oldOffset oldLen saved bytes listLen 2 hlenW (by decide) (by decide)
+    hsalign hslack hover hvalid (by show (WB + 112) &&& ~~~(1 : Word) = WB + 112; decide)
+  have hk20C := cpsTripleWithin_extend_code k20_mono hk20
+  -- Compose head ;; jal ;; K20.
+  have s1 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) hhead hjalF
+  have s2 := cpsTripleWithin_seq_perm_same_cr
+    (fun _ hp => by
+      rw [regsAt_listNthFrame]
+      simp only [show saved.ra = WB + 112 from rfl, show saved.s0 = listBase from rfl,
+        show saved.s1 = len from rfl, show saved.s2 = s2v from rfl,
+        show saved.s3 = s3 from rfl, show saved.s4 = s4 from rfl,
+        show saved.s5 = s5 from rfl]
+      xperm_hyp hp) s1 hk20C
+  exact cpsTripleWithin_mono_nSteps (by omega) s2
+
+#print axioms wdField2Call
+
 end EvmAsm.Codegen.WithdrawalDecodeSpec

--- a/EvmAsm/Codegen/Programs/WithdrawalDecodeClose2.lean
+++ b/EvmAsm/Codegen/Programs/WithdrawalDecodeClose2.lean
@@ -489,4 +489,86 @@ theorem wdField2Setup (v10 v11 v12 v13 v14 listBase len : Word) :
 
 #print axioms wdField2Setup
 
+/-! ## Field-0 call adapter: arg shuffle ;; jal ;; strict K34 selector -/
+
+open EvmAsm.Codegen.RlpFieldToU64SAsm in
+set_option maxRecDepth 8000 in
+/-- Field-0 RLP call adapter [8]-[12] + the strict `rlp_field_to_u64` selector:
+    the arg shuffle establishes K34's `flatPre` for index 0 / output `outBase`,
+    the `jal` at [12] links `ra := WB+52` and enters the selector, whose
+    `flatPost` (success/failure with the field-0 `Result` pinned) is returned. -/
+theorem wdField0Call
+    (spW newSp raIn listBase len outBase oldOut oldOffset oldLen old14
+      s3 s4 s5 v10 v11 v12 v13 : Word)
+    (bytes : List (BitVec 8)) (listLen : Nat)
+    (hnewSp : newSp = spW + signExtend12 (-32 : BitVec 12))
+    (hlenW : len = BitVec.ofNat 64 listLen)
+    (hsalign : listBase.toNat % 8 = 0)
+    (hslack : listLen + 9 ≤ bytes.length)
+    (hover : listBase.toNat + bytes.length < 2 ^ 64)
+    (hvalid : ∀ k, k < bytes.length →
+      isValidByteAccess (listBase + BitVec.ofNat 64 k) = true) :
+    let outer : Saved := { ra := WB + 52, s0 := listBase, s1 := len }
+    let saved : EvmAsm.Codegen.RlpListNthItemSAsm.Saved :=
+      { ra := B + 48, s0 := listBase, s1 := outBase, s2 := outBase, s3 := s3,
+        s4 := s4, s5 := s5 }
+    let callSteps := 1 + ((12 + ((85 + 93 * (0 + 2)) + 6)) + 9)
+    let tailSteps := (7 + (1 + (7 * (2 ^ 64 - 1) + 11))) + 5
+    let n34 := (7 + 4 + callSteps) + ((1 + tailSteps) + 5)
+    cpsTripleWithin (4 + (1 + n34)) (WB + 32) (WB + 52) fullCode
+      (((.x1 : Reg) ↦ᵣ raIn) ** (.x2 ↦ᵣ spW) ** (.x8 ↦ᵣ listBase) ** (.x9 ↦ᵣ len) **
+        (.x18 ↦ᵣ outBase) ** (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ v11) ** (.x12 ↦ᵣ v12) **
+        (.x13 ↦ᵣ v13) ** (.x14 ↦ᵣ old14) ** frameSlotsOwn frame newSp **
+        stackFree newSp 8 ** regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+        (.x19 ↦ᵣ s3) ** (.x20 ↦ᵣ s4) ** (.x21 ↦ᵣ s5) ** regOwn .x28 ** regOwn .x29 **
+        regOwn .x30 ** regOwn .x31 ** (.x0 ↦ᵣ (0 : Word)) ** bytesRegion listBase bytes **
+        (outBase ↦ₘ oldOut) ** (offsetCell ↦ₘ oldOffset) ** (lengthCell ↦ₘ oldLen))
+      (((.x1 : Reg) ↦ᵣ (WB + 52)) **
+        flatPost spW newSp listBase oldOffset oldLen outer saved bytes listLen 0) := by
+  intro outer saved callSteps tailSteps n34
+  -- [8]-[11] arg shuffle → K34's flatPre
+  have hsetup := wdField0Setup v10 v11 v12 v13 listBase len outBase
+  have hsetupF := cpsTripleWithin_frameR
+    ((.x1 ↦ᵣ raIn) ** (.x2 ↦ᵣ spW) ** (.x14 ↦ᵣ old14) ** frameSlotsOwn frame newSp **
+     stackFree newSp 8 ** regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+     (.x19 ↦ᵣ s3) ** (.x20 ↦ᵣ s4) ** (.x21 ↦ᵣ s5) ** regOwn .x28 ** regOwn .x29 **
+     regOwn .x30 ** regOwn .x31 ** (.x0 ↦ᵣ (0 : Word)) ** bytesRegion listBase bytes **
+     (outBase ↦ₘ oldOut) ** (offsetCell ↦ₘ oldOffset) ** (lengthCell ↦ₘ oldLen))
+    (by repeat' first
+        | exact pcFree_regIs | exact pcFree_memIs | exact bytesRegion_pcFree _ _
+        | exact pcFree_regOwn | exact pcFree_frameSlotsOwn _ _ | exact pcFree_stackFree _ _
+        | apply pcFree_sepConj) hsetup
+  have hhead : cpsTripleWithin 4 (WB + 32) (WB + 48) fullCode
+      (((.x1 : Reg) ↦ᵣ raIn) ** (.x2 ↦ᵣ spW) ** (.x8 ↦ᵣ listBase) ** (.x9 ↦ᵣ len) **
+        (.x18 ↦ᵣ outBase) ** (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ v11) ** (.x12 ↦ᵣ v12) **
+        (.x13 ↦ᵣ v13) ** (.x14 ↦ᵣ old14) ** frameSlotsOwn frame newSp **
+        stackFree newSp 8 ** regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+        (.x19 ↦ᵣ s3) ** (.x20 ↦ᵣ s4) ** (.x21 ↦ᵣ s5) ** regOwn .x28 ** regOwn .x29 **
+        regOwn .x30 ** regOwn .x31 ** (.x0 ↦ᵣ (0 : Word)) ** bytesRegion listBase bytes **
+        (outBase ↦ₘ oldOut) ** (offsetCell ↦ₘ oldOffset) ** (lengthCell ↦ₘ oldLen))
+      ((.x1 ↦ᵣ raIn) **
+       flatPre spW newSp listBase len (0 : Word) outBase oldOut oldOffset oldLen old14
+         outer outBase s3 s4 s5 bytes) :=
+    cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
+      (fun _ hq => by unfold flatPre wholeRest outer; xperm_hyp hq) hsetupF
+  -- [12] jal rlp_field_to_u64 + strict K34.
+  have hflat := rlpFieldToU64_flat_spec_within spW newSp listBase len (0 : Word) outBase
+    oldOut oldOffset oldLen old14 outer outBase s3 s4 s5 bytes listLen 0 hnewSp hlenW
+    (by decide) (by decide) hsalign hslack hover hvalid
+    (by show (WB + 52) &&& ~~~(1 : Word) = WB + 52; decide)
+  have hflatC := cpsTripleWithin_extend_code k34_mono hflat
+  have hcall := callWithin_spec (WB + 48) B raIn
+    (jalOff GuestAddrs.rlp_field_to_u64 (GuestAddrs.withdrawal_decode + 48))
+    n34 (by show (WB + 48) + signExtend21 _ = B; decide)
+    (fun a i hi => wd_mono a i
+      (CodeReq.ofProg_mem_at WB (WB + 48) withdrawalDecode_prog 12
+        (.JAL .x1 (jalOff GuestAddrs.rlp_field_to_u64 (GuestAddrs.withdrawal_decode + 48)))
+        (by bv_omega) (by rw [wd_length]; decide) rfl (by rw [wd_length]; decide) a i hi))
+    (by unfold flatPre wholeRest; pcf) hflatC
+  rw [show (WB + 48 + 4 : Word) = WB + 52 from by bv_omega] at hcall
+  -- Compose head ;; call.
+  exact cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) hhead hcall
+
+#print axioms wdField0Call
+
 end EvmAsm.Codegen.WithdrawalDecodeSpec

--- a/EvmAsm/Codegen/Programs/WithdrawalDecodeClose3.lean
+++ b/EvmAsm/Codegen/Programs/WithdrawalDecodeClose3.lean
@@ -571,4 +571,80 @@ theorem savedFrameK34_own (newSp : Word) (saved : Saved) :
 
 #print axioms savedFrameK34_own
 
+/-! ## Return-edge tails: dispatch exit ;; status store ;; epilogue
+
+    Both the common failure tail ([53], `WB+212`) and the success tail
+    ([51]-[52], `WB+204`) fall into the shared epilogue core ([54]-[59]).  These
+    two lemmas stitch each status-store tail to `wdEpiCore`, generic over the
+    caller's remaining footprint `G0`. -/
+
+set_option maxRecDepth 8000 in
+/-- Failure edge `WB+212 → raIn`: store `a0 := 1` and run the epilogue. -/
+theorem wdFailEpi
+    (sp0 spW raIn s0Old s1Old s2Old x1old x8old x9old x18old v10old : Word)
+    (G0 : Assertion) (hG0 : G0.pcFree)
+    (hspW : spW = sp0 + signExtend12 (-32 : BitVec 12))
+    (hret : raIn &&& ~~~(1 : Word) = raIn) :
+    cpsTripleWithin 7 (WB + 212) raIn fullCode
+      (((.x10 : Reg) ↦ᵣ v10old) **
+       ((.x2 ↦ᵣ spW) ** (.x1 ↦ᵣ x1old) ** (.x8 ↦ᵣ x8old) ** (.x9 ↦ᵣ x9old) **
+        (.x18 ↦ᵣ x18old) ** (spW ↦ₘ raIn) ** ((spW + 8) ↦ₘ s0Old) **
+        ((spW + 16) ↦ₘ s1Old) ** ((spW + 24) ↦ₘ s2Old)) ** G0)
+      (((.x10 : Reg) ↦ᵣ (1 : Word)) **
+       ((.x2 ↦ᵣ sp0) ** (.x1 ↦ᵣ raIn) ** (.x8 ↦ᵣ s0Old) ** (.x9 ↦ᵣ s1Old) **
+        (.x18 ↦ᵣ s2Old) ** (spW ↦ₘ raIn) ** ((spW + 8) ↦ₘ s0Old) **
+        ((spW + 16) ↦ₘ s1Old) ** ((spW + 24) ↦ₘ s2Old)) ** G0) := by
+  have hft := wdFailTail v10old
+    (((.x2 ↦ᵣ spW) ** (.x1 ↦ᵣ x1old) ** (.x8 ↦ᵣ x8old) ** (.x9 ↦ᵣ x9old) **
+      (.x18 ↦ᵣ x18old) ** (spW ↦ₘ raIn) ** ((spW + 8) ↦ₘ s0Old) **
+      ((spW + 16) ↦ₘ s1Old) ** ((spW + 24) ↦ₘ s2Old)) ** G0)
+    (by
+      repeat' first
+        | exact hG0
+        | exact pcFree_regIs
+        | exact pcFree_memIs
+        | apply pcFree_sepConj)
+  have hepi := wdEpiCore sp0 spW raIn s0Old s1Old s2Old x1old x8old x9old x18old
+    (((.x10 : Reg) ↦ᵣ (1 : Word)) ** G0)
+    (by exact pcFree_sepConj pcFree_regIs hG0) hspW hret
+  exact cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp) (fun _ hq => by xperm_hyp hq)
+    (cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) hft hepi)
+
+#print axioms wdFailEpi
+
+set_option maxRecDepth 8000 in
+/-- Success edge `WB+204 → raIn`: store `a0 := 0`, jump to the epilogue, and
+    run it. -/
+theorem wdSuccessEpi
+    (sp0 spW raIn s0Old s1Old s2Old x1old x8old x9old x18old v10old : Word)
+    (G0 : Assertion) (hG0 : G0.pcFree)
+    (hspW : spW = sp0 + signExtend12 (-32 : BitVec 12))
+    (hret : raIn &&& ~~~(1 : Word) = raIn) :
+    cpsTripleWithin 8 (WB + 204) raIn fullCode
+      (((.x10 : Reg) ↦ᵣ v10old) **
+       ((.x2 ↦ᵣ spW) ** (.x1 ↦ᵣ x1old) ** (.x8 ↦ᵣ x8old) ** (.x9 ↦ᵣ x9old) **
+        (.x18 ↦ᵣ x18old) ** (spW ↦ₘ raIn) ** ((spW + 8) ↦ₘ s0Old) **
+        ((spW + 16) ↦ₘ s1Old) ** ((spW + 24) ↦ₘ s2Old)) ** G0)
+      (((.x10 : Reg) ↦ᵣ (0 : Word)) **
+       ((.x2 ↦ᵣ sp0) ** (.x1 ↦ᵣ raIn) ** (.x8 ↦ᵣ s0Old) ** (.x9 ↦ᵣ s1Old) **
+        (.x18 ↦ᵣ s2Old) ** (spW ↦ₘ raIn) ** ((spW + 8) ↦ₘ s0Old) **
+        ((spW + 16) ↦ₘ s1Old) ** ((spW + 24) ↦ₘ s2Old)) ** G0) := by
+  have hst := wdSuccessTail v10old
+    (((.x2 ↦ᵣ spW) ** (.x1 ↦ᵣ x1old) ** (.x8 ↦ᵣ x8old) ** (.x9 ↦ᵣ x9old) **
+      (.x18 ↦ᵣ x18old) ** (spW ↦ₘ raIn) ** ((spW + 8) ↦ₘ s0Old) **
+      ((spW + 16) ↦ₘ s1Old) ** ((spW + 24) ↦ₘ s2Old)) ** G0)
+    (by
+      repeat' first
+        | exact hG0
+        | exact pcFree_regIs
+        | exact pcFree_memIs
+        | apply pcFree_sepConj)
+  have hepi := wdEpiCore sp0 spW raIn s0Old s1Old s2Old x1old x8old x9old x18old
+    (((.x10 : Reg) ↦ᵣ (0 : Word)) ** G0)
+    (by exact pcFree_sepConj pcFree_regIs hG0) hspW hret
+  exact cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp) (fun _ hq => by xperm_hyp hq)
+    (cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) hst hepi)
+
+#print axioms wdSuccessEpi
+
 end EvmAsm.Codegen.WithdrawalDecodeSpec

--- a/EvmAsm/Codegen/Programs/WithdrawalDecodeClose3.lean
+++ b/EvmAsm/Codegen/Programs/WithdrawalDecodeClose3.lean
@@ -355,4 +355,197 @@ theorem k20Dispatch (spW listBase oldOffset oldLen : Word)
 
 #print axioms k20Dispatch
 
+/-! ## Per-field stages: field call ;; status dispatch -/
+
+open EvmAsm.Codegen.RlpFieldToU64SAsm in
+set_option maxRecDepth 8000 in
+/-- Field-0 stage [8]-[13] (`WB+32`): the field-0 K34 call composed with its
+    status dispatch at [13].  Nonzero status → `WB+212`; status `0` → `WB+56`. -/
+theorem wdField0Stage
+    (spW newSp raIn listBase len outBase oldOut oldOffset oldLen old14
+      s3 s4 s5 v10 v11 v12 v13 : Word)
+    (bytes : List (BitVec 8)) (listLen : Nat)
+    (hnewSp : newSp = spW + signExtend12 (-32 : BitVec 12))
+    (hlenW : len = BitVec.ofNat 64 listLen)
+    (hsalign : listBase.toNat % 8 = 0)
+    (hslack : listLen + 9 ≤ bytes.length)
+    (hover : listBase.toNat + bytes.length < 2 ^ 64)
+    (hvalid : ∀ k, k < bytes.length →
+      isValidByteAccess (listBase + BitVec.ofNat 64 k) = true) :
+    let outer : Saved := { ra := WB + 52, s0 := listBase, s1 := len }
+    let saved : EvmAsm.Codegen.RlpListNthItemSAsm.Saved :=
+      { ra := B + 48, s0 := listBase, s1 := outBase, s2 := outBase, s3 := s3,
+        s4 := s4, s5 := s5 }
+    let callSteps := 1 + ((12 + ((85 + 93 * (0 + 2)) + 6)) + 9)
+    let tailSteps := (7 + (1 + (7 * (2 ^ 64 - 1) + 11))) + 5
+    let n34 := (7 + 4 + callSteps) + ((1 + tailSteps) + 5)
+    cpsBranchWithin (4 + (1 + n34) + 1) (WB + 32) fullCode
+      (((.x1 : Reg) ↦ᵣ raIn) ** (.x2 ↦ᵣ spW) ** (.x8 ↦ᵣ listBase) ** (.x9 ↦ᵣ len) **
+        (.x18 ↦ᵣ outBase) ** (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ v11) ** (.x12 ↦ᵣ v12) **
+        (.x13 ↦ᵣ v13) ** (.x14 ↦ᵣ old14) ** frameSlotsOwn frame newSp **
+        stackFree newSp 8 ** regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+        (.x19 ↦ᵣ s3) ** (.x20 ↦ᵣ s4) ** (.x21 ↦ᵣ s5) ** regOwn .x28 ** regOwn .x29 **
+        regOwn .x30 ** regOwn .x31 ** (.x0 ↦ᵣ (0 : Word)) ** bytesRegion listBase bytes **
+        (outBase ↦ₘ oldOut) ** (offsetCell ↦ₘ oldOffset) ** (lengthCell ↦ₘ oldLen))
+      (WB + 212)
+        (k34FailPost spW newSp listBase oldOffset oldLen (WB + 52) outer saved bytes
+          listLen 0)
+      (WB + 56)
+        (k34ContPost spW newSp listBase (WB + 52) outer saved bytes listLen 0) := by
+  intro outer saved callSteps tailSteps n34
+  have hcall := wdField0Call spW newSp raIn listBase len outBase oldOut oldOffset
+    oldLen old14 s3 s4 s5 v10 v11 v12 v13 bytes listLen hnewSp hlenW hsalign hslack
+    hover hvalid
+  have hmem : ∀ a i, CodeReq.singleton (WB + 52) (.BNE .x10 .x0 (160 : BitVec 13))
+      a = some i → fullCode a = some i := fun a i hi => wd_mono a i
+    (CodeReq.ofProg_mem_at WB (WB + 52) withdrawalDecode_prog 13
+      (.BNE .x10 .x0 (160 : BitVec 13)) (by bv_omega) (by rw [wd_length]; decide)
+      rfl (by rw [wd_length]; decide) a i hi)
+  have hdisp := k34Dispatch spW newSp listBase oldOffset oldLen (WB + 52) outer saved
+    bytes listLen 0 (WB + 52) (WB + 212) (WB + 56) (160 : BitVec 13) hmem
+    (by rw [show signExtend13 (160 : BitVec 13) = (160 : Word) from by decide]; bv_omega)
+    (by bv_omega)
+  exact cpsTripleWithin_seq_branch_same_cr hcall hdisp
+
+#print axioms wdField0Stage
+
+open EvmAsm.Codegen.RlpFieldToU64SAsm in
+set_option maxRecDepth 8000 in
+/-- Field-1 stage [14]-[19] (`WB+56`): field-1 K34 call + dispatch at [19].
+    Nonzero status → `WB+212`; status `0` → `WB+80`. -/
+theorem wdField1Stage
+    (spW newSp raIn listBase len outBase oldOut oldOffset oldLen old14
+      s3 s4 s5 v10 v11 v12 v13 : Word)
+    (bytes : List (BitVec 8)) (listLen : Nat)
+    (hnewSp : newSp = spW + signExtend12 (-32 : BitVec 12))
+    (hlenW : len = BitVec.ofNat 64 listLen)
+    (hsalign : listBase.toNat % 8 = 0)
+    (hslack : listLen + 9 ≤ bytes.length)
+    (hover : listBase.toNat + bytes.length < 2 ^ 64)
+    (hvalid : ∀ k, k < bytes.length →
+      isValidByteAccess (listBase + BitVec.ofNat 64 k) = true) :
+    let outer : Saved := { ra := WB + 76, s0 := listBase, s1 := len }
+    let saved : EvmAsm.Codegen.RlpListNthItemSAsm.Saved :=
+      { ra := B + 48, s0 := listBase, s1 := outBase + 8, s2 := outBase, s3 := s3,
+        s4 := s4, s5 := s5 }
+    let callSteps := 1 + ((12 + ((85 + 93 * (1 + 2)) + 6)) + 9)
+    let tailSteps := (7 + (1 + (7 * (2 ^ 64 - 1) + 11))) + 5
+    let n34 := (7 + 4 + callSteps) + ((1 + tailSteps) + 5)
+    cpsBranchWithin (4 + (1 + n34) + 1) (WB + 56) fullCode
+      (((.x1 : Reg) ↦ᵣ raIn) ** (.x2 ↦ᵣ spW) ** (.x8 ↦ᵣ listBase) ** (.x9 ↦ᵣ len) **
+        (.x18 ↦ᵣ outBase) ** (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ v11) ** (.x12 ↦ᵣ v12) **
+        (.x13 ↦ᵣ v13) ** (.x14 ↦ᵣ old14) ** frameSlotsOwn frame newSp **
+        stackFree newSp 8 ** regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+        (.x19 ↦ᵣ s3) ** (.x20 ↦ᵣ s4) ** (.x21 ↦ᵣ s5) ** regOwn .x28 ** regOwn .x29 **
+        regOwn .x30 ** regOwn .x31 ** (.x0 ↦ᵣ (0 : Word)) ** bytesRegion listBase bytes **
+        ((outBase + 8) ↦ₘ oldOut) ** (offsetCell ↦ₘ oldOffset) ** (lengthCell ↦ₘ oldLen))
+      (WB + 212)
+        (k34FailPost spW newSp listBase oldOffset oldLen (WB + 76) outer saved bytes
+          listLen 1)
+      (WB + 80)
+        (k34ContPost spW newSp listBase (WB + 76) outer saved bytes listLen 1) := by
+  intro outer saved callSteps tailSteps n34
+  have hcall := wdField1Call spW newSp raIn listBase len outBase oldOut oldOffset
+    oldLen old14 s3 s4 s5 v10 v11 v12 v13 bytes listLen hnewSp hlenW hsalign hslack
+    hover hvalid
+  have hmem : ∀ a i, CodeReq.singleton (WB + 76) (.BNE .x10 .x0 (136 : BitVec 13))
+      a = some i → fullCode a = some i := fun a i hi => wd_mono a i
+    (CodeReq.ofProg_mem_at WB (WB + 76) withdrawalDecode_prog 19
+      (.BNE .x10 .x0 (136 : BitVec 13)) (by bv_omega) (by rw [wd_length]; decide)
+      rfl (by rw [wd_length]; decide) a i hi)
+  have hdisp := k34Dispatch spW newSp listBase oldOffset oldLen (WB + 76) outer saved
+    bytes listLen 1 (WB + 76) (WB + 212) (WB + 80) (136 : BitVec 13) hmem
+    (by rw [show signExtend13 (136 : BitVec 13) = (136 : Word) from by decide]; bv_omega)
+    (by bv_omega)
+  exact cpsTripleWithin_seq_branch_same_cr hcall hdisp
+
+#print axioms wdField1Stage
+
+open EvmAsm.Codegen.RlpFieldToU64SAsm in
+set_option maxRecDepth 8000 in
+/-- Field-3 stage [45]-[50] (`WB+180`): field-3 K34 call + dispatch at [50].
+    Nonzero status → `WB+212`; status `0` → `WB+204`. -/
+theorem wdField3Stage
+    (spW newSp raIn listBase len outBase oldOut oldOffset oldLen old14
+      s3 s4 s5 v10 v11 v12 v13 : Word)
+    (bytes : List (BitVec 8)) (listLen : Nat)
+    (hnewSp : newSp = spW + signExtend12 (-32 : BitVec 12))
+    (hlenW : len = BitVec.ofNat 64 listLen)
+    (hsalign : listBase.toNat % 8 = 0)
+    (hslack : listLen + 9 ≤ bytes.length)
+    (hover : listBase.toNat + bytes.length < 2 ^ 64)
+    (hvalid : ∀ k, k < bytes.length →
+      isValidByteAccess (listBase + BitVec.ofNat 64 k) = true) :
+    let outer : Saved := { ra := WB + 200, s0 := listBase, s1 := len }
+    let saved : EvmAsm.Codegen.RlpListNthItemSAsm.Saved :=
+      { ra := B + 48, s0 := listBase, s1 := outBase + 40, s2 := outBase, s3 := s3,
+        s4 := s4, s5 := s5 }
+    let callSteps := 1 + ((12 + ((85 + 93 * (3 + 2)) + 6)) + 9)
+    let tailSteps := (7 + (1 + (7 * (2 ^ 64 - 1) + 11))) + 5
+    let n34 := (7 + 4 + callSteps) + ((1 + tailSteps) + 5)
+    cpsBranchWithin (4 + (1 + n34) + 1) (WB + 180) fullCode
+      (((.x1 : Reg) ↦ᵣ raIn) ** (.x2 ↦ᵣ spW) ** (.x8 ↦ᵣ listBase) ** (.x9 ↦ᵣ len) **
+        (.x18 ↦ᵣ outBase) ** (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ v11) ** (.x12 ↦ᵣ v12) **
+        (.x13 ↦ᵣ v13) ** (.x14 ↦ᵣ old14) ** frameSlotsOwn frame newSp **
+        stackFree newSp 8 ** regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+        (.x19 ↦ᵣ s3) ** (.x20 ↦ᵣ s4) ** (.x21 ↦ᵣ s5) ** regOwn .x28 ** regOwn .x29 **
+        regOwn .x30 ** regOwn .x31 ** (.x0 ↦ᵣ (0 : Word)) ** bytesRegion listBase bytes **
+        ((outBase + 40) ↦ₘ oldOut) ** (offsetCell ↦ₘ oldOffset) ** (lengthCell ↦ₘ oldLen))
+      (WB + 212)
+        (k34FailPost spW newSp listBase oldOffset oldLen (WB + 200) outer saved bytes
+          listLen 3)
+      (WB + 204)
+        (k34ContPost spW newSp listBase (WB + 200) outer saved bytes listLen 3) := by
+  intro outer saved callSteps tailSteps n34
+  have hcall := wdField3Call spW newSp raIn listBase len outBase oldOut oldOffset
+    oldLen old14 s3 s4 s5 v10 v11 v12 v13 bytes listLen hnewSp hlenW hsalign hslack
+    hover hvalid
+  have hmem : ∀ a i, CodeReq.singleton (WB + 200) (.BNE .x10 .x0 (12 : BitVec 13))
+      a = some i → fullCode a = some i := fun a i hi => wd_mono a i
+    (CodeReq.ofProg_mem_at WB (WB + 200) withdrawalDecode_prog 50
+      (.BNE .x10 .x0 (12 : BitVec 13)) (by bv_omega) (by rw [wd_length]; decide)
+      rfl (by rw [wd_length]; decide) a i hi)
+  have hdisp := k34Dispatch spW newSp listBase oldOffset oldLen (WB + 200) outer saved
+    bytes listLen 3 (WB + 200) (WB + 212) (WB + 204) (12 : BitVec 13) hmem
+    (by rw [show signExtend13 (12 : BitVec 13) = (12 : Word) from by decide]; bv_omega)
+    (by bv_omega)
+  exact cpsTripleWithin_seq_branch_same_cr hcall hdisp
+
+#print axioms wdField3Stage
+
+open EvmAsm.Codegen.RlpListNthItemSAsm in
+set_option maxRecDepth 8000 in
+/-- Field-2 stage [20]-[28] (`WB+80`): field-2 K20 call + dispatch at [28].
+    Nonzero status → `WB+212`; status `0` → `WB+116` (length check). -/
+theorem wdField2Stage
+    (spW raIn listBase len s2v s3 s4 s5 oldOffset oldLen v10 v11 v12 v13 v14 : Word)
+    (bytes : List (BitVec 8)) (listLen : Nat)
+    (hlenW : len = BitVec.ofNat 64 listLen)
+    (hsalign : listBase.toNat % 8 = 0)
+    (hslack : listLen + 9 ≤ bytes.length)
+    (hover : listBase.toNat + bytes.length < 2 ^ 64)
+    (hvalid : ∀ k, k < bytes.length →
+      isValidByteAccess (listBase + BitVec.ofNat 64 k) = true) :
+    let saved : EvmAsm.Codegen.RlpListNthItemSAsm.Saved :=
+      { ra := WB + 112, s0 := listBase, s1 := len, s2 := s2v, s3 := s3, s4 := s4,
+        s5 := s5 }
+    let n20 := (12 + ((85 + 93 * (2 + 2)) + 6)) + 9
+    cpsBranchWithin (7 + (1 + n20) + 1) (WB + 80) fullCode
+      (((.x1 : Reg) ↦ᵣ raIn) ** (.x2 ↦ᵣ spW) ** (.x8 ↦ᵣ listBase) ** (.x9 ↦ᵣ len) **
+        (.x18 ↦ᵣ s2v) ** (.x19 ↦ᵣ s3) ** (.x20 ↦ᵣ s4) ** (.x21 ↦ᵣ s5) **
+        (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ v11) ** (.x12 ↦ᵣ v12) ** (.x13 ↦ᵣ v13) **
+        (.x14 ↦ᵣ v14) ** stackFree spW 8 ** regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+        regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+        (.x0 ↦ᵣ (0 : Word)) ** bytesRegion listBase bytes **
+        (wdOffsetAddr ↦ₘ oldOffset) ** (wdLengthAddr ↦ₘ oldLen))
+      (WB + 212) (k20FailPost spW listBase oldOffset oldLen saved bytes listLen)
+      (WB + 116) (k20ContPost spW listBase saved bytes listLen) := by
+  intro saved n20
+  have hcall := wdField2Call spW raIn listBase len s2v s3 s4 s5 oldOffset oldLen
+    v10 v11 v12 v13 v14 bytes listLen hlenW hsalign hslack hover hvalid
+  have hdisp := k20Dispatch spW listBase oldOffset oldLen saved bytes listLen
+  exact cpsTripleWithin_seq_branch_same_cr hcall hdisp
+
+#print axioms wdField2Stage
+
 end EvmAsm.Codegen.WithdrawalDecodeSpec

--- a/EvmAsm/Codegen/Programs/WithdrawalDecodeClose3.lean
+++ b/EvmAsm/Codegen/Programs/WithdrawalDecodeClose3.lean
@@ -222,4 +222,137 @@ theorem k34Dispatch (spW newSp listBase oldOffset oldLen raRet : Word)
 
 #print axioms k34Dispatch
 
+/-! ## K20 (field-2) status-dispatch post-conditions
+
+    The address field is decoded by `rlp_list_nth_item` (K20), whose call
+    adapter exposes `flatReturnResult`: a single existential over the returned
+    `status`/`offset`/`length` with a pinned `Result`.  After the `BNE x10, x0`
+    at [28]:
+
+    * status `0` continues (`contTarget`), the selected content offset/length
+      written to the `wd_offset`/`wd_length` cells and a `Success` pinned; and
+    * a nonzero status (`1`) fails (`failTarget`), with the K20 `Failure`
+      pinned. -/
+
+open EvmAsm.Codegen.RlpListNthItemSAsm (listNthFrame savedVals regsAt_listNthFrame
+  Success Failure flatReturnResult)
+
+/-- Continue-exit post (status `0`) of the field-2 K20 dispatch. -/
+def k20ContPost (spW listBase : Word)
+    (saved : EvmAsm.Codegen.RlpListNthItemSAsm.Saved)
+    (bytes : List (BitVec 8)) (listLen : Nat) : Assertion :=
+  fun h => ∃ offset len v11 v12,
+    ((⌜EvmAsm.Codegen.RlpListNthItemSAsm.Success bytes listBase listLen 2 offset
+        len⌝ : Assertion) **
+     ((((.x2 ↦ᵣ spW) ** regsAt listNthFrame (savedVals saved) ** stackFree spW 8) **
+       ((.x10 ↦ᵣ (0 : Word)) ** regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+        (.x11 ↦ᵣ v11) ** (.x12 ↦ᵣ v12) ** regOwn .x13 ** regOwn .x14 **
+        regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+        (.x0 ↦ᵣ (0 : Word)) ** bytesRegion listBase bytes **
+        (wdOffsetAddr ↦ₘ offset) ** (wdLengthAddr ↦ₘ len))))) h
+
+/-- Fail-exit post (nonzero status) of the field-2 K20 dispatch. -/
+def k20FailPost (spW listBase oldOffset oldLen : Word)
+    (saved : EvmAsm.Codegen.RlpListNthItemSAsm.Saved)
+    (bytes : List (BitVec 8)) (listLen : Nat) : Assertion :=
+  fun h => ∃ status offset len v11 v12,
+    ((⌜EvmAsm.Codegen.RlpListNthItemSAsm.Result bytes listBase listLen 2 oldOffset
+        oldLen status offset len ∧ status ≠ (0 : Word)⌝ : Assertion) **
+     ((((.x2 ↦ᵣ spW) ** regsAt listNthFrame (savedVals saved) ** stackFree spW 8) **
+       ((.x10 ↦ᵣ status) ** regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+        (.x11 ↦ᵣ v11) ** (.x12 ↦ᵣ v12) ** regOwn .x13 ** regOwn .x14 **
+        regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+        (.x0 ↦ᵣ (0 : Word)) ** bytesRegion listBase bytes **
+        (wdOffsetAddr ↦ₘ offset) ** (wdLengthAddr ↦ₘ len))))) h
+
+set_option maxRecDepth 8000 in
+/-- Field-2 (K20) post-call status dispatch at [28] (`WB+112`): route the
+    `rlp_list_nth_item` status to the failure tail (`WB+212`) on nonzero, or to
+    the length check (`WB+116`) on status `0`. -/
+theorem k20Dispatch (spW listBase oldOffset oldLen : Word)
+    (saved : EvmAsm.Codegen.RlpListNthItemSAsm.Saved)
+    (bytes : List (BitVec 8)) (listLen : Nat) :
+    cpsBranchWithin 1 (WB + 112) fullCode
+      (flatReturnResult spW listBase (2 : Word) wdOffsetAddr wdLengthAddr oldOffset
+        oldLen saved bytes listLen 2)
+      (WB + 212) (k20FailPost spW listBase oldOffset oldLen saved bytes listLen)
+      (WB + 116) (k20ContPost spW listBase saved bytes listLen) := by
+  have hmem : ∀ a i, CodeReq.singleton (WB + 112) (.BNE .x10 .x0 (100 : BitVec 13))
+      a = some i → fullCode a = some i := fun a i hi => wd_mono a i
+    (CodeReq.ofProg_mem_at WB (WB + 112) withdrawalDecode_prog 28
+      (.BNE .x10 .x0 (100 : BitVec 13)) (by bv_omega) (by rw [wd_length]; decide)
+      rfl (by rw [wd_length]; decide) a i hi)
+  refine cpsBranchWithin_weaken (P := fun h => ∃ status offset len v11 v12,
+      ((((.x2 ↦ᵣ spW) ** regsAt listNthFrame (savedVals saved) ** stackFree spW 8) **
+        ((.x10 ↦ᵣ status) ** regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+         (.x11 ↦ᵣ v11) ** (.x12 ↦ᵣ v12) ** regOwn .x13 ** regOwn .x14 **
+         regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+         (.x0 ↦ᵣ (0 : Word)) ** bytesRegion listBase bytes **
+         (wdOffsetAddr ↦ₘ offset) ** (wdLengthAddr ↦ₘ len))) **
+       ⌜EvmAsm.Codegen.RlpListNthItemSAsm.Result bytes listBase listLen 2 oldOffset
+         oldLen status offset len⌝) h)
+    (fun h hp => hp) (fun _ hq => hq) (fun _ hq => hq) ?_
+  refine cpsBranchWithin_exists_pre (fun status => ?_)
+  refine cpsBranchWithin_exists_pre (fun offset => ?_)
+  refine cpsBranchWithin_exists_pre (fun len => ?_)
+  refine cpsBranchWithin_exists_pre (fun v11 => ?_)
+  refine cpsBranchWithin_exists_pre (fun v12 => ?_)
+  let REST : Assertion :=
+    (((.x2 ↦ᵣ spW) ** regsAt listNthFrame (savedVals saved) ** stackFree spW 8) **
+     (regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+      (.x11 ↦ᵣ v11) ** (.x12 ↦ᵣ v12) ** regOwn .x13 ** regOwn .x14 **
+      regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+      bytesRegion listBase bytes **
+      (wdOffsetAddr ↦ₘ offset) ** (wdLengthAddr ↦ₘ len))) **
+    ⌜EvmAsm.Codegen.RlpListNthItemSAsm.Result bytes listBase listLen 2 oldOffset
+      oldLen status offset len⌝
+  have hbne := bne_spec_gen_within .x10 .x0 (100 : BitVec 13) status (0 : Word) (WB + 112)
+  rw [show (WB + 112 : Word) + signExtend13 (100 : BitVec 13) = WB + 212 from by
+      rw [show signExtend13 (100 : BitVec 13) = (100 : Word) from by decide]; bv_omega,
+    show (WB + 112 : Word) + 4 = WB + 116 from by bv_omega] at hbne
+  have hbneL := cpsBranchWithin_extend_code hmem hbne
+  have hbneF := cpsBranchWithin_frameR REST (by unfold REST; pcf) hbneL
+  refine cpsBranchWithin_weaken (fun h hp => by
+      unfold REST
+      xperm_hyp hp)
+    (fun h hq => by
+      -- taken: status ≠ 0.
+      refine ⟨status, offset, len, v11, v12, ?_⟩
+      unfold REST at hq
+      obtain ⟨h1, h2, hd, hu, hA, hR⟩ := hq
+      obtain ⟨h3, h4, hd2, hu2, hx10, hrest⟩ := hA
+      have hne : status ≠ (0 : Word) := ((sepConj_pure_right h4).1 hrest).2
+      have hx0 : ((.x0 : Reg) ↦ᵣ (0 : Word)) h4 := ((sepConj_pure_right h4).1 hrest).1
+      have hbody := ((sepConj_pure_right h2).1 hR).1
+      have hres := ((sepConj_pure_right h2).1 hR).2
+      apply (sepConj_pure_left h).2
+      refine ⟨⟨hres, hne⟩, ?_⟩
+      have hq' : (((.x10 ↦ᵣ status) ** ((.x0 : Reg) ↦ᵣ (0 : Word))) ** _) h :=
+        ⟨h1, h2, hd, hu, ⟨h3, h4, hd2, hu2, hx10, hx0⟩, hbody⟩
+      xperm_hyp hq')
+    (fun h hq => by
+      -- not-taken: status = 0.
+      unfold REST at hq
+      obtain ⟨h1, h2, hd, hu, hA, hR⟩ := hq
+      obtain ⟨h3, h4, hd2, hu2, hx10, hrest⟩ := hA
+      have hz : status = (0 : Word) := ((sepConj_pure_right h4).1 hrest).2
+      have hx0 : ((.x0 : Reg) ↦ᵣ (0 : Word)) h4 := ((sepConj_pure_right h4).1 hrest).1
+      have hres := ((sepConj_pure_right h2).1 hR).2
+      have hbody := ((sepConj_pure_right h2).1 hR).1
+      have hsucc : EvmAsm.Codegen.RlpListNthItemSAsm.Success bytes listBase listLen 2
+          offset len := by
+        rw [hz] at hres
+        cases hres with
+        | ok o l hok => exact hok
+      refine ⟨offset, len, v11, v12, ?_⟩
+      subst hz
+      apply (sepConj_pure_left h).2
+      refine ⟨hsucc, ?_⟩
+      have hq' : (((.x10 ↦ᵣ (0 : Word)) ** ((.x0 : Reg) ↦ᵣ (0 : Word))) ** _) h :=
+        ⟨h1, h2, hd, hu, ⟨h3, h4, hd2, hu2, hx10, hx0⟩, hbody⟩
+      xperm_hyp hq')
+    hbneF
+
+#print axioms k20Dispatch
+
 end EvmAsm.Codegen.WithdrawalDecodeSpec

--- a/EvmAsm/Codegen/Programs/WithdrawalDecodeClose3.lean
+++ b/EvmAsm/Codegen/Programs/WithdrawalDecodeClose3.lean
@@ -1,0 +1,225 @@
+/-
+  `withdrawalDecode_prog` caller-contract composition, part 3.
+
+  This module hosts the four post-call status dispatches ([13], [19], [28],
+  [50]) and the final 4-way compose into `withdrawal_decode_spec_within`.
+
+  Each field call returns the merged callee's `flatPost` / `flatReturnResult`
+  disjunction.  A `BNE x10, x0` at the dispatch routes the status word: a
+  nonzero status (RLP parse failure, or a K34 status ≠ 0) branches to the
+  common failure tail (`WB+212`); status `0` continues.  The dispatches are
+  modelled on `HeaderExtractNumberSpec.hdrEpilogue`'s `flatPost` case-split,
+  adding the branch routing.
+
+  No `sorry`/`admit`/`native_decide`/`bv_decide`; classical-3 axioms only.
+-/
+
+import EvmAsm.Codegen.Programs.WithdrawalDecodeClose2
+
+namespace EvmAsm.Codegen.WithdrawalDecodeSpec
+
+open EvmAsm.Rv64 EvmAsm.Rv64.SAsm
+open EvmAsm.Codegen.RlpFieldToU64SAsm
+
+/-! ## K34 status-dispatch post-conditions
+
+    A K34 field call (`rlp_field_to_u64`, fields 0/1/3) exposes `flatPost`, a
+    disjunction of `flatSuccessReturned` (status = `wrapperStatus`, pinned by a
+    `Result`) and `flatFailureReturned` (status = `1`, `Result … 1 0`).  After
+    the `BNE x10, x0`:
+
+    * the **continue** exit keeps the success payload with the status pinned to
+      `0` (the genuine per-field decode); and
+    * the **fail** exit keeps whichever payload witnessed a nonzero status —
+      either a success payload with `wrapperStatus ≠ 0`, or the failure payload
+      (`status = 1`).  Both retain the callee `Result`, so the compose can name
+      the exact failing stage. -/
+
+/-- Continue-exit post (status `0`) of a K34 field dispatch. -/
+def k34ContPost (spW newSp listBase raRet : Word) (outer : Saved)
+    (saved : EvmAsm.Codegen.RlpListNthItemSAsm.Saved)
+    (bytes : List (BitVec 8)) (listLen index : Nat) : Assertion :=
+  fun h => ∃ offset len v12 x5 ss ov,
+    ((.x1 ↦ᵣ raRet) **
+     (((.x2 ↦ᵣ spW) ** (.x8 ↦ᵣ outer.s0) ** (.x9 ↦ᵣ outer.s1) **
+       savedFrame newSp outer) **
+      successPayload newSp listBase offset len v12 x5 ss (0 : Word) ov saved
+        bytes listLen index)) h
+
+/-- Fail-exit post of a K34 field dispatch: either a success payload with a
+    nonzero wrapper status, or the failure payload. -/
+def k34FailPost (spW newSp listBase oldOffset oldLen raRet : Word) (outer : Saved)
+    (saved : EvmAsm.Codegen.RlpListNthItemSAsm.Saved)
+    (bytes : List (BitVec 8)) (listLen index : Nat) : Assertion :=
+  fun h =>
+    (∃ offset len v12 x5 ss ws ov,
+      ((⌜ws ≠ (0 : Word)⌝ : Assertion) **
+       ((.x1 ↦ᵣ raRet) **
+        (((.x2 ↦ᵣ spW) ** (.x8 ↦ᵣ outer.s0) ** (.x9 ↦ᵣ outer.s1) **
+          savedFrame newSp outer) **
+         successPayload newSp listBase offset len v12 x5 ss ws ov saved
+           bytes listLen index))) h) ∨
+    (∃ v11 v12,
+      ((.x1 ↦ᵣ raRet) **
+       (((.x2 ↦ᵣ spW) ** (.x8 ↦ᵣ outer.s0) ** (.x9 ↦ᵣ outer.s1) **
+         savedFrame newSp outer) **
+        failurePayload newSp listBase oldOffset oldLen v11 v12 saved bytes
+          listLen index)) h)
+
+set_option maxRecDepth 8000 in
+/-- Generic K34 post-call status dispatch: after a `flatPost`, the `BNE x10, x0`
+    at `bnePc` routes a nonzero status to `failTarget` and status `0` to
+    `contTarget`. -/
+theorem k34Dispatch (spW newSp listBase oldOffset oldLen raRet : Word)
+    (outer : Saved) (saved : EvmAsm.Codegen.RlpListNthItemSAsm.Saved)
+    (bytes : List (BitVec 8)) (listLen index : Nat)
+    (bnePc failTarget contTarget : Word) (boff : BitVec 13)
+    (hmem : ∀ a i, CodeReq.singleton bnePc (.BNE .x10 .x0 boff) a = some i →
+      fullCode a = some i)
+    (hfail : bnePc + signExtend13 boff = failTarget)
+    (hcont : bnePc + 4 = contTarget) :
+    cpsBranchWithin 1 bnePc fullCode
+      ((.x1 ↦ᵣ raRet) **
+       flatPost spW newSp listBase oldOffset oldLen outer saved bytes listLen index)
+      failTarget
+        (k34FailPost spW newSp listBase oldOffset oldLen raRet outer saved bytes
+          listLen index)
+      contTarget
+        (k34ContPost spW newSp listBase raRet outer saved bytes listLen index) := by
+  -- Success arm.
+  have hbrS : cpsBranchWithin 1 bnePc fullCode
+      ((.x1 ↦ᵣ raRet) **
+       flatSuccessReturned spW newSp listBase outer saved bytes listLen index)
+      failTarget
+        (k34FailPost spW newSp listBase oldOffset oldLen raRet outer saved bytes
+          listLen index)
+      contTarget
+        (k34ContPost spW newSp listBase raRet outer saved bytes listLen index) := by
+    refine cpsBranchWithin_weaken (P := fun h => ∃ offset len v12 x5 ss ws ov,
+        ((.x1 ↦ᵣ raRet) **
+         (((.x2 ↦ᵣ spW) ** (.x8 ↦ᵣ outer.s0) ** (.x9 ↦ᵣ outer.s1) **
+           savedFrame newSp outer) **
+          successPayload newSp listBase offset len v12 x5 ss ws ov saved
+            bytes listLen index)) h)
+      (fun h hp => by
+        obtain ⟨h1, h2, hd, hu, hx1, ⟨o, l, v12, x5, ss, ws, ov, hG⟩⟩ := hp
+        exact ⟨o, l, v12, x5, ss, ws, ov, h1, h2, hd, hu, hx1, hG⟩)
+      (fun _ hq => hq) (fun _ hq => hq) ?_
+    refine cpsBranchWithin_exists_pre (fun offset => ?_)
+    refine cpsBranchWithin_exists_pre (fun len => ?_)
+    refine cpsBranchWithin_exists_pre (fun v12 => ?_)
+    refine cpsBranchWithin_exists_pre (fun x5 => ?_)
+    refine cpsBranchWithin_exists_pre (fun ss => ?_)
+    refine cpsBranchWithin_exists_pre (fun ws => ?_)
+    refine cpsBranchWithin_exists_pre (fun ov => ?_)
+    -- The rest of the pre, besides x10 and x0.
+    let REST : Assertion :=
+      (.x1 ↦ᵣ raRet) **
+      (((.x2 ↦ᵣ spW) ** (.x8 ↦ᵣ outer.s0) ** (.x9 ↦ᵣ outer.s1) **
+        savedFrame newSp outer) **
+       (regOwn .x6 ** regOwn .x7 ** regOwn .x28 ** bytesRegion listBase bytes **
+        (.x18 ↦ᵣ saved.s2) ** (.x19 ↦ᵣ saved.s3) ** (.x20 ↦ᵣ saved.s4) **
+        (.x21 ↦ᵣ saved.s5) ** stackFree newSp 8 ** (.x12 ↦ᵣ v12) **
+        regOwn .x13 ** regOwn .x14 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+        (offsetCell ↦ₘ offset) ** (lengthCell ↦ₘ len) ** (.x5 ↦ᵣ x5) **
+        (.x11 ↦ᵣ ss) ** (saved.s1 ↦ₘ ov)) **
+       ⌜Result bytes listBase listLen index ws ov⌝)
+    have hbne := bne_spec_gen_within .x10 .x0 boff ws (0 : Word) bnePc
+    rw [hfail, hcont] at hbne
+    have hbneL := cpsBranchWithin_extend_code hmem hbne
+    have hbneF := cpsBranchWithin_frameR REST (by unfold REST; pcf) hbneL
+    refine cpsBranchWithin_weaken (fun h hp => by
+        unfold REST
+        unfold successPayload at hp
+        xperm_hyp hp)
+      (fun h hq => by
+        -- taken: ws ≠ 0.
+        refine Or.inl ⟨offset, len, v12, x5, ss, ws, ov, ?_⟩
+        unfold REST at hq
+        unfold successPayload
+        xperm_hyp hq)
+      (fun h hq => by
+        -- not-taken: ws = 0.
+        refine ⟨offset, len, v12, x5, ss, ov, ?_⟩
+        unfold REST at hq
+        have hz : ws = (0 : Word) := by
+          obtain ⟨h1, h2, hd, hu, hA, hR⟩ := hq
+          obtain ⟨h3, h4, hd2, hu2, hx10, hrest⟩ := hA
+          exact ((sepConj_pure_right h4).1 hrest).2
+        subst hz
+        unfold successPayload
+        obtain ⟨h1, h2, hd, hu, hA, hR⟩ := hq
+        obtain ⟨h3, h4, hd2, hu2, hx10, hrest⟩ := hA
+        have hx0 : ((.x0 : Reg) ↦ᵣ (0 : Word)) h4 := ((sepConj_pure_right h4).1 hrest).1
+        have hq' : (((.x10 ↦ᵣ (0 : Word)) ** ((.x0 : Reg) ↦ᵣ (0 : Word))) ** _) h :=
+          ⟨h1, h2, hd, hu, ⟨h3, h4, hd2, hu2, hx10, hx0⟩, hR⟩
+        xperm_hyp hq')
+      hbneF
+  -- Failure arm.
+  have hbrF : cpsBranchWithin 1 bnePc fullCode
+      ((.x1 ↦ᵣ raRet) **
+       flatFailureReturned spW newSp listBase oldOffset oldLen outer saved bytes
+         listLen index)
+      failTarget
+        (k34FailPost spW newSp listBase oldOffset oldLen raRet outer saved bytes
+          listLen index)
+      contTarget
+        (k34ContPost spW newSp listBase raRet outer saved bytes listLen index) := by
+    refine cpsBranchWithin_weaken (P := fun h => ∃ v11 v12,
+        ((.x1 ↦ᵣ raRet) **
+         (((.x2 ↦ᵣ spW) ** (.x8 ↦ᵣ outer.s0) ** (.x9 ↦ᵣ outer.s1) **
+           savedFrame newSp outer) **
+          failurePayload newSp listBase oldOffset oldLen v11 v12 saved bytes
+            listLen index)) h)
+      (fun h hp => by
+        obtain ⟨h1, h2, hd, hu, hx1, ⟨v11, v12, hG⟩⟩ := hp
+        exact ⟨v11, v12, h1, h2, hd, hu, hx1, hG⟩)
+      (fun _ hq => hq) (fun _ hq => hq) ?_
+    refine cpsBranchWithin_exists_pre (fun v11 => ?_)
+    refine cpsBranchWithin_exists_pre (fun v12 => ?_)
+    let REST : Assertion :=
+      (.x1 ↦ᵣ raRet) **
+      (((.x2 ↦ᵣ spW) ** (.x8 ↦ᵣ outer.s0) ** (.x9 ↦ᵣ outer.s1) **
+        savedFrame newSp outer) **
+       (regOwn .x5 ** regOwn .x6 ** regOwn .x7 ** (.x11 ↦ᵣ v11) ** (.x12 ↦ᵣ v12) **
+        regOwn .x13 ** regOwn .x14 ** regOwn .x28 ** regOwn .x29 ** regOwn .x30 **
+        regOwn .x31 ** (.x18 ↦ᵣ saved.s2) ** (.x19 ↦ᵣ saved.s3) **
+        (.x20 ↦ᵣ saved.s4) ** (.x21 ↦ᵣ saved.s5) ** stackFree newSp 8 **
+        bytesRegion listBase bytes ** (offsetCell ↦ₘ oldOffset) **
+        (lengthCell ↦ₘ oldLen) ** (saved.s1 ↦ₘ (0 : Word))) **
+       ⌜Result bytes listBase listLen index 1 0⌝)
+    have hbne := bne_spec_gen_within .x10 .x0 boff (1 : Word) (0 : Word) bnePc
+    rw [hfail, hcont] at hbne
+    have hbneL := cpsBranchWithin_extend_code hmem hbne
+    have hbneF := cpsBranchWithin_frameR REST (by unfold REST; pcf) hbneL
+    refine cpsBranchWithin_weaken (fun h hp => by
+        unfold REST
+        unfold failurePayload at hp
+        xperm_hyp hp)
+      (fun h hq => by
+        refine Or.inr ⟨v11, v12, ?_⟩
+        unfold REST at hq
+        unfold failurePayload
+        obtain ⟨h1, h2, hd, hu, hA, hR⟩ := hq
+        obtain ⟨h3, h4, hd2, hu2, hx10, hrest⟩ := hA
+        have hx0 : ((.x0 : Reg) ↦ᵣ (0 : Word)) h4 := ((sepConj_pure_right h4).1 hrest).1
+        have hq' : (((.x10 ↦ᵣ (1 : Word)) ** ((.x0 : Reg) ↦ᵣ (0 : Word))) ** _) h :=
+          ⟨h1, h2, hd, hu, ⟨h3, h4, hd2, hu2, hx10, hx0⟩, hR⟩
+        xperm_hyp hq')
+      (fun h hq => by
+        exfalso
+        have hz : (1 : Word) = (0 : Word) := by
+          obtain ⟨h1, h2, hd, hu, hA, hR⟩ := hq
+          obtain ⟨h3, h4, hd2, hu2, hx10, hrest⟩ := hA
+          exact ((sepConj_pure_right h4).1 hrest).2
+        exact absurd hz (by decide))
+      hbneF
+  -- Combine the two arms over `flatPost`.
+  have hor := cpsBranchWithin_pre_or hbrS hbrF
+  refine cpsBranchWithin_weaken (fun h hp => ?_) (fun _ hq => hq) (fun _ hq => hq) hor
+  unfold flatPost at hp
+  exact sepConj_or_split h hp
+
+#print axioms k34Dispatch
+
+end EvmAsm.Codegen.WithdrawalDecodeSpec

--- a/EvmAsm/Codegen/Programs/WithdrawalDecodeClose3.lean
+++ b/EvmAsm/Codegen/Programs/WithdrawalDecodeClose3.lean
@@ -548,4 +548,27 @@ theorem wdField2Stage
 
 #print axioms wdField2Stage
 
+/-! ## Frame reshape helpers -/
+
+/-- Generic: saved frame slots weaken to merely-owned slots. -/
+private theorem frameSlotsSaved_own (fr : FrameDesc) (newSp : Word) (vals : Reg → Word) :
+    ∀ h, frameSlotsSaved fr newSp vals h → frameSlotsOwn fr newSp h := by
+  induction fr with
+  | nil => intro h hp; simpa only [frameSlotsSaved_nil, frameSlotsOwn_nil] using hp
+  | cons p rest ih =>
+    intro h hp
+    rw [frameSlotsSaved_cons] at hp
+    rw [frameSlotsOwn_cons]
+    exact sepConj_mono memIs_implies_memOwn ih h hp
+
+/-- K34's saved frame weakens to the merely-owned frame slots (`frameSlotsOwn`),
+    the shape each subsequent K34 field call requires. -/
+theorem savedFrameK34_own (newSp : Word) (saved : Saved) :
+    ∀ h, savedFrame newSp saved h → frameSlotsOwn frame newSp h := by
+  intro h hp
+  rw [← frameSlotsSaved_frame] at hp
+  exact frameSlotsSaved_own frame newSp (savedVals saved) h hp
+
+#print axioms savedFrameK34_own
+
 end EvmAsm.Codegen.WithdrawalDecodeSpec

--- a/EvmAsm/Codegen/Programs/WithdrawalDecodeClose4.lean
+++ b/EvmAsm/Codegen/Programs/WithdrawalDecodeClose4.lean
@@ -225,6 +225,27 @@ theorem wdStack12_to_k20 (spW : Word) : ∀ h,
 
 #print axioms wdStack12_to_k20
 
+/-- Weaken the value-carrying temporaries `x5/x11/x12` (regIs) into ownership,
+    folding the callee residue into `wdScratch`.  The `x19/x20/x21` callee-saved
+    values and the remaining already-owned temporaries pass through unchanged.
+    This is the common "(c) weaken regIs→regOwn" step of every fail-arm reshape. -/
+theorem wdScratch_of_regs (s3 s4 s5 x5v x11v x12v : Word) : ∀ h,
+    ((.x19 ↦ᵣ s3) ** (.x20 ↦ᵣ s4) ** (.x21 ↦ᵣ s5) ** (.x5 ↦ᵣ x5v) **
+     regOwn .x6 ** regOwn .x7 ** (.x11 ↦ᵣ x11v) ** (.x12 ↦ᵣ x12v) ** regOwn .x13 **
+     regOwn .x14 ** regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+     (.x0 ↦ᵣ (0 : Word))) h →
+    wdScratch s3 s4 s5 h := by
+  intro h hp
+  unfold wdScratch
+  exact sepConj_mono_right (sepConj_mono_right (sepConj_mono_right
+          (sepConj_mono (regIs_implies_regOwn .x5)
+            (sepConj_mono_right (sepConj_mono_right
+              (sepConj_mono (regIs_implies_regOwn .x11)
+                (sepConj_mono_left (regIs_implies_regOwn .x12))))))))
+        h hp
+
+#print axioms wdScratch_of_regs
+
 /-! ## Generic `DecodeFailure` witness extraction
 
     Both K34 fail sub-cases (a success payload with a nonzero wrapper status, or

--- a/EvmAsm/Codegen/Programs/WithdrawalDecodeClose4.lean
+++ b/EvmAsm/Codegen/Programs/WithdrawalDecodeClose4.lean
@@ -544,4 +544,113 @@ theorem wdK34FailArm (sp0 spW newSp raIn listBase oldOffset oldLen raRet
 
 #print axioms wdK34FailArm
 
+set_option maxRecDepth 8000 in
+/-- Field-2 (K20) fail-post PRE reshape into the `wdFailArm` shape.  Structurally
+    distinct from the K34 arms (a `regsAt listNthFrame` caller-save bundle and a
+    `stackFree spW 8` discipline reclaimed with the four deep cells `wdStackK20Deep`
+    instead of a `newSp` frame), but the same surgery: DF via `wdK20FailDF`, weaken
+    `x11/x12` via `wdScratch_of_regs_own5`, fold the stack via `wdStack12_of_k20`,
+    regOwn `x10`, `xperm`.  The per-field-2 fold `hleft` packages `Frest` plus the
+    payload's two `wd_offset`/`wd_length` cells into `wdFailLeftover`. -/
+theorem wdK20FailPre (spW raIn listBase oldOffset oldLen outBase
+      s0Old s1Old s2Old : Word)
+    (saved : EvmAsm.Codegen.RlpListNthItemSAsm.Saved)
+    (bytes : List (BitVec 8)) (listLen : Nat)
+    (Frest : Assertion)
+    (hleft : ∀ (offset len : Word), ∀ h,
+      (wdScratch saved.s3 saved.s4 saved.s5 ** stackFree spW 12 **
+       bytesRegion listBase bytes ** (wdOffsetAddr ↦ₘ offset) ** (wdLengthAddr ↦ₘ len) **
+       Frest) h →
+      wdFailLeftover spW outBase listBase saved.s3 saved.s4 saved.s5 bytes h) :
+    ∀ h,
+      (k20FailPost spW listBase oldOffset oldLen saved bytes listLen **
+       (spW ↦ₘ raIn) ** ((spW + 8) ↦ₘ s0Old) ** ((spW + 16) ↦ₘ s1Old) **
+       ((spW + 24) ↦ₘ s2Old) ** wdStackK20Deep spW ** Frest) h →
+      (((.x2 ↦ᵣ spW) ** (.x1 ↦ᵣ saved.ra) ** (.x8 ↦ᵣ saved.s0) ** (.x9 ↦ᵣ saved.s1) **
+        (.x18 ↦ᵣ saved.s2) ** (spW ↦ₘ raIn) ** ((spW + 8) ↦ₘ s0Old) **
+        ((spW + 16) ↦ₘ s1Old) ** ((spW + 24) ↦ₘ s2Old) **
+        ((⌜DecodeFailure bytes listBase listLen⌝ : Assertion) **
+         wdFailLeftover spW outBase listBase saved.s3 saved.s4 saved.s5 bytes)) **
+       regOwn .x10) h := by
+  intro h hp
+  obtain ⟨ha, hb, hdab, huab, hkp, hRp⟩ := hp
+  have hDF : DecodeFailure bytes listBase listLen :=
+    wdK20FailDF spW listBase oldOffset oldLen saved bytes listLen ha hkp
+  unfold k20FailPost at hkp
+  obtain ⟨status, offset, len, v11, v12, hp0⟩ := hkp
+  obtain ⟨_, hcore⟩ := (sepConj_pure_left ha).1 hp0
+  rw [EvmAsm.Codegen.RlpListNthItemSAsm.regsAt_listNthFrame] at hcore
+  have hcomb :
+      ((((.x2 ↦ᵣ spW) **
+         ((.x1 ↦ᵣ saved.ra) ** (.x8 ↦ᵣ saved.s0) ** (.x9 ↦ᵣ saved.s1) **
+          (.x18 ↦ᵣ saved.s2) ** (.x19 ↦ᵣ saved.s3) ** (.x20 ↦ᵣ saved.s4) **
+          (.x21 ↦ᵣ saved.s5)) ** stackFree spW 8) **
+        ((.x10 ↦ᵣ status) ** regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+         (.x11 ↦ᵣ v11) ** (.x12 ↦ᵣ v12) ** regOwn .x13 ** regOwn .x14 **
+         regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+         (.x0 ↦ᵣ (0 : Word)) ** bytesRegion listBase bytes **
+         (wdOffsetAddr ↦ₘ offset) ** (wdLengthAddr ↦ₘ len))) **
+       ((spW ↦ₘ raIn) ** ((spW + 8) ↦ₘ s0Old) ** ((spW + 16) ↦ₘ s1Old) **
+        ((spW + 24) ↦ₘ s2Old) ** wdStackK20Deep spW ** Frest)) h :=
+    ⟨ha, hb, hdab, huab, hcore, hRp⟩
+  have hg_top :
+      ((( .x2 ↦ᵣ spW) ** (.x1 ↦ᵣ saved.ra) ** (.x8 ↦ᵣ saved.s0) ** (.x9 ↦ᵣ saved.s1) **
+         (.x18 ↦ᵣ saved.s2) ** (spW ↦ₘ raIn) ** ((spW + 8) ↦ₘ s0Old) **
+         ((spW + 16) ↦ₘ s1Old) ** ((spW + 24) ↦ₘ s2Old) **
+         ((wdStackK20Deep spW ** stackFree spW 8) **
+          ((.x19 ↦ᵣ saved.s3) ** (.x20 ↦ᵣ saved.s4) ** (.x21 ↦ᵣ saved.s5) **
+           regOwn .x5 ** regOwn .x6 ** regOwn .x7 ** (.x11 ↦ᵣ v11) **
+           (.x12 ↦ᵣ v12) ** regOwn .x13 ** regOwn .x14 ** regOwn .x28 **
+           regOwn .x29 ** regOwn .x30 ** regOwn .x31 ** (.x0 ↦ᵣ (0 : Word))) **
+          bytesRegion listBase bytes ** (wdOffsetAddr ↦ₘ offset) **
+          (wdLengthAddr ↦ₘ len) ** Frest)) **
+        (.x10 ↦ᵣ status)) h := by
+    xperm_hyp hcomb
+  refine sepConj_mono ?_ (regIs_implies_regOwn .x10) h hg_top
+  refine sepConj_mono_right (sepConj_mono_right (sepConj_mono_right
+    (sepConj_mono_right (sepConj_mono_right (sepConj_mono_right (sepConj_mono_right
+    (sepConj_mono_right (sepConj_mono_right ?_))))))))
+  intro h' hl
+  refine (sepConj_pure_left h').2 ⟨hDF, ?_⟩
+  have h2 :
+      (stackFree spW 12 ** wdScratch saved.s3 saved.s4 saved.s5 **
+       bytesRegion listBase bytes ** (wdOffsetAddr ↦ₘ offset) ** (wdLengthAddr ↦ₘ len) **
+       Frest) h' :=
+    sepConj_mono (wdStack12_of_k20 spW)
+      (sepConj_mono_left (wdScratch_of_regs_own5 saved.s3 saved.s4 saved.s5 v11 v12))
+      h' hl
+  refine hleft offset len h' ?_
+  xperm_hyp h2
+
+#print axioms wdK20FailPre
+
+set_option maxRecDepth 8000 in
+/-- The complete K20 (field-2 list) fail arm: `wdK20FailPre ;; wdFailArm`. -/
+theorem wdK20FailArm (sp0 spW raIn listBase oldOffset oldLen outBase
+      s0Old s1Old s2Old : Word)
+    (saved : EvmAsm.Codegen.RlpListNthItemSAsm.Saved)
+    (bytes oldAddr pad4 : List (BitVec 8)) (listLen : Nat)
+    (Frest : Assertion)
+    (hspW : spW = sp0 + signExtend12 (-32 : BitVec 12))
+    (hret : raIn &&& ~~~(1 : Word) = raIn)
+    (hleft : ∀ (offset len : Word), ∀ h,
+      (wdScratch saved.s3 saved.s4 saved.s5 ** stackFree spW 12 **
+       bytesRegion listBase bytes ** (wdOffsetAddr ↦ₘ offset) ** (wdLengthAddr ↦ₘ len) **
+       Frest) h →
+      wdFailLeftover spW outBase listBase saved.s3 saved.s4 saved.s5 bytes h) :
+    cpsTripleWithin 7 (WB + 212) raIn fullCode
+      (k20FailPost spW listBase oldOffset oldLen saved bytes listLen **
+       (spW ↦ₘ raIn) ** ((spW + 8) ↦ₘ s0Old) ** ((spW + 16) ↦ₘ s1Old) **
+       ((spW + 24) ↦ₘ s2Old) ** wdStackK20Deep spW ** Frest)
+      (wdWholePost sp0 spW raIn s0Old s1Old s2Old outBase listBase saved.s3 saved.s4
+        saved.s5 listLen bytes oldAddr pad4) :=
+  cpsTripleWithin_weaken
+    (wdK20FailPre spW raIn listBase oldOffset oldLen outBase s0Old s1Old s2Old
+      saved bytes listLen Frest hleft)
+    (fun _ hq => hq)
+    (wdFailArm sp0 spW raIn s0Old s1Old s2Old saved.ra saved.s0 saved.s1 saved.s2
+      outBase listBase saved.s3 saved.s4 saved.s5 bytes oldAddr pad4 listLen hspW hret)
+
+#print axioms wdK20FailArm
+
 end EvmAsm.Codegen.WithdrawalDecodeSpec

--- a/EvmAsm/Codegen/Programs/WithdrawalDecodeClose4.lean
+++ b/EvmAsm/Codegen/Programs/WithdrawalDecodeClose4.lean
@@ -1,0 +1,74 @@
+/-
+  `withdrawalDecode_prog` caller-contract composition, part 4 — the final close.
+
+  This module threads the four field stages, the length check, and the address
+  copy loop into the whole-program caller contract
+  `withdrawal_decode_spec_within`, routing every parse-failure exit through the
+  common failure tail (`wdFailEpi`) and the all-fields-ok exit through the
+  success tail (`wdSuccessEpi`).
+
+  The composition is inside-out: per-boundary reshape lemmas line up each
+  stage's continue-post with the next stage's pre (and each fail-post with the
+  failure tail), and a thin final compose stitches the reshaped pieces via
+  `cpsBranchWithin_merge_same_cr`.
+
+  No `sorry`/`admit`/`native_decide`/`bv_decide`; classical-3 axioms only.
+-/
+
+import EvmAsm.Codegen.Programs.WithdrawalDecodeClose3
+
+namespace EvmAsm.Codegen.WithdrawalDecodeSpec
+
+open EvmAsm.Rv64 EvmAsm.Rv64.SAsm
+open EvmAsm.Codegen.RlpFieldToU64SAsm
+
+/-! ## Whole-program post-condition pieces -/
+
+/-- The registers/slots common to both the success and the failure return:
+    the restored caller registers (`x2/x1/x8/x9/x18`) and the four withdrawal
+    saved slots (`spW..spW+24`), exactly `wdEpiCore`'s non-`G` post. -/
+def wdCommon (sp0 spW wra cs0 cs1 cs2 : Word) : Assertion :=
+  (.x2 ↦ᵣ sp0) ** (.x1 ↦ᵣ wra) ** (.x8 ↦ᵣ cs0) ** (.x9 ↦ᵣ cs1) **
+  (.x18 ↦ᵣ cs2) ** (spW ↦ₘ wra) ** ((spW + 8) ↦ₘ cs0) **
+  ((spW + 16) ↦ₘ cs1) ** ((spW + 24) ↦ₘ cs2)
+
+theorem pcFree_wdCommon (sp0 spW wra cs0 cs1 cs2 : Word) :
+    (wdCommon sp0 spW wra cs0 cs1 cs2).pcFree := by
+  unfold wdCommon
+  repeat' first | exact pcFree_regIs | exact pcFree_memIs | apply pcFree_sepConj
+
+/-- The mutable leftover after a failure return: the whole 48-byte output struct
+    (contents forgotten, only ownership retained), the input region, the two
+    `wd_offset`/`wd_length` cells, and the reclaimed 12-cell scratch stack. -/
+def wdFailLeftover (spW outBase listBase : Word) (bytes : List (BitVec 8)) :
+    Assertion :=
+  fun h => ∃ (o0 o1 o3 woff wlen : Word) (addr20 pad4 : List (BitVec 8)),
+    ((outBase ↦ₘ o0) ** ((outBase + 8) ↦ₘ o1) **
+     bytesRegion (outBase + 16) addr20 ** bytesRegion (outBase + 36) pad4 **
+     ((outBase + 40) ↦ₘ o3) ** bytesRegion listBase bytes **
+     (wdOffsetAddr ↦ₘ woff) ** (wdLengthAddr ↦ₘ wlen) ** stackFree spW 12) h
+
+/-- The output-struct leftover after a success return, each cell tied to the
+    genuinely decoded field value (`outputSuccess`), plus the untouched input
+    region, the two data cells (still holding the address offset/length), and
+    the reclaimed scratch stack. -/
+def wdSuccessOut (spW outBase listBase v0 v1 v3 o2 l2 : Word)
+    (bytes oldAddr pad4 : List (BitVec 8)) : Assertion :=
+  outputSuccess outBase v0 v1 v3 o2 bytes oldAddr pad4 **
+  bytesRegion listBase bytes ** (wdOffsetAddr ↦ₘ o2) ** (wdLengthAddr ↦ₘ l2) **
+  stackFree spW 12
+
+/-- The whole-program post: `a0 = 0` with the genuine decoded output struct, or
+    `a0 = 1` with a witnessed `DecodeFailure` and the owned leftover. -/
+def wdWholePost (sp0 spW wra cs0 cs1 cs2 outBase listBase : Word)
+    (listLen : Nat) (bytes oldAddr pad4 : List (BitVec 8)) : Assertion :=
+  fun h =>
+    (∃ (v0 v1 v3 o2 l2 : Word),
+      ((⌜Decoded bytes listBase listLen v0 v1 v3 o2 l2⌝ : Assertion) **
+       ((.x10 ↦ᵣ (0 : Word)) ** wdCommon sp0 spW wra cs0 cs1 cs2 **
+        wdSuccessOut spW outBase listBase v0 v1 v3 o2 l2 bytes oldAddr pad4)) h) ∨
+    (((⌜DecodeFailure bytes listBase listLen⌝ : Assertion) **
+      ((.x10 ↦ᵣ (1 : Word)) ** wdCommon sp0 spW wra cs0 cs1 cs2 **
+       wdFailLeftover spW outBase listBase bytes)) h)
+
+end EvmAsm.Codegen.WithdrawalDecodeSpec

--- a/EvmAsm/Codegen/Programs/WithdrawalDecodeClose4.lean
+++ b/EvmAsm/Codegen/Programs/WithdrawalDecodeClose4.lean
@@ -141,4 +141,75 @@ theorem wdStack12_of_k34 (sp0 spW newSp : Word)
 
 #print axioms wdStack12_of_k34
 
+/-- Carve a K34 field call's scratch shape out of `stackFree spW 12` (the reverse
+    of `wdStack12_of_k34`, used on the continue/forward path). -/
+theorem wdStack12_to_k34 (sp0 spW newSp : Word)
+    (hnewSp : newSp = spW + signExtend12 (-32 : BitVec 12)) : ∀ h,
+    stackFree spW 12 h →
+    (memOwn (spW - BitVec.ofNat 64 8) **
+     frameSlotsOwn frame newSp ** stackFree newSp 8) h := by
+  intro h hp
+  have hse : signExtend12 (-32 : BitVec 12) = (0xFFFFFFFFFFFFFFE0 : Word) := by decide
+  subst hnewSp
+  rw [hse]
+  simp only [frameSlotsOwn, frame, List.foldr, sepConj_emp_right',
+    show signExtend12 (0 : BitVec 12) = (0 : Word) from by decide,
+    show signExtend12 (8 : BitVec 12) = (8 : Word) from by decide,
+    show signExtend12 (16 : BitVec 12) = (16 : Word) from by decide]
+  simp only [stackFree] at hp ⊢
+  simp only [sepConj_emp_right', Nat.reduceMul, Nat.reduceAdd] at hp ⊢
+  rw [show spW + (18446744073709551584 : Word) + (0 : Word)
+        = spW - BitVec.ofNat 64 32 from by bv_omega,
+      show spW + (18446744073709551584 : Word) + (8 : Word)
+        = spW - BitVec.ofNat 64 24 from by bv_omega,
+      show spW + (18446744073709551584 : Word) + (16 : Word)
+        = spW - BitVec.ofNat 64 16 from by bv_omega,
+      show spW + (18446744073709551584 : Word) - BitVec.ofNat 64 64
+        = spW - BitVec.ofNat 64 96 from by bv_omega,
+      show spW + (18446744073709551584 : Word) - BitVec.ofNat 64 56
+        = spW - BitVec.ofNat 64 88 from by bv_omega,
+      show spW + (18446744073709551584 : Word) - BitVec.ofNat 64 48
+        = spW - BitVec.ofNat 64 80 from by bv_omega,
+      show spW + (18446744073709551584 : Word) - BitVec.ofNat 64 40
+        = spW - BitVec.ofNat 64 72 from by bv_omega,
+      show spW + (18446744073709551584 : Word) - BitVec.ofNat 64 32
+        = spW - BitVec.ofNat 64 64 from by bv_omega,
+      show spW + (18446744073709551584 : Word) - BitVec.ofNat 64 24
+        = spW - BitVec.ofNat 64 56 from by bv_omega,
+      show spW + (18446744073709551584 : Word) - BitVec.ofNat 64 16
+        = spW - BitVec.ofNat 64 48 from by bv_omega,
+      show spW + (18446744073709551584 : Word) - BitVec.ofNat 64 8
+        = spW - BitVec.ofNat 64 40 from by bv_omega]
+  xperm_hyp hp
+
+#print axioms wdStack12_to_k34
+
+/-- The four deep scratch cells `stackFree spW 8` leaves free out of the whole
+    12-cell region (used at the K20 field-2 boundary). -/
+def wdStackK20Deep (spW : Word) : Assertion :=
+  memOwn (spW - BitVec.ofNat 64 96) ** memOwn (spW - BitVec.ofNat 64 88) **
+  memOwn (spW - BitVec.ofNat 64 80) ** memOwn (spW - BitVec.ofNat 64 72)
+
+theorem pcFree_wdStackK20Deep (spW : Word) : (wdStackK20Deep spW).pcFree := by
+  unfold wdStackK20Deep
+  repeat' first | exact pcFree_memOwn | apply pcFree_sepConj
+
+/-- Assemble a K20 field call's reclaimed scratch back into `stackFree spW 12`. -/
+theorem wdStack12_of_k20 (spW : Word) : ∀ h,
+    (wdStackK20Deep spW ** stackFree spW 8) h → stackFree spW 12 h := by
+  intro h hp
+  simp only [stackFree, wdStackK20Deep, Nat.reduceMul] at hp ⊢
+  xperm_hyp hp
+
+#print axioms wdStack12_of_k20
+
+/-- Carve a K20 field call's scratch shape out of `stackFree spW 12`. -/
+theorem wdStack12_to_k20 (spW : Word) : ∀ h,
+    stackFree spW 12 h → (wdStackK20Deep spW ** stackFree spW 8) h := by
+  intro h hp
+  simp only [stackFree, wdStackK20Deep, Nat.reduceMul] at hp ⊢
+  xperm_hyp hp
+
+#print axioms wdStack12_to_k20
+
 end EvmAsm.Codegen.WithdrawalDecodeSpec

--- a/EvmAsm/Codegen/Programs/WithdrawalDecodeClose4.lean
+++ b/EvmAsm/Codegen/Programs/WithdrawalDecodeClose4.lean
@@ -212,4 +212,26 @@ theorem wdStack12_to_k20 (spW : Word) : ∀ h,
 
 #print axioms wdStack12_to_k20
 
+/-! ## Failure-tail arm -/
+
+set_option maxRecDepth 8000 in
+/-- The common failure tail `WB+212 → wra`, generic over the (owned) `x10` value
+    on entry, the pre-restore register values, and the preserved footprint `G0`. -/
+theorem wdFailEpiRO (sp0 spW wra cs0 cs1 cs2 x1old x8old x9old x18old : Word)
+    (G0 : Assertion) (hG0 : G0.pcFree)
+    (hspW : spW = sp0 + signExtend12 (-32 : BitVec 12))
+    (hret : wra &&& ~~~(1 : Word) = wra) :
+    cpsTripleWithin 7 (WB + 212) wra fullCode
+      (((.x2 ↦ᵣ spW) ** (.x1 ↦ᵣ x1old) ** (.x8 ↦ᵣ x8old) ** (.x9 ↦ᵣ x9old) **
+        (.x18 ↦ᵣ x18old) ** (spW ↦ₘ wra) ** ((spW + 8) ↦ₘ cs0) **
+        ((spW + 16) ↦ₘ cs1) ** ((spW + 24) ↦ₘ cs2) ** G0) ** regOwn .x10)
+      (((.x10 ↦ᵣ (1 : Word)) ** wdCommon sp0 spW wra cs0 cs1 cs2) ** G0) := by
+  refine cpsTripleWithin_of_forall_regIs_to_regOwn (fun v10 => ?_)
+  have h := wdFailEpi sp0 spW wra cs0 cs1 cs2 x1old x8old x9old x18old v10 G0 hG0 hspW hret
+  refine cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp) (fun _ hq => ?_) h
+  unfold wdCommon
+  xperm_hyp hq
+
+#print axioms wdFailEpiRO
+
 end EvmAsm.Codegen.WithdrawalDecodeSpec

--- a/EvmAsm/Codegen/Programs/WithdrawalDecodeClose4.lean
+++ b/EvmAsm/Codegen/Programs/WithdrawalDecodeClose4.lean
@@ -255,6 +255,25 @@ theorem wdK34FailDF (spW newSp listBase oldOffset oldLen raRet : Word)
 
 #print axioms wdK34FailDF
 
+/-- The field-2 (K20) fail post pins a `Result` with a nonzero status; casing it
+    forces the `fail` constructor (status `1`), exposing the `Failure` that the
+    `DecodeFailure.field2List` arm needs.  The `ok` (status `0`) case contradicts
+    the pinned nonzero fact. -/
+theorem wdK20FailDF (spW listBase oldOffset oldLen : Word)
+    (saved : EvmAsm.Codegen.RlpListNthItemSAsm.Saved)
+    (bytes : List (BitVec 8)) (listLen : Nat) :
+    ∀ h, k20FailPost spW listBase oldOffset oldLen saved bytes listLen h →
+      DecodeFailure bytes listBase listLen := by
+  intro h hp
+  unfold k20FailPost at hp
+  obtain ⟨status, offset, len, v11, v12, hp⟩ := hp
+  obtain ⟨⟨hres, hnz⟩, _⟩ := (sepConj_pure_left h).1 hp
+  cases hres with
+  | ok o l hok => exact absurd rfl hnz
+  | fail hfail => exact DecodeFailure.field2List hfail
+
+#print axioms wdK20FailDF
+
 /-! ## Failure-tail arm -/
 
 set_option maxRecDepth 8000 in

--- a/EvmAsm/Codegen/Programs/WithdrawalDecodeClose4.lean
+++ b/EvmAsm/Codegen/Programs/WithdrawalDecodeClose4.lean
@@ -98,8 +98,7 @@ def wdWholePost (sp0 spW wra cs0 cs1 cs2 outBase listBase s3 s4 s5 : Word)
     two shapes hold the same 12 owned cells. -/
 
 /-- Assemble a K34 field call's reclaimed scratch back into `stackFree spW 12`. -/
-theorem wdStack12_of_k34 (sp0 spW newSp : Word)
-    (hspW : spW = sp0 + signExtend12 (-32 : BitVec 12))
+theorem wdStack12_of_k34 (spW newSp : Word)
     (hnewSp : newSp = spW + signExtend12 (-32 : BitVec 12)) : ∀ h,
     (memOwn (spW - BitVec.ofNat 64 8) **
      frameSlotsOwn frame newSp ** stackFree newSp 8) h →
@@ -140,6 +139,20 @@ theorem wdStack12_of_k34 (sp0 spW newSp : Word)
   xperm_hyp hp
 
 #print axioms wdStack12_of_k34
+
+/-- The K34 boundary reconcile absorbing the saved frame: a K34 field call's
+    `savedFrame` (3 saved slots) plus its `stackFree newSp 8` and the framed-off
+    top cell reassemble into `stackFree spW 12`. -/
+theorem wdStack12_of_k34_saved (spW newSp : Word) (outer : Saved)
+    (hnewSp : newSp = spW + signExtend12 (-32 : BitVec 12)) : ∀ h,
+    (memOwn (spW - BitVec.ofNat 64 8) **
+     savedFrame newSp outer ** stackFree newSp 8) h →
+    stackFree spW 12 h := by
+  intro h hp
+  refine wdStack12_of_k34 spW newSp hnewSp h ?_
+  exact sepConj_mono_right (sepConj_mono_left (savedFrameK34_own newSp outer)) h hp
+
+#print axioms wdStack12_of_k34_saved
 
 /-- Carve a K34 field call's scratch shape out of `stackFree spW 12` (the reverse
     of `wdStack12_of_k34`, used on the continue/forward path). -/

--- a/EvmAsm/Codegen/Programs/WithdrawalDecodeClose4.lean
+++ b/EvmAsm/Codegen/Programs/WithdrawalDecodeClose4.lean
@@ -246,6 +246,24 @@ theorem wdScratch_of_regs (s3 s4 s5 x5v x11v x12v : Word) : ∀ h,
 
 #print axioms wdScratch_of_regs
 
+/-- Failure-payload variant of `wdScratch_of_regs`: `x5` arrives already owned,
+    only `x11/x12` need weakening. -/
+theorem wdScratch_of_regs_own5 (s3 s4 s5 x11v x12v : Word) : ∀ h,
+    ((.x19 ↦ᵣ s3) ** (.x20 ↦ᵣ s4) ** (.x21 ↦ᵣ s5) ** regOwn .x5 **
+     regOwn .x6 ** regOwn .x7 ** (.x11 ↦ᵣ x11v) ** (.x12 ↦ᵣ x12v) ** regOwn .x13 **
+     regOwn .x14 ** regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+     (.x0 ↦ᵣ (0 : Word))) h →
+    wdScratch s3 s4 s5 h := by
+  intro h hp
+  unfold wdScratch
+  exact sepConj_mono_right (sepConj_mono_right (sepConj_mono_right (sepConj_mono_right
+          (sepConj_mono_right (sepConj_mono_right
+            (sepConj_mono (regIs_implies_regOwn .x11)
+              (sepConj_mono_left (regIs_implies_regOwn .x12))))))))
+        h hp
+
+#print axioms wdScratch_of_regs_own5
+
 /-! ## Generic `DecodeFailure` witness extraction
 
     Both K34 fail sub-cases (a success payload with a nonzero wrapper status, or
@@ -359,5 +377,133 @@ theorem wdFailArm (sp0 spW wra cs0 cs1 cs2 x1old x8old x9old x18old
   xperm_hyp hq
 
 #print axioms wdFailArm
+
+set_option maxRecDepth 8000 in
+/-- K34 fail-post PRE reshape into the `wdFailArm` shape.  The register/pure/stack
+    surgery is common to all three K34 fields (0/1/3); the only field-specific
+    input is the memory fold `hleft`, which packages the ambient rest `Frest`
+    plus the payload's own output cell (at `saved.s1`) and the two RLP cells into
+    `wdFailLeftover`.  Both `flatPost` fail sub-cases (success payload with a
+    nonzero wrapper status, or failure payload with status `1`) collapse to the
+    same reshaped pre. -/
+theorem wdK34FailPre (spW newSp raIn listBase oldOffset oldLen raRet
+      s0Old s1Old s2Old : Word)
+    (outer : Saved) (saved : EvmAsm.Codegen.RlpListNthItemSAsm.Saved)
+    (bytes : List (BitVec 8)) (listLen index : Nat)
+    (Frest : Assertion)
+    (hnewSp : newSp = spW + signExtend12 (-32 : BitVec 12))
+    (mkDF : ∀ (status v : Word), status ≠ (0 : Word) →
+      EvmAsm.Codegen.RlpFieldToU64SAsm.Result bytes listBase listLen index status v →
+      DecodeFailure bytes listBase listLen)
+    (hleft : ∀ (roff rlen ov : Word), ∀ h,
+      (wdScratch saved.s3 saved.s4 saved.s5 ** stackFree spW 12 **
+       bytesRegion listBase bytes ** (offsetCell ↦ₘ roff) ** (lengthCell ↦ₘ rlen) **
+       (saved.s1 ↦ₘ ov) ** Frest) h →
+      wdFailLeftover spW saved.s2 listBase saved.s3 saved.s4 saved.s5 bytes h) :
+    ∀ h,
+      (k34FailPost spW newSp listBase oldOffset oldLen raRet outer saved bytes
+        listLen index **
+       memOwn (spW - BitVec.ofNat 64 8) ** (spW ↦ₘ raIn) ** ((spW + 8) ↦ₘ s0Old) **
+       ((spW + 16) ↦ₘ s1Old) ** ((spW + 24) ↦ₘ s2Old) ** Frest) h →
+      (((.x2 ↦ᵣ spW) ** (.x1 ↦ᵣ raRet) ** (.x8 ↦ᵣ outer.s0) ** (.x9 ↦ᵣ outer.s1) **
+        (.x18 ↦ᵣ saved.s2) ** (spW ↦ₘ raIn) ** ((spW + 8) ↦ₘ s0Old) **
+        ((spW + 16) ↦ₘ s1Old) ** ((spW + 24) ↦ₘ s2Old) **
+        ((⌜DecodeFailure bytes listBase listLen⌝ : Assertion) **
+         wdFailLeftover spW saved.s2 listBase saved.s3 saved.s4 saved.s5 bytes)) **
+       regOwn .x10) h := by
+  intro h hp
+  obtain ⟨ha, hb, hdab, huab, hkp, hRp⟩ := hp
+  have hDF : DecodeFailure bytes listBase listLen :=
+    wdK34FailDF spW newSp listBase oldOffset oldLen raRet outer saved bytes listLen
+      index mkDF ha hkp
+  unfold k34FailPost at hkp
+  rcases hkp with ⟨offset, len, v12, x5r, ss, ws, ov, hs⟩ | ⟨v11, v12, hf⟩
+  · -- success payload with nonzero wrapper status
+    obtain ⟨_, hX⟩ := (sepConj_pure_left ha).1 hs
+    have hcomb :
+        (((.x1 ↦ᵣ raRet) **
+          (((.x2 ↦ᵣ spW) ** (.x8 ↦ᵣ outer.s0) ** (.x9 ↦ᵣ outer.s1) **
+            savedFrame newSp outer) **
+           EvmAsm.Codegen.RlpFieldToU64SAsm.successPayload newSp listBase offset len
+             v12 x5r ss ws ov saved bytes listLen index)) **
+         (memOwn (spW - BitVec.ofNat 64 8) ** (spW ↦ₘ raIn) ** ((spW + 8) ↦ₘ s0Old) **
+          ((spW + 16) ↦ₘ s1Old) ** ((spW + 24) ↦ₘ s2Old) ** Frest)) h :=
+      ⟨ha, hb, hdab, huab, hX, hRp⟩
+    unfold EvmAsm.Codegen.RlpFieldToU64SAsm.successPayload at hcomb
+    have hgR :
+        (((( .x2 ↦ᵣ spW) ** (.x1 ↦ᵣ raRet) ** (.x8 ↦ᵣ outer.s0) ** (.x9 ↦ᵣ outer.s1) **
+           (.x18 ↦ᵣ saved.s2) ** (spW ↦ₘ raIn) ** ((spW + 8) ↦ₘ s0Old) **
+           ((spW + 16) ↦ₘ s1Old) ** ((spW + 24) ↦ₘ s2Old) **
+           ((memOwn (spW - BitVec.ofNat 64 8) ** savedFrame newSp outer **
+             stackFree newSp 8) **
+            ((.x19 ↦ᵣ saved.s3) ** (.x20 ↦ᵣ saved.s4) ** (.x21 ↦ᵣ saved.s5) **
+             (.x5 ↦ᵣ x5r) ** regOwn .x6 ** regOwn .x7 ** (.x11 ↦ᵣ ss) **
+             (.x12 ↦ᵣ v12) ** regOwn .x13 ** regOwn .x14 ** regOwn .x28 **
+             regOwn .x29 ** regOwn .x30 ** regOwn .x31 ** (.x0 ↦ᵣ (0 : Word))) **
+            bytesRegion listBase bytes ** (offsetCell ↦ₘ offset) **
+            (lengthCell ↦ₘ len) ** (saved.s1 ↦ₘ ov) ** Frest)) **
+          (.x10 ↦ᵣ ws)) **
+         ⌜EvmAsm.Codegen.RlpFieldToU64SAsm.Result bytes listBase listLen index ws ov⌝) h := by
+      xperm_hyp hcomb
+    have hg_top := ((sepConj_pure_right h).1 hgR).1
+    refine sepConj_mono ?_ (regIs_implies_regOwn .x10) h hg_top
+    refine sepConj_mono_right (sepConj_mono_right (sepConj_mono_right
+      (sepConj_mono_right (sepConj_mono_right (sepConj_mono_right (sepConj_mono_right
+      (sepConj_mono_right (sepConj_mono_right ?_))))))))
+    intro h' hl
+    refine (sepConj_pure_left h').2 ⟨hDF, ?_⟩
+    have h2 :
+        (stackFree spW 12 ** wdScratch saved.s3 saved.s4 saved.s5 **
+         bytesRegion listBase bytes ** (offsetCell ↦ₘ offset) ** (lengthCell ↦ₘ len) **
+         (saved.s1 ↦ₘ ov) ** Frest) h' :=
+      sepConj_mono (wdStack12_of_k34_saved spW newSp outer hnewSp)
+        (sepConj_mono_left (wdScratch_of_regs saved.s3 saved.s4 saved.s5 x5r ss v12))
+        h' hl
+    refine hleft offset len ov h' ?_
+    xperm_hyp h2
+  · -- failure payload with status 1
+    have hcomb :
+        (((.x1 ↦ᵣ raRet) **
+          (((.x2 ↦ᵣ spW) ** (.x8 ↦ᵣ outer.s0) ** (.x9 ↦ᵣ outer.s1) **
+            savedFrame newSp outer) **
+           EvmAsm.Codegen.RlpFieldToU64SAsm.failurePayload newSp listBase oldOffset
+             oldLen v11 v12 saved bytes listLen index)) **
+         (memOwn (spW - BitVec.ofNat 64 8) ** (spW ↦ₘ raIn) ** ((spW + 8) ↦ₘ s0Old) **
+          ((spW + 16) ↦ₘ s1Old) ** ((spW + 24) ↦ₘ s2Old) ** Frest)) h :=
+      ⟨ha, hb, hdab, huab, hf, hRp⟩
+    unfold EvmAsm.Codegen.RlpFieldToU64SAsm.failurePayload at hcomb
+    have hgR :
+        (((( .x2 ↦ᵣ spW) ** (.x1 ↦ᵣ raRet) ** (.x8 ↦ᵣ outer.s0) ** (.x9 ↦ᵣ outer.s1) **
+           (.x18 ↦ᵣ saved.s2) ** (spW ↦ₘ raIn) ** ((spW + 8) ↦ₘ s0Old) **
+           ((spW + 16) ↦ₘ s1Old) ** ((spW + 24) ↦ₘ s2Old) **
+           ((memOwn (spW - BitVec.ofNat 64 8) ** savedFrame newSp outer **
+             stackFree newSp 8) **
+            ((.x19 ↦ᵣ saved.s3) ** (.x20 ↦ᵣ saved.s4) ** (.x21 ↦ᵣ saved.s5) **
+             regOwn .x5 ** regOwn .x6 ** regOwn .x7 ** (.x11 ↦ᵣ v11) **
+             (.x12 ↦ᵣ v12) ** regOwn .x13 ** regOwn .x14 ** regOwn .x28 **
+             regOwn .x29 ** regOwn .x30 ** regOwn .x31 ** (.x0 ↦ᵣ (0 : Word))) **
+            bytesRegion listBase bytes ** (offsetCell ↦ₘ oldOffset) **
+            (lengthCell ↦ₘ oldLen) ** (saved.s1 ↦ₘ (0 : Word)) ** Frest)) **
+          (.x10 ↦ᵣ (1 : Word))) **
+         ⌜EvmAsm.Codegen.RlpFieldToU64SAsm.Result bytes listBase listLen index 1 0⌝) h := by
+      xperm_hyp hcomb
+    have hg_top := ((sepConj_pure_right h).1 hgR).1
+    refine sepConj_mono ?_ (regIs_implies_regOwn .x10) h hg_top
+    refine sepConj_mono_right (sepConj_mono_right (sepConj_mono_right
+      (sepConj_mono_right (sepConj_mono_right (sepConj_mono_right (sepConj_mono_right
+      (sepConj_mono_right (sepConj_mono_right ?_))))))))
+    intro h' hl
+    refine (sepConj_pure_left h').2 ⟨hDF, ?_⟩
+    have h2 :
+        (stackFree spW 12 ** wdScratch saved.s3 saved.s4 saved.s5 **
+         bytesRegion listBase bytes ** (offsetCell ↦ₘ oldOffset) ** (lengthCell ↦ₘ oldLen) **
+         (saved.s1 ↦ₘ (0 : Word)) ** Frest) h' :=
+      sepConj_mono (wdStack12_of_k34_saved spW newSp outer hnewSp)
+        (sepConj_mono_left (wdScratch_of_regs_own5 saved.s3 saved.s4 saved.s5 v11 v12))
+        h' hl
+    refine hleft oldOffset oldLen 0 h' ?_
+    xperm_hyp h2
+
+#print axioms wdK34FailPre
 
 end EvmAsm.Codegen.WithdrawalDecodeSpec

--- a/EvmAsm/Codegen/Programs/WithdrawalDecodeClose4.lean
+++ b/EvmAsm/Codegen/Programs/WithdrawalDecodeClose4.lean
@@ -506,4 +506,42 @@ theorem wdK34FailPre (spW newSp raIn listBase oldOffset oldLen raRet
 
 #print axioms wdK34FailPre
 
+set_option maxRecDepth 8000 in
+/-- The complete K34 fail arm as a single triple: from `k34FailPost` (framed over
+    the prologue slots, the reclaimed top cell, and the ambient rest `Frest`) run
+    the failure tail `WB+212 → raIn` to the whole-program failure post.  This is
+    `wdK34FailPre ;; wdFailArm`; the backbone merges it against each field stage's
+    fail edge.  Generic over the field index and constructor via `mkDF`/`hleft`. -/
+theorem wdK34FailArm (sp0 spW newSp raIn listBase oldOffset oldLen raRet
+      s0Old s1Old s2Old : Word)
+    (outer : Saved) (saved : EvmAsm.Codegen.RlpListNthItemSAsm.Saved)
+    (bytes oldAddr pad4 : List (BitVec 8)) (listLen index : Nat)
+    (Frest : Assertion)
+    (hspW : spW = sp0 + signExtend12 (-32 : BitVec 12))
+    (hnewSp : newSp = spW + signExtend12 (-32 : BitVec 12))
+    (hret : raIn &&& ~~~(1 : Word) = raIn)
+    (mkDF : ∀ (status v : Word), status ≠ (0 : Word) →
+      EvmAsm.Codegen.RlpFieldToU64SAsm.Result bytes listBase listLen index status v →
+      DecodeFailure bytes listBase listLen)
+    (hleft : ∀ (roff rlen ov : Word), ∀ h,
+      (wdScratch saved.s3 saved.s4 saved.s5 ** stackFree spW 12 **
+       bytesRegion listBase bytes ** (offsetCell ↦ₘ roff) ** (lengthCell ↦ₘ rlen) **
+       (saved.s1 ↦ₘ ov) ** Frest) h →
+      wdFailLeftover spW saved.s2 listBase saved.s3 saved.s4 saved.s5 bytes h) :
+    cpsTripleWithin 7 (WB + 212) raIn fullCode
+      (k34FailPost spW newSp listBase oldOffset oldLen raRet outer saved bytes
+        listLen index **
+       memOwn (spW - BitVec.ofNat 64 8) ** (spW ↦ₘ raIn) ** ((spW + 8) ↦ₘ s0Old) **
+       ((spW + 16) ↦ₘ s1Old) ** ((spW + 24) ↦ₘ s2Old) ** Frest)
+      (wdWholePost sp0 spW raIn s0Old s1Old s2Old saved.s2 listBase saved.s3 saved.s4
+        saved.s5 listLen bytes oldAddr pad4) :=
+  cpsTripleWithin_weaken
+    (wdK34FailPre spW newSp raIn listBase oldOffset oldLen raRet s0Old s1Old s2Old
+      outer saved bytes listLen index Frest hnewSp mkDF hleft)
+    (fun _ hq => hq)
+    (wdFailArm sp0 spW raIn s0Old s1Old s2Old raRet outer.s0 outer.s1 saved.s2
+      saved.s2 listBase saved.s3 saved.s4 saved.s5 bytes oldAddr pad4 listLen hspW hret)
+
+#print axioms wdK34FailArm
+
 end EvmAsm.Codegen.WithdrawalDecodeSpec

--- a/EvmAsm/Codegen/Programs/WithdrawalDecodeClose4.lean
+++ b/EvmAsm/Codegen/Programs/WithdrawalDecodeClose4.lean
@@ -71,4 +71,56 @@ def wdWholePost (sp0 spW wra cs0 cs1 cs2 outBase listBase : Word)
       ((.x10 ↦ᵣ (1 : Word)) ** wdCommon sp0 spW wra cs0 cs1 cs2 **
        wdFailLeftover spW outBase listBase bytes)) h)
 
+/-! ## Scratch-stack reconcile (K34 boundary)
+
+    The whole-program pre owns `stackFree spW 12` (cells `spW-8 … spW-96`).  A
+    K34 field call allocates its own frame at `newSp = spW - 32`, using the top
+    cell `spW-8` framed off plus `frameSlotsOwn frame newSp` (3 cells
+    `spW-16, spW-24, spW-32`) and `stackFree newSp 8` (cells `spW-40 … spW-96`).  These
+    two shapes hold the same 12 owned cells. -/
+
+/-- Assemble a K34 field call's reclaimed scratch back into `stackFree spW 12`. -/
+theorem wdStack12_of_k34 (sp0 spW newSp : Word)
+    (hspW : spW = sp0 + signExtend12 (-32 : BitVec 12))
+    (hnewSp : newSp = spW + signExtend12 (-32 : BitVec 12)) : ∀ h,
+    (memOwn (spW - BitVec.ofNat 64 8) **
+     frameSlotsOwn frame newSp ** stackFree newSp 8) h →
+    stackFree spW 12 h := by
+  intro h hp
+  have hse : signExtend12 (-32 : BitVec 12) = (0xFFFFFFFFFFFFFFE0 : Word) := by decide
+  subst hnewSp
+  rw [hse] at hp
+  simp only [frameSlotsOwn, frame, List.foldr, sepConj_emp_right',
+    show signExtend12 (0 : BitVec 12) = (0 : Word) from by decide,
+    show signExtend12 (8 : BitVec 12) = (8 : Word) from by decide,
+    show signExtend12 (16 : BitVec 12) = (16 : Word) from by decide] at hp
+  simp only [stackFree] at hp ⊢
+  simp only [sepConj_emp_right', Nat.reduceMul, Nat.reduceAdd] at hp ⊢
+  -- normalise every K34-frame cell address to the canonical `spW - N#64` form
+  rw [show spW + (18446744073709551584 : Word) + (0 : Word)
+        = spW - BitVec.ofNat 64 32 from by bv_omega,
+      show spW + (18446744073709551584 : Word) + (8 : Word)
+        = spW - BitVec.ofNat 64 24 from by bv_omega,
+      show spW + (18446744073709551584 : Word) + (16 : Word)
+        = spW - BitVec.ofNat 64 16 from by bv_omega,
+      show spW + (18446744073709551584 : Word) - BitVec.ofNat 64 64
+        = spW - BitVec.ofNat 64 96 from by bv_omega,
+      show spW + (18446744073709551584 : Word) - BitVec.ofNat 64 56
+        = spW - BitVec.ofNat 64 88 from by bv_omega,
+      show spW + (18446744073709551584 : Word) - BitVec.ofNat 64 48
+        = spW - BitVec.ofNat 64 80 from by bv_omega,
+      show spW + (18446744073709551584 : Word) - BitVec.ofNat 64 40
+        = spW - BitVec.ofNat 64 72 from by bv_omega,
+      show spW + (18446744073709551584 : Word) - BitVec.ofNat 64 32
+        = spW - BitVec.ofNat 64 64 from by bv_omega,
+      show spW + (18446744073709551584 : Word) - BitVec.ofNat 64 24
+        = spW - BitVec.ofNat 64 56 from by bv_omega,
+      show spW + (18446744073709551584 : Word) - BitVec.ofNat 64 16
+        = spW - BitVec.ofNat 64 48 from by bv_omega,
+      show spW + (18446744073709551584 : Word) - BitVec.ofNat 64 8
+        = spW - BitVec.ofNat 64 40 from by bv_omega] at hp
+  xperm_hyp hp
+
+#print axioms wdStack12_of_k34
+
 end EvmAsm.Codegen.WithdrawalDecodeSpec

--- a/EvmAsm/Codegen/Programs/WithdrawalDecodeClose4.lean
+++ b/EvmAsm/Codegen/Programs/WithdrawalDecodeClose4.lean
@@ -247,4 +247,15 @@ theorem wdFailEpiRO (sp0 spW wra cs0 cs1 cs2 x1old x8old x9old x18old : Word)
 
 #print axioms wdFailEpiRO
 
+theorem pcFree_wdFailLeftover (spW outBase listBase s3 s4 s5 : Word)
+    (bytes : List (BitVec 8)) :
+    (wdFailLeftover spW outBase listBase s3 s4 s5 bytes).pcFree := by
+  intro h hp
+  obtain ⟨_, _, _, _, _, _, _, _, _, hbody⟩ := hp
+  revert h hbody
+  show Assertion.pcFree _
+  repeat' first
+    | exact pcFree_memIs | exact bytesRegion_pcFree _ _ | exact pcFree_stackFree _ _
+    | exact pcFree_wdScratch _ _ _ | apply pcFree_sepConj
+
 end EvmAsm.Codegen.WithdrawalDecodeSpec

--- a/EvmAsm/Codegen/Programs/WithdrawalDecodeClose4.lean
+++ b/EvmAsm/Codegen/Programs/WithdrawalDecodeClose4.lean
@@ -307,4 +307,36 @@ theorem pcFree_wdFailLeftover (spW outBase listBase s3 s4 s5 : Word)
     | exact pcFree_memIs | exact bytesRegion_pcFree _ _ | exact pcFree_stackFree _ _
     | exact pcFree_wdScratch _ _ _ | apply pcFree_sepConj
 
+#print axioms pcFree_wdFailLeftover
+
+set_option maxRecDepth 8000 in
+/-- Generic fail arm: from any reshaped fail-pre — the restored-caller registers
+    and stack slots plus `⌜DecodeFailure⌝ ** wdFailLeftover` as the preserved
+    footprint `G0`, and an owned `x10` — the failure tail (`WB+212 → wra`) lands
+    the whole-program failure post.  Every fail arm (K34 fields 0/1/3, K20
+    field-2 list, length-check) reduces to this after its own PRE reshape. -/
+theorem wdFailArm (sp0 spW wra cs0 cs1 cs2 x1old x8old x9old x18old
+      outBase listBase s3 s4 s5 : Word)
+    (bytes oldAddr pad4 : List (BitVec 8)) (listLen : Nat)
+    (hspW : spW = sp0 + signExtend12 (-32 : BitVec 12))
+    (hret : wra &&& ~~~(1 : Word) = wra) :
+    cpsTripleWithin 7 (WB + 212) wra fullCode
+      (((.x2 ↦ᵣ spW) ** (.x1 ↦ᵣ x1old) ** (.x8 ↦ᵣ x8old) ** (.x9 ↦ᵣ x9old) **
+        (.x18 ↦ᵣ x18old) ** (spW ↦ₘ wra) ** ((spW + 8) ↦ₘ cs0) **
+        ((spW + 16) ↦ₘ cs1) ** ((spW + 24) ↦ₘ cs2) **
+        ((⌜DecodeFailure bytes listBase listLen⌝ : Assertion) **
+         wdFailLeftover spW outBase listBase s3 s4 s5 bytes)) ** regOwn .x10)
+      (wdWholePost sp0 spW wra cs0 cs1 cs2 outBase listBase s3 s4 s5 listLen bytes
+        oldAddr pad4) := by
+  refine cpsTripleWithin_weaken (fun _ hp => hp) (fun h hq => Or.inr ?_)
+    (wdFailEpiRO sp0 spW wra cs0 cs1 cs2 x1old x8old x9old x18old
+      ((⌜DecodeFailure bytes listBase listLen⌝ : Assertion) **
+        wdFailLeftover spW outBase listBase s3 s4 s5 bytes)
+      (pcFree_sepConj pcFree_pure (pcFree_wdFailLeftover _ _ _ _ _ _ _)) hspW hret)
+  -- hq : ((x10↦1 ** wdCommon) ** (⌜DF⌝ ** wdFailLeftover)) h
+  -- goal : (⌜DF⌝ ** (x10↦1 ** wdCommon ** wdFailLeftover)) h
+  xperm_hyp hq
+
+#print axioms wdFailArm
+
 end EvmAsm.Codegen.WithdrawalDecodeSpec

--- a/EvmAsm/Codegen/Programs/WithdrawalDecodeClose4.lean
+++ b/EvmAsm/Codegen/Programs/WithdrawalDecodeClose4.lean
@@ -156,7 +156,7 @@ theorem wdStack12_of_k34_saved (spW newSp : Word) (outer : Saved)
 
 /-- Carve a K34 field call's scratch shape out of `stackFree spW 12` (the reverse
     of `wdStack12_of_k34`, used on the continue/forward path). -/
-theorem wdStack12_to_k34 (sp0 spW newSp : Word)
+theorem wdStack12_to_k34 (spW newSp : Word)
     (hnewSp : newSp = spW + signExtend12 (-32 : BitVec 12)) : ∀ h,
     stackFree spW 12 h →
     (memOwn (spW - BitVec.ofNat 64 8) **
@@ -211,7 +211,7 @@ theorem pcFree_wdStackK20Deep (spW : Word) : (wdStackK20Deep spW).pcFree := by
 theorem wdStack12_of_k20 (spW : Word) : ∀ h,
     (wdStackK20Deep spW ** stackFree spW 8) h → stackFree spW 12 h := by
   intro h hp
-  simp only [stackFree, wdStackK20Deep, Nat.reduceMul] at hp ⊢
+  simp only [stackFree, wdStackK20Deep] at hp ⊢
   xperm_hyp hp
 
 #print axioms wdStack12_of_k20
@@ -220,10 +220,40 @@ theorem wdStack12_of_k20 (spW : Word) : ∀ h,
 theorem wdStack12_to_k20 (spW : Word) : ∀ h,
     stackFree spW 12 h → (wdStackK20Deep spW ** stackFree spW 8) h := by
   intro h hp
-  simp only [stackFree, wdStackK20Deep, Nat.reduceMul] at hp ⊢
+  simp only [stackFree, wdStackK20Deep] at hp ⊢
   xperm_hyp hp
 
 #print axioms wdStack12_to_k20
+
+/-! ## Generic `DecodeFailure` witness extraction
+
+    Both K34 fail sub-cases (a success payload with a nonzero wrapper status, or
+    the failure payload with status `1`) pin a callee `Result`.  Fusing that with
+    the nonzero-status fact yields a `DecodeFailure` via whichever constructor the
+    field maps to (supplied as `mkDF`).  Parametric over the field index and the
+    constructor — the three K34 fail arms (fields 0/1/3) instantiate it. -/
+theorem wdK34FailDF (spW newSp listBase oldOffset oldLen raRet : Word)
+    (outer : Saved) (saved : EvmAsm.Codegen.RlpListNthItemSAsm.Saved)
+    (bytes : List (BitVec 8)) (listLen index : Nat)
+    (mkDF : ∀ (status v : Word), status ≠ (0 : Word) →
+      EvmAsm.Codegen.RlpFieldToU64SAsm.Result bytes listBase listLen index status v →
+      DecodeFailure bytes listBase listLen) :
+    ∀ h, k34FailPost spW newSp listBase oldOffset oldLen raRet outer saved bytes
+      listLen index h → DecodeFailure bytes listBase listLen := by
+  intro h hp
+  unfold k34FailPost at hp
+  rcases hp with ⟨offset, len, v12, x5, ss, ws, ov, hs⟩ | ⟨v11, v12, hf⟩
+  · obtain ⟨hnz, hrest⟩ := (sepConj_pure_left h).1 hs
+    obtain ⟨_, hb, _, _, _, hB⟩ := hrest
+    obtain ⟨_, hd, _, _, _, hSucc⟩ := hB
+    unfold EvmAsm.Codegen.RlpFieldToU64SAsm.successPayload at hSucc
+    exact mkDF ws ov hnz ((sepConj_pure_right hd).1 hSucc).2
+  · obtain ⟨_, hb, _, _, _, hB⟩ := hf
+    obtain ⟨_, hd, _, _, _, hFail⟩ := hB
+    unfold EvmAsm.Codegen.RlpFieldToU64SAsm.failurePayload at hFail
+    exact mkDF 1 0 (by decide) ((sepConj_pure_right hd).1 hFail).2
+
+#print axioms wdK34FailDF
 
 /-! ## Failure-tail arm -/
 

--- a/EvmAsm/Codegen/Programs/WithdrawalDecodeClose4.lean
+++ b/EvmAsm/Codegen/Programs/WithdrawalDecodeClose4.lean
@@ -37,39 +37,57 @@ theorem pcFree_wdCommon (sp0 spW wra cs0 cs1 cs2 : Word) :
   unfold wdCommon
   repeat' first | exact pcFree_regIs | exact pcFree_memIs | apply pcFree_sepConj
 
+/-- The clobbered temporaries left owned on return, together with the three
+    callee-saved registers `x19/x20/x21` (holding the caller's `s3/s4/s5`, which
+    the RLP callees preserve) and the zero register.  Common to both returns. -/
+def wdScratch (s3 s4 s5 : Word) : Assertion :=
+  (.x19 ↦ᵣ s3) ** (.x20 ↦ᵣ s4) ** (.x21 ↦ᵣ s5) **
+  regOwn .x5 ** regOwn .x6 ** regOwn .x7 ** regOwn .x11 ** regOwn .x12 **
+  regOwn .x13 ** regOwn .x14 ** regOwn .x28 ** regOwn .x29 ** regOwn .x30 **
+  regOwn .x31 ** (.x0 ↦ᵣ (0 : Word))
+
+theorem pcFree_wdScratch (s3 s4 s5 : Word) : (wdScratch s3 s4 s5).pcFree := by
+  unfold wdScratch
+  repeat' first | exact pcFree_regIs | exact pcFree_regOwn | apply pcFree_sepConj
+
 /-- The mutable leftover after a failure return: the whole 48-byte output struct
-    (contents forgotten, only ownership retained), the input region, the two
-    `wd_offset`/`wd_length` cells, and the reclaimed 12-cell scratch stack. -/
-def wdFailLeftover (spW outBase listBase : Word) (bytes : List (BitVec 8)) :
+    (contents forgotten, only ownership retained), the input region, the four
+    data cells, the clobbered temporaries, and the reclaimed 12-cell scratch
+    stack. -/
+def wdFailLeftover (spW outBase listBase s3 s4 s5 : Word) (bytes : List (BitVec 8)) :
     Assertion :=
-  fun h => ∃ (o0 o1 o3 woff wlen : Word) (addr20 pad4 : List (BitVec 8)),
+  fun h => ∃ (o0 o1 o3 woff wlen roff rlen : Word) (addr20 pad4 : List (BitVec 8)),
     ((outBase ↦ₘ o0) ** ((outBase + 8) ↦ₘ o1) **
      bytesRegion (outBase + 16) addr20 ** bytesRegion (outBase + 36) pad4 **
      ((outBase + 40) ↦ₘ o3) ** bytesRegion listBase bytes **
-     (wdOffsetAddr ↦ₘ woff) ** (wdLengthAddr ↦ₘ wlen) ** stackFree spW 12) h
+     (wdOffsetAddr ↦ₘ woff) ** (wdLengthAddr ↦ₘ wlen) **
+     (offsetCell ↦ₘ roff) ** (lengthCell ↦ₘ rlen) ** stackFree spW 12 **
+     wdScratch s3 s4 s5) h
 
 /-- The output-struct leftover after a success return, each cell tied to the
     genuinely decoded field value (`outputSuccess`), plus the untouched input
-    region, the two data cells (still holding the address offset/length), and
-    the reclaimed scratch stack. -/
-def wdSuccessOut (spW outBase listBase v0 v1 v3 o2 l2 : Word)
+    region, the two data cells (still holding the address offset/length), the
+    clobbered temporaries, and the reclaimed scratch stack. -/
+def wdSuccessOut (spW outBase listBase s3 s4 s5 v0 v1 v3 o2 l2 : Word)
     (bytes oldAddr pad4 : List (BitVec 8)) : Assertion :=
-  outputSuccess outBase v0 v1 v3 o2 bytes oldAddr pad4 **
-  bytesRegion listBase bytes ** (wdOffsetAddr ↦ₘ o2) ** (wdLengthAddr ↦ₘ l2) **
-  stackFree spW 12
+  fun h => ∃ (roff rlen : Word),
+    (outputSuccess outBase v0 v1 v3 o2 bytes oldAddr pad4 **
+     bytesRegion listBase bytes ** (wdOffsetAddr ↦ₘ o2) ** (wdLengthAddr ↦ₘ l2) **
+     (offsetCell ↦ₘ roff) ** (lengthCell ↦ₘ rlen) ** stackFree spW 12 **
+     wdScratch s3 s4 s5) h
 
 /-- The whole-program post: `a0 = 0` with the genuine decoded output struct, or
     `a0 = 1` with a witnessed `DecodeFailure` and the owned leftover. -/
-def wdWholePost (sp0 spW wra cs0 cs1 cs2 outBase listBase : Word)
+def wdWholePost (sp0 spW wra cs0 cs1 cs2 outBase listBase s3 s4 s5 : Word)
     (listLen : Nat) (bytes oldAddr pad4 : List (BitVec 8)) : Assertion :=
   fun h =>
     (∃ (v0 v1 v3 o2 l2 : Word),
       ((⌜Decoded bytes listBase listLen v0 v1 v3 o2 l2⌝ : Assertion) **
        ((.x10 ↦ᵣ (0 : Word)) ** wdCommon sp0 spW wra cs0 cs1 cs2 **
-        wdSuccessOut spW outBase listBase v0 v1 v3 o2 l2 bytes oldAddr pad4)) h) ∨
+        wdSuccessOut spW outBase listBase s3 s4 s5 v0 v1 v3 o2 l2 bytes oldAddr pad4)) h) ∨
     (((⌜DecodeFailure bytes listBase listLen⌝ : Assertion) **
       ((.x10 ↦ᵣ (1 : Word)) ** wdCommon sp0 spW wra cs0 cs1 cs2 **
-       wdFailLeftover spW outBase listBase bytes)) h)
+       wdFailLeftover spW outBase listBase s3 s4 s5 bytes)) h)
 
 /-! ## Scratch-stack reconcile (K34 boundary)
 

--- a/EvmAsm/Codegen/Programs/WithdrawalDecodeClose5.lean
+++ b/EvmAsm/Codegen/Programs/WithdrawalDecodeClose5.lean
@@ -23,6 +23,7 @@ namespace EvmAsm.Codegen.WithdrawalDecodeSpec
 
 open EvmAsm.Rv64 EvmAsm.Rv64.SAsm
 open EvmAsm.Codegen.RlpFieldToU64SAsm
+open EvmAsm.Evm64.Terminating (copyIntoRegion)
 
 /-! ## CONT-side reshape (K34 boundary)
 
@@ -323,5 +324,367 @@ theorem wdSuccessContentBound (bytes : List (BitVec 8)) (listBase : Word)
   exact strictNthItem_content_le hnth hcur (by omega)
 
 #print axioms wdSuccessContentBound
+
+/-! ## Field-2 middle segment (`WB+116 → raIn`)
+
+    The K20 continue exit reshapes into the length check `WB+116`; a `len ≠ 20`
+    edge is the `field2Len` failure, and the `len = 20` edge copies the 20 address
+    bytes (`wdCopySetup ;; wdCopyLoop`) and hands off to the field-3 backbone. -/
+
+/-- Introduce EIGHT owned registers' values at once (trailing `regOwn` chain). -/
+theorem cpsTripleWithin_of_forall_regIs_to_regOwn8
+    {nSteps : Nat} {entry exit_ : Word} {r1 r2 r3 r4 r5 r6 r7 r8 : Reg}
+    {P Q : Assertion} {cr : CodeReq}
+    (h : ∀ v1 v2 v3 v4 v5 v6 v7 v8, cpsTripleWithin nSteps entry exit_ cr
+      (P ** (r1 ↦ᵣ v1) ** (r2 ↦ᵣ v2) ** (r3 ↦ᵣ v3) ** (r4 ↦ᵣ v4) **
+       (r5 ↦ᵣ v5) ** (r6 ↦ᵣ v6) ** (r7 ↦ᵣ v7) ** (r8 ↦ᵣ v8)) Q) :
+    cpsTripleWithin nSteps entry exit_ cr
+      (P ** regOwn r1 ** regOwn r2 ** regOwn r3 ** regOwn r4 **
+       regOwn r5 ** regOwn r6 ** regOwn r7 ** regOwn r8) Q := by
+  intro R hR s hcr hPR hpc
+  obtain ⟨hp, hcompat, k1, k2, d0, u0, hPP, hRb⟩ := hPR
+  obtain ⟨k3, k4, d1, u1, hP3, hO1⟩ := hPP
+  obtain ⟨a1, b1, e1, f1, ⟨v1, hv1⟩, hO2⟩ := hO1
+  obtain ⟨a2, b2, e2, f2, ⟨v2, hv2⟩, hO3⟩ := hO2
+  obtain ⟨a3, b3, e3, f3, ⟨v3, hv3⟩, hO4⟩ := hO3
+  obtain ⟨a4, b4, e4, f4, ⟨v4, hv4⟩, hO5⟩ := hO4
+  obtain ⟨a5, b5, e5, f5, ⟨v5, hv5⟩, hO6⟩ := hO5
+  obtain ⟨a6, b6, e6, f6, ⟨v6, hv6⟩, hO7⟩ := hO6
+  obtain ⟨a7, b7, e7, f7, ⟨v7, hv7⟩, ⟨v8, hv8⟩⟩ := hO7
+  exact h v1 v2 v3 v4 v5 v6 v7 v8 R hR s hcr
+    ⟨hp, hcompat, k1, k2, d0, u0,
+      ⟨k3, k4, d1, u1, hP3,
+        a1, b1, e1, f1, hv1, a2, b2, e2, f2, hv2, a3, b3, e3, f3, hv3,
+        a4, b4, e4, f4, hv4, a5, b5, e5, f5, hv5, a6, b6, e6, f6, hv6,
+        a7, b7, e7, f7, hv7, hv8⟩, hRb⟩ hpc
+
+/-- All clobbered temporaries (as concrete `regIs` cells) weaken into
+    `wdScratch`; `x31` arrives already owned. -/
+theorem wdScratch_of_regIs (s3 s4 s5 v5 v6 v7 v11 v12 v13 v14 v28 v29 v30 : Word) : ∀ h,
+    ((.x19 ↦ᵣ s3) ** (.x20 ↦ᵣ s4) ** (.x21 ↦ᵣ s5) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) **
+     (.x7 ↦ᵣ v7) ** (.x11 ↦ᵣ v11) ** (.x12 ↦ᵣ v12) ** (.x13 ↦ᵣ v13) ** (.x14 ↦ᵣ v14) **
+     (.x28 ↦ᵣ v28) ** (.x29 ↦ᵣ v29) ** (.x30 ↦ᵣ v30) ** regOwn .x31 **
+     (.x0 ↦ᵣ (0 : Word))) h →
+    wdScratch s3 s4 s5 h := by
+  intro h hp
+  unfold wdScratch
+  exact sepConj_mono_right (sepConj_mono_right (sepConj_mono_right
+    (sepConj_mono (regIs_implies_regOwn .x5) (sepConj_mono (regIs_implies_regOwn .x6)
+    (sepConj_mono (regIs_implies_regOwn .x7) (sepConj_mono (regIs_implies_regOwn .x11)
+    (sepConj_mono (regIs_implies_regOwn .x12) (sepConj_mono (regIs_implies_regOwn .x13)
+    (sepConj_mono (regIs_implies_regOwn .x14) (sepConj_mono (regIs_implies_regOwn .x28)
+    (sepConj_mono (regIs_implies_regOwn .x29)
+      (sepConj_mono_left (regIs_implies_regOwn .x30))))))))))))) h hp
+
+/-- `pcFree` discharge covering `wdStackK20Deep`/`wdScratch` frames. -/
+local macro "pcfw" : tactic =>
+  `(tactic| repeat' first
+    | exact bytesRegion_pcFree _ _
+    | exact pcFree_regIs
+    | exact pcFree_regOwn
+    | exact pcFree_memIs
+    | exact pcFree_memOwn
+    | exact pcFree_pure
+    | exact pcFree_stackFree _ _
+    | exact pcFree_wdStackK20Deep _
+    | exact pcFree_wdScratch _ _ _
+    | exact pcFree_frameSlotsOwn _ _
+    | apply pcFree_sepConj)
+
+set_option maxRecDepth 8000 in
+/-- Field-2 continue → whole-program post (`WB+116 → raIn`): reshape the K20
+    continue payload into the length check, then either fail on `len ≠ 20`
+    (`field2Len`) or copy the 20 address bytes and run the field-3 backbone. -/
+theorem wdField2ContEpi
+    (sp0 spW newSp raIn listBase len outBase v0 v1 oldOut oldOffset oldLen
+      s0Old s1Old s2Old s3 s4 s5 : Word)
+    (bytes oldAddr pad4 : List (BitVec 8)) (listLen : Nat)
+    (hspW : spW = sp0 + signExtend12 (-32 : BitVec 12))
+    (hnewSp : newSp = spW + signExtend12 (-32 : BitVec 12))
+    (hret : raIn &&& ~~~(1 : Word) = raIn)
+    (hlenW : len = BitVec.ofNat 64 listLen)
+    (hsalign : listBase.toNat % 8 = 0)
+    (hslack : listLen + 9 ≤ bytes.length)
+    (hover : listBase.toNat + bytes.length < 2 ^ 64)
+    (hvalid : ∀ k, k < bytes.length →
+      isValidByteAccess (listBase + BitVec.ofNat 64 k) = true)
+    (houtalign : outBase.toNat % 8 = 0)
+    (houtover : outBase.toNat + 48 < 2 ^ 64)
+    (haddrlen : oldAddr.length = 20)
+    (houtvalid : ∀ k, k < 20 →
+      isValidByteAccess ((outBase + 16) + BitVec.ofNat 64 k) = true)
+    (hf0 : Result bytes listBase listLen 0 (0 : Word) v0)
+    (hf1 : Result bytes listBase listLen 1 (0 : Word) v1) :
+    let saved2 : EvmAsm.Codegen.RlpListNthItemSAsm.Saved :=
+      { ra := WB + 112, s0 := listBase, s1 := len, s2 := outBase, s3 := s3, s4 := s4,
+        s5 := s5 }
+    cpsTripleWithin (5 + (5 + (6 * (19 + 1)) +
+        ((4 + (1 + ((7 + 4 + (1 + ((12 + ((85 + 93 * (3 + 2)) + 6)) + 9))) +
+          ((1 + ((7 + (1 + (7 * (2 ^ 64 - 1) + 11))) + 5)) + 5))) + 1) + 8)))
+      (WB + 116) raIn fullCode
+      (k20ContPost spW listBase saved2 bytes listLen **
+       (wdStackK20Deep spW ** (spW ↦ₘ raIn) ** ((spW + 8) ↦ₘ s0Old) **
+        ((spW + 16) ↦ₘ s1Old) ** ((spW + 24) ↦ₘ s2Old) ** (outBase ↦ₘ v0) **
+        ((outBase + 8) ↦ₘ v1) ** bytesRegion (outBase + 16) oldAddr **
+        bytesRegion (outBase + 36) pad4 ** ((outBase + 40) ↦ₘ oldOut) **
+        (offsetCell ↦ₘ oldOffset) ** (lengthCell ↦ₘ oldLen)))
+      (wdWholePost sp0 spW raIn s0Old s1Old s2Old outBase listBase s3 s4 s5 listLen bytes
+        oldAddr pad4) := by
+  intro saved2
+  -- (1) Expose the K20 continue existentials + `Success` + eight owned temporaries.
+  refine cpsTripleWithin_weaken
+    (P := fun h => ∃ offset len' v11 v12,
+      ((⌜EvmAsm.Codegen.RlpListNthItemSAsm.Success bytes listBase listLen 2 offset
+          len'⌝ : Assertion) **
+       (((.x2 ↦ᵣ spW) ** (.x1 ↦ᵣ (WB + 112)) ** (.x8 ↦ᵣ listBase) ** (.x9 ↦ᵣ len) **
+         (.x18 ↦ᵣ outBase) ** (.x19 ↦ᵣ s3) ** (.x20 ↦ᵣ s4) ** (.x21 ↦ᵣ s5) **
+         stackFree spW 8 ** (.x10 ↦ᵣ (0 : Word)) ** (.x11 ↦ᵣ v11) ** (.x12 ↦ᵣ v12) **
+         (.x0 ↦ᵣ (0 : Word)) ** regOwn .x31 ** bytesRegion listBase bytes **
+         (wdOffsetAddr ↦ₘ offset) ** (wdLengthAddr ↦ₘ len') ** (spW ↦ₘ raIn) **
+         ((spW + 8) ↦ₘ s0Old) ** ((spW + 16) ↦ₘ s1Old) ** ((spW + 24) ↦ₘ s2Old) **
+         (outBase ↦ₘ v0) ** ((outBase + 8) ↦ₘ v1) ** bytesRegion (outBase + 16) oldAddr **
+         bytesRegion (outBase + 36) pad4 ** ((outBase + 40) ↦ₘ oldOut) **
+         wdStackK20Deep spW ** (offsetCell ↦ₘ oldOffset) ** (lengthCell ↦ₘ oldLen)) **
+        regOwn .x5 ** regOwn .x6 ** regOwn .x7 ** regOwn .x13 ** regOwn .x14 **
+        regOwn .x28 ** regOwn .x29 ** regOwn .x30)) h)
+    (fun h hp => by
+      obtain ⟨h1, h2, hd, hu, hk, hacc⟩ := hp
+      obtain ⟨offset, len', v11, v12, hbody⟩ := hk
+      refine ⟨offset, len', v11, v12, ?_⟩
+      obtain ⟨hsucc, hbig⟩ := (sepConj_pure_left h1).1 hbody
+      refine (sepConj_pure_left h).2 ⟨hsucc, ?_⟩
+      have hcomb :
+          ((((.x2 ↦ᵣ spW) ** regsAt EvmAsm.Codegen.RlpListNthItemSAsm.listNthFrame
+              (EvmAsm.Codegen.RlpListNthItemSAsm.savedVals saved2) ** stackFree spW 8) **
+            ((.x10 ↦ᵣ (0 : Word)) ** regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+             (.x11 ↦ᵣ v11) ** (.x12 ↦ᵣ v12) ** regOwn .x13 ** regOwn .x14 **
+             regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+             (.x0 ↦ᵣ (0 : Word)) ** bytesRegion listBase bytes **
+             (wdOffsetAddr ↦ₘ offset) ** (wdLengthAddr ↦ₘ len'))) **
+           (wdStackK20Deep spW ** (spW ↦ₘ raIn) ** ((spW + 8) ↦ₘ s0Old) **
+            ((spW + 16) ↦ₘ s1Old) ** ((spW + 24) ↦ₘ s2Old) ** (outBase ↦ₘ v0) **
+            ((outBase + 8) ↦ₘ v1) ** bytesRegion (outBase + 16) oldAddr **
+            bytesRegion (outBase + 36) pad4 ** ((outBase + 40) ↦ₘ oldOut) **
+            (offsetCell ↦ₘ oldOffset) ** (lengthCell ↦ₘ oldLen))) h :=
+        ⟨h1, h2, hd, hu, hbig, hacc⟩
+      rw [EvmAsm.Codegen.RlpListNthItemSAsm.regsAt_listNthFrame] at hcomb
+      simp only [show (saved2.ra : Word) = WB + 112 from rfl,
+        show (saved2.s0 : Word) = listBase from rfl, show (saved2.s1 : Word) = len from rfl,
+        show (saved2.s2 : Word) = outBase from rfl, show (saved2.s3 : Word) = s3 from rfl,
+        show (saved2.s4 : Word) = s4 from rfl, show (saved2.s5 : Word) = s5 from rfl] at hcomb
+      xperm_hyp hcomb)
+    (fun _ hq => hq) ?_
+  refine cpsTripleWithin_exists_pre_gen (fun offset => ?_)
+  refine cpsTripleWithin_exists_pre_gen (fun len' => ?_)
+  refine cpsTripleWithin_exists_pre_gen (fun v11 => ?_)
+  refine cpsTripleWithin_exists_pre_gen (fun v12 => ?_)
+  refine cpsTripleWithin_pure_pre (fun hsucc => ?_)
+  refine cpsTripleWithin_of_forall_regIs_to_regOwn8 (fun v5 v6 v7 v13 v14 v28 v29 v30 => ?_)
+  -- (2) The length-check branch, framed by the untouched footprint `FL`.
+  have hbr := cpsBranchWithin_frameR
+    ((.x2 ↦ᵣ spW) ** (.x1 ↦ᵣ (WB + 112)) ** (.x8 ↦ᵣ listBase) ** (.x9 ↦ᵣ len) **
+     (.x18 ↦ᵣ outBase) ** (.x19 ↦ᵣ s3) ** (.x20 ↦ᵣ s4) ** (.x21 ↦ᵣ s5) **
+     stackFree spW 8 ** (.x10 ↦ᵣ (0 : Word)) ** (.x11 ↦ᵣ v11) ** (.x12 ↦ᵣ v12) **
+     (.x0 ↦ᵣ (0 : Word)) ** regOwn .x31 ** (.x13 ↦ᵣ v13) ** (.x14 ↦ᵣ v14) **
+     (.x28 ↦ᵣ v28) ** (.x29 ↦ᵣ v29) ** (.x30 ↦ᵣ v30) ** bytesRegion listBase bytes **
+     (wdOffsetAddr ↦ₘ offset) ** (spW ↦ₘ raIn) ** ((spW + 8) ↦ₘ s0Old) **
+     ((spW + 16) ↦ₘ s1Old) ** ((spW + 24) ↦ₘ s2Old) ** (outBase ↦ₘ v0) **
+     ((outBase + 8) ↦ₘ v1) ** bytesRegion (outBase + 16) oldAddr **
+     bytesRegion (outBase + 36) pad4 ** ((outBase + 40) ↦ₘ oldOut) ** wdStackK20Deep spW **
+     (offsetCell ↦ₘ oldOffset) ** (lengthCell ↦ₘ oldLen))
+    (by pcfw) (wdLenCheck v5 v6 v7 len')
+  refine cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp) (fun _ hq => hq)
+    (cpsBranchWithin_merge_same_cr hbr ?fail ?cont)
+  case cont =>
+    -- len = 20: copy setup ;; copy loop ;; field-3 backbone.
+    have hoffnorm : (BitVec.ofNat 64 offset.toNat : Word) = offset := by
+      rw [BitVec.ofNat_toNat, BitVec.setWidth_eq]
+    refine cpsTripleWithin_weaken
+      (P := (⌜len' = (20 : Word)⌝ : Assertion) **
+        (((.x6 ↦ᵣ len') ** (.x7 ↦ᵣ (20 : Word))) ** (.x5 ↦ᵣ wdLengthAddr) **
+         (wdLengthAddr ↦ₘ len') **
+         ((.x2 ↦ᵣ spW) ** (.x1 ↦ᵣ (WB + 112)) ** (.x8 ↦ᵣ listBase) ** (.x9 ↦ᵣ len) **
+          (.x18 ↦ᵣ outBase) ** (.x19 ↦ᵣ s3) ** (.x20 ↦ᵣ s4) ** (.x21 ↦ᵣ s5) **
+          stackFree spW 8 ** (.x10 ↦ᵣ (0 : Word)) ** (.x11 ↦ᵣ v11) ** (.x12 ↦ᵣ v12) **
+          (.x0 ↦ᵣ (0 : Word)) ** regOwn .x31 ** (.x13 ↦ᵣ v13) ** (.x14 ↦ᵣ v14) **
+          (.x28 ↦ᵣ v28) ** (.x29 ↦ᵣ v29) ** (.x30 ↦ᵣ v30) ** bytesRegion listBase bytes **
+          (wdOffsetAddr ↦ₘ offset) ** (spW ↦ₘ raIn) ** ((spW + 8) ↦ₘ s0Old) **
+          ((spW + 16) ↦ₘ s1Old) ** ((spW + 24) ↦ₘ s2Old) ** (outBase ↦ₘ v0) **
+          ((outBase + 8) ↦ₘ v1) ** bytesRegion (outBase + 16) oldAddr **
+          bytesRegion (outBase + 36) pad4 ** ((outBase + 40) ↦ₘ oldOut) **
+          wdStackK20Deep spW ** (offsetCell ↦ₘ oldOffset) ** (lengthCell ↦ₘ oldLen))))
+      (fun h hp => by
+        have hleneq : len' = (20 : Word) := by
+          have hp2 := hp
+          obtain ⟨cp, _, _, _, hcp, _⟩ := hp2
+          obtain ⟨gg, _, _, _, hgrp, _⟩ := hcp
+          obtain ⟨a, b, _, _, _, hg3⟩ := hgrp
+          exact ((sepConj_pure_right b).1 hg3).2
+        refine (sepConj_pure_left h).2 ⟨hleneq, ?_⟩
+        have hp' : ((((.x6 ↦ᵣ len') ** (.x7 ↦ᵣ (20 : Word))) ** (.x5 ↦ᵣ wdLengthAddr) **
+            (wdLengthAddr ↦ₘ len')) **
+           ((.x2 ↦ᵣ spW) ** (.x1 ↦ᵣ (WB + 112)) ** (.x8 ↦ᵣ listBase) ** (.x9 ↦ᵣ len) **
+            (.x18 ↦ᵣ outBase) ** (.x19 ↦ᵣ s3) ** (.x20 ↦ᵣ s4) ** (.x21 ↦ᵣ s5) **
+            stackFree spW 8 ** (.x10 ↦ᵣ (0 : Word)) ** (.x11 ↦ᵣ v11) ** (.x12 ↦ᵣ v12) **
+            (.x0 ↦ᵣ (0 : Word)) ** regOwn .x31 ** (.x13 ↦ᵣ v13) ** (.x14 ↦ᵣ v14) **
+            (.x28 ↦ᵣ v28) ** (.x29 ↦ᵣ v29) ** (.x30 ↦ᵣ v30) ** bytesRegion listBase bytes **
+            (wdOffsetAddr ↦ₘ offset) ** (spW ↦ₘ raIn) ** ((spW + 8) ↦ₘ s0Old) **
+            ((spW + 16) ↦ₘ s1Old) ** ((spW + 24) ↦ₘ s2Old) ** (outBase ↦ₘ v0) **
+            ((outBase + 8) ↦ₘ v1) ** bytesRegion (outBase + 16) oldAddr **
+            bytesRegion (outBase + 36) pad4 ** ((outBase + 40) ↦ₘ oldOut) **
+            wdStackK20Deep spW ** (offsetCell ↦ₘ oldOffset) ** (lengthCell ↦ₘ oldLen))) h :=
+          sepConj_mono_left
+            (fun h'' hcp => sepConj_mono_left sepConj_strip_pure_end2 h'' hcp) h hp
+        xperm_hyp hp')
+      (fun _ hq => hq) ?_
+    refine cpsTripleWithin_pure_pre (fun hleneq => ?_)
+    -- copy setup [34]-[38].
+    have hcs := cpsTripleWithin_frameR
+      ((.x6 ↦ᵣ len') ** (.x7 ↦ᵣ (20 : Word)) ** (wdLengthAddr ↦ₘ len') ** (.x2 ↦ᵣ spW) **
+       (.x1 ↦ᵣ (WB + 112)) ** (.x9 ↦ᵣ len) ** (.x10 ↦ᵣ (0 : Word)) ** (.x11 ↦ᵣ v11) **
+       (.x12 ↦ᵣ v12) ** (.x0 ↦ᵣ (0 : Word)) ** regOwn .x31 ** (.x13 ↦ᵣ v13) **
+       (.x14 ↦ᵣ v14) ** (.x30 ↦ᵣ v30) ** (.x19 ↦ᵣ s3) ** (.x20 ↦ᵣ s4) ** (.x21 ↦ᵣ s5) **
+       stackFree spW 8 ** bytesRegion listBase bytes ** (spW ↦ₘ raIn) **
+       ((spW + 8) ↦ₘ s0Old) ** ((spW + 16) ↦ₘ s1Old) ** ((spW + 24) ↦ₘ s2Old) **
+       (outBase ↦ₘ v0) ** ((outBase + 8) ↦ₘ v1) ** bytesRegion (outBase + 16) oldAddr **
+       bytesRegion (outBase + 36) pad4 ** ((outBase + 40) ↦ₘ oldOut) ** wdStackK20Deep spW **
+       (offsetCell ↦ₘ oldOffset) ** (lengthCell ↦ₘ oldLen))
+      (by pcfw) (wdCopySetup wdLengthAddr v28 v29 listBase outBase offset)
+    -- copy loop [39]-[44].
+    have hcl := cpsTripleWithin_frameR
+      ((.x5 ↦ᵣ wdOffsetAddr) ** (.x8 ↦ᵣ listBase) ** (.x18 ↦ᵣ outBase) **
+       (wdOffsetAddr ↦ₘ offset) ** (.x7 ↦ᵣ (20 : Word)) ** (wdLengthAddr ↦ₘ len') **
+       (.x2 ↦ᵣ spW) ** (.x1 ↦ᵣ (WB + 112)) ** (.x9 ↦ᵣ len) ** (.x10 ↦ᵣ (0 : Word)) **
+       (.x11 ↦ᵣ v11) ** (.x12 ↦ᵣ v12) ** regOwn .x31 ** (.x13 ↦ᵣ v13) ** (.x14 ↦ᵣ v14) **
+       (.x19 ↦ᵣ s3) ** (.x20 ↦ᵣ s4) ** (.x21 ↦ᵣ s5) ** stackFree spW 8 ** (spW ↦ₘ raIn) **
+       ((spW + 8) ↦ₘ s0Old) ** ((spW + 16) ↦ₘ s1Old) ** ((spW + 24) ↦ₘ s2Old) **
+       (outBase ↦ₘ v0) ** ((outBase + 8) ↦ₘ v1) ** bytesRegion (outBase + 36) pad4 **
+       ((outBase + 40) ↦ₘ oldOut) ** wdStackK20Deep spW ** (offsetCell ↦ₘ oldOffset) **
+       (lengthCell ↦ₘ oldLen))
+      (by pcfw)
+      (wdCopyLoop listBase (outBase + 16) v30 bytes oldAddr offset.toNat 0 0 19 hsalign
+        (by bv_omega)
+        (by have := wdSuccessContentBound bytes listBase listLen offset len' hslack hover hsucc
+            rw [hleneq] at this; simp only [show (20 : Word).toNat = 20 from by decide] at this
+            omega)
+        (by omega) hover (by bv_omega) hvalid
+        (by intro k hk; rw [haddrlen] at hk; exact houtvalid k hk))
+    -- field-3 backbone [45]-[59].
+    have hbb := wdBBField3 sp0 spW newSp (WB + 112) raIn listBase len outBase oldOut oldOffset
+      oldLen v14 s3 s4 s5 (0 : Word) v11 v12 v13 v0 v1 offset len' s0Old s1Old s2Old bytes
+      oldAddr pad4 listLen hnewSp hspW hret hlenW hsalign hslack hover hvalid hf0 hf1 hsucc
+      (by rw [hleneq]; decide)
+    -- bridge 1: copy-setup post → copy-loop pre.
+    have s1 := cpsTripleWithin_seq_perm_same_cr
+      (fun h hp => by
+        rw [show (BitVec.ofNat 64 (19 + 1) : Word) = len' from by rw [hleneq]; decide,
+          show listBase + BitVec.ofNat 64 (offset.toNat + 0) = listBase + offset from by
+            rw [Nat.add_zero, hoffnorm],
+          show (outBase + 16) + BitVec.ofNat 64 (0 + 0) = outBase + 16 from by bv_omega,
+          show copyIntoRegion oldAddr bytes 0 offset.toNat 0 = oldAddr from rfl]
+        xperm_hyp hp)
+      hcs hcl
+    -- bridge 2: copy-loop post → field-3 backbone pre.
+    have s2 := cpsTripleWithin_seq_perm_same_cr
+      (fun h hp => by
+        have hp1 : ((regOwn .x6 ** regOwn .x28 ** regOwn .x29 ** regOwn .x30 **
+            (.x0 ↦ᵣ (0 : Word)) ** bytesRegion listBase bytes **
+            bytesRegion (outBase + 16) (addrCopied bytes oldAddr offset)) **
+           ((.x5 ↦ᵣ wdOffsetAddr) ** (.x8 ↦ᵣ listBase) ** (.x18 ↦ᵣ outBase) **
+            (wdOffsetAddr ↦ₘ offset) ** (.x7 ↦ᵣ (20 : Word)) ** (wdLengthAddr ↦ₘ len') **
+            (.x2 ↦ᵣ spW) ** (.x1 ↦ᵣ (WB + 112)) ** (.x9 ↦ᵣ len) ** (.x10 ↦ᵣ (0 : Word)) **
+            (.x11 ↦ᵣ v11) ** (.x12 ↦ᵣ v12) ** regOwn .x31 ** (.x13 ↦ᵣ v13) ** (.x14 ↦ᵣ v14) **
+            (.x19 ↦ᵣ s3) ** (.x20 ↦ᵣ s4) ** (.x21 ↦ᵣ s5) ** stackFree spW 8 ** (spW ↦ₘ raIn) **
+            ((spW + 8) ↦ₘ s0Old) ** ((spW + 16) ↦ₘ s1Old) ** ((spW + 24) ↦ₘ s2Old) **
+            (outBase ↦ₘ v0) ** ((outBase + 8) ↦ₘ v1) ** bytesRegion (outBase + 36) pad4 **
+            ((outBase + 40) ↦ₘ oldOut) ** wdStackK20Deep spW ** (offsetCell ↦ₘ oldOffset) **
+            (lengthCell ↦ₘ oldLen))) h := by
+          refine sepConj_mono_left ?_ h hp
+          intro h' hcl'
+          exact sepConj_mono (regIs_implies_regOwn .x6) (sepConj_mono (regIs_implies_regOwn .x28)
+            (sepConj_mono_left (regIs_implies_regOwn .x29))) h' hcl'
+        have hg : (((stackFree spW 8 ** wdStackK20Deep spW) **
+            ((.x5 ↦ᵣ wdOffsetAddr) ** (.x7 ↦ᵣ (20 : Word))) **
+            ((.x1 ↦ᵣ (WB + 112)) ** (.x2 ↦ᵣ spW) ** (.x8 ↦ᵣ listBase) ** (.x9 ↦ᵣ len) **
+             (.x18 ↦ᵣ outBase) ** (.x10 ↦ᵣ (0 : Word)) ** (.x11 ↦ᵣ v11) ** (.x12 ↦ᵣ v12) **
+             (.x13 ↦ᵣ v13) ** (.x14 ↦ᵣ v14) ** regOwn .x6 ** (.x19 ↦ᵣ s3) ** (.x20 ↦ᵣ s4) **
+             (.x21 ↦ᵣ s5) ** regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+             (.x0 ↦ᵣ (0 : Word)) ** bytesRegion listBase bytes ** ((outBase + 40) ↦ₘ oldOut) **
+             (offsetCell ↦ₘ oldOffset) ** (lengthCell ↦ₘ oldLen) ** (spW ↦ₘ raIn) **
+             ((spW + 8) ↦ₘ s0Old) ** ((spW + 16) ↦ₘ s1Old) ** ((spW + 24) ↦ₘ s2Old) **
+             (outBase ↦ₘ v0) ** ((outBase + 8) ↦ₘ v1) **
+             bytesRegion (outBase + 16) (addrCopied bytes oldAddr offset) **
+             bytesRegion (outBase + 36) pad4 ** (wdOffsetAddr ↦ₘ offset) **
+             (wdLengthAddr ↦ₘ len'))) h) := by
+          xperm_hyp hp1
+        have hg2 : (((memOwn (spW - BitVec.ofNat 64 8) ** frameSlotsOwn frame newSp **
+            stackFree newSp 8) ** (regOwn .x5 ** regOwn .x7) **
+            ((.x1 ↦ᵣ (WB + 112)) ** (.x2 ↦ᵣ spW) ** (.x8 ↦ᵣ listBase) ** (.x9 ↦ᵣ len) **
+             (.x18 ↦ᵣ outBase) ** (.x10 ↦ᵣ (0 : Word)) ** (.x11 ↦ᵣ v11) ** (.x12 ↦ᵣ v12) **
+             (.x13 ↦ᵣ v13) ** (.x14 ↦ᵣ v14) ** regOwn .x6 ** (.x19 ↦ᵣ s3) ** (.x20 ↦ᵣ s4) **
+             (.x21 ↦ᵣ s5) ** regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+             (.x0 ↦ᵣ (0 : Word)) ** bytesRegion listBase bytes ** ((outBase + 40) ↦ₘ oldOut) **
+             (offsetCell ↦ₘ oldOffset) ** (lengthCell ↦ₘ oldLen) ** (spW ↦ₘ raIn) **
+             ((spW + 8) ↦ₘ s0Old) ** ((spW + 16) ↦ₘ s1Old) ** ((spW + 24) ↦ₘ s2Old) **
+             (outBase ↦ₘ v0) ** ((outBase + 8) ↦ₘ v1) **
+             bytesRegion (outBase + 16) (addrCopied bytes oldAddr offset) **
+             bytesRegion (outBase + 36) pad4 ** (wdOffsetAddr ↦ₘ offset) **
+             (wdLengthAddr ↦ₘ len'))) h) := by
+          refine sepConj_mono ?_ (sepConj_mono ?_ (fun _ x => x)) h hg
+          · intro h' hs
+            exact wdStack12_to_k34 spW newSp hnewSp h'
+              (wdStack12_of_k20 spW h' (by xperm_hyp hs))
+          · intro h' hr
+            exact sepConj_mono (regIs_implies_regOwn .x5) (regIs_implies_regOwn .x7) h' hr
+        xperm_hyp hg2)
+      s1 hbb
+    refine cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp) (fun _ hq => hq) s2
+  case fail =>
+    -- len ≠ 20: `field2Len` failure through the failure tail.
+    refine cpsTripleWithin_weaken (fun h hp => ?_) (fun _ hq => hq)
+      (cpsTripleWithin_mono_nSteps (Nat.le_trans (by norm_num) (Nat.le_add_right _ _))
+        (wdFailArm sp0 spW raIn s0Old s1Old s2Old (WB + 112) listBase len outBase
+          outBase listBase s3 s4 s5 bytes oldAddr pad4 listLen hspW hret))
+    have hne : len' ≠ (20 : Word) := by
+      have hp2 := hp
+      obtain ⟨fp, fl, _, _, hfp, _⟩ := hp2
+      obtain ⟨g1, g2, _, _, hgrp, _⟩ := hfp
+      obtain ⟨a, b, _, _, _, hg3⟩ := hgrp
+      exact ((sepConj_pure_right b).1 hg3).2
+    have hne20 : len'.toNat ≠ 20 := by
+      intro heq; exact hne (by apply BitVec.eq_of_toNat_eq; rw [heq]; decide)
+    have hDF : DecodeFailure bytes listBase listLen :=
+      DecodeFailure.field2Len offset len' hsucc hne20
+    have hp' := sepConj_mono_left (sepConj_mono_left sepConj_strip_pure_end2) h hp
+    have hg : (((.x2 ↦ᵣ spW) ** (.x1 ↦ᵣ (WB + 112)) ** (.x8 ↦ᵣ listBase) ** (.x9 ↦ᵣ len) **
+        (.x18 ↦ᵣ outBase) ** (spW ↦ₘ raIn) ** ((spW + 8) ↦ₘ s0Old) ** ((spW + 16) ↦ₘ s1Old) **
+        ((spW + 24) ↦ₘ s2Old) **
+        (((.x19 ↦ᵣ s3) ** (.x20 ↦ᵣ s4) ** (.x21 ↦ᵣ s5) ** (.x5 ↦ᵣ wdLengthAddr) **
+          (.x6 ↦ᵣ len') ** (.x7 ↦ᵣ (20 : Word)) ** (.x11 ↦ᵣ v11) ** (.x12 ↦ᵣ v12) **
+          (.x13 ↦ᵣ v13) ** (.x14 ↦ᵣ v14) ** (.x28 ↦ᵣ v28) ** (.x29 ↦ᵣ v29) ** (.x30 ↦ᵣ v30) **
+          regOwn .x31 ** (.x0 ↦ᵣ (0 : Word))) **
+         ((wdStackK20Deep spW ** stackFree spW 8) ** (outBase ↦ₘ v0) ** ((outBase + 8) ↦ₘ v1) **
+          bytesRegion (outBase + 16) oldAddr ** bytesRegion (outBase + 36) pad4 **
+          ((outBase + 40) ↦ₘ oldOut) ** bytesRegion listBase bytes ** (wdOffsetAddr ↦ₘ offset) **
+          (wdLengthAddr ↦ₘ len') ** (offsetCell ↦ₘ oldOffset) ** (lengthCell ↦ₘ oldLen)))) **
+       (.x10 ↦ᵣ (0 : Word))) h := by
+      xperm_hyp hp'
+    refine sepConj_mono ?_ (regIs_implies_regOwn .x10) h hg
+    refine sepConj_mono_right (sepConj_mono_right (sepConj_mono_right (sepConj_mono_right
+      (sepConj_mono_right (sepConj_mono_right (sepConj_mono_right (sepConj_mono_right
+      (sepConj_mono_right ?_))))))))
+    intro h' hgg
+    refine (sepConj_pure_left h').2 ⟨hDF, ?_⟩
+    refine ⟨v0, v1, oldOut, offset, len', oldOffset, oldLen, oldAddr, pad4, ?_⟩
+    have hgg2 : (wdScratch s3 s4 s5 ** stackFree spW 12 ** (outBase ↦ₘ v0) **
+        ((outBase + 8) ↦ₘ v1) ** bytesRegion (outBase + 16) oldAddr **
+        bytesRegion (outBase + 36) pad4 ** ((outBase + 40) ↦ₘ oldOut) **
+        bytesRegion listBase bytes ** (wdOffsetAddr ↦ₘ offset) ** (wdLengthAddr ↦ₘ len') **
+        (offsetCell ↦ₘ oldOffset) ** (lengthCell ↦ₘ oldLen)) h' := by
+      refine sepConj_mono (wdScratch_of_regIs s3 s4 s5 wdLengthAddr len' (20 : Word) v11 v12
+        v13 v14 v28 v29 v30) (sepConj_mono_left (wdStack12_of_k20 spW)) h' hgg
+    xperm_hyp hgg2
+
+#print axioms wdField2ContEpi
 
 end EvmAsm.Codegen.WithdrawalDecodeSpec

--- a/EvmAsm/Codegen/Programs/WithdrawalDecodeClose5.lean
+++ b/EvmAsm/Codegen/Programs/WithdrawalDecodeClose5.lean
@@ -799,4 +799,173 @@ theorem wdBBField2
 
 #print axioms wdBBField2
 
+/-! ## Field-1 backbone merge
+
+    Merge the field-1 (K34) stage's two exits: the parse-fail edge routes through
+    `wdK34FailArm ... 1` (`DecodeFailure.field1`), the continue edge reshapes the
+    K34 continue payload (`wdContReshape`), pins the field-1 `Result`, rebuilds
+    the K34→K20 stack discipline and hands off to the field-2 backbone. -/
+
+set_option maxRecDepth 8000 in
+/-- The field-1 backbone: field-1 stage `WB+56 → raIn`, both exits landing
+    `wdWholePost`.  The upstream field-0 decode fact `hf0` arrives as a hypothesis;
+    field-1's own decode fact is pinned from the continue payload and threaded to
+    the field-2 backbone. -/
+theorem wdBBField1
+    (sp0 spW newSp raEntry raSaved listBase len outBase oldOut1 oldOffset1 oldLen1 old14
+      s3 s4 s5 v10 v11 v12 v13 v0 s0Old s1Old s2Old oldOut2 wOldOff wOldLen : Word)
+    (bytes oldAddr pad4 : List (BitVec 8)) (listLen : Nat)
+    (hnewSp : newSp = spW + signExtend12 (-32 : BitVec 12))
+    (hspW : spW = sp0 + signExtend12 (-32 : BitVec 12))
+    (hret : raSaved &&& ~~~(1 : Word) = raSaved)
+    (hlenW : len = BitVec.ofNat 64 listLen)
+    (hsalign : listBase.toNat % 8 = 0)
+    (hslack : listLen + 9 ≤ bytes.length)
+    (hover : listBase.toNat + bytes.length < 2 ^ 64)
+    (hvalid : ∀ k, k < bytes.length →
+      isValidByteAccess (listBase + BitVec.ofNat 64 k) = true)
+    (houtalign : outBase.toNat % 8 = 0)
+    (houtover : outBase.toNat + 48 < 2 ^ 64)
+    (haddrlen : oldAddr.length = 20)
+    (houtvalid : ∀ k, k < 20 →
+      isValidByteAccess ((outBase + 16) + BitVec.ofNat 64 k) = true)
+    (hf0 : Result bytes listBase listLen 0 (0 : Word) v0) :
+    cpsTripleWithin ((4 + (1 + ((7 + 4 + (1 + ((12 + ((85 + 93 * (1 + 2)) + 6)) + 9))) +
+        ((1 + ((7 + (1 + (7 * (2 ^ 64 - 1) + 11))) + 5)) + 5))) + 1) +
+        ((7 + (1 + ((12 + ((85 + 93 * (2 + 2)) + 6)) + 9)) + 1) +
+        (5 + (5 + (6 * (19 + 1)) +
+        ((4 + (1 + ((7 + 4 + (1 + ((12 + ((85 + 93 * (3 + 2)) + 6)) + 9))) +
+          ((1 + ((7 + (1 + (7 * (2 ^ 64 - 1) + 11))) + 5)) + 5))) + 1) + 8)))))
+      (WB + 56) raSaved fullCode
+      ((((.x1 : Reg) ↦ᵣ raEntry) ** (.x2 ↦ᵣ spW) ** (.x8 ↦ᵣ listBase) ** (.x9 ↦ᵣ len) **
+        (.x18 ↦ᵣ outBase) ** (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ v11) ** (.x12 ↦ᵣ v12) **
+        (.x13 ↦ᵣ v13) ** (.x14 ↦ᵣ old14) ** frameSlotsOwn frame newSp **
+        stackFree newSp 8 ** regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+        (.x19 ↦ᵣ s3) ** (.x20 ↦ᵣ s4) ** (.x21 ↦ᵣ s5) ** regOwn .x28 ** regOwn .x29 **
+        regOwn .x30 ** regOwn .x31 ** (.x0 ↦ᵣ (0 : Word)) ** bytesRegion listBase bytes **
+        ((outBase + 8) ↦ₘ oldOut1) ** (offsetCell ↦ₘ oldOffset1) ** (lengthCell ↦ₘ oldLen1)) **
+       (memOwn (spW - BitVec.ofNat 64 8) ** (spW ↦ₘ raSaved) ** ((spW + 8) ↦ₘ s0Old) **
+        ((spW + 16) ↦ₘ s1Old) ** ((spW + 24) ↦ₘ s2Old) ** (outBase ↦ₘ v0) **
+        bytesRegion (outBase + 16) oldAddr ** bytesRegion (outBase + 36) pad4 **
+        ((outBase + 40) ↦ₘ oldOut2) ** (wdOffsetAddr ↦ₘ wOldOff) ** (wdLengthAddr ↦ₘ wOldLen)))
+      (wdWholePost sp0 spW raSaved s0Old s1Old s2Old outBase listBase s3 s4 s5 listLen bytes
+        oldAddr pad4) := by
+  have hstage := wdField1Stage spW newSp raEntry listBase len outBase oldOut1 oldOffset1
+    oldLen1 old14 s3 s4 s5 v10 v11 v12 v13 bytes listLen hnewSp hlenW hsalign hslack hover
+    hvalid
+  have hbr := cpsBranchWithin_frameR
+    (memOwn (spW - BitVec.ofNat 64 8) ** (spW ↦ₘ raSaved) ** ((spW + 8) ↦ₘ s0Old) **
+     ((spW + 16) ↦ₘ s1Old) ** ((spW + 24) ↦ₘ s2Old) ** (outBase ↦ₘ v0) **
+     bytesRegion (outBase + 16) oldAddr ** bytesRegion (outBase + 36) pad4 **
+     ((outBase + 40) ↦ₘ oldOut2) ** (wdOffsetAddr ↦ₘ wOldOff) ** (wdLengthAddr ↦ₘ wOldLen))
+    (by pcfw) hstage
+  -- fail edge → DecodeFailure.field1 via wdK34FailArm
+  have harm := wdK34FailArm sp0 spW newSp raSaved listBase oldOffset1 oldLen1 (WB + 76)
+    s0Old s1Old s2Old { ra := WB + 76, s0 := listBase, s1 := len }
+    { ra := B + 48, s0 := listBase, s1 := outBase + 8, s2 := outBase, s3 := s3, s4 := s4,
+      s5 := s5 } bytes oldAddr pad4 listLen 1
+    ((outBase ↦ₘ v0) ** bytesRegion (outBase + 16) oldAddr **
+     bytesRegion (outBase + 36) pad4 ** ((outBase + 40) ↦ₘ oldOut2) **
+     (wdOffsetAddr ↦ₘ wOldOff) ** (wdLengthAddr ↦ₘ wOldLen))
+    hspW hnewSp hret
+    (fun status v hnz hres => DecodeFailure.field1 status v hnz hres)
+    (fun roff rlen ov' h hp => by
+      refine ⟨v0, ov', oldOut2, wOldOff, wOldLen, roff, rlen, oldAddr, pad4, ?_⟩
+      xperm_hyp hp)
+  have h_t := cpsTripleWithin_mono_nSteps
+    (show (7 : Nat) ≤ ((7 + (1 + ((12 + ((85 + 93 * (2 + 2)) + 6)) + 9)) + 1) +
+        (5 + (5 + (6 * (19 + 1)) +
+        ((4 + (1 + ((7 + 4 + (1 + ((12 + ((85 + 93 * (3 + 2)) + 6)) + 9))) +
+          ((1 + ((7 + (1 + (7 * (2 ^ 64 - 1) + 11))) + 5)) + 5))) + 1) + 8)))) from by omega)
+    harm
+  -- continue edge → field-1 Result pinned, K34→K20 reshape, field-2 backbone
+  have h_f : cpsTripleWithin ((7 + (1 + ((12 + ((85 + 93 * (2 + 2)) + 6)) + 9)) + 1) +
+      (5 + (5 + (6 * (19 + 1)) +
+      ((4 + (1 + ((7 + 4 + (1 + ((12 + ((85 + 93 * (3 + 2)) + 6)) + 9))) +
+        ((1 + ((7 + (1 + (7 * (2 ^ 64 - 1) + 11))) + 5)) + 5))) + 1) + 8))))
+      (WB + 80) raSaved fullCode
+      (k34ContPost spW newSp listBase (WB + 76) { ra := WB + 76, s0 := listBase, s1 := len }
+        { ra := B + 48, s0 := listBase, s1 := outBase + 8, s2 := outBase, s3 := s3, s4 := s4,
+          s5 := s5 } bytes listLen 1 **
+       (memOwn (spW - BitVec.ofNat 64 8) ** (spW ↦ₘ raSaved) ** ((spW + 8) ↦ₘ s0Old) **
+        ((spW + 16) ↦ₘ s1Old) ** ((spW + 24) ↦ₘ s2Old) ** (outBase ↦ₘ v0) **
+        bytesRegion (outBase + 16) oldAddr ** bytesRegion (outBase + 36) pad4 **
+        ((outBase + 40) ↦ₘ oldOut2) ** (wdOffsetAddr ↦ₘ wOldOff) ** (wdLengthAddr ↦ₘ wOldLen)))
+      (wdWholePost sp0 spW raSaved s0Old s1Old s2Old outBase listBase s3 s4 s5 listLen bytes
+        oldAddr pad4) := by
+    -- expose the K34 continue existentials + pin the field-1 `Result`
+    refine cpsTripleWithin_weaken
+      (P := fun h => ∃ offset len' v12' x5' ss' ov,
+        ((⌜Result bytes listBase listLen 1 (0 : Word) ov⌝ : Assertion) **
+         (((.x1 ↦ᵣ (WB + 76)) **
+           (((.x2 ↦ᵣ spW) ** (.x8 ↦ᵣ listBase) ** (.x9 ↦ᵣ len) **
+             savedFrame newSp { ra := WB + 76, s0 := listBase, s1 := len }) **
+            successPayload newSp listBase offset len' v12' x5' ss' (0 : Word) ov
+              { ra := B + 48, s0 := listBase, s1 := outBase + 8, s2 := outBase, s3 := s3,
+                s4 := s4, s5 := s5 } bytes listLen 1)) **
+          (memOwn (spW - BitVec.ofNat 64 8) ** (spW ↦ₘ raSaved) ** ((spW + 8) ↦ₘ s0Old) **
+           ((spW + 16) ↦ₘ s1Old) ** ((spW + 24) ↦ₘ s2Old) ** (outBase ↦ₘ v0) **
+           bytesRegion (outBase + 16) oldAddr ** bytesRegion (outBase + 36) pad4 **
+           ((outBase + 40) ↦ₘ oldOut2) ** (wdOffsetAddr ↦ₘ wOldOff) **
+           (wdLengthAddr ↦ₘ wOldLen)))) h)
+      (fun h hp => by
+        obtain ⟨h1, h2, hd, hu, hk, hacc⟩ := hp
+        obtain ⟨offset, len', v12', x5', ss', ov, hbody⟩ := hk
+        refine ⟨offset, len', v12', x5', ss', ov, ?_⟩
+        have hRes : Result bytes listBase listLen 1 (0 : Word) ov := by
+          obtain ⟨_, _, _, _, _, hbody2⟩ := hbody
+          obtain ⟨_, _, _, _, _, hspp⟩ := hbody2
+          unfold successPayload at hspp
+          exact ((sepConj_pure_right _).1 hspp).2
+        exact (sepConj_pure_left h).2 ⟨hRes, h1, h2, hd, hu, hbody, hacc⟩)
+      (fun _ hq => hq) ?_
+    refine cpsTripleWithin_exists_pre_gen (fun offset => ?_)
+    refine cpsTripleWithin_exists_pre_gen (fun len' => ?_)
+    refine cpsTripleWithin_exists_pre_gen (fun v12' => ?_)
+    refine cpsTripleWithin_exists_pre_gen (fun x5' => ?_)
+    refine cpsTripleWithin_exists_pre_gen (fun ss' => ?_)
+    refine cpsTripleWithin_exists_pre_gen (fun ov => ?_)
+    refine cpsTripleWithin_pure_pre (fun hf1 => ?_)
+    -- reshape (K34 continue payload + accumulator) into (stack/x5-isolated form) ** regOwn x13 ** regOwn x14
+    refine cpsTripleWithin_weaken
+      (P := ((memOwn (spW - BitVec.ofNat 64 8) ** frameSlotsOwn frame newSp **
+          stackFree newSp 8) ** (.x5 ↦ᵣ x5') ** (.x1 ↦ᵣ (WB + 76)) **
+          (⌜Result bytes listBase listLen 1 (0 : Word) ov⌝ : Assertion) **
+          (.x2 ↦ᵣ spW) ** (.x8 ↦ᵣ listBase) ** (.x9 ↦ᵣ len) **
+          (.x18 ↦ᵣ outBase) ** (.x19 ↦ᵣ s3) ** (.x20 ↦ᵣ s4) ** (.x21 ↦ᵣ s5) **
+          (.x10 ↦ᵣ (0 : Word)) ** (.x11 ↦ᵣ ss') ** (.x12 ↦ᵣ v12') ** regOwn .x6 **
+          regOwn .x7 ** regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+          (.x0 ↦ᵣ (0 : Word)) ** bytesRegion listBase bytes ** (wdOffsetAddr ↦ₘ wOldOff) **
+          (wdLengthAddr ↦ₘ wOldLen) ** (spW ↦ₘ raSaved) ** ((spW + 8) ↦ₘ s0Old) **
+          ((spW + 16) ↦ₘ s1Old) ** ((spW + 24) ↦ₘ s2Old) ** (outBase ↦ₘ v0) **
+          ((outBase + 8) ↦ₘ ov) ** bytesRegion (outBase + 16) oldAddr **
+          bytesRegion (outBase + 36) pad4 ** ((outBase + 40) ↦ₘ oldOut2) **
+          (offsetCell ↦ₘ offset) ** (lengthCell ↦ₘ len')) **
+         regOwn .x13 ** regOwn .x14)
+      (fun h hp => by
+        have hcb := sepConj_mono_left
+          (wdContReshape spW newSp listBase (WB + 76) offset len' v12' x5' ss' ov
+            { ra := WB + 76, s0 := listBase, s1 := len }
+            { ra := B + 48, s0 := listBase, s1 := outBase + 8, s2 := outBase, s3 := s3,
+              s4 := s4, s5 := s5 } bytes listLen 1) h hp
+        unfold wdContBundle at hcb
+        xperm_hyp hcb)
+      (fun _ hq => hq) ?_
+    refine cpsTripleWithin_of_forall_regIs_to_regOwn2 (fun v13' v14' => ?_)
+    refine cpsTripleWithin_weaken
+      (fun h hp => by
+        have hp0 := sepConj_mono_left sepConj_strip_pure_depth3 h hp
+        have hg2 := sepConj_mono_left (sepConj_mono
+          (fun h' hs => wdStack12_to_k20 spW h' (wdStack12_of_k34 spW newSp hnewSp h' hs))
+          (sepConj_mono_left (regIs_implies_regOwn .x5))) h hp0
+        xperm_hyp hg2)
+      (fun _ hq => hq)
+      (wdBBField2 sp0 spW newSp (WB + 76) raSaved listBase len outBase s3 s4 s5
+        (0 : Word) ss' v12' v13' v14' v0 ov s0Old s1Old s2Old oldOut2 wOldOff wOldLen offset
+        len' bytes oldAddr pad4 listLen hnewSp hspW hret hlenW hsalign hslack hover hvalid
+        houtalign houtover haddrlen houtvalid hf0 hf1)
+  exact cpsBranchWithin_merge_same_cr hbr h_t h_f
+
+#print axioms wdBBField1
+
 end EvmAsm.Codegen.WithdrawalDecodeSpec

--- a/EvmAsm/Codegen/Programs/WithdrawalDecodeClose5.lean
+++ b/EvmAsm/Codegen/Programs/WithdrawalDecodeClose5.lean
@@ -77,4 +77,123 @@ theorem wdContReshape (spW newSp listBase raRet offset len v12 x5 ss ov : Word)
 
 #print axioms wdContReshape
 
+/-! ## Field-3 continue: the success-content tie
+
+    Field 3's continue exit (`WB+204`) is the all-fields-decoded success path.
+    The upstream field decode facts (fields 0/1 `Result`, the field-2 `Success`
+    with length `20`) arrive as hypotheses; combined with field 3's own pinned
+    `Result` they assemble `Decoded`, and the written output cells assemble
+    `outputSuccess`.  The success tail (`wdSuccessEpi`, `WB+204 → raIn`) then
+    stores `a0 := 0` and returns, landing the whole-program success post. -/
+
+set_option maxRecDepth 8000 in
+/-- Field-3 continue → success return: from `k34ContPost` (index 3, framed over
+    the reclaimed top cell, the four saved slots, the already-written
+    field-0/1/address output cells, the address data cells) plus the upstream
+    decode facts, run the success tail to the whole-program success post. -/
+theorem wdField3ContEpi
+    (sp0 spW newSp raIn listBase len outBase v0 v1 o2 l2
+      s0Old s1Old s2Old s3 s4 s5 : Word)
+    (bytes oldAddr pad4 : List (BitVec 8)) (listLen : Nat)
+    (hspW : spW = sp0 + signExtend12 (-32 : BitVec 12))
+    (hnewSp : newSp = spW + signExtend12 (-32 : BitVec 12))
+    (hret : raIn &&& ~~~(1 : Word) = raIn)
+    (hf0 : Result bytes listBase listLen 0 (0 : Word) v0)
+    (hf1 : Result bytes listBase listLen 1 (0 : Word) v1)
+    (hf2 : EvmAsm.Codegen.RlpListNthItemSAsm.Success bytes listBase listLen 2 o2 l2)
+    (hl2 : l2.toNat = 20) :
+    let outer3 : Saved := { ra := WB + 200, s0 := listBase, s1 := len }
+    let saved3 : EvmAsm.Codegen.RlpListNthItemSAsm.Saved :=
+      { ra := B + 48, s0 := listBase, s1 := outBase + 40, s2 := outBase, s3 := s3,
+        s4 := s4, s5 := s5 }
+    cpsTripleWithin 8 (WB + 204) raIn fullCode
+      (k34ContPost spW newSp listBase (WB + 200) outer3 saved3 bytes listLen 3 **
+       (memOwn (spW - BitVec.ofNat 64 8) ** (spW ↦ₘ raIn) ** ((spW + 8) ↦ₘ s0Old) **
+        ((spW + 16) ↦ₘ s1Old) ** ((spW + 24) ↦ₘ s2Old) ** (outBase ↦ₘ v0) **
+        ((outBase + 8) ↦ₘ v1) ** bytesRegion (outBase + 16) (addrCopied bytes oldAddr o2) **
+        bytesRegion (outBase + 36) pad4 ** (wdOffsetAddr ↦ₘ o2) ** (wdLengthAddr ↦ₘ l2)))
+      (wdWholePost sp0 spW raIn s0Old s1Old s2Old outBase listBase s3 s4 s5 listLen bytes
+        oldAddr pad4) := by
+  intro outer3 saved3
+  refine cpsTripleWithin_weaken (P := fun h => ∃ offset len' v12 x5 ss ov,
+      (((.x1 ↦ᵣ (WB + 200)) **
+        (((.x2 ↦ᵣ spW) ** (.x8 ↦ᵣ outer3.s0) ** (.x9 ↦ᵣ outer3.s1) **
+          savedFrame newSp outer3) **
+         successPayload newSp listBase offset len' v12 x5 ss (0 : Word) ov saved3
+           bytes listLen 3)) **
+       (memOwn (spW - BitVec.ofNat 64 8) ** (spW ↦ₘ raIn) ** ((spW + 8) ↦ₘ s0Old) **
+        ((spW + 16) ↦ₘ s1Old) ** ((spW + 24) ↦ₘ s2Old) ** (outBase ↦ₘ v0) **
+        ((outBase + 8) ↦ₘ v1) ** bytesRegion (outBase + 16) (addrCopied bytes oldAddr o2) **
+        bytesRegion (outBase + 36) pad4 ** (wdOffsetAddr ↦ₘ o2) ** (wdLengthAddr ↦ₘ l2))) h)
+    (fun h hp => by
+      obtain ⟨h1, h2, hd, hu, hk, hacc⟩ := hp
+      unfold k34ContPost at hk
+      obtain ⟨offset, len', v12, x5, ss, ov, hbody⟩ := hk
+      exact ⟨offset, len', v12, x5, ss, ov, h1, h2, hd, hu, hbody, hacc⟩)
+    (fun _ hq => hq) ?_
+  refine cpsTripleWithin_exists_pre_gen (fun offset => ?_)
+  refine cpsTripleWithin_exists_pre_gen (fun len' => ?_)
+  refine cpsTripleWithin_exists_pre_gen (fun v12 => ?_)
+  refine cpsTripleWithin_exists_pre_gen (fun x5 => ?_)
+  refine cpsTripleWithin_exists_pre_gen (fun ss => ?_)
+  refine cpsTripleWithin_exists_pre_gen (fun ov => ?_)
+  -- G0: the untouched footprint threaded through `wdSuccessEpi`.
+  set G0 : Assertion :=
+    (⌜Result bytes listBase listLen 3 (0 : Word) ov⌝ : Assertion) **
+    (outputSuccess outBase v0 v1 ov o2 bytes oldAddr pad4 ** bytesRegion listBase bytes **
+     (wdOffsetAddr ↦ₘ o2) ** (wdLengthAddr ↦ₘ l2) ** (offsetCell ↦ₘ offset) **
+     (lengthCell ↦ₘ len') ** stackFree spW 12 ** wdScratch s3 s4 s5) with hG0def
+  have hG0 : G0.pcFree := by
+    rw [hG0def]; unfold outputSuccess wdScratch
+    repeat' first
+      | exact pcFree_pure | exact pcFree_regIs | exact pcFree_memIs | exact pcFree_regOwn
+      | exact bytesRegion_pcFree _ _ | exact pcFree_stackFree _ _ | apply pcFree_sepConj
+  have hepi := wdSuccessEpi sp0 spW raIn s0Old s1Old s2Old (WB + 200) listBase len outBase
+    (0 : Word) G0 hG0 hspW hret
+  refine cpsTripleWithin_weaken (fun h hp => ?_) (fun h hq => ?_) hepi
+  · -- pre reshape: (bodyCore ** accum) → wdSuccessEpi pre
+    unfold successPayload at hp
+    simp only [show (outer3.s0 : Word) = listBase from rfl,
+      show (outer3.s1 : Word) = len from rfl,
+      show (saved3.s1 : Word) = outBase + 40 from rfl,
+      show (saved3.s2 : Word) = outBase from rfl, show (saved3.s3 : Word) = s3 from rfl,
+      show (saved3.s4 : Word) = s4 from rfl, show (saved3.s5 : Word) = s5 from rfl] at hp
+    have hgR : ((.x10 ↦ᵣ (0 : Word)) **
+        ((.x2 ↦ᵣ spW) ** (.x1 ↦ᵣ (WB + 200)) ** (.x8 ↦ᵣ listBase) ** (.x9 ↦ᵣ len) **
+         (.x18 ↦ᵣ outBase) ** (spW ↦ₘ raIn) ** ((spW + 8) ↦ₘ s0Old) **
+         ((spW + 16) ↦ₘ s1Old) ** ((spW + 24) ↦ₘ s2Old)) **
+        (⌜Result bytes listBase listLen 3 (0 : Word) ov⌝ : Assertion) **
+        ((outBase ↦ₘ v0) ** ((outBase + 8) ↦ₘ v1) **
+         bytesRegion (outBase + 16) (addrCopied bytes oldAddr o2) **
+         bytesRegion (outBase + 36) pad4 ** ((outBase + 40) ↦ₘ ov)) **
+        bytesRegion listBase bytes ** (wdOffsetAddr ↦ₘ o2) ** (wdLengthAddr ↦ₘ l2) **
+        (offsetCell ↦ₘ offset) ** (lengthCell ↦ₘ len') **
+        (memOwn (spW - BitVec.ofNat 64 8) ** savedFrame newSp outer3 **
+         stackFree newSp 8) **
+        ((.x19 ↦ᵣ s3) ** (.x20 ↦ᵣ s4) ** (.x21 ↦ᵣ s5) ** (.x5 ↦ᵣ x5) ** regOwn .x6 **
+         regOwn .x7 ** (.x11 ↦ᵣ ss) ** (.x12 ↦ᵣ v12) ** regOwn .x13 ** regOwn .x14 **
+         regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+         (.x0 ↦ᵣ (0 : Word)))) h := by
+      xperm_hyp hp
+    rw [hG0def]
+    exact sepConj_mono_right (sepConj_mono_right (sepConj_mono_right
+      (sepConj_mono (fun _ hx => hx)
+        (sepConj_mono_right (sepConj_mono_right (sepConj_mono_right (sepConj_mono_right
+          (sepConj_mono_right
+            (sepConj_mono (wdStack12_of_k34_saved spW newSp outer3 hnewSp)
+              (wdScratch_of_regs s3 s4 s5 x5 ss v12))))))))))
+      h hgR
+  · -- post reshape: wdSuccessEpi post → whole-program success
+    rw [hG0def] at hq
+    have hf3 : Result bytes listBase listLen 3 (0 : Word) ov := by
+      obtain ⟨_, _, _, _, _, hR⟩ := hq
+      obtain ⟨_, _, _, _, _, hG0'⟩ := hR
+      exact ((sepConj_pure_left _).1 hG0').1
+    refine Or.inl ⟨v0, v1, ov, o2, l2,
+      (sepConj_pure_left h).2 ⟨⟨hf0, hf1, hf2, hl2, hf3⟩, ?_⟩⟩
+    exact sepConj_mono_right (sepConj_mono (fun _ hx => hx)
+      (fun h' hg0 => ⟨offset, len', ((sepConj_pure_left h').1 hg0).2⟩)) h hq
+
+#print axioms wdField3ContEpi
+
 end EvmAsm.Codegen.WithdrawalDecodeSpec

--- a/EvmAsm/Codegen/Programs/WithdrawalDecodeClose5.lean
+++ b/EvmAsm/Codegen/Programs/WithdrawalDecodeClose5.lean
@@ -1,0 +1,80 @@
+/-
+  `withdrawalDecode_prog` caller-contract composition, part 5 — the CONT side
+  and the whole-program close.
+
+  Close4 finished every parse-failure exit (`wdK34FailArm`, `wdK20FailArm`,
+  `wdFailArm`).  This module supplies the mirror image on the continue side:
+
+    * `wdContReshape` — the cont analog of `wdK34FailPre`: a K34 field call's
+      `k34ContPost` (status `0`, success payload) reshaped into the shared
+      register/frame bundle each downstream stage consumes, weakening the saved
+      frame (`savedFrame → frameSlotsOwn`) and keeping the freshly-written output
+      cell together with the pinned field `Result`.
+    * the merge-chain backbone stitching the four field stages, the length
+      check and the copy loop into a single `WB+32 → raIn` triple; and
+    * the top-level `withdrawal_decode_spec_within = wdPrologue ;; backbone`.
+
+  No `sorry`/`admit`/`native_decide`/`bv_decide`; classical-3 axioms only.
+-/
+
+import EvmAsm.Codegen.Programs.WithdrawalDecodeClose4
+
+namespace EvmAsm.Codegen.WithdrawalDecodeSpec
+
+open EvmAsm.Rv64 EvmAsm.Rv64.SAsm
+open EvmAsm.Codegen.RlpFieldToU64SAsm
+
+/-! ## CONT-side reshape (K34 boundary)
+
+    A K34 field call's continue exit (`k34ContPost`, status `0`) keeps a success
+    payload with a genuine field decode.  The reshape below lines that payload up
+    with the shared field-stage register/frame layout: the saved frame weakens to
+    the merely-owned slots (`savedFrameK34_own`), and the payload's temporaries
+    reappear as the next stage's `regIs`/`regOwn` cells.  The freshly-written
+    output cell (`saved.s1 ↦ ov`) and the pinned per-field `Result` are carried
+    forward so the whole-program success post can assemble `Decoded`. -/
+
+/-- The shared cont-boundary bundle: the register/frame state a downstream field
+    stage consumes, together with the just-written output cell and the pinned
+    field `Result`.  The saved frame has already been weakened to `frameSlotsOwn`
+    and the scratch stack retained as `stackFree newSp 8`. -/
+def wdContBundle (spW newSp listBase raRet offset len v12 x5 ss ov : Word)
+    (outer : Saved) (saved : EvmAsm.Codegen.RlpListNthItemSAsm.Saved)
+    (bytes : List (BitVec 8)) (listLen index : Nat) : Assertion :=
+  (.x1 ↦ᵣ raRet) ** (.x2 ↦ᵣ spW) ** (.x8 ↦ᵣ outer.s0) ** (.x9 ↦ᵣ outer.s1) **
+  frameSlotsOwn frame newSp ** (.x18 ↦ᵣ saved.s2) ** (.x19 ↦ᵣ saved.s3) **
+  (.x20 ↦ᵣ saved.s4) ** (.x21 ↦ᵣ saved.s5) ** regOwn .x6 ** regOwn .x7 **
+  regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 ** stackFree newSp 8 **
+  (.x5 ↦ᵣ x5) ** (.x10 ↦ᵣ (0 : Word)) ** (.x11 ↦ᵣ ss) ** (.x12 ↦ᵣ v12) **
+  regOwn .x13 ** regOwn .x14 ** (.x0 ↦ᵣ (0 : Word)) ** bytesRegion listBase bytes **
+  (offsetCell ↦ₘ offset) ** (lengthCell ↦ₘ len) ** (saved.s1 ↦ₘ ov) **
+  (⌜Result bytes listBase listLen index (0 : Word) ov⌝ : Assertion)
+
+set_option maxRecDepth 8000 in
+/-- CONT reshape: a K34 field call's peeled `k34ContPost` body (a status-`0`
+    success payload) reshapes into `wdContBundle`.  Weaken the saved frame to
+    `frameSlotsOwn` and permute; the field `Result`, the written output cell
+    `saved.s1 ↦ ov` and the temporaries all carry through unchanged.  Generic
+    over the field index — the backbone instantiates it at boundaries 0→1, 1→2,
+    2→3. -/
+theorem wdContReshape (spW newSp listBase raRet offset len v12 x5 ss ov : Word)
+    (outer : Saved) (saved : EvmAsm.Codegen.RlpListNthItemSAsm.Saved)
+    (bytes : List (BitVec 8)) (listLen index : Nat) : ∀ h,
+    ((.x1 ↦ᵣ raRet) **
+     (((.x2 ↦ᵣ spW) ** (.x8 ↦ᵣ outer.s0) ** (.x9 ↦ᵣ outer.s1) **
+       savedFrame newSp outer) **
+      successPayload newSp listBase offset len v12 x5 ss (0 : Word) ov saved
+        bytes listLen index)) h →
+    wdContBundle spW newSp listBase raRet offset len v12 x5 ss ov outer saved bytes
+      listLen index h := by
+  intro h hp
+  unfold successPayload at hp
+  have hp2 := sepConj_mono_right (sepConj_mono_left
+    (sepConj_mono_right (sepConj_mono_right (sepConj_mono_right
+      (savedFrameK34_own newSp outer))))) h hp
+  unfold wdContBundle
+  xperm_hyp hp2
+
+#print axioms wdContReshape
+
+end EvmAsm.Codegen.WithdrawalDecodeSpec

--- a/EvmAsm/Codegen/Programs/WithdrawalDecodeClose5.lean
+++ b/EvmAsm/Codegen/Programs/WithdrawalDecodeClose5.lean
@@ -687,4 +687,116 @@ theorem wdField2ContEpi
 
 #print axioms wdField2ContEpi
 
+/-! ## Field-2 backbone merge
+
+    Merge the field-2 (K20) stage's two exits: the parse-fail edge routes through
+    `wdK20FailArm` (constructor `DecodeFailure.field2List`), the continue edge
+    through `wdField2ContEpi` (length check + address copy + field-3 backbone).
+    Both land the whole-program post; the reclaimed deep scratch, the prologue
+    slots, the already-written field-0/1 output cells, the address/pad cells and
+    the `wd_offset`/`wd_length`/K34-scratch data cells are framed ambient across
+    both. -/
+
+set_option maxRecDepth 8000 in
+/-- The field-2 backbone: field-2 stage `WB+80 → raIn`, both exits landing
+    `wdWholePost`.  The upstream field-0/1 decode facts arrive as hypotheses;
+    the accumulator carries the deep scratch cells, the saved slots, the reclaimed
+    top cell (as `wdStackK20Deep`), the field-0/1 output cells and the data
+    cells. -/
+theorem wdBBField2
+    (sp0 spW newSp raEntry raSaved listBase len outBase s3 s4 s5 v10 v11 v12 v13 v14
+      v0 v1 s0Old s1Old s2Old oldOut wOldOff wOldLen oldOffset34 oldLen34 : Word)
+    (bytes oldAddr pad4 : List (BitVec 8)) (listLen : Nat)
+    (hnewSp : newSp = spW + signExtend12 (-32 : BitVec 12))
+    (hspW : spW = sp0 + signExtend12 (-32 : BitVec 12))
+    (hret : raSaved &&& ~~~(1 : Word) = raSaved)
+    (hlenW : len = BitVec.ofNat 64 listLen)
+    (hsalign : listBase.toNat % 8 = 0)
+    (hslack : listLen + 9 ≤ bytes.length)
+    (hover : listBase.toNat + bytes.length < 2 ^ 64)
+    (hvalid : ∀ k, k < bytes.length →
+      isValidByteAccess (listBase + BitVec.ofNat 64 k) = true)
+    (houtalign : outBase.toNat % 8 = 0)
+    (houtover : outBase.toNat + 48 < 2 ^ 64)
+    (haddrlen : oldAddr.length = 20)
+    (houtvalid : ∀ k, k < 20 →
+      isValidByteAccess ((outBase + 16) + BitVec.ofNat 64 k) = true)
+    (hf0 : Result bytes listBase listLen 0 (0 : Word) v0)
+    (hf1 : Result bytes listBase listLen 1 (0 : Word) v1) :
+    cpsTripleWithin ((7 + (1 + ((12 + ((85 + 93 * (2 + 2)) + 6)) + 9)) + 1) +
+        (5 + (5 + (6 * (19 + 1)) +
+        ((4 + (1 + ((7 + 4 + (1 + ((12 + ((85 + 93 * (3 + 2)) + 6)) + 9))) +
+          ((1 + ((7 + (1 + (7 * (2 ^ 64 - 1) + 11))) + 5)) + 5))) + 1) + 8))))
+      (WB + 80) raSaved fullCode
+      ((((.x1 : Reg) ↦ᵣ raEntry) ** (.x2 ↦ᵣ spW) ** (.x8 ↦ᵣ listBase) ** (.x9 ↦ᵣ len) **
+        (.x18 ↦ᵣ outBase) ** (.x19 ↦ᵣ s3) ** (.x20 ↦ᵣ s4) ** (.x21 ↦ᵣ s5) **
+        (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ v11) ** (.x12 ↦ᵣ v12) ** (.x13 ↦ᵣ v13) **
+        (.x14 ↦ᵣ v14) ** stackFree spW 8 ** regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+        regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+        (.x0 ↦ᵣ (0 : Word)) ** bytesRegion listBase bytes **
+        (wdOffsetAddr ↦ₘ wOldOff) ** (wdLengthAddr ↦ₘ wOldLen)) **
+       (wdStackK20Deep spW ** (spW ↦ₘ raSaved) ** ((spW + 8) ↦ₘ s0Old) **
+        ((spW + 16) ↦ₘ s1Old) ** ((spW + 24) ↦ₘ s2Old) ** (outBase ↦ₘ v0) **
+        ((outBase + 8) ↦ₘ v1) ** bytesRegion (outBase + 16) oldAddr **
+        bytesRegion (outBase + 36) pad4 ** ((outBase + 40) ↦ₘ oldOut) **
+        (offsetCell ↦ₘ oldOffset34) ** (lengthCell ↦ₘ oldLen34)))
+      (wdWholePost sp0 spW raSaved s0Old s1Old s2Old outBase listBase s3 s4 s5 listLen bytes
+        oldAddr pad4) := by
+  have hstage := wdField2Stage spW raEntry listBase len outBase s3 s4 s5 wOldOff wOldLen
+    v10 v11 v12 v13 v14 bytes listLen hlenW hsalign hslack hover hvalid
+  have hbr := cpsBranchWithin_frameR
+    (wdStackK20Deep spW ** (spW ↦ₘ raSaved) ** ((spW + 8) ↦ₘ s0Old) **
+     ((spW + 16) ↦ₘ s1Old) ** ((spW + 24) ↦ₘ s2Old) ** (outBase ↦ₘ v0) **
+     ((outBase + 8) ↦ₘ v1) ** bytesRegion (outBase + 16) oldAddr **
+     bytesRegion (outBase + 36) pad4 ** ((outBase + 40) ↦ₘ oldOut) **
+     (offsetCell ↦ₘ oldOffset34) ** (lengthCell ↦ₘ oldLen34))
+    (by pcfw) hstage
+  -- fail edge → DecodeFailure.field2List via wdK20FailArm
+  have h_t : cpsTripleWithin (5 + (5 + (6 * (19 + 1)) +
+        ((4 + (1 + ((7 + 4 + (1 + ((12 + ((85 + 93 * (3 + 2)) + 6)) + 9))) +
+          ((1 + ((7 + (1 + (7 * (2 ^ 64 - 1) + 11))) + 5)) + 5))) + 1) + 8)))
+      (WB + 212) raSaved fullCode
+      (k20FailPost spW listBase wOldOff wOldLen
+        { ra := WB + 112, s0 := listBase, s1 := len, s2 := outBase, s3 := s3, s4 := s4,
+          s5 := s5 } bytes listLen **
+       (wdStackK20Deep spW ** (spW ↦ₘ raSaved) ** ((spW + 8) ↦ₘ s0Old) **
+        ((spW + 16) ↦ₘ s1Old) ** ((spW + 24) ↦ₘ s2Old) ** (outBase ↦ₘ v0) **
+        ((outBase + 8) ↦ₘ v1) ** bytesRegion (outBase + 16) oldAddr **
+        bytesRegion (outBase + 36) pad4 ** ((outBase + 40) ↦ₘ oldOut) **
+        (offsetCell ↦ₘ oldOffset34) ** (lengthCell ↦ₘ oldLen34)))
+      (wdWholePost sp0 spW raSaved s0Old s1Old s2Old outBase listBase s3 s4 s5 listLen bytes
+        oldAddr pad4) := by
+    have harm : cpsTripleWithin 7 (WB + 212) raSaved fullCode
+        (k20FailPost spW listBase wOldOff wOldLen
+          { ra := WB + 112, s0 := listBase, s1 := len, s2 := outBase, s3 := s3, s4 := s4,
+            s5 := s5 } bytes listLen **
+         (wdStackK20Deep spW ** (spW ↦ₘ raSaved) ** ((spW + 8) ↦ₘ s0Old) **
+          ((spW + 16) ↦ₘ s1Old) ** ((spW + 24) ↦ₘ s2Old) ** (outBase ↦ₘ v0) **
+          ((outBase + 8) ↦ₘ v1) ** bytesRegion (outBase + 16) oldAddr **
+          bytesRegion (outBase + 36) pad4 ** ((outBase + 40) ↦ₘ oldOut) **
+          (offsetCell ↦ₘ oldOffset34) ** (lengthCell ↦ₘ oldLen34)))
+        (wdWholePost sp0 spW raSaved s0Old s1Old s2Old outBase listBase s3 s4 s5 listLen bytes
+          oldAddr pad4) := cpsTripleWithin_weaken
+      (fun h hp => sepConj_mono_right
+        (fun h' hf => by simp only [wdStackK20Deep] at hf ⊢; xperm_hyp hf) h hp)
+      (fun _ hq => hq)
+      (wdK20FailArm sp0 spW raSaved listBase wOldOff wOldLen outBase s0Old s1Old s2Old
+        { ra := WB + 112, s0 := listBase, s1 := len, s2 := outBase, s3 := s3, s4 := s4,
+          s5 := s5 } bytes oldAddr pad4 listLen
+        ((outBase ↦ₘ v0) ** ((outBase + 8) ↦ₘ v1) ** bytesRegion (outBase + 16) oldAddr **
+         bytesRegion (outBase + 36) pad4 ** ((outBase + 40) ↦ₘ oldOut) **
+         (offsetCell ↦ₘ oldOffset34) ** (lengthCell ↦ₘ oldLen34))
+        hspW hret
+        (fun offset len h hp => by
+          refine ⟨v0, v1, oldOut, offset, len, oldOffset34, oldLen34, oldAddr, pad4, ?_⟩
+          xperm_hyp hp))
+    exact cpsTripleWithin_mono_nSteps (by omega) harm
+  -- continue edge → length check + copy + field-3 backbone
+  have h_f := wdField2ContEpi sp0 spW newSp raSaved listBase len outBase v0 v1 oldOut
+    oldOffset34 oldLen34 s0Old s1Old s2Old s3 s4 s5 bytes oldAddr pad4 listLen hspW hnewSp
+    hret hlenW hsalign hslack hover hvalid houtalign houtover haddrlen houtvalid hf0 hf1
+  exact cpsBranchWithin_merge_same_cr hbr h_t h_f
+
+#print axioms wdBBField2
+
 end EvmAsm.Codegen.WithdrawalDecodeSpec

--- a/EvmAsm/Codegen/Programs/WithdrawalDecodeClose5.lean
+++ b/EvmAsm/Codegen/Programs/WithdrawalDecodeClose5.lean
@@ -274,4 +274,54 @@ theorem wdBBField3
 
 #print axioms wdBBField3
 
+/-! ## Field-2 content bound
+
+    The address copy loop reads 20 source bytes at the selected content offset
+    `o2`.  A K20 `Success` pins a `StrictNthItem` decode chain whose final item's
+    content span stays within the declared list length; combined with the input
+    slack this bounds the source read `o2.toNat + 20 ≤ bytes.length`. -/
+
+open EvmAsm.Codegen.RlpListNthItemSAsm in
+/-- The selected item's content span (offset + length) fits inside the declared
+    list window `endOff`.  Induction on the `StrictNthItem` chain: each
+    non-final decode strictly advances the cursor but stays `≤ endOff`
+    (`rlpItemDecode_advance`), and the final decode's content span is bounded by
+    `rlpItemDecode_field0_content_span`. -/
+theorem strictNthItem_content_le {bytes : List (BitVec 8)} {base : Word}
+    {endOff : Nat} : ∀ {index cursorOff : Nat} {next len : Word},
+    StrictNthItem bytes base (base + BitVec.ofNat 64 endOff) index cursorOff next len →
+    cursorOff ≤ endOff →
+    base.toNat + endOff + 9 < 2 ^ 64 →
+    (next - len - base).toNat + len.toNat ≤ endOff := by
+  intro index cursorOff next len h
+  induction h with
+  | zero off n l hitem =>
+      intro hcursor hover
+      exact (EvmAsm.Rv64.RLP.rlpItemDecode_field0_content_span hitem hcursor hover).2.2
+  | succ idx off n l fn fl hitem hrest ih =>
+      intro hcursor hover
+      have hadv := EvmAsm.Codegen.BalAccountNonstorageFinalsSpec.rlpItemDecode_advance
+        hitem hcursor hover
+      exact ih hadv.2.2 hover
+
+#print axioms strictNthItem_content_le
+
+open EvmAsm.Codegen.RlpListNthItemSAsm in
+/-- From a K20 `Success` (index 2), the selected content offset plus length fits
+    inside the declared list length. -/
+theorem wdSuccessContentBound (bytes : List (BitVec 8)) (listBase : Word)
+    (listLen : Nat) (offset len' : Word)
+    (hslack : listLen + 9 ≤ bytes.length)
+    (hover : listBase.toNat + bytes.length < 2 ^ 64)
+    (hsucc : EvmAsm.Codegen.RlpListNthItemSAsm.Success bytes listBase listLen 2 offset len') :
+    offset.toNat + len'.toNat ≤ listLen := by
+  obtain ⟨cursorOff, endPtr, next, hpay, hnth, hoff⟩ := hsucc
+  have hend := hpay.end_eq
+  have hcur := hpay.cursor_le
+  subst hend
+  subst hoff
+  exact strictNthItem_content_le hnth hcur (by omega)
+
+#print axioms wdSuccessContentBound
+
 end EvmAsm.Codegen.WithdrawalDecodeSpec

--- a/EvmAsm/Codegen/Programs/WithdrawalDecodeClose5.lean
+++ b/EvmAsm/Codegen/Programs/WithdrawalDecodeClose5.lean
@@ -1140,4 +1140,78 @@ theorem wdBBField0
 
 #print axioms wdBBField0
 
+/-! ## Whole-program caller contract
+
+    `withdrawal_decode_spec_within = wdPrologue ;; wdBBField0`.  The prologue
+    ([0]-[7]) allocates the frame and loads `s0/s1/s2`; the field-0 backbone
+    ([8]-[59]) decodes all four fields and returns.  The caller-facing precondition
+    owns the 12-cell scratch (`stackFree spW 12`, carved into the field-0 K34
+    frame via `wdStack12_to_k34`), the four save slots, the 48-byte output struct,
+    the RLP input, and the two guest data-cell pairs. -/
+
+set_option maxRecDepth 8000 in
+/-- Whole-program caller contract for `withdrawalDecode_prog`: decode the RLP
+    withdrawal at `listBase` into the 48-byte output struct at `outBase`,
+    returning `a0 = 0` with a genuine `Decoded` verdict or `a0 = 1` with a
+    witnessed `DecodeFailure`. -/
+theorem withdrawal_decode_spec_within
+    (sp0 spW newSp raSaved s0Old s1Old s2Old listBase len outBase v13 v14 oldOut0
+      oldOffset0 oldLen0 fld1Out oldOut2 wOldOff wOldLen s3 s4 s5 : Word)
+    (bytes oldAddr pad4 : List (BitVec 8)) (listLen : Nat)
+    (hnewSp : newSp = spW + signExtend12 (-32 : BitVec 12))
+    (hspW : spW = sp0 + signExtend12 (-32 : BitVec 12))
+    (hret : raSaved &&& ~~~(1 : Word) = raSaved)
+    (hlenW : len = BitVec.ofNat 64 listLen)
+    (hsalign : listBase.toNat % 8 = 0)
+    (hslack : listLen + 9 ≤ bytes.length)
+    (hover : listBase.toNat + bytes.length < 2 ^ 64)
+    (hvalid : ∀ k, k < bytes.length →
+      isValidByteAccess (listBase + BitVec.ofNat 64 k) = true)
+    (houtalign : outBase.toNat % 8 = 0)
+    (houtover : outBase.toNat + 48 < 2 ^ 64)
+    (haddrlen : oldAddr.length = 20)
+    (houtvalid : ∀ k, k < 20 →
+      isValidByteAccess ((outBase + 16) + BitVec.ofNat 64 k) = true) :
+    cpsTripleWithin (8 +
+        ((4 + (1 + ((7 + 4 + (1 + ((12 + ((85 + 93 * (0 + 2)) + 6)) + 9))) +
+        ((1 + ((7 + (1 + (7 * (2 ^ 64 - 1) + 11))) + 5)) + 5))) + 1) +
+        ((4 + (1 + ((7 + 4 + (1 + ((12 + ((85 + 93 * (1 + 2)) + 6)) + 9))) +
+        ((1 + ((7 + (1 + (7 * (2 ^ 64 - 1) + 11))) + 5)) + 5))) + 1) +
+        ((7 + (1 + ((12 + ((85 + 93 * (2 + 2)) + 6)) + 9)) + 1) +
+        (5 + (5 + (6 * (19 + 1)) +
+        ((4 + (1 + ((7 + 4 + (1 + ((12 + ((85 + 93 * (3 + 2)) + 6)) + 9))) +
+          ((1 + ((7 + (1 + (7 * (2 ^ 64 - 1) + 11))) + 5)) + 5))) + 1) + 8)))))))
+      WB raSaved fullCode
+      (stackFree spW 12 ** (.x2 ↦ᵣ sp0) ** (.x1 ↦ᵣ raSaved) ** (.x8 ↦ᵣ s0Old) **
+       (.x9 ↦ᵣ s1Old) ** (.x18 ↦ᵣ s2Old) ** (.x10 ↦ᵣ listBase) ** (.x11 ↦ᵣ len) **
+       (.x12 ↦ᵣ outBase) ** (.x13 ↦ᵣ v13) ** (.x14 ↦ᵣ v14) ** (.x19 ↦ᵣ s3) **
+       (.x20 ↦ᵣ s4) ** (.x21 ↦ᵣ s5) ** regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+       regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 ** (.x0 ↦ᵣ (0 : Word)) **
+       memOwn spW ** memOwn (spW + 8) ** memOwn (spW + 16) ** memOwn (spW + 24) **
+       bytesRegion listBase bytes ** (outBase ↦ₘ oldOut0) ** ((outBase + 8) ↦ₘ fld1Out) **
+       bytesRegion (outBase + 16) oldAddr ** bytesRegion (outBase + 36) pad4 **
+       ((outBase + 40) ↦ₘ oldOut2) ** (offsetCell ↦ₘ oldOffset0) ** (lengthCell ↦ₘ oldLen0) **
+       (wdOffsetAddr ↦ₘ wOldOff) ** (wdLengthAddr ↦ₘ wOldLen))
+      (wdWholePost sp0 spW raSaved s0Old s1Old s2Old outBase listBase s3 s4 s5 listLen bytes
+        oldAddr pad4) := by
+  have hbb := wdBBField0 sp0 spW newSp raSaved raSaved listBase len outBase oldOut0
+    oldOffset0 oldLen0 v14 s3 s4 s5 listBase len outBase v13 fld1Out oldOut2 wOldOff wOldLen
+    s0Old s1Old s2Old bytes oldAddr pad4 listLen hnewSp hspW hret hlenW hsalign hslack hover
+    hvalid houtalign houtover haddrlen houtvalid
+  have hpro := wdPrologue sp0 spW raSaved s0Old s1Old s2Old listBase len outBase
+    ((.x13 ↦ᵣ v13) ** (.x14 ↦ᵣ v14) ** frameSlotsOwn frame newSp ** stackFree newSp 8 **
+     regOwn .x5 ** regOwn .x6 ** regOwn .x7 ** (.x19 ↦ᵣ s3) ** (.x20 ↦ᵣ s4) **
+     (.x21 ↦ᵣ s5) ** regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+     (.x0 ↦ᵣ (0 : Word)) ** bytesRegion listBase bytes ** (outBase ↦ₘ oldOut0) **
+     (offsetCell ↦ₘ oldOffset0) ** (lengthCell ↦ₘ oldLen0) ** memOwn (spW - BitVec.ofNat 64 8) **
+     ((outBase + 8) ↦ₘ fld1Out) ** bytesRegion (outBase + 16) oldAddr **
+     bytesRegion (outBase + 36) pad4 ** ((outBase + 40) ↦ₘ oldOut2) **
+     (wdOffsetAddr ↦ₘ wOldOff) ** (wdLengthAddr ↦ₘ wOldLen)) (by pcfw) hspW
+  have hcomp := cpsTripleWithin_seq_perm_same_cr (fun h hq => by xperm_hyp hq) hpro hbb
+  refine cpsTripleWithin_weaken (fun h hp => ?_) (fun _ hq => hq) hcomp
+  have hp2 := sepConj_mono_left (wdStack12_to_k34 spW newSp hnewSp) h hp
+  xperm_hyp hp2
+
+#print axioms withdrawal_decode_spec_within
+
 end EvmAsm.Codegen.WithdrawalDecodeSpec

--- a/EvmAsm/Codegen/Programs/WithdrawalDecodeClose5.lean
+++ b/EvmAsm/Codegen/Programs/WithdrawalDecodeClose5.lean
@@ -968,4 +968,176 @@ theorem wdBBField1
 
 #print axioms wdBBField1
 
+/-! ## Field-0 backbone merge
+
+    Merge the field-0 (K34) stage's two exits: the parse-fail edge routes through
+    `wdK34FailArm ... 0` (`DecodeFailure.field0`), the continue edge reshapes the
+    K34 continue payload (`wdContReshape`), pins the field-0 `Result`, and hands
+    off directly to the field-1 backbone (K34→K34: the frame passes through with
+    no stack transform).  This is the entry backbone; no upstream decode facts
+    arrive. -/
+
+set_option maxRecDepth 8000 in
+/-- The field-0 backbone: field-0 stage `WB+32 → raIn`, both exits landing
+    `wdWholePost`.  Field-0's own decode fact is pinned from the continue payload
+    and threaded to the field-1 backbone. -/
+theorem wdBBField0
+    (sp0 spW newSp raEntry raSaved listBase len outBase oldOut0 oldOffset0 oldLen0 old14
+      s3 s4 s5 v10 v11 v12 v13 fld1Out oldOut2 wOldOff wOldLen s0Old s1Old s2Old : Word)
+    (bytes oldAddr pad4 : List (BitVec 8)) (listLen : Nat)
+    (hnewSp : newSp = spW + signExtend12 (-32 : BitVec 12))
+    (hspW : spW = sp0 + signExtend12 (-32 : BitVec 12))
+    (hret : raSaved &&& ~~~(1 : Word) = raSaved)
+    (hlenW : len = BitVec.ofNat 64 listLen)
+    (hsalign : listBase.toNat % 8 = 0)
+    (hslack : listLen + 9 ≤ bytes.length)
+    (hover : listBase.toNat + bytes.length < 2 ^ 64)
+    (hvalid : ∀ k, k < bytes.length →
+      isValidByteAccess (listBase + BitVec.ofNat 64 k) = true)
+    (houtalign : outBase.toNat % 8 = 0)
+    (houtover : outBase.toNat + 48 < 2 ^ 64)
+    (haddrlen : oldAddr.length = 20)
+    (houtvalid : ∀ k, k < 20 →
+      isValidByteAccess ((outBase + 16) + BitVec.ofNat 64 k) = true) :
+    cpsTripleWithin ((4 + (1 + ((7 + 4 + (1 + ((12 + ((85 + 93 * (0 + 2)) + 6)) + 9))) +
+        ((1 + ((7 + (1 + (7 * (2 ^ 64 - 1) + 11))) + 5)) + 5))) + 1) +
+        ((4 + (1 + ((7 + 4 + (1 + ((12 + ((85 + 93 * (1 + 2)) + 6)) + 9))) +
+        ((1 + ((7 + (1 + (7 * (2 ^ 64 - 1) + 11))) + 5)) + 5))) + 1) +
+        ((7 + (1 + ((12 + ((85 + 93 * (2 + 2)) + 6)) + 9)) + 1) +
+        (5 + (5 + (6 * (19 + 1)) +
+        ((4 + (1 + ((7 + 4 + (1 + ((12 + ((85 + 93 * (3 + 2)) + 6)) + 9))) +
+          ((1 + ((7 + (1 + (7 * (2 ^ 64 - 1) + 11))) + 5)) + 5))) + 1) + 8))))))
+      (WB + 32) raSaved fullCode
+      ((((.x1 : Reg) ↦ᵣ raEntry) ** (.x2 ↦ᵣ spW) ** (.x8 ↦ᵣ listBase) ** (.x9 ↦ᵣ len) **
+        (.x18 ↦ᵣ outBase) ** (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ v11) ** (.x12 ↦ᵣ v12) **
+        (.x13 ↦ᵣ v13) ** (.x14 ↦ᵣ old14) ** frameSlotsOwn frame newSp **
+        stackFree newSp 8 ** regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+        (.x19 ↦ᵣ s3) ** (.x20 ↦ᵣ s4) ** (.x21 ↦ᵣ s5) ** regOwn .x28 ** regOwn .x29 **
+        regOwn .x30 ** regOwn .x31 ** (.x0 ↦ᵣ (0 : Word)) ** bytesRegion listBase bytes **
+        (outBase ↦ₘ oldOut0) ** (offsetCell ↦ₘ oldOffset0) ** (lengthCell ↦ₘ oldLen0)) **
+       (memOwn (spW - BitVec.ofNat 64 8) ** (spW ↦ₘ raSaved) ** ((spW + 8) ↦ₘ s0Old) **
+        ((spW + 16) ↦ₘ s1Old) ** ((spW + 24) ↦ₘ s2Old) ** ((outBase + 8) ↦ₘ fld1Out) **
+        bytesRegion (outBase + 16) oldAddr ** bytesRegion (outBase + 36) pad4 **
+        ((outBase + 40) ↦ₘ oldOut2) ** (wdOffsetAddr ↦ₘ wOldOff) ** (wdLengthAddr ↦ₘ wOldLen)))
+      (wdWholePost sp0 spW raSaved s0Old s1Old s2Old outBase listBase s3 s4 s5 listLen bytes
+        oldAddr pad4) := by
+  have hstage := wdField0Stage spW newSp raEntry listBase len outBase oldOut0 oldOffset0
+    oldLen0 old14 s3 s4 s5 v10 v11 v12 v13 bytes listLen hnewSp hlenW hsalign hslack hover
+    hvalid
+  have hbr := cpsBranchWithin_frameR
+    (memOwn (spW - BitVec.ofNat 64 8) ** (spW ↦ₘ raSaved) ** ((spW + 8) ↦ₘ s0Old) **
+     ((spW + 16) ↦ₘ s1Old) ** ((spW + 24) ↦ₘ s2Old) ** ((outBase + 8) ↦ₘ fld1Out) **
+     bytesRegion (outBase + 16) oldAddr ** bytesRegion (outBase + 36) pad4 **
+     ((outBase + 40) ↦ₘ oldOut2) ** (wdOffsetAddr ↦ₘ wOldOff) ** (wdLengthAddr ↦ₘ wOldLen))
+    (by pcfw) hstage
+  -- fail edge → DecodeFailure.field0 via wdK34FailArm
+  have harm := wdK34FailArm sp0 spW newSp raSaved listBase oldOffset0 oldLen0 (WB + 52)
+    s0Old s1Old s2Old { ra := WB + 52, s0 := listBase, s1 := len }
+    { ra := B + 48, s0 := listBase, s1 := outBase, s2 := outBase, s3 := s3, s4 := s4,
+      s5 := s5 } bytes oldAddr pad4 listLen 0
+    (((outBase + 8) ↦ₘ fld1Out) ** bytesRegion (outBase + 16) oldAddr **
+     bytesRegion (outBase + 36) pad4 ** ((outBase + 40) ↦ₘ oldOut2) **
+     (wdOffsetAddr ↦ₘ wOldOff) ** (wdLengthAddr ↦ₘ wOldLen))
+    hspW hnewSp hret
+    (fun status v hnz hres => DecodeFailure.field0 status v hnz hres)
+    (fun roff rlen ov' h hp => by
+      refine ⟨ov', fld1Out, oldOut2, wOldOff, wOldLen, roff, rlen, oldAddr, pad4, ?_⟩
+      xperm_hyp hp)
+  have h_t := cpsTripleWithin_mono_nSteps
+    (show (7 : Nat) ≤ ((4 + (1 + ((7 + 4 + (1 + ((12 + ((85 + 93 * (1 + 2)) + 6)) + 9))) +
+        ((1 + ((7 + (1 + (7 * (2 ^ 64 - 1) + 11))) + 5)) + 5))) + 1) +
+        ((7 + (1 + ((12 + ((85 + 93 * (2 + 2)) + 6)) + 9)) + 1) +
+        (5 + (5 + (6 * (19 + 1)) +
+        ((4 + (1 + ((7 + 4 + (1 + ((12 + ((85 + 93 * (3 + 2)) + 6)) + 9))) +
+          ((1 + ((7 + (1 + (7 * (2 ^ 64 - 1) + 11))) + 5)) + 5))) + 1) + 8))))) from by omega)
+    harm
+  -- continue edge → field-0 Result pinned, K34→K34 passthrough, field-1 backbone
+  have h_f : cpsTripleWithin ((4 + (1 + ((7 + 4 + (1 + ((12 + ((85 + 93 * (1 + 2)) + 6)) + 9))) +
+      ((1 + ((7 + (1 + (7 * (2 ^ 64 - 1) + 11))) + 5)) + 5))) + 1) +
+      ((7 + (1 + ((12 + ((85 + 93 * (2 + 2)) + 6)) + 9)) + 1) +
+      (5 + (5 + (6 * (19 + 1)) +
+      ((4 + (1 + ((7 + 4 + (1 + ((12 + ((85 + 93 * (3 + 2)) + 6)) + 9))) +
+        ((1 + ((7 + (1 + (7 * (2 ^ 64 - 1) + 11))) + 5)) + 5))) + 1) + 8)))))
+      (WB + 56) raSaved fullCode
+      (k34ContPost spW newSp listBase (WB + 52) { ra := WB + 52, s0 := listBase, s1 := len }
+        { ra := B + 48, s0 := listBase, s1 := outBase, s2 := outBase, s3 := s3, s4 := s4,
+          s5 := s5 } bytes listLen 0 **
+       (memOwn (spW - BitVec.ofNat 64 8) ** (spW ↦ₘ raSaved) ** ((spW + 8) ↦ₘ s0Old) **
+        ((spW + 16) ↦ₘ s1Old) ** ((spW + 24) ↦ₘ s2Old) ** ((outBase + 8) ↦ₘ fld1Out) **
+        bytesRegion (outBase + 16) oldAddr ** bytesRegion (outBase + 36) pad4 **
+        ((outBase + 40) ↦ₘ oldOut2) ** (wdOffsetAddr ↦ₘ wOldOff) ** (wdLengthAddr ↦ₘ wOldLen)))
+      (wdWholePost sp0 spW raSaved s0Old s1Old s2Old outBase listBase s3 s4 s5 listLen bytes
+        oldAddr pad4) := by
+    refine cpsTripleWithin_weaken
+      (P := fun h => ∃ offset len' v12' x5' ss' ov,
+        ((⌜Result bytes listBase listLen 0 (0 : Word) ov⌝ : Assertion) **
+         (((.x1 ↦ᵣ (WB + 52)) **
+           (((.x2 ↦ᵣ spW) ** (.x8 ↦ᵣ listBase) ** (.x9 ↦ᵣ len) **
+             savedFrame newSp { ra := WB + 52, s0 := listBase, s1 := len }) **
+            successPayload newSp listBase offset len' v12' x5' ss' (0 : Word) ov
+              { ra := B + 48, s0 := listBase, s1 := outBase, s2 := outBase, s3 := s3,
+                s4 := s4, s5 := s5 } bytes listLen 0)) **
+          (memOwn (spW - BitVec.ofNat 64 8) ** (spW ↦ₘ raSaved) ** ((spW + 8) ↦ₘ s0Old) **
+           ((spW + 16) ↦ₘ s1Old) ** ((spW + 24) ↦ₘ s2Old) ** ((outBase + 8) ↦ₘ fld1Out) **
+           bytesRegion (outBase + 16) oldAddr ** bytesRegion (outBase + 36) pad4 **
+           ((outBase + 40) ↦ₘ oldOut2) ** (wdOffsetAddr ↦ₘ wOldOff) **
+           (wdLengthAddr ↦ₘ wOldLen)))) h)
+      (fun h hp => by
+        obtain ⟨h1, h2, hd, hu, hk, hacc⟩ := hp
+        obtain ⟨offset, len', v12', x5', ss', ov, hbody⟩ := hk
+        refine ⟨offset, len', v12', x5', ss', ov, ?_⟩
+        have hRes : Result bytes listBase listLen 0 (0 : Word) ov := by
+          obtain ⟨_, _, _, _, _, hbody2⟩ := hbody
+          obtain ⟨_, _, _, _, _, hspp⟩ := hbody2
+          unfold successPayload at hspp
+          exact ((sepConj_pure_right _).1 hspp).2
+        exact (sepConj_pure_left h).2 ⟨hRes, h1, h2, hd, hu, hbody, hacc⟩)
+      (fun _ hq => hq) ?_
+    refine cpsTripleWithin_exists_pre_gen (fun offset => ?_)
+    refine cpsTripleWithin_exists_pre_gen (fun len' => ?_)
+    refine cpsTripleWithin_exists_pre_gen (fun v12' => ?_)
+    refine cpsTripleWithin_exists_pre_gen (fun x5' => ?_)
+    refine cpsTripleWithin_exists_pre_gen (fun ss' => ?_)
+    refine cpsTripleWithin_exists_pre_gen (fun ov => ?_)
+    refine cpsTripleWithin_pure_pre (fun hf0 => ?_)
+    refine cpsTripleWithin_weaken
+      (P := ((memOwn (spW - BitVec.ofNat 64 8) ** frameSlotsOwn frame newSp **
+          stackFree newSp 8) ** (.x5 ↦ᵣ x5') ** (.x1 ↦ᵣ (WB + 52)) **
+          (⌜Result bytes listBase listLen 0 (0 : Word) ov⌝ : Assertion) **
+          (.x2 ↦ᵣ spW) ** (.x8 ↦ᵣ listBase) ** (.x9 ↦ᵣ len) **
+          (.x18 ↦ᵣ outBase) ** (.x19 ↦ᵣ s3) ** (.x20 ↦ᵣ s4) ** (.x21 ↦ᵣ s5) **
+          (.x10 ↦ᵣ (0 : Word)) ** (.x11 ↦ᵣ ss') ** (.x12 ↦ᵣ v12') ** regOwn .x6 **
+          regOwn .x7 ** regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+          (.x0 ↦ᵣ (0 : Word)) ** bytesRegion listBase bytes ** (wdOffsetAddr ↦ₘ wOldOff) **
+          (wdLengthAddr ↦ₘ wOldLen) ** (spW ↦ₘ raSaved) ** ((spW + 8) ↦ₘ s0Old) **
+          ((spW + 16) ↦ₘ s1Old) ** ((spW + 24) ↦ₘ s2Old) ** (outBase ↦ₘ ov) **
+          ((outBase + 8) ↦ₘ fld1Out) ** bytesRegion (outBase + 16) oldAddr **
+          bytesRegion (outBase + 36) pad4 ** ((outBase + 40) ↦ₘ oldOut2) **
+          (offsetCell ↦ₘ offset) ** (lengthCell ↦ₘ len')) **
+         regOwn .x13 ** regOwn .x14)
+      (fun h hp => by
+        have hcb := sepConj_mono_left
+          (wdContReshape spW newSp listBase (WB + 52) offset len' v12' x5' ss' ov
+            { ra := WB + 52, s0 := listBase, s1 := len }
+            { ra := B + 48, s0 := listBase, s1 := outBase, s2 := outBase, s3 := s3,
+              s4 := s4, s5 := s5 } bytes listLen 0) h hp
+        unfold wdContBundle at hcb
+        xperm_hyp hcb)
+      (fun _ hq => hq) ?_
+    refine cpsTripleWithin_of_forall_regIs_to_regOwn2 (fun v13' v14' => ?_)
+    refine cpsTripleWithin_weaken
+      (fun h hp => by
+        have hp0 := sepConj_mono_left sepConj_strip_pure_depth3 h hp
+        have hg2 := sepConj_mono_left
+          (sepConj_mono_right (sepConj_mono_left (regIs_implies_regOwn .x5))) h hp0
+        xperm_hyp hg2)
+      (fun _ hq => hq)
+      (wdBBField1 sp0 spW newSp (WB + 52) raSaved listBase len outBase fld1Out offset len'
+        v14' s3 s4 s5 (0 : Word) ss' v12' v13' ov s0Old s1Old s2Old oldOut2 wOldOff wOldLen
+        bytes oldAddr pad4 listLen hnewSp hspW hret hlenW hsalign hslack hover hvalid
+        houtalign houtover haddrlen houtvalid hf0)
+  exact cpsBranchWithin_merge_same_cr hbr h_t h_f
+
+#print axioms wdBBField0
+
 end EvmAsm.Codegen.WithdrawalDecodeSpec

--- a/EvmAsm/Codegen/Programs/WithdrawalDecodeClose5.lean
+++ b/EvmAsm/Codegen/Programs/WithdrawalDecodeClose5.lean
@@ -196,4 +196,82 @@ theorem wdField3ContEpi
 
 #print axioms wdField3ContEpi
 
+/-! ## Field-3 backbone merge
+
+    Merge the field-3 stage's two exits: the parse-fail edge routes through
+    `wdK34FailArm 3` (constructor `DecodeFailure.field3`), the continue edge
+    through `wdField3ContEpi` (the success tie).  Both land the whole-program
+    post; the four saved slots, the reclaimed top cell and the upstream output
+    cells are framed ambient across both. -/
+
+set_option maxRecDepth 8000 in
+/-- The field-3 backbone: field-3 stage `WB+180 → raIn`, both exits landing
+    `wdWholePost`.  The accumulator carries fields 0/1 output cells, the address
+    copy, pad, the address data cells, the saved slots and the reclaimed top
+    cell; the upstream decode facts arrive as hypotheses. -/
+theorem wdBBField3
+    (sp0 spW newSp raEntry raSaved listBase len outBase oldOut oldOffset oldLen old14
+      s3 s4 s5 v10 v11 v12 v13 v0 v1 o2 l2 s0Old s1Old s2Old : Word)
+    (bytes oldAddr pad4 : List (BitVec 8)) (listLen : Nat)
+    (hnewSp : newSp = spW + signExtend12 (-32 : BitVec 12))
+    (hspW : spW = sp0 + signExtend12 (-32 : BitVec 12))
+    (hret : raSaved &&& ~~~(1 : Word) = raSaved)
+    (hlenW : len = BitVec.ofNat 64 listLen)
+    (hsalign : listBase.toNat % 8 = 0)
+    (hslack : listLen + 9 ≤ bytes.length)
+    (hover : listBase.toNat + bytes.length < 2 ^ 64)
+    (hvalid : ∀ k, k < bytes.length →
+      isValidByteAccess (listBase + BitVec.ofNat 64 k) = true)
+    (hf0 : Result bytes listBase listLen 0 (0 : Word) v0)
+    (hf1 : Result bytes listBase listLen 1 (0 : Word) v1)
+    (hf2 : EvmAsm.Codegen.RlpListNthItemSAsm.Success bytes listBase listLen 2 o2 l2)
+    (hl2 : l2.toNat = 20) :
+    let callSteps := 1 + ((12 + ((85 + 93 * (3 + 2)) + 6)) + 9)
+    let tailSteps := (7 + (1 + (7 * (2 ^ 64 - 1) + 11))) + 5
+    let n34 := (7 + 4 + callSteps) + ((1 + tailSteps) + 5)
+    cpsTripleWithin ((4 + (1 + n34) + 1) + 8) (WB + 180) raSaved fullCode
+      ((((.x1 : Reg) ↦ᵣ raEntry) ** (.x2 ↦ᵣ spW) ** (.x8 ↦ᵣ listBase) ** (.x9 ↦ᵣ len) **
+        (.x18 ↦ᵣ outBase) ** (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ v11) ** (.x12 ↦ᵣ v12) **
+        (.x13 ↦ᵣ v13) ** (.x14 ↦ᵣ old14) ** frameSlotsOwn frame newSp **
+        stackFree newSp 8 ** regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+        (.x19 ↦ᵣ s3) ** (.x20 ↦ᵣ s4) ** (.x21 ↦ᵣ s5) ** regOwn .x28 ** regOwn .x29 **
+        regOwn .x30 ** regOwn .x31 ** (.x0 ↦ᵣ (0 : Word)) ** bytesRegion listBase bytes **
+        ((outBase + 40) ↦ₘ oldOut) ** (offsetCell ↦ₘ oldOffset) ** (lengthCell ↦ₘ oldLen)) **
+       (memOwn (spW - BitVec.ofNat 64 8) ** (spW ↦ₘ raSaved) ** ((spW + 8) ↦ₘ s0Old) **
+        ((spW + 16) ↦ₘ s1Old) ** ((spW + 24) ↦ₘ s2Old) ** (outBase ↦ₘ v0) **
+        ((outBase + 8) ↦ₘ v1) ** bytesRegion (outBase + 16) (addrCopied bytes oldAddr o2) **
+        bytesRegion (outBase + 36) pad4 ** (wdOffsetAddr ↦ₘ o2) ** (wdLengthAddr ↦ₘ l2)))
+      (wdWholePost sp0 spW raSaved s0Old s1Old s2Old outBase listBase s3 s4 s5 listLen bytes
+        oldAddr pad4) := by
+  intro callSteps tailSteps n34
+  have hstage := wdField3Stage spW newSp raEntry listBase len outBase oldOut oldOffset
+    oldLen old14 s3 s4 s5 v10 v11 v12 v13 bytes listLen hnewSp hlenW hsalign hslack hover
+    hvalid
+  have hbr := cpsBranchWithin_frameR
+    (memOwn (spW - BitVec.ofNat 64 8) ** (spW ↦ₘ raSaved) ** ((spW + 8) ↦ₘ s0Old) **
+     ((spW + 16) ↦ₘ s1Old) ** ((spW + 24) ↦ₘ s2Old) ** (outBase ↦ₘ v0) **
+     ((outBase + 8) ↦ₘ v1) ** bytesRegion (outBase + 16) (addrCopied bytes oldAddr o2) **
+     bytesRegion (outBase + 36) pad4 ** (wdOffsetAddr ↦ₘ o2) ** (wdLengthAddr ↦ₘ l2))
+    (by repeat' first
+        | exact pcFree_memOwn | exact pcFree_memIs | exact bytesRegion_pcFree _ _
+        | apply pcFree_sepConj) hstage
+  have h_t := cpsTripleWithin_mono_nSteps (show (7 : Nat) ≤ 8 from by omega)
+    (wdK34FailArm sp0 spW newSp raSaved listBase oldOffset oldLen (WB + 200) s0Old s1Old
+      s2Old { ra := WB + 200, s0 := listBase, s1 := len }
+      { ra := B + 48, s0 := listBase, s1 := outBase + 40, s2 := outBase, s3 := s3,
+        s4 := s4, s5 := s5 } bytes oldAddr pad4 listLen 3
+      ((outBase ↦ₘ v0) ** ((outBase + 8) ↦ₘ v1) **
+       bytesRegion (outBase + 16) (addrCopied bytes oldAddr o2) **
+       bytesRegion (outBase + 36) pad4 ** (wdOffsetAddr ↦ₘ o2) ** (wdLengthAddr ↦ₘ l2))
+      hspW hnewSp hret
+      (fun status v hnz hres => DecodeFailure.field3 status v hnz hres)
+      (fun roff rlen ov h hp => by
+        refine ⟨v0, v1, ov, o2, l2, roff, rlen, addrCopied bytes oldAddr o2, pad4, ?_⟩
+        xperm_hyp hp))
+  have h_f := wdField3ContEpi sp0 spW newSp raSaved listBase len outBase v0 v1 o2 l2
+    s0Old s1Old s2Old s3 s4 s5 bytes oldAddr pad4 listLen hspW hnewSp hret hf0 hf1 hf2 hl2
+  exact cpsBranchWithin_merge_same_cr hbr h_t h_f
+
+#print axioms wdBBField3
+
 end EvmAsm.Codegen.WithdrawalDecodeSpec

--- a/EvmAsm/Codegen/Programs/WithdrawalDecodeLoop.lean
+++ b/EvmAsm/Codegen/Programs/WithdrawalDecodeLoop.lean
@@ -1,0 +1,173 @@
+/-
+  The 20-byte address copy loop of `withdrawalDecode_prog` ([39]-[44]).
+
+  The address field is materialised by a byte-safe `LBU`/`SB` do-while copy
+  (the pkljc #10343 byte-fix): with `x28` the source cursor, `x29` the output
+  cursor, `x6` the remaining count and `x30` the byte scratch, each iteration
+
+    [39] LBU x30, 0(x28)   [40] SB  x30, 0(x29)
+    [41] ADDI x28, x28, 1  [42] ADDI x29, x29, 1
+    [43] ADDI x6,  x6, -1  [44] BNE x6, x0, -20
+
+  copies one byte and decrements the counter.  This module hosts the reusable
+  per-byte step (`wdCopyBody5`, instructions [39]-[43]), whose content tie is
+  the same `copyIntoRegion` accumulator used by the header-root extractors.
+
+  No `sorry`/`admit`/`native_decide`/`bv_decide`; classical-3 axioms only.
+-/
+
+import EvmAsm.Codegen.Programs.WithdrawalDecodeSpec
+
+namespace EvmAsm.Codegen.WithdrawalDecodeSpec
+
+open EvmAsm.Rv64 EvmAsm.Rv64.SAsm
+open EvmAsm.Evm64.Terminating (copyIntoRegion copyIntoRegion_length)
+
+private theorem wd_succ_dec (n : Nat) :
+    BitVec.ofNat 64 (n + 1) + signExtend12 (-1 : BitVec 12) = BitVec.ofNat 64 n := by
+  apply BitVec.eq_of_toNat_eq
+  have hs : (signExtend12 (-1 : BitVec 12) : Word).toNat = 18446744073709551615 := by decide
+  rw [BitVec.toNat_add, hs, BitVec.toNat_ofNat, BitVec.toNat_ofNat]
+  omega
+
+private theorem wd_advance (b : Word) (m : Nat) :
+    (b + BitVec.ofNat 64 m) + signExtend12 (1 : BitVec 12) = b + BitVec.ofNat 64 (m + 1) := by
+  rw [show signExtend12 (1 : BitVec 12) = (1 : Word) from by decide]; bv_omega
+
+set_option maxRecDepth 8000 in
+/-- One copy-loop body ([39]-[43], `WB+156 → WB+176`): copy one byte from
+    `srcBase[srcOff+i]` to `dstBase[dstOff+i]` (advancing both cursors) and
+    decrement the counter from `m+1` to `m`.  The destination content grows by
+    one byte in the `copyIntoRegion` accumulator. -/
+theorem wdCopyBody5 (srcBase dstBase x30old : Word)
+    (srcBytes dstBytes : List (BitVec 8)) (srcOff dstOff i m : Nat)
+    (h_src_align : srcBase.toNat % 8 = 0)
+    (h_dst_align : dstBase.toNat % 8 = 0)
+    (h_src_lt : srcOff + i < srcBytes.length)
+    (h_dst_lt : dstOff + i < dstBytes.length)
+    (h_src_over : srcBase.toNat + srcBytes.length < 2 ^ 64)
+    (h_dst_over : dstBase.toNat + dstBytes.length < 2 ^ 64)
+    (h_src_valid : ∀ k, k < srcBytes.length →
+      isValidByteAccess (srcBase + BitVec.ofNat 64 k) = true)
+    (h_dst_valid : ∀ k, k < dstBytes.length →
+      isValidByteAccess (dstBase + BitVec.ofNat 64 k) = true) :
+    cpsTripleWithin 5 (WB + 156) (WB + 176) fullCode
+      (((.x6 : Reg) ↦ᵣ BitVec.ofNat 64 (m + 1)) **
+       ((.x28 : Reg) ↦ᵣ (srcBase + BitVec.ofNat 64 (srcOff + i))) **
+       ((.x29 : Reg) ↦ᵣ (dstBase + BitVec.ofNat 64 (dstOff + i))) **
+       ((.x30 : Reg) ↦ᵣ x30old) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+       bytesRegion srcBase srcBytes **
+       bytesRegion dstBase (copyIntoRegion dstBytes srcBytes dstOff srcOff i))
+      (((.x6 : Reg) ↦ᵣ BitVec.ofNat 64 m) **
+       ((.x28 : Reg) ↦ᵣ (srcBase + BitVec.ofNat 64 (srcOff + (i + 1)))) **
+       ((.x29 : Reg) ↦ᵣ (dstBase + BitVec.ofNat 64 (dstOff + (i + 1)))) **
+       ((.x30 : Reg) ↦ᵣ ((srcBytes.getD (srcOff + i) 0).zeroExtend 64)) **
+       ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+       bytesRegion srcBase srcBytes **
+       bytesRegion dstBase (copyIntoRegion dstBytes srcBytes dstOff srcOff (i + 1))) := by
+  set bval := srcBytes[srcOff + i]'h_src_lt with hbval
+  have htrunc : (bval.zeroExtend 64).truncate 8 = bval := by
+    apply BitVec.eq_of_toNat_eq
+    rw [BitVec.toNat_setWidth, BitVec.toNat_setWidth]
+    have := bval.isLt
+    rw [Nat.mod_eq_of_lt (by omega), Nat.mod_eq_of_lt (by omega)]
+  have hgetd : srcBytes.getD (srcOff + i) 0 = bval := by
+    rw [hbval, List.getD_eq_getElem?_getD, List.getElem?_eq_getElem h_src_lt]; rfl
+  have hstep : copyIntoRegion dstBytes srcBytes dstOff srcOff (i + 1)
+      = (copyIntoRegion dstBytes srcBytes dstOff srcOff i).set (dstOff + i) bval := by
+    simp only [copyIntoRegion, hgetd]
+  -- [39] lbu x30, 0(x28)
+  have hlbu := bytesRegion_lbu_within .x30 .x28 srcBase x30old (WB + 156)
+    srcBytes (srcOff + i) (by decide) h_src_align h_src_lt (by omega)
+    (h_src_valid (srcOff + i) h_src_lt)
+  rw [show (WB + 156 : Word) + 4 = WB + 160 from by bv_omega, ← hbval] at hlbu
+  have hlbue := cpsTripleWithin_extend_code wd_mono
+    (cpsTripleWithin_extend_code (cr' := wdCode)
+      (CodeReq.ofProg_mem_at WB (WB + 156) withdrawalDecode_prog 39
+        (.LBU .x30 .x28 (0 : BitVec 12)) (by bv_omega) (by rw [wd_length]; decide)
+        rfl (by rw [wd_length]; decide)) hlbu)
+  have hlbuf := cpsTripleWithin_frameR
+    (((.x6 : Reg) ↦ᵣ BitVec.ofNat 64 (m + 1)) **
+     ((.x29 : Reg) ↦ᵣ (dstBase + BitVec.ofNat 64 (dstOff + i))) **
+     ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+     bytesRegion dstBase (copyIntoRegion dstBytes srcBytes dstOff srcOff i))
+    (by repeat' first | exact bytesRegion_pcFree _ _ | exact pcFree_regIs | apply pcFree_sepConj) hlbue
+  -- [40] sb x30, 0(x29)
+  have hsb := bytesRegion_sb_within .x29 .x30 dstBase (bval.zeroExtend 64) (WB + 160)
+    (copyIntoRegion dstBytes srcBytes dstOff srcOff i) (dstOff + i) h_dst_align
+    (by rw [copyIntoRegion_length]; omega) (by omega)
+    (h_dst_valid (dstOff + i) h_dst_lt)
+  rw [htrunc, ← hstep, show (WB + 160 : Word) + 4 = WB + 164 from by bv_omega] at hsb
+  have hsbe := cpsTripleWithin_extend_code wd_mono
+    (cpsTripleWithin_extend_code (cr' := wdCode)
+      (CodeReq.ofProg_mem_at WB (WB + 160) withdrawalDecode_prog 40
+        (.SB .x29 .x30 (0 : BitVec 12)) (by bv_omega) (by rw [wd_length]; decide)
+        rfl (by rw [wd_length]; decide)) hsb)
+  have hsbf := cpsTripleWithin_frameR
+    (((.x6 : Reg) ↦ᵣ BitVec.ofNat 64 (m + 1)) **
+     ((.x28 : Reg) ↦ᵣ (srcBase + BitVec.ofNat 64 (srcOff + i))) **
+     ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+     bytesRegion srcBase srcBytes)
+    (by repeat' first | exact bytesRegion_pcFree _ _ | exact pcFree_regIs | apply pcFree_sepConj) hsbe
+  -- [41] addi x28, x28, 1
+  have h3 := addi_spec_gen_same_within .x28
+    (srcBase + BitVec.ofNat 64 (srcOff + i)) (1 : BitVec 12) (WB + 164) (by decide)
+  rw [wd_advance srcBase (srcOff + i),
+      show srcOff + i + 1 = srcOff + (i + 1) from by omega,
+      show (WB + 164 : Word) + 4 = WB + 168 from by bv_omega] at h3
+  have h3e := cpsTripleWithin_extend_code wd_mono
+    (cpsTripleWithin_extend_code (cr' := wdCode)
+      (CodeReq.ofProg_mem_at WB (WB + 164) withdrawalDecode_prog 41
+        (.ADDI .x28 .x28 (1 : BitVec 12)) (by bv_omega) (by rw [wd_length]; decide)
+        rfl (by rw [wd_length]; decide)) h3)
+  have h3f := cpsTripleWithin_frameR
+    (((.x6 : Reg) ↦ᵣ BitVec.ofNat 64 (m + 1)) **
+     ((.x29 : Reg) ↦ᵣ (dstBase + BitVec.ofNat 64 (dstOff + i))) **
+     ((.x30 : Reg) ↦ᵣ (bval.zeroExtend 64)) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+     bytesRegion srcBase srcBytes **
+     bytesRegion dstBase (copyIntoRegion dstBytes srcBytes dstOff srcOff (i + 1)))
+    (by repeat' first | exact bytesRegion_pcFree _ _ | exact pcFree_regIs | apply pcFree_sepConj) h3e
+  -- [42] addi x29, x29, 1
+  have h4 := addi_spec_gen_same_within .x29
+    (dstBase + BitVec.ofNat 64 (dstOff + i)) (1 : BitVec 12) (WB + 168) (by decide)
+  rw [wd_advance dstBase (dstOff + i),
+      show dstOff + i + 1 = dstOff + (i + 1) from by omega,
+      show (WB + 168 : Word) + 4 = WB + 172 from by bv_omega] at h4
+  have h4e := cpsTripleWithin_extend_code wd_mono
+    (cpsTripleWithin_extend_code (cr' := wdCode)
+      (CodeReq.ofProg_mem_at WB (WB + 168) withdrawalDecode_prog 42
+        (.ADDI .x29 .x29 (1 : BitVec 12)) (by bv_omega) (by rw [wd_length]; decide)
+        rfl (by rw [wd_length]; decide)) h4)
+  have h4f := cpsTripleWithin_frameR
+    (((.x6 : Reg) ↦ᵣ BitVec.ofNat 64 (m + 1)) **
+     ((.x28 : Reg) ↦ᵣ (srcBase + BitVec.ofNat 64 (srcOff + (i + 1)))) **
+     ((.x30 : Reg) ↦ᵣ (bval.zeroExtend 64)) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+     bytesRegion srcBase srcBytes **
+     bytesRegion dstBase (copyIntoRegion dstBytes srcBytes dstOff srcOff (i + 1)))
+    (by repeat' first | exact bytesRegion_pcFree _ _ | exact pcFree_regIs | apply pcFree_sepConj) h4e
+  -- [43] addi x6, x6, -1
+  have h5 := addi_spec_gen_same_within .x6 (BitVec.ofNat 64 (m + 1)) (-1 : BitVec 12)
+    (WB + 172) (by decide)
+  rw [wd_succ_dec m, show (WB + 172 : Word) + 4 = WB + 176 from by bv_omega] at h5
+  have h5e := cpsTripleWithin_extend_code wd_mono
+    (cpsTripleWithin_extend_code (cr' := wdCode)
+      (CodeReq.ofProg_mem_at WB (WB + 172) withdrawalDecode_prog 43
+        (.ADDI .x6 .x6 (-1 : BitVec 12)) (by bv_omega) (by rw [wd_length]; decide)
+        rfl (by rw [wd_length]; decide)) h5)
+  have h5f := cpsTripleWithin_frameR
+    (((.x28 : Reg) ↦ᵣ (srcBase + BitVec.ofNat 64 (srcOff + (i + 1)))) **
+     ((.x29 : Reg) ↦ᵣ (dstBase + BitVec.ofNat 64 (dstOff + (i + 1)))) **
+     ((.x30 : Reg) ↦ᵣ (bval.zeroExtend 64)) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+     bytesRegion srcBase srcBytes **
+     bytesRegion dstBase (copyIntoRegion dstBytes srcBytes dstOff srcOff (i + 1)))
+    (by repeat' first | exact bytesRegion_pcFree _ _ | exact pcFree_regIs | apply pcFree_sepConj) h5e
+  have s12 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_chunked hp) hlbuf hsbf
+  have s123 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_chunked hp) s12 h3f
+  have s1234 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_chunked hp) s123 h4f
+  have s12345 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_chunked hp) s1234 h5f
+  exact cpsTripleWithin_weaken (fun _ hp => by xperm_chunked hp)
+    (fun _ hq => by rw [hgetd]; xperm_chunked hq) s12345
+
+#print axioms wdCopyBody5
+
+end EvmAsm.Codegen.WithdrawalDecodeSpec

--- a/EvmAsm/Codegen/Programs/WithdrawalDecodeLoop.lean
+++ b/EvmAsm/Codegen/Programs/WithdrawalDecodeLoop.lean
@@ -170,4 +170,124 @@ theorem wdCopyBody5 (srcBase dstBase x30old : Word)
 
 #print axioms wdCopyBody5
 
+private theorem wd_ofNat_ne_zero (n : Nat) (h : n + 1 < 2 ^ 64) :
+    BitVec.ofNat 64 (n + 1) ≠ (0 : Word) := by
+  intro heq
+  have h2 := congrArg BitVec.toNat heq
+  rw [BitVec.toNat_ofNat, Nat.mod_eq_of_lt h,
+      show (0 : Word).toNat = 0 from by decide] at h2
+  omega
+
+set_option maxRecDepth 8000 in
+/-- The bottom-tested 20-byte copy loop closure ([39]-[44], `WB+156 → WB+180`):
+    each round copies one byte via `wdCopyBody5` ([39]-[43]) and then `BNE x6, x0`
+    at [44] loops back to the header while the counter is nonzero, exiting when it
+    reaches `0`.  Copies `n+1` bytes, growing the `copyIntoRegion` accumulator. -/
+theorem wdCopyLoop (srcBase dstBase x30old : Word)
+    (srcBytes dstBytes : List (BitVec 8)) (srcOff dstOff i n : Nat)
+    (h_src_align : srcBase.toNat % 8 = 0)
+    (h_dst_align : dstBase.toNat % 8 = 0)
+    (h_src_bound : srcOff + i + (n + 1) ≤ srcBytes.length)
+    (h_dst_bound : dstOff + i + (n + 1) ≤ dstBytes.length)
+    (h_src_over : srcBase.toNat + srcBytes.length < 2 ^ 64)
+    (h_dst_over : dstBase.toNat + dstBytes.length < 2 ^ 64)
+    (h_src_valid : ∀ k, k < srcBytes.length →
+      isValidByteAccess (srcBase + BitVec.ofNat 64 k) = true)
+    (h_dst_valid : ∀ k, k < dstBytes.length →
+      isValidByteAccess (dstBase + BitVec.ofNat 64 k) = true) :
+    cpsTripleWithin (6 * (n + 1)) (WB + 156) (WB + 180) fullCode
+      (((.x6 : Reg) ↦ᵣ BitVec.ofNat 64 (n + 1)) **
+       ((.x28 : Reg) ↦ᵣ (srcBase + BitVec.ofNat 64 (srcOff + i))) **
+       ((.x29 : Reg) ↦ᵣ (dstBase + BitVec.ofNat 64 (dstOff + i))) **
+       ((.x30 : Reg) ↦ᵣ x30old) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+       bytesRegion srcBase srcBytes **
+       bytesRegion dstBase (copyIntoRegion dstBytes srcBytes dstOff srcOff i))
+      (((.x6 : Reg) ↦ᵣ (0 : Word)) **
+       ((.x28 : Reg) ↦ᵣ (srcBase + BitVec.ofNat 64 (srcOff + (i + (n + 1))))) **
+       ((.x29 : Reg) ↦ᵣ (dstBase + BitVec.ofNat 64 (dstOff + (i + (n + 1))))) **
+       regOwn .x30 ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+       bytesRegion srcBase srcBytes **
+       bytesRegion dstBase
+         (copyIntoRegion dstBytes srcBytes dstOff srcOff (i + (n + 1)))) := by
+  have hsrc_lt : srcBytes.length < 2 ^ 64 := by omega
+  have htaken : (WB + 176 : Word) + signExtend13 (-20 : BitVec 13) = WB + 156 := by
+    rw [show signExtend13 (-20 : BitVec 13) = (-20 : Word) from by decide]; bv_omega
+  have hfall : (WB + 176 : Word) + 4 = WB + 180 := by bv_omega
+  induction n generalizing i x30old with
+  | zero =>
+    -- one iteration: body (x6: 1 → 0) then BNE not-taken → exit.
+    have hbody := wdCopyBody5 srcBase dstBase x30old srcBytes dstBytes srcOff dstOff i 0
+      h_src_align h_dst_align (by omega) (by omega) h_src_over h_dst_over
+      h_src_valid h_dst_valid
+    have hbne := bne_spec_gen_within .x6 .x0 (-20 : BitVec 13) (BitVec.ofNat 64 0)
+      (0 : Word) (WB + 176)
+    rw [htaken, hfall] at hbne
+    have hbnee := cpsBranchWithin_extend_code wd_mono
+      (cpsBranchWithin_extend_code (cr' := wdCode)
+        (CodeReq.ofProg_mem_at WB (WB + 176) withdrawalDecode_prog 44
+          (.BNE .x6 .x0 (-20 : BitVec 13)) (by bv_omega) (by rw [wd_length]; decide)
+          rfl (by rw [wd_length]; decide)) hbne)
+    have hnt := cpsBranchWithin_ntakenStripPure2 hbnee (fun hp hQt => by
+      obtain ⟨_, _, _, _, _, hQ⟩ := hQt
+      exact ((sepConj_pure_right _).1 hQ).2 (by decide))
+    have hntf := cpsTripleWithin_frameR
+      (((.x28 : Reg) ↦ᵣ (srcBase + BitVec.ofNat 64 (srcOff + (i + 1)))) **
+       ((.x29 : Reg) ↦ᵣ (dstBase + BitVec.ofNat 64 (dstOff + (i + 1)))) **
+       ((.x30 : Reg) ↦ᵣ ((srcBytes.getD (srcOff + i) 0).zeroExtend 64)) **
+       bytesRegion srcBase srcBytes **
+       bytesRegion dstBase (copyIntoRegion dstBytes srcBytes dstOff srcOff (i + 1)))
+      (by repeat' first | exact bytesRegion_pcFree _ _ | exact pcFree_regIs | apply pcFree_sepConj) hnt
+    have s1 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_chunked hp) hbody hntf
+    refine cpsTripleWithin_mono_nSteps (nSteps := 5 + 1) (by omega) ?_
+    exact cpsTripleWithin_weaken (fun _ hp => by xperm_chunked hp)
+      (fun _ hq => by
+        simp only [Nat.zero_add]
+        rw [show (BitVec.ofNat 64 0 : Word) = 0 from by decide] at hq
+        have hq2 := sepConj_mono_left (regIs_implies_regOwn .x30) _
+          (show (((.x30 : Reg) ↦ᵣ ((srcBytes.getD (srcOff + i) 0).zeroExtend 64)) **
+            ((.x6 : Reg) ↦ᵣ (0 : Word)) **
+            ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+            ((.x28 : Reg) ↦ᵣ (srcBase + BitVec.ofNat 64 (srcOff + (i + 1)))) **
+            ((.x29 : Reg) ↦ᵣ (dstBase + BitVec.ofNat 64 (dstOff + (i + 1)))) **
+            bytesRegion srcBase srcBytes **
+            bytesRegion dstBase
+              (copyIntoRegion dstBytes srcBytes dstOff srcOff (i + 1))) _ from by
+            xperm_chunked hq)
+        xperm_chunked hq2) s1
+  | succ k ih =>
+    -- body (x6: k+2 → k+1) then BNE taken → header, then loop (k+1 more).
+    have hbody := wdCopyBody5 srcBase dstBase x30old srcBytes dstBytes srcOff dstOff i (k + 1)
+      h_src_align h_dst_align (by omega) (by omega) h_src_over h_dst_over
+      h_src_valid h_dst_valid
+    have hbne := bne_spec_gen_within .x6 .x0 (-20 : BitVec 13) (BitVec.ofNat 64 (k + 1))
+      (0 : Word) (WB + 176)
+    rw [htaken, hfall] at hbne
+    have hbnee := cpsBranchWithin_extend_code wd_mono
+      (cpsBranchWithin_extend_code (cr' := wdCode)
+        (CodeReq.ofProg_mem_at WB (WB + 176) withdrawalDecode_prog 44
+          (.BNE .x6 .x0 (-20 : BitVec 13)) (by bv_omega) (by rw [wd_length]; decide)
+          rfl (by rw [wd_length]; decide)) hbne)
+    have htk := cpsBranchWithin_takenStripPure2 hbnee (fun hp hQf => by
+      obtain ⟨_, _, _, _, _, hQ⟩ := hQf
+      exact wd_ofNat_ne_zero k (by omega) ((sepConj_pure_right _).1 hQ).2)
+    have htkf := cpsTripleWithin_frameR
+      (((.x28 : Reg) ↦ᵣ (srcBase + BitVec.ofNat 64 (srcOff + (i + 1)))) **
+       ((.x29 : Reg) ↦ᵣ (dstBase + BitVec.ofNat 64 (dstOff + (i + 1)))) **
+       ((.x30 : Reg) ↦ᵣ ((srcBytes.getD (srcOff + i) 0).zeroExtend 64)) **
+       bytesRegion srcBase srcBytes **
+       bytesRegion dstBase (copyIntoRegion dstBytes srcBytes dstOff srcOff (i + 1)))
+      (by repeat' first | exact bytesRegion_pcFree _ _ | exact pcFree_regIs | apply pcFree_sepConj) htk
+    have hih := ih ((srcBytes.getD (srcOff + i) 0).zeroExtend 64) (i + 1)
+      (by omega) (by omega)
+    -- compose: body ;; bne-taken ;; ih
+    have s1 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_chunked hp) hbody htkf
+    have s2 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_chunked hp) s1 hih
+    refine cpsTripleWithin_mono_nSteps (nSteps := (5 + 1) + 6 * (k + 1)) (by omega) ?_
+    exact cpsTripleWithin_weaken (fun _ hp => by xperm_chunked hp)
+      (fun _ hq => by
+        simp only [show i + 1 + (k + 1) = i + (k + 1 + 1) from by omega] at hq
+        xperm_chunked hq) s2
+
+#print axioms wdCopyLoop
+
 end EvmAsm.Codegen.WithdrawalDecodeSpec

--- a/EvmAsm/Codegen/Programs/WithdrawalDecodeSpec.lean
+++ b/EvmAsm/Codegen/Programs/WithdrawalDecodeSpec.lean
@@ -1,0 +1,109 @@
+/-
+  Whole-program caller contract scaffolding for `withdrawalDecode_prog`
+  (`Programs/Withdrawal.lean`, PR-K49, 60 instructions, entry
+  `GuestAddrs.withdrawal_decode`).
+
+  A withdrawal is the RLP list `[index, validator_index, address, amount]`.
+  The accessor decodes it into a 48-byte output struct:
+
+       0..  8  index           (u64 LE)   -- field 0, via rlp_field_to_u64
+       8.. 16  validator_index (u64 LE)   -- field 1, via rlp_field_to_u64
+      16.. 36  address         (20 B)     -- field 2, via rlp_list_nth_item + copy
+      36.. 40  zero pad
+      40.. 48  amount          (u64 LE)   -- field 3, via rlp_field_to_u64
+
+  Calling convention:
+    a0 (input)  : withdrawal_rlp ptr        (saved into s0/x8)
+    a1 (input)  : withdrawal_rlp byte length (saved into s1/x9)
+    a2 (input)  : 48-byte output struct ptr  (saved into s2/x18)
+    ra (input)  : return
+    a0 (output) : 0 success / 1 parse fail (any field's RLP failure, or the
+                  address length ≠ 20)
+
+  Both u64 fields and the address field reuse the merged strict callees:
+  `rlp_field_to_u64` (fields 0/1/3) and `rlp_list_nth_item` (field 2).  The
+  latter's linked code is already a sub-union of `rlp_field_to_u64`'s code, so
+  the full linked closure here is `wdCode ∪ RlpFieldToU64SAsm.code`, exactly as
+  in `HeaderExtractNumberSpec`.
+
+  This module hosts the code layout, disjointness/mono lemmas, the semantic
+  decode model, and the caller-facing pre/post.
+
+  No `sorry`/`admit`/`native_decide`/`bv_decide`; classical-3 axioms only.
+-/
+
+import EvmAsm.Codegen.Programs.RlpFieldToU64FlatSAsm
+import EvmAsm.Codegen.Programs.Withdrawal
+
+namespace EvmAsm.Codegen.WithdrawalDecodeSpec
+
+open EvmAsm.Rv64 EvmAsm.Rv64.RLP EvmAsm.Rv64.SAsm
+open EvmAsm.Codegen.RlpFieldToU64SAsm
+
+/-! ## Code layout -/
+
+/-- The accessor body's fixed guest base address. -/
+abbrev WB : Word := (GuestAddrs.withdrawal_decode : Word)
+
+theorem wd_length : withdrawalDecode_prog.length = 60 := by decide
+
+/-- The wrapper's own re-emitted instructions at `withdrawal_decode`. -/
+def wdCode : CodeReq := CodeReq.ofProg WB withdrawalDecode_prog
+
+/-- The full linked closure: this accessor plus the strict `rlp_field_to_u64`
+    selector (whose linked closure already contains `rlp_list_nth_item` and
+    `rlp_content_to_u64`). -/
+def fullCode : CodeReq := wdCode.union EvmAsm.Codegen.RlpFieldToU64SAsm.code
+
+theorem wd_disjoint :
+    wdCode.Disjoint EvmAsm.Codegen.RlpFieldToU64SAsm.code := by
+  unfold wdCode EvmAsm.Codegen.RlpFieldToU64SAsm.code
+  refine CodeReq.Disjoint.union_right ?_
+    (CodeReq.Disjoint.union_right ?_ ?_)
+  · unfold EvmAsm.Codegen.RlpFieldToU64SAsm.wrapperCode
+      EvmAsm.Codegen.RlpFieldToU64SAsm.B WB
+    apply CodeReq.Disjoint.ofProg_ranges
+    · rw [wd_length]; decide
+    · rw [EvmAsm.Codegen.RlpFieldToU64SAsm.program_length]; decide
+    · rw [wd_length, EvmAsm.Codegen.RlpFieldToU64SAsm.program_length]; decide
+  · unfold EvmAsm.Codegen.RlpListNthItemSAsm.code
+      EvmAsm.Codegen.RlpListNthItemSAsm.B WB
+    apply CodeReq.Disjoint.ofProg_ranges
+    · rw [wd_length]; decide
+    · rw [EvmAsm.Codegen.RlpListNthItemSAsm.total_length]; decide
+    · rw [wd_length, EvmAsm.Codegen.RlpListNthItemSAsm.total_length]; decide
+  · unfold EvmAsm.Codegen.RlpFieldToU64SAsm.contentCode
+      rlp_content_to_u64_code EvmAsm.Codegen.RlpFieldToU64SAsm.C64B WB
+    apply CodeReq.Disjoint.ofProg_ranges
+    · rw [wd_length]; decide
+    · rw [rlp_content_to_u64_prog_length]; decide
+    · rw [wd_length, rlp_content_to_u64_prog_length]; decide
+
+#print axioms wd_disjoint
+
+/-- K34's linked code is subsumed by the accessor's full closure. -/
+theorem k34_mono :
+    ∀ a i, EvmAsm.Codegen.RlpFieldToU64SAsm.code a = some i → fullCode a = some i := by
+  intro a i hi
+  unfold fullCode
+  exact CodeReq.mono_union_right wd_disjoint (fun _ _ h => h) a i hi
+
+theorem wd_mono : ∀ a i, wdCode a = some i → fullCode a = some i := by
+  intro a i hi
+  unfold fullCode
+  exact CodeReq.union_mono_left a i hi
+
+/-- The strict `rlp_list_nth_item` subroutine (called for the address field) is
+    a sub-union of K34's code, hence of the full closure. -/
+theorem k20_mono :
+    ∀ a i, EvmAsm.Codegen.RlpListNthItemSAsm.code a = some i → fullCode a = some i := by
+  intro a i hi
+  refine k34_mono a i ?_
+  unfold EvmAsm.Codegen.RlpFieldToU64SAsm.code
+  exact CodeReq.mono_union_right EvmAsm.Codegen.RlpFieldToU64SAsm.wrapper_list_disjoint
+    (CodeReq.union_mono_left) a i hi
+
+#print axioms k34_mono
+#print axioms k20_mono
+
+end EvmAsm.Codegen.WithdrawalDecodeSpec

--- a/EvmAsm/Codegen/Programs/WithdrawalDecodeSpec.lean
+++ b/EvmAsm/Codegen/Programs/WithdrawalDecodeSpec.lean
@@ -34,6 +34,7 @@
 
 import EvmAsm.Codegen.Programs.RlpFieldToU64FlatSAsm
 import EvmAsm.Codegen.Programs.Withdrawal
+import EvmAsm.Evm64.Terminating.ReturnWindowLoopSpec
 
 namespace EvmAsm.Codegen.WithdrawalDecodeSpec
 
@@ -105,5 +106,69 @@ theorem k20_mono :
 
 #print axioms k34_mono
 #print axioms k20_mono
+
+/-! ## Semantic decode model
+
+    Tied to the merged callee `Result`/`Success` relations.  The three u64
+    fields (index/validator_index/amount) decode via K34's `Result` (status 0);
+    the address field decodes via K20's `Success` and must be exactly 20 bytes.
+    All four are indexed positions in the same strict RLP list. -/
+
+open EvmAsm.Evm64.Terminating (copyIntoRegion copyIntoRegion_length)
+
+/-- The genuine success verdict: every field decodes (u64 status 0) and the
+    address field is exactly 20 content bytes at relative offset `o2`. -/
+def Decoded (bytes : List (BitVec 8)) (listBase : Word) (listLen : Nat)
+    (v0 v1 v3 : Word) (o2 l2 : Word) : Prop :=
+  EvmAsm.Codegen.RlpFieldToU64SAsm.Result bytes listBase listLen 0 (0 : Word) v0 ∧
+  EvmAsm.Codegen.RlpFieldToU64SAsm.Result bytes listBase listLen 1 (0 : Word) v1 ∧
+  EvmAsm.Codegen.RlpListNthItemSAsm.Success bytes listBase listLen 2 o2 l2 ∧
+  l2.toNat = 20 ∧
+  EvmAsm.Codegen.RlpFieldToU64SAsm.Result bytes listBase listLen 3 (0 : Word) v3
+
+/-- The 20 address content bytes copied forward from the input `bytes` (at the
+    relative content offset `o2`) into the caller's old 20-byte address slot. -/
+def addrCopied (bytes oldAddr : List (BitVec 8)) (o2 : Word) : List (BitVec 8) :=
+  copyIntoRegion oldAddr bytes 0 o2.toNat 20
+
+theorem addrCopied_length (bytes oldAddr : List (BitVec 8)) (o2 : Word)
+    (hlen : oldAddr.length = 20) :
+    (addrCopied bytes oldAddr o2).length = 20 := by
+  unfold addrCopied; rw [copyIntoRegion_length]; exact hlen
+
+/-- The 48-byte output struct after a **successful** decode, with each cell tied
+    to the actual decoded field value:
+      +0  = index (v0),  +8 = validator_index (v1),
+      +16 = 20-byte address copy,  +36 = 4-byte pad (unchanged),
+      +40 = amount (v3). -/
+def outputSuccess (outBase v0 v1 v3 o2 : Word)
+    (bytes oldAddr pad4 : List (BitVec 8)) : Assertion :=
+  (outBase ↦ₘ v0) ** ((outBase + 8) ↦ₘ v1) **
+  bytesRegion (outBase + 16) (addrCopied bytes oldAddr o2) **
+  bytesRegion (outBase + 36) pad4 **
+  ((outBase + 40) ↦ₘ v3)
+
+/-- A withdrawal-decode **failure** outcome, matching the program's short-circuit
+    dispatch (field 0 → field 1 → field 2 list → address length → field 3).
+    Each arm names the *actual* failing stage via the merged callee semantics
+    (no decode-determinism assumed). -/
+inductive DecodeFailure (bytes : List (BitVec 8)) (listBase : Word)
+    (listLen : Nat) : Prop
+  | field0 (status v : Word) (hnz : status ≠ 0)
+      (h : EvmAsm.Codegen.RlpFieldToU64SAsm.Result bytes listBase listLen 0 status v) :
+      DecodeFailure bytes listBase listLen
+  | field1 (status v : Word) (hnz : status ≠ 0)
+      (h : EvmAsm.Codegen.RlpFieldToU64SAsm.Result bytes listBase listLen 1 status v) :
+      DecodeFailure bytes listBase listLen
+  | field2List
+      (h : EvmAsm.Codegen.RlpListNthItemSAsm.Failure bytes listBase listLen 2) :
+      DecodeFailure bytes listBase listLen
+  | field2Len (o2 l2 : Word)
+      (h : EvmAsm.Codegen.RlpListNthItemSAsm.Success bytes listBase listLen 2 o2 l2)
+      (hlen : l2.toNat ≠ 20) :
+      DecodeFailure bytes listBase listLen
+  | field3 (status v : Word) (hnz : status ≠ 0)
+      (h : EvmAsm.Codegen.RlpFieldToU64SAsm.Result bytes listBase listLen 3 status v) :
+      DecodeFailure bytes listBase listLen
 
 end EvmAsm.Codegen.WithdrawalDecodeSpec


### PR DESCRIPTION
## `withdrawalDecode` caller `Fn.Spec` (pkljc-unblocked; first multi-field decoder)

Proves `withdrawal_decode_spec_within` for the 60-instruction accessor decoding a withdrawal
RLP `[index, validator_index, address, amount]` into a 48-byte output struct.

**Proof-only. No `merge!` — for review.** Base main (pkljc withdrawal fix merged). The first
of the multi-field decoders — establishes the reusable decoder-compose machinery
(generic fail/cont reshapes + the per-field backbone-merge template) that accountDecode /
headerExtendedDecode will reuse.

### Genuine content ties (total post `wdWholePost`)
- **a0=0 (success)**: output struct = the genuinely-decoded fields — index/validator_index/amount
  (3 u64) each pinned to `rlp_field_to_u64`'s `Result`, and the address = `copyIntoRegion oldAddr
  bytes 0 offset.toNat 20` tied to `rlp_list_nth_item`'s `Success … 2 offset len ∧ len=20`
  (assembled into `Decoded`).
- **a0=1 (failure)**: the `DecodeFailure` raw-outcome disjunction — `field0`/`field1`/`field3`
  (K34 nonzero status), `field2List` (K20 `Failure`), `field2Len` (address len≠20) — each pinned
  to the actual callee outcome. No decode-determinism assumed.

### Structure (reusable machinery)
Generic fail reshape `wdK34FailPre`/`wdK20FailPre` + tail `wdFailArm`; generic cont reshape
`wdContReshape`; the per-field backbone-merge template `wdBBField3` (`cpsBranchWithin_merge_same_cr`
+ frame/accumulator), mirrored to `wdBBField2/1/0`; the K34↔K20 stack reconciles. Top-level =
`wdPrologue ;; wdBBField0`.

### Verification
- `lake build` green (4693 jobs); `#print axioms withdrawal_decode_spec_within` → `[propext,
  Classical.choice, Quot.sound]`. `check-axioms`: 88 witnesses, classical-only.
- Full guard set green; files ≤1500. No `sorry`/`native_decide`/`bv_decide`/`maxHeartbeats`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
