### PR TITLE
chore: remove redundant in-source #print axioms in ChainValidate ordering routines

### DIFF
--- a/EvmAsm/Codegen/Programs/ChainValidateConsecutiveNumbersLoop.lean
+++ b/EvmAsm/Codegen/Programs/ChainValidateConsecutiveNumbersLoop.lean
@@ -69,7 +69,6 @@ theorem cvcnSpill (hbi iW prevVal old5 : Word) :
       (by bv_omega) (by rw [cvcn_length]; decide) rfl (by rw [cvcn_length]; decide)) s40
   runBlock hla32 s34' hla35 s37' hla38 s40'
 
-#print axioms cvcnSpill
 
 /-! ## Reload block (instructions 50--56): load `cur`/`prev`, compute `prev + 1`
 
@@ -111,7 +110,6 @@ theorem cvcnReload (curVal prevVal old5 o28 o29 : Word) :
       (by bv_omega) (by rw [cvcn_length]; decide) rfl (by rw [cvcn_length]; decide)) s56
   runBlock hla50 s52' hla53 s55' s56'
 
-#print axioms cvcnReload
 
 /-! ## Advance block (instructions 57--69): update `prev`, step iterator, loop
 
@@ -187,7 +185,6 @@ theorem cvcnAdvance (hbi lenBase iW curVal old5 o6 o7 o21 o30 o31 : Word) (Li : 
       (by bv_omega) (by rw [cvcn_length]; decide) rfl (by rw [cvcn_length]; decide)) s69
   runBlock hla57 s59' hla60 s62' s63' s64' s65' s66' s67' s68' s69'
 
-#print axioms cvcnAdvance
 
 /-! ## Loop-body argument setup (instructions 41--47): load call args
 
@@ -235,7 +232,6 @@ theorem cvcnArgSetup (hbi lenBase iW : Word) (Li : Nat)
     (CodeReq.ofProg_mem_at D (D + 188) cvcnProg 47 (.ADDI .x13 .x13 (EvmAsm.Rv64.laLo (D + 184) Num)) (by bv_omega) (by rw [cvcn_length]; decide) (by decide) (by rw [cvcn_length]; decide))
   runBlock s41' s42' s43' s44' s45' hla46
 
-#print axioms cvcnArgSetup
 
 /-! ## Header-0 argument setup (instructions 18--22): load call args for header 0
 
@@ -271,7 +267,6 @@ theorem cvcnHdr0Setup (hdrBase lenBase : Word) (L0 : Nat) (old10 old11 old12 old
     (CodeReq.ofProg_mem_at D (D + 88) cvcnProg 22 (.ADDI .x13 .x13 (EvmAsm.Rv64.laLo (D + 84) Num)) (by bv_omega) (by rw [cvcn_length]; decide) (by decide) (by rw [cvcn_length]; decide))
   runBlock s18' s19' s20' hla21
 
-#print axioms cvcnHdr0Setup
 
 /-- pcFree discharger covering the assertion atoms used throughout the loop. -/
 local macro "pcfx" : tactic =>
@@ -313,7 +308,6 @@ theorem cvcnSetup (hbi lenBase iW prevVal : Word) (Li : Nat)
   refine cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp) (fun _ hq => by xperm_hyp hq)
     (cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) hspillF hargsF)
 
-#print axioms cvcnSetup
 
 /-! ## K34's whole-routine step count for field index 11. -/
 abbrev nCall : Nat :=
@@ -451,7 +445,6 @@ theorem cvcnCall (spC hdrBase lenBase hbi iW validPtr firstBadPtr prevVal : Word
         (sepConj_mono (regIs_implies_regOwn .x28) (fun _ x => x)))) h hp'
   xperm_hyp hp''
 
-#print axioms cvcnCall
 
 /-! ## Call block with the consumed scratch registers owned
 
@@ -514,7 +507,6 @@ theorem cvcnCallOwned (spC hdrBase lenBase hbi iW validPtr firstBadPtr prevVal :
     (cvcnCall spC hdrBase lenBase hbi iW validPtr firstBadPtr prevVal Li nN oldOut oldOff oldLen
       v14 v1 v5 v10 v11 v12 v13 v28 bytes csaved hsalign hslack hover hvalid)
 
-#print axioms cvcnCallOwned
 
 /-! ## Normalizing K34's `flatPost` into a single Result-carrying assertion
 
@@ -597,7 +589,6 @@ theorem flatPost_normalize (spC hbi hdrBase validPtr firstBadPtr nN lenBase prev
         (fun _ x => x)))) h hp1
     xperm_hyp hp2
 
-#print axioms flatPost_normalize
 
 /-- K34's 3-slot saved frame, once restored, weakens to the merely-owned frame
     slots the loop invariant carries. -/
@@ -611,7 +602,6 @@ theorem k34SavedFrame_implies_frameSlotsOwn (newSp : Word)
     EvmAsm.Codegen.RlpFieldToU64SAsm.frame newSp
     (EvmAsm.Codegen.RlpFieldToU64SAsm.savedVals saved) h hp
 
-#print axioms k34SavedFrame_implies_frameSlotsOwn
 
 /-! ## Entry half of one loop iteration: guard → call → K34 flatPost
 
@@ -712,7 +702,6 @@ theorem cvcnIterEntry (spC hdrBase lenBase validPtr firstBadPtr prevVal : Word)
       rw [show (BitVec.ofNat 64 i) <<< 3 = BitVec.ofNat 64 (8 * i) from shiftLeft3_ofNat i]
       xperm_hyp hp) hguardF hcallF)
 
-#print axioms cvcnIterEntry
 
 /-! ## Status/order dispatch (instruction 49 onward): tie K34's `Result` to the post
 
@@ -1316,7 +1305,6 @@ theorem cvcnIterDispatch
           (sepConj_mono (k34SavedFrame_implies_frameSlotsOwn _ _) (fun _ x => x))))))) h hp1
         xperm_hyp hp2
 
-#print axioms cvcnIterDispatch
 
 /-! ## One full loop iteration: guard → call → dispatch (`D+124 → raIn`, `1 ≤ i < N`)
 
@@ -1407,6 +1395,5 @@ theorem cvcnIter (sp0 spC hdrBase lenBase validPtr firstBadPtr raIn : Word)
         firstBadPtr raIn prevVal csaved bigBytes lengths i oldOff oldLen nTail hi1 hi hN hspC rfl
         hraSaved hret halign hlen hprevOk hprefix htail))
 
-#print axioms cvcnIter
 
 end EvmAsm.Codegen.ChainValidateConsecutiveNumbersSpec

--- a/EvmAsm/Codegen/Programs/ChainValidateConsecutiveNumbersLoopClose.lean
+++ b/EvmAsm/Codegen/Programs/ChainValidateConsecutiveNumbersLoopClose.lean
@@ -147,7 +147,6 @@ theorem cvcnHdr0Call (spC hdrBase lenBase validPtr firstBadPtr x21val : Word) (L
   have hp'' := sepConj_mono (regIs_implies_regOwn .x5) (fun _ x => x) h hp'
   xperm_hyp hp''
 
-#print axioms cvcnHdr0Call
 
 /-! ## Header-0 finish (instructions 25--30): save initial prev, set base_1, i:=1
 
@@ -190,7 +189,6 @@ theorem cvcnHdr0Finish (hdrBase lenBase ts0 : Word) (L0 : Nat) (old5 o6 o7 o21 :
       (by bv_omega) (by rw [cvcn_length]; decide) rfl (by rw [cvcn_length]; decide)) s30
   runBlock hla25 s27' s28' s29' s30'
 
-#print axioms cvcnHdr0Finish
 
 /-! ## Loop induction (`D+124 → raIn`, entering iteration `i`, `1 ≤ i ≤ N`)
 
@@ -369,7 +367,6 @@ theorem cvcnLoop (sp0 spC hdrBase lenBase validPtr firstBadPtr raIn : Word)
         (hAllValid i hi)
         (fun _ => ih (i + 1) (by omega) (by omega) (by omega))
 
-#print axioms cvcnLoop
 
 /-! ## Header-0 flatPost normalization (K34 saved-ra = `LinkRA0`)
 
@@ -451,7 +448,6 @@ theorem flatPost_normalize0 (spC hbi hdrBase validPtr firstBadPtr nN lenBase pre
         (fun _ x => x)))) h hp1
     xperm_hyp hp2
 
-#print axioms flatPost_normalize0
 
 /-! ## Header-0 status dispatch (instruction 24 onward): tie header-0's `Result`
 
@@ -804,7 +800,6 @@ theorem cvcnHdr0Dispatch
           (sepConj_mono (k34SavedFrame_implies_frameSlotsOwn _ _) (fun _ x => x))))) h hp1
         xperm_hyp hp2
 
-#print axioms cvcnHdr0Dispatch
 
 /-! ## Header-0 block (instructions 18--30): call ;; status dispatch
 
@@ -861,7 +856,6 @@ theorem cvcnHdr0Block
   refine cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp) (fun _ hq => hq)
     (cpsTripleWithin_seq_perm_same_cr (fun h hp => by xperm_hyp hp) hcallF hdisp)
 
-#print axioms cvcnHdr0Block
 
 set_option maxRecDepth 8000 in
 /-- **`chain_validate_consecutive_numbers` caller contract.**  The
@@ -1117,6 +1111,5 @@ theorem chain_validate_consecutive_numbers_spec_within
   refine cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp) (fun _ hq => hq)
     (cpsTripleWithin_seq_perm_same_cr (fun h hp => by xperm_hyp hp) hproF htail)
 
-#print axioms chain_validate_consecutive_numbers_spec_within
 
 end EvmAsm.Codegen.ChainValidateConsecutiveNumbersSpec

--- a/EvmAsm/Codegen/Programs/ChainValidateConsecutiveNumbersSpec.lean
+++ b/EvmAsm/Codegen/Programs/ChainValidateConsecutiveNumbersSpec.lean
@@ -107,7 +107,6 @@ theorem cvcn_disjoint :
     · rw [EvmAsm.Rv64.RLP.rlp_content_to_u64_prog_length]; decide
     · left; rw [cvcn_length]; decide
 
-#print axioms cvcn_disjoint
 
 /-- K34's linked code is subsumed by the chain accessor's full closure. -/
 theorem k34_mono :
@@ -345,7 +344,6 @@ theorem cvcnPrologue
   have h16 := li_spec_gen_within .x5 (1 : Word) (2 : Word) (D + 64) (by decide)
   runBlock h0 h1 h2 h3 h4 h5 h6 h7 h8 h9 h10 h11 h12 h13 h14 h15 h16
 
-#print axioms cvcnPrologue
 
 /-! ## Epilogue (instructions 83--91): restore + return -/
 
@@ -435,7 +433,6 @@ theorem cvcnEpilogue
   exact cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
     (fun _ hq => by xperm_hyp hq) hall
 
-#print axioms cvcnEpilogue
 
 /-! ## All-valid exit (instruction 82 → epilogue): `a0 := 0`, then return -/
 
@@ -480,7 +477,6 @@ theorem retAllValid
   exact cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
     (fun _ hq => by xperm_hyp hq) hall
 
-#print axioms retAllValid
 
 /-! ## Violation exit (instructions 70--76 → epilogue)
 
@@ -569,7 +565,6 @@ theorem retViolation
   exact cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
     (fun _ hq => by xperm_hyp hq) hall
 
-#print axioms retViolation
 
 /-! ## Parse-fail exit (instructions 77--81 → epilogue)
 
@@ -646,6 +641,5 @@ theorem retParseFail
   exact cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
     (fun _ hq => by xperm_hyp hq) hall
 
-#print axioms retParseFail
 
 end EvmAsm.Codegen.ChainValidateConsecutiveNumbersSpec

--- a/EvmAsm/Codegen/Programs/ChainValidateIncreasingTimestampsLoop.lean
+++ b/EvmAsm/Codegen/Programs/ChainValidateIncreasingTimestampsLoop.lean
@@ -69,7 +69,6 @@ theorem cvitSpill (hbi iW prevVal old5 : Word) :
       (by bv_omega) (by rw [cvit_length]; decide) rfl (by rw [cvit_length]; decide)) s40
   runBlock hla32 s34' hla35 s37' hla38 s40'
 
-#print axioms cvitSpill
 
 /-! ## Reload block (instructions 50--55): load `cur` and `prev` for the compare
 
@@ -104,7 +103,6 @@ theorem cvitReload (curVal prevVal old5 o28 o29 : Word) :
       (by bv_omega) (by rw [cvit_length]; decide) rfl (by rw [cvit_length]; decide)) s55
   runBlock hla50 s52' hla53 s55'
 
-#print axioms cvitReload
 
 /-! ## Advance block (instructions 57--69): update `prev`, step iterator, loop
 
@@ -180,7 +178,6 @@ theorem cvitAdvance (hbi lenBase iW curVal old5 o6 o7 o21 o30 o31 : Word) (Li : 
       (by bv_omega) (by rw [cvit_length]; decide) rfl (by rw [cvit_length]; decide)) s69
   runBlock hla57 s59' hla60 s62' s63' s64' s65' s66' s67' s68' s69'
 
-#print axioms cvitAdvance
 
 /-! ## Loop-body argument setup (instructions 41--47): load call args
 
@@ -228,7 +225,6 @@ theorem cvitArgSetup (hbi lenBase iW : Word) (Li : Nat)
     (CodeReq.ofProg_mem_at D (D + 188) cvitProg 47 (.ADDI .x13 .x13 (EvmAsm.Rv64.laLo (D + 184) Ts)) (by bv_omega) (by rw [cvit_length]; decide) (by decide) (by rw [cvit_length]; decide))
   runBlock s41' s42' s43' s44' s45' hla46
 
-#print axioms cvitArgSetup
 
 /-! ## Header-0 argument setup (instructions 18--22): load call args for header 0
 
@@ -264,7 +260,6 @@ theorem cvitHdr0Setup (hdrBase lenBase : Word) (L0 : Nat) (old10 old11 old12 old
     (CodeReq.ofProg_mem_at D (D + 88) cvitProg 22 (.ADDI .x13 .x13 (EvmAsm.Rv64.laLo (D + 84) Ts)) (by bv_omega) (by rw [cvit_length]; decide) (by decide) (by rw [cvit_length]; decide))
   runBlock s18' s19' s20' hla21
 
-#print axioms cvitHdr0Setup
 
 /-- pcFree discharger covering the assertion atoms used throughout the loop. -/
 local macro "pcfx" : tactic =>
@@ -306,7 +301,6 @@ theorem cvitSetup (hbi lenBase iW prevVal : Word) (Li : Nat)
   refine cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp) (fun _ hq => by xperm_hyp hq)
     (cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) hspillF hargsF)
 
-#print axioms cvitSetup
 
 /-! ## K34's whole-routine step count for field index 11. -/
 abbrev nCall : Nat :=
@@ -444,7 +438,6 @@ theorem cvitCall (spC hdrBase lenBase hbi iW validPtr firstBadPtr prevVal : Word
         (sepConj_mono (regIs_implies_regOwn .x28) (fun _ x => x)))) h hp'
   xperm_hyp hp''
 
-#print axioms cvitCall
 
 /-! ## Call block with the consumed scratch registers owned
 
@@ -507,7 +500,6 @@ theorem cvitCallOwned (spC hdrBase lenBase hbi iW validPtr firstBadPtr prevVal :
     (cvitCall spC hdrBase lenBase hbi iW validPtr firstBadPtr prevVal Li nN oldOut oldOff oldLen
       v14 v1 v5 v10 v11 v12 v13 v28 bytes csaved hsalign hslack hover hvalid)
 
-#print axioms cvitCallOwned
 
 /-! ## Normalizing K34's `flatPost` into a single Result-carrying assertion
 
@@ -590,7 +582,6 @@ theorem flatPost_normalize (spC hbi hdrBase validPtr firstBadPtr nN lenBase prev
         (fun _ x => x)))) h hp1
     xperm_hyp hp2
 
-#print axioms flatPost_normalize
 
 /-- K34's 3-slot saved frame, once restored, weakens to the merely-owned frame
     slots the loop invariant carries. -/
@@ -604,7 +595,6 @@ theorem k34SavedFrame_implies_frameSlotsOwn (newSp : Word)
     EvmAsm.Codegen.RlpFieldToU64SAsm.frame newSp
     (EvmAsm.Codegen.RlpFieldToU64SAsm.savedVals saved) h hp
 
-#print axioms k34SavedFrame_implies_frameSlotsOwn
 
 /-! ## Entry half of one loop iteration: guard → call → K34 flatPost
 
@@ -705,7 +695,6 @@ theorem cvitIterEntry (spC hdrBase lenBase validPtr firstBadPtr prevVal : Word)
       rw [show (BitVec.ofNat 64 i) <<< 3 = BitVec.ofNat 64 (8 * i) from shiftLeft3_ofNat i]
       xperm_hyp hp) hguardF hcallF)
 
-#print axioms cvitIterEntry
 
 /-! ## Status/order dispatch (instruction 49 onward): tie K34's `Result` to the post
 
@@ -1303,7 +1292,6 @@ theorem cvitIterDispatch
           (sepConj_mono (k34SavedFrame_implies_frameSlotsOwn _ _) (fun _ x => x))))))) h hp1
         xperm_hyp hp2
 
-#print axioms cvitIterDispatch
 
 /-! ## One full loop iteration: guard → call → dispatch (`D+124 → raIn`, `1 ≤ i < N`)
 
@@ -1394,6 +1382,5 @@ theorem cvitIter (sp0 spC hdrBase lenBase validPtr firstBadPtr raIn : Word)
         firstBadPtr raIn prevVal csaved bigBytes lengths i oldOff oldLen nTail hi1 hi hN hspC rfl
         hraSaved hret halign hlen hprevOk hprefix htail))
 
-#print axioms cvitIter
 
 end EvmAsm.Codegen.ChainValidateIncreasingTimestampsSpec

--- a/EvmAsm/Codegen/Programs/ChainValidateIncreasingTimestampsLoopClose.lean
+++ b/EvmAsm/Codegen/Programs/ChainValidateIncreasingTimestampsLoopClose.lean
@@ -147,7 +147,6 @@ theorem cvitHdr0Call (spC hdrBase lenBase validPtr firstBadPtr x21val : Word) (L
   have hp'' := sepConj_mono (regIs_implies_regOwn .x5) (fun _ x => x) h hp'
   xperm_hyp hp''
 
-#print axioms cvitHdr0Call
 
 /-! ## Header-0 finish (instructions 25--30): save initial prev, set base_1, i:=1
 
@@ -190,7 +189,6 @@ theorem cvitHdr0Finish (hdrBase lenBase ts0 : Word) (L0 : Nat) (old5 o6 o7 o21 :
       (by bv_omega) (by rw [cvit_length]; decide) rfl (by rw [cvit_length]; decide)) s30
   runBlock hla25 s27' s28' s29' s30'
 
-#print axioms cvitHdr0Finish
 
 /-! ## Loop induction (`D+124 → raIn`, entering iteration `i`, `1 ≤ i ≤ N`)
 
@@ -369,7 +367,6 @@ theorem cvitLoop (sp0 spC hdrBase lenBase validPtr firstBadPtr raIn : Word)
         (hAllValid i hi)
         (fun _ => ih (i + 1) (by omega) (by omega) (by omega))
 
-#print axioms cvitLoop
 
 /-! ## Header-0 flatPost normalization (K34 saved-ra = `LinkRA0`)
 
@@ -451,7 +448,6 @@ theorem flatPost_normalize0 (spC hbi hdrBase validPtr firstBadPtr nN lenBase pre
         (fun _ x => x)))) h hp1
     xperm_hyp hp2
 
-#print axioms flatPost_normalize0
 
 /-! ## Header-0 status dispatch (instruction 24 onward): tie header-0's `Result`
 
@@ -804,7 +800,6 @@ theorem cvitHdr0Dispatch
           (sepConj_mono (k34SavedFrame_implies_frameSlotsOwn _ _) (fun _ x => x))))) h hp1
         xperm_hyp hp2
 
-#print axioms cvitHdr0Dispatch
 
 /-! ## Header-0 block (instructions 18--30): call ;; status dispatch
 
@@ -861,7 +856,6 @@ theorem cvitHdr0Block
   refine cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp) (fun _ hq => hq)
     (cpsTripleWithin_seq_perm_same_cr (fun h hp => by xperm_hyp hp) hcallF hdisp)
 
-#print axioms cvitHdr0Block
 
 set_option maxRecDepth 8000 in
 /-- **`chain_validate_increasing_timestamps` caller contract.**  The
@@ -1113,6 +1107,5 @@ theorem chain_validate_increasing_timestamps_spec_within
   refine cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp) (fun _ hq => hq)
     (cpsTripleWithin_seq_perm_same_cr (fun h hp => by xperm_hyp hp) hproF htail)
 
-#print axioms chain_validate_increasing_timestamps_spec_within
 
 end EvmAsm.Codegen.ChainValidateIncreasingTimestampsSpec

--- a/EvmAsm/Codegen/Programs/ChainValidateIncreasingTimestampsSpec.lean
+++ b/EvmAsm/Codegen/Programs/ChainValidateIncreasingTimestampsSpec.lean
@@ -107,7 +107,6 @@ theorem cvit_disjoint :
     · rw [EvmAsm.Rv64.RLP.rlp_content_to_u64_prog_length]; decide
     · left; rw [cvit_length]; decide
 
-#print axioms cvit_disjoint
 
 /-- K34's linked code is subsumed by the chain accessor's full closure. -/
 theorem k34_mono :
@@ -341,7 +340,6 @@ theorem cvitPrologue
   have h16 := li_spec_gen_within .x5 (1 : Word) (2 : Word) (D + 64) (by decide)
   runBlock h0 h1 h2 h3 h4 h5 h6 h7 h8 h9 h10 h11 h12 h13 h14 h15 h16
 
-#print axioms cvitPrologue
 
 /-! ## Epilogue (instructions 83--91): restore + return -/
 
@@ -431,7 +429,6 @@ theorem cvitEpilogue
   exact cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
     (fun _ hq => by xperm_hyp hq) hall
 
-#print axioms cvitEpilogue
 
 /-! ## All-valid exit (instruction 82 → epilogue): `a0 := 0`, then return -/
 
@@ -476,7 +473,6 @@ theorem retAllValid
   exact cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
     (fun _ hq => by xperm_hyp hq) hall
 
-#print axioms retAllValid
 
 /-! ## Violation exit (instructions 70--76 → epilogue)
 
@@ -565,7 +561,6 @@ theorem retViolation
   exact cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
     (fun _ hq => by xperm_hyp hq) hall
 
-#print axioms retViolation
 
 /-! ## Parse-fail exit (instructions 77--81 → epilogue)
 
@@ -642,6 +637,5 @@ theorem retParseFail
   exact cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
     (fun _ hq => by xperm_hyp hq) hall
 
-#print axioms retParseFail
 
 end EvmAsm.Codegen.ChainValidateIncreasingTimestampsSpec


### PR DESCRIPTION
Part of the deferred ChainValidate `#print axioms` cleanup lane (prover1 confirmed ChainValidate*.lean stable: all 6 chainValidate proofs merged, zero in-flight).

Removes `#print axioms` commands from 6 files (52 lines):
- ChainValidateConsecutiveNumbersLoop/LoopClose/Spec
- ChainValidateIncreasingTimestampsLoop/LoopClose/Spec

Pure deletion (col-0 anchored); no proof-logic change.

Verified: `lake build` green; `scripts/check-axioms.sh` = 88 witnesses, classical axioms only.