### PR TITLE
chore: remove redundant in-source #print axioms in ChainValidate blob-gas routines

### DIFF
--- a/EvmAsm/Codegen/Programs/ChainValidateBlobGasMultipleLoop.lean
+++ b/EvmAsm/Codegen/Programs/ChainValidateBlobGasMultipleLoop.lean
@@ -84,7 +84,6 @@ theorem cvbgmSetup (hbi lenBase spC iW : Word) (Li : Nat)
     (CodeReq.ofProg_mem_at D (D + 120) cvbgmProg 30 (.ADDI .x13 .x13 (EvmAsm.Rv64.laLo (D + 116) Field)) (by bv_omega) (by rw [cvbgm_length]; decide) (by decide) (by rw [cvbgm_length]; decide))
   runBlock hla18 s20' hla21 s23' s24' s25' s26' s27' s28' hla29
 
-#print axioms cvbgmSetup
 
 /-- AND rd, rs1, rs2 with all three registers distinct: `rd := rs1 &&& rs2`. -/
 theorem and_spec_within (rd rs1 rs2 : Reg) (v1 v2 vOld : Word) (base : Word)
@@ -153,7 +152,6 @@ theorem cvbgmReload (hbi iW value : Word) (old5 o18 o21 o6 o7 o30 : Word) :
     (CodeReq.ofProg_mem_at D (D + 176) cvbgmProg 44 (.AND .x30 .x6 .x7) (by bv_omega) (by rw [cvbgm_length]; decide) rfl (by rw [cvbgm_length]; decide)) s44
   runBlock hla33 s35' hla36 s38' hla39 s41' s42' s43' s44'
 
-#print axioms cvbgmReload
 
 /-! ## Advance block (instructions 46--51): step the iterator, loop back
 
@@ -196,7 +194,6 @@ theorem cvbgmAdvance (hbi lenBase iW : Word) (Li : Nat) (o28 o29 : Word) :
     (CodeReq.ofProg_mem_at D (D + 204) cvbgmProg 51 (.JAL .x0 (-136 : BitVec 21)) (by bv_omega) (by rw [cvbgm_length]; decide) rfl (by rw [cvbgm_length]; decide)) s51
   runBlock s46' s47' s48' s49' s50' s51'
 
-#print axioms cvbgmAdvance
 
 /-! ## Arithmetic helper for the value comparison. -/
 
@@ -342,7 +339,6 @@ theorem cvbgmCall (hbi lenBase spC iW : Word) (Li : Nat)
     (sepConj_mono (regIs_implies_regOwn .x28) (fun _ x => x)) h hp'
   xperm_hyp hp''
 
-#print axioms cvbgmCall
 
 /-! ## Call block with the consumed scratch registers owned
 
@@ -405,7 +401,6 @@ theorem cvbgmCallOwned (hbi lenBase spC iW : Word) (Li : Nat)
     (cvbgmCall hbi lenBase spC iW Li nN s3 s4 oldOut oldOff oldLen v14 v1 v5 v10 v11 v12 v13 v28
       bytes csaved hsalign hslack hover hvalid)
 
-#print axioms cvbgmCallOwned
 
 /-! ## Entry half of one iteration: guard → call → K34 flatPost
 
@@ -508,7 +503,6 @@ theorem cvbgmIterEntry (spC hdrBase lenBase validPtr firstBadPtr : Word)
       rw [show (BitVec.ofNat 64 i) <<< 3 = BitVec.ofNat 64 (8 * i) from shiftLeft3_ofNat i]
       xperm_hyp hp) hguardF hcallF)
 
-#print axioms cvbgmIterEntry
 
 /-! ## Normalizing K34's `flatPost` into a single Result-carrying assertion
 
@@ -591,7 +585,6 @@ theorem flatPost_normalize (spC hbi validPtr firstBadPtr nN lenBase iW oldOff ol
         (fun _ x => x)))) h hp1
     xperm_hyp hp2
 
-#print axioms flatPost_normalize
 
 /-- K34's 3-slot saved frame, once restored, weakens to the merely-owned frame
     slots the loop invariant carries. -/
@@ -1157,7 +1150,6 @@ theorem cvbgmIterDispatch
           (sepConj_mono (k34SavedFrame_implies_frameSlotsOwn _ _) (fun _ x => x)))) h hp1
         xperm_hyp hp2
 
-#print axioms cvbgmIterDispatch
 
 /-! ## One full iteration: guard → call → dispatch (`D+68 → raIn`, `i < N`)
 
@@ -1242,6 +1234,5 @@ theorem cvbgmIter (sp0 spC hdrBase lenBase validPtr firstBadPtr raIn : Word)
         firstBadPtr raIn csaved bigBytes lengths i oldOff oldLen nTail hi hN hspC rfl hraSaved
         hret halign hlen hprefix htail))
 
-#print axioms cvbgmIter
 
 end EvmAsm.Codegen.ChainValidateBlobGasMultipleSpec

--- a/EvmAsm/Codegen/Programs/ChainValidateBlobGasMultipleLoopClose.lean
+++ b/EvmAsm/Codegen/Programs/ChainValidateBlobGasMultipleLoopClose.lean
@@ -178,7 +178,6 @@ theorem cvbgmLoop (sp0 spC hdrBase lenBase validPtr firstBadPtr raIn : Word)
         (hAllValid i hi) hpre
         (fun hpre' => ih (i + 1) (by omega) (by omega) hpre')
 
-#print axioms cvbgmLoop
 
 set_option maxRecDepth 8000 in
 /-- **`chain_validate_blob_gas_used_multiple` caller contract.**  The
@@ -271,6 +270,5 @@ theorem chain_validate_blob_gas_used_multiple_spec_within
       (sepConj_mono (regIs_implies_regOwn .x14) (fun _ x => x))))))) h hp1
     xperm_hyp hp2) hpro hloop
 
-#print axioms chain_validate_blob_gas_used_multiple_spec_within
 
 end EvmAsm.Codegen.ChainValidateBlobGasMultipleSpec

--- a/EvmAsm/Codegen/Programs/ChainValidateBlobGasMultipleSpec.lean
+++ b/EvmAsm/Codegen/Programs/ChainValidateBlobGasMultipleSpec.lean
@@ -102,7 +102,6 @@ theorem cvbgm_disjoint :
     · rw [EvmAsm.Rv64.RLP.rlp_content_to_u64_prog_length]; decide
     · left; rw [cvbgm_length]; decide
 
-#print axioms cvbgm_disjoint
 
 /-- K34's linked code is subsumed by the chain accessor's full closure. -/
 theorem k34_mono :
@@ -313,7 +312,6 @@ theorem cvbgmPrologue
   have h16 := li_spec_gen_within .x21 cs5 (0 : Word) (D + 64) (by decide)
   runBlock h0 h1 h2 h3 h4 h5 h6 h7 h8 h9 h10 h11 h12 h13 h14 h15 h16
 
-#print axioms cvbgmPrologue
 
 /-! ## Epilogue (instructions 57--65): restore + return -/
 
@@ -403,7 +401,6 @@ theorem cvbgmEpilogue
   exact cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
     (fun _ hq => by xperm_hyp hq) hall
 
-#print axioms cvbgmEpilogue
 
 /-! ## All-valid exit (instruction 56 → epilogue): `a0 := 0`, then return -/
 
@@ -448,7 +445,6 @@ theorem retAllValid
   exact cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
     (fun _ hq => by xperm_hyp hq) hall
 
-#print axioms retAllValid
 
 /-! ## Violation exit (instructions 50--53 → epilogue)
 
@@ -512,7 +508,6 @@ theorem retViolation
   exact cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
     (fun _ hq => by xperm_hyp hq) hall
 
-#print axioms retViolation
 
 /-! ## Parse-fail exit (instructions 54--55 → epilogue)
 
@@ -569,6 +564,5 @@ theorem retParseFail
   exact cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
     (fun _ hq => by xperm_hyp hq) hall
 
-#print axioms retParseFail
 
 end EvmAsm.Codegen.ChainValidateBlobGasMultipleSpec

--- a/EvmAsm/Codegen/Programs/ChainValidateBlobGasUnderMaxLoop.lean
+++ b/EvmAsm/Codegen/Programs/ChainValidateBlobGasUnderMaxLoop.lean
@@ -84,7 +84,6 @@ theorem cvbgumSetup (hbi lenBase spC iW : Word) (Li : Nat)
     (CodeReq.ofProg_mem_at D (D + 120) cvbgumProg 30 (.ADDI .x13 .x13 (EvmAsm.Rv64.laLo (D + 116) Field)) (by bv_omega) (by rw [cvbgum_length]; decide) (by decide) (by rw [cvbgum_length]; decide))
   runBlock hla18 s20' hla21 s23' s24' s25' s26' s27' s28' hla29
 
-#print axioms cvbgumSetup
 
 /-! ## Reload block (instructions 33--42): restore iter state + load value
 
@@ -130,7 +129,6 @@ theorem cvbgumReload (hbi iW value : Word) (old5 o18 o21 o6 o7 : Word) :
     (CodeReq.ofProg_mem_at D (D + 168) cvbgumProg 42 (.LUI .x7 (672 : BitVec 20)) (by bv_omega) (by rw [cvbgum_length]; decide) rfl (by rw [cvbgum_length]; decide)) s42
   runBlock hla33 s35' hla36 s38' hla39 s41' s42'
 
-#print axioms cvbgumReload
 
 /-! ## Advance block (instructions 44--49): step the iterator, loop back
 
@@ -172,7 +170,6 @@ theorem cvbgumAdvance (hbi lenBase iW : Word) (Li : Nat) (o28 o29 : Word) :
     (CodeReq.ofProg_mem_at D (D + 196) cvbgumProg 49 (.JAL .x0 (-128 : BitVec 21)) (by bv_omega) (by rw [cvbgum_length]; decide) rfl (by rw [cvbgum_length]; decide)) s49
   runBlock s44' s45' s46' s47' s48' s49'
 
-#print axioms cvbgumAdvance
 
 /-! ## Arithmetic helper for the value comparison. -/
 
@@ -318,7 +315,6 @@ theorem cvbgumCall (hbi lenBase spC iW : Word) (Li : Nat)
     (sepConj_mono (regIs_implies_regOwn .x28) (fun _ x => x)) h hp'
   xperm_hyp hp''
 
-#print axioms cvbgumCall
 
 /-! ## Call block with the consumed scratch registers owned
 
@@ -381,7 +377,6 @@ theorem cvbgumCallOwned (hbi lenBase spC iW : Word) (Li : Nat)
     (cvbgumCall hbi lenBase spC iW Li nN s3 s4 oldOut oldOff oldLen v14 v1 v5 v10 v11 v12 v13 v28
       bytes csaved hsalign hslack hover hvalid)
 
-#print axioms cvbgumCallOwned
 
 /-! ## Entry half of one iteration: guard → call → K34 flatPost
 
@@ -484,7 +479,6 @@ theorem cvbgumIterEntry (spC hdrBase lenBase validPtr firstBadPtr : Word)
       rw [show (BitVec.ofNat 64 i) <<< 3 = BitVec.ofNat 64 (8 * i) from shiftLeft3_ofNat i]
       xperm_hyp hp) hguardF hcallF)
 
-#print axioms cvbgumIterEntry
 
 /-! ## Normalizing K34's `flatPost` into a single Result-carrying assertion
 
@@ -567,7 +561,6 @@ theorem flatPost_normalize (spC hbi validPtr firstBadPtr nN lenBase iW oldOff ol
         (fun _ x => x)))) h hp1
     xperm_hyp hp2
 
-#print axioms flatPost_normalize
 
 /-- K34's 3-slot saved frame, once restored, weakens to the merely-owned frame
     slots the loop invariant carries. -/
@@ -1129,7 +1122,6 @@ theorem cvbgumIterDispatch
           (sepConj_mono (k34SavedFrame_implies_frameSlotsOwn _ _) (fun _ x => x)))) h hp1
         xperm_hyp hp2
 
-#print axioms cvbgumIterDispatch
 
 /-! ## One full iteration: guard → call → dispatch (`D+68 → raIn`, `i < N`)
 
@@ -1214,6 +1206,5 @@ theorem cvbgumIter (sp0 spC hdrBase lenBase validPtr firstBadPtr raIn : Word)
         firstBadPtr raIn csaved bigBytes lengths i oldOff oldLen nTail hi hN hspC rfl hraSaved
         hret halign hlen hprefix htail))
 
-#print axioms cvbgumIter
 
 end EvmAsm.Codegen.ChainValidateBlobGasUnderMaxSpec

--- a/EvmAsm/Codegen/Programs/ChainValidateBlobGasUnderMaxLoopClose.lean
+++ b/EvmAsm/Codegen/Programs/ChainValidateBlobGasUnderMaxLoopClose.lean
@@ -178,7 +178,6 @@ theorem cvbgumLoop (sp0 spC hdrBase lenBase validPtr firstBadPtr raIn : Word)
         (hAllValid i hi) hpre
         (fun hpre' => ih (i + 1) (by omega) (by omega) hpre')
 
-#print axioms cvbgumLoop
 
 set_option maxRecDepth 8000 in
 /-- **`chain_validate_blob_gas_used_under_max` caller contract.**  The
@@ -269,6 +268,5 @@ theorem chain_validate_blob_gas_used_under_max_spec_within
       (sepConj_mono (regIs_implies_regOwn .x14) (fun _ x => x))))))) h hp1
     xperm_hyp hp2) hpro hloop
 
-#print axioms chain_validate_blob_gas_used_under_max_spec_within
 
 end EvmAsm.Codegen.ChainValidateBlobGasUnderMaxSpec

--- a/EvmAsm/Codegen/Programs/ChainValidateBlobGasUnderMaxSpec.lean
+++ b/EvmAsm/Codegen/Programs/ChainValidateBlobGasUnderMaxSpec.lean
@@ -98,7 +98,6 @@ theorem cvbgum_disjoint :
     · rw [EvmAsm.Rv64.RLP.rlp_content_to_u64_prog_length]; decide
     · left; rw [cvbgum_length]; decide
 
-#print axioms cvbgum_disjoint
 
 /-- K34's linked code is subsumed by the chain accessor's full closure. -/
 theorem k34_mono :
@@ -305,7 +304,6 @@ theorem cvbgumPrologue
   have h16 := li_spec_gen_within .x21 cs5 (0 : Word) (D + 64) (by decide)
   runBlock h0 h1 h2 h3 h4 h5 h6 h7 h8 h9 h10 h11 h12 h13 h14 h15 h16
 
-#print axioms cvbgumPrologue
 
 /-! ## Epilogue (instructions 57--65): restore + return -/
 
@@ -395,7 +393,6 @@ theorem cvbgumEpilogue
   exact cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
     (fun _ hq => by xperm_hyp hq) hall
 
-#print axioms cvbgumEpilogue
 
 /-! ## All-valid exit (instruction 56 → epilogue): `a0 := 0`, then return -/
 
@@ -440,7 +437,6 @@ theorem retAllValid
   exact cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
     (fun _ hq => by xperm_hyp hq) hall
 
-#print axioms retAllValid
 
 /-! ## Violation exit (instructions 50--53 → epilogue)
 
@@ -504,7 +500,6 @@ theorem retViolation
   exact cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
     (fun _ hq => by xperm_hyp hq) hall
 
-#print axioms retViolation
 
 /-! ## Parse-fail exit (instructions 54--55 → epilogue)
 
@@ -561,6 +556,5 @@ theorem retParseFail
   exact cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
     (fun _ hq => by xperm_hyp hq) hall
 
-#print axioms retParseFail
 
 end EvmAsm.Codegen.ChainValidateBlobGasUnderMaxSpec


### PR DESCRIPTION
Part of the deferred ChainValidate `#print axioms` cleanup lane (prover1 confirmed ChainValidate*.lean stable: all 6 chainValidate proofs merged, zero in-flight).

Removes `#print axioms` commands from 6 files (34 lines):
- ChainValidateBlobGasMultipleLoop/LoopClose/Spec
- ChainValidateBlobGasUnderMaxLoop/LoopClose/Spec

Pure deletion (col-0 anchored `sed '/^#print axioms /d'`); no proof-logic change.

Verified: `lake build` green; `scripts/check-axioms.sh` = 88 witnesses, classical axioms only.