### PR TITLE
chore: remove redundant in-source #print axioms in ChainValidate limit routines

### DIFF
--- a/EvmAsm/Codegen/Programs/ChainValidateExtraDataLengthLoop.lean
+++ b/EvmAsm/Codegen/Programs/ChainValidateExtraDataLengthLoop.lean
@@ -125,7 +125,6 @@ theorem cvedlSetup (hbi lenBase spC iW : Word) (Li : Nat)
     (CodeReq.ofProg_mem_at C (C + 128) cvedlProg 32 (.ADDI .x14 .x14 (EvmAsm.Rv64.laLo (C + 124) CLen)) (by bv_omega) (by rw [cvedl_length]; decide) (by decide) (by rw [cvedl_length]; decide))
   runBlock hla18 s20' hla21 s23' s24' s25' s26' s27' s28' hla29 hla31
 
-#print axioms cvedlSetup
 
 /-- K20's whole-routine step count for field index 12 (same as the template). -/
 abbrev nCall : Nat := (12 + ((85 + 93 * (12 + 2)) + 6)) + 9
@@ -246,7 +245,6 @@ theorem cvedlCall (hbi lenBase spC iW : Word) (Li : Nat)
     (sepConj_mono (regIs_implies_regOwn .x28) (fun _ x => x)) h hp'
   xperm_hyp hp''
 
-#print axioms cvedlCall
 
 /-! ## Reload block (instructions 35--44): restore iter state + load length
 
@@ -297,7 +295,6 @@ theorem cvedlReload (hbi iW len : Word) (old5 o18 o21 o6 o7 : Word) :
     (CodeReq.ofProg_mem_at C (C + 176) cvedlProg 44 (.LI .x7 (32 : Word)) (by bv_omega) (by rw [cvedl_length]; decide) rfl (by rw [cvedl_length]; decide)) s44
   runBlock hla35 s37' hla38 s40' hla41 s43' s44'
 
-#print axioms cvedlReload
 
 /-! ## Advance block (instructions 46--51): step the iterator, loop back
 
@@ -345,7 +342,6 @@ theorem cvedlAdvance (hbi lenBase iW : Word) (Li : Nat) (o28 o29 : Word) :
     (CodeReq.ofProg_mem_at C (C + 204) cvedlProg 51 (.JAL .x0 (-136 : BitVec 21)) (by bv_omega) (by rw [cvedl_length]; decide) rfl (by rw [cvedl_length]; decide)) s51
   runBlock s46' s47' s48' s49' s50' s51'
 
-#print axioms cvedlAdvance
 
 /-! ## Arithmetic helpers for the loop induction -/
 
@@ -434,7 +430,6 @@ theorem cvedlCallOwned (hbi lenBase spC iW : Word) (Li : Nat)
     (cvedlCall hbi lenBase spC iW Li s0 s3 s4 oldOff oldLen v1 v5 v10 v11 v12 v13 v14 v28
       bytes csaved hsalign hslack hover hvalid)
 
-#print axioms cvedlCallOwned
 
 /-! ## Entry half of one iteration: guard → call → K20 returnResult
 
@@ -529,7 +524,6 @@ theorem cvedlIterEntry (spC hdrBase lenBase validPtr firstBadPtr : Word)
       rw [show (BitVec.ofNat 64 i) <<< 3 = BitVec.ofNat 64 (8 * i) from shiftLeft3_ofNat i]
       xperm_hyp hp) hguardF hcallF)
 
-#print axioms cvedlIterEntry
 
 /-- pcFree discharger covering the assertion atoms used in the dispatch. -/
 local macro "pcfx" : tactic =>
@@ -1095,7 +1089,6 @@ theorem cvedlIterDispatch
           (cpsTripleWithin_mono_nSteps (show 1 + (24 + nTail) ≤ 25 + nTail by omega)
             (cpsTripleWithin_seq_perm_same_cr (fun _ hp => hp) hntakenF hcont))
 
-#print axioms cvedlIterDispatch
 
 /-! ## One full iteration: guard → call → dispatch (`C+68 → raIn`, `i < N`)
 
@@ -1173,6 +1166,5 @@ theorem cvedlIter (sp0 spC hdrBase lenBase validPtr firstBadPtr raIn : Word)
         firstBadPtr raIn csaved bigBytes lengths i oldOff oldLen nTail hi hN hspC rfl hraSaved
         hret halign hlen hprefix htail))
 
-#print axioms cvedlIter
 
 end EvmAsm.Codegen.ChainValidateExtraDataLengthSpec

--- a/EvmAsm/Codegen/Programs/ChainValidateExtraDataLengthLoopClose.lean
+++ b/EvmAsm/Codegen/Programs/ChainValidateExtraDataLengthLoopClose.lean
@@ -162,7 +162,6 @@ theorem cvedlLoop (sp0 spC hdrBase lenBase validPtr firstBadPtr raIn : Word)
         (hAllValid i hi) hpre
         (fun hpre' => ih (i + 1) (by omega) (by omega) hpre')
 
-#print axioms cvedlLoop
 
 set_option maxRecDepth 8000 in
 /-- **`chain_validate_extra_data_length` caller contract.**  The 69-instruction
@@ -248,6 +247,5 @@ theorem chain_validate_extra_data_length_spec_within
       (sepConj_mono (regIs_implies_regOwn .x14) (fun _ x => x))))))) h hp1
     xperm_hyp hp2) hpro hloop
 
-#print axioms chain_validate_extra_data_length_spec_within
 
 end EvmAsm.Codegen.ChainValidateExtraDataLengthSpec

--- a/EvmAsm/Codegen/Programs/ChainValidateExtraDataLengthSpec.lean
+++ b/EvmAsm/Codegen/Programs/ChainValidateExtraDataLengthSpec.lean
@@ -74,7 +74,6 @@ theorem cvedl_disjoint :
   · right
     rw [EvmAsm.Codegen.RlpListNthItemSAsm.total_length]; decide
 
-#print axioms cvedl_disjoint
 
 /-- K20's linked code is subsumed by the chain accessor's full closure. -/
 theorem k20_mono :
@@ -348,7 +347,6 @@ theorem cvedlPrologue
   have h16 := li_spec_gen_within .x21 cs5 (0 : Word) (C + 64) (by decide)
   runBlock h0 h1 h2 h3 h4 h5 h6 h7 h8 h9 h10 h11 h12 h13 h14 h15 h16
 
-#print axioms cvedlPrologue
 
 /-! ## Epilogue (instructions 60--68): restore + return
 
@@ -442,7 +440,6 @@ theorem cvedlEpilogue
   exact cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
     (fun _ hq => by xperm_hyp hq) hall
 
-#print axioms cvedlEpilogue
 
 /-! ## All-valid exit (instruction 59 → epilogue): `a0 := 0`, then return -/
 
@@ -491,7 +488,6 @@ theorem retAllValid
   exact cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
     (fun _ hq => by xperm_hyp hq) hall
 
-#print axioms retAllValid
 
 /-! ## Violation exit (instructions 52--55 → epilogue)
 
@@ -561,7 +557,6 @@ theorem retViolation
   exact cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
     (fun _ hq => by xperm_hyp hq) hall
 
-#print axioms retViolation
 
 /-! ## Parse-fail exit (instructions 56--58 → epilogue)
 
@@ -623,6 +618,5 @@ theorem retParseFail
   exact cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
     (fun _ hq => by xperm_hyp hq) hall
 
-#print axioms retParseFail
 
 end EvmAsm.Codegen.ChainValidateExtraDataLengthSpec

--- a/EvmAsm/Codegen/Programs/ChainValidateGasUsedUnderLimitLoop.lean
+++ b/EvmAsm/Codegen/Programs/ChainValidateGasUsedUnderLimitLoop.lean
@@ -93,7 +93,6 @@ theorem cvgulSetup1 (hbi lenBase spC iW : Word) (Li : Nat)
     (CodeReq.ofProg_mem_at D (D + 120) cvgulProg 30 (.ADDI .x13 .x13 (EvmAsm.Rv64.laLo (D + 116) GasUsed)) (by bv_omega) (by rw [cvgul_length]; decide) (by decide) (by rw [cvgul_length]; decide))
   runBlock hla18 s20' hla21 s23' s24' s25' s26' s27' s28' hla29
 
-#print axioms cvgulSetup1
 
 /-! ## Reload + setup block for call 2 (instructions 33--45)
 
@@ -152,7 +151,6 @@ theorem cvgulReloadSetup2 (hbi lenBase iW : Word) (Li : Nat)
     (CodeReq.ofProg_mem_at D (D + 180) cvgulProg 45 (.ADDI .x13 .x13 (EvmAsm.Rv64.laLo (D + 176) GasLimit)) (by bv_omega) (by rw [cvgul_length]; decide) (by decide) (by rw [cvgul_length]; decide))
   runBlock hla33 s35' hla36 s38' s39' s40' s41' s42' s43' hla44
 
-#print axioms cvgulReloadSetup2
 
 /-! ## Compare block (instructions 48--59): reload iterator + both values
 
@@ -200,7 +198,6 @@ theorem cvgulCompare (hbi iW gu gl : Word) (old5 o18 o21 o6 o7 : Word) :
     (CodeReq.ofProg_mem_at D (D + 236) cvgulProg 59 (.LD .x7 .x5 (0 : BitVec 12)) (by bv_omega) (by rw [cvgul_length]; decide) rfl (by rw [cvgul_length]; decide)) s59
   runBlock hla48 s50' hla51 s53' hla54 s56' hla57 s59'
 
-#print axioms cvgulCompare
 
 /-! ## Advance block (instructions 61--66): step the iterator, loop back
 
@@ -242,7 +239,6 @@ theorem cvgulAdvance (hbi lenBase iW : Word) (Li : Nat) (o28 o29 : Word) :
     (CodeReq.ofProg_mem_at D (D + 264) cvgulProg 66 (.JAL .x0 (-196 : BitVec 21)) (by bv_omega) (by rw [cvgul_length]; decide) rfl (by rw [cvgul_length]; decide)) s66
   runBlock s61' s62' s63' s64' s65' s66'
 
-#print axioms cvgulAdvance
 
 /-! ## Call block 1 (instructions 18--31 + K34): setup1 ;; jal ;; rlp_field_to_u64
 
@@ -372,7 +368,6 @@ theorem cvgulCall1 (hbi lenBase spC iW : Word) (Li : Nat)
     (sepConj_mono (regIs_implies_regOwn .x28) (fun _ x => x)) h hp'
   xperm_hyp hp''
 
-#print axioms cvgulCall1
 
 /-! ## Call block 1 with the consumed scratch registers owned -/
 
@@ -432,7 +427,6 @@ theorem cvgulCall1Owned (hbi lenBase spC iW : Word) (Li : Nat)
     (cvgulCall1 hbi lenBase spC iW Li nN s3 s4 oldOut oldOff oldLen v14 v1 v5 v10 v11 v12 v13 v28
       bytes csaved hsalign hslack hover hvalid)
 
-#print axioms cvgulCall1Owned
 
 /-! ## Call block 2 (instructions 33--46 + K34): reloadSetup2 ;; jal ;; rlp_field_to_u64
 
@@ -564,7 +558,6 @@ theorem cvgulCall2 (hbi lenBase spC iW : Word) (Li : Nat)
     (sepConj_mono (regIs_implies_regOwn .x28) (fun _ x => x)) h hp'
   xperm_hyp hp''
 
-#print axioms cvgulCall2
 
 /-! ## Normalizing K34's `flatPost` into a single Result-carrying assertion
 
@@ -644,7 +637,6 @@ theorem flatPost_normalize (spC hbi validPtr firstBadPtr nN lenBase iW linkRA ce
         (fun _ x => x)))) h hp1
     xperm_hyp hp2
 
-#print axioms flatPost_normalize
 
 /-- K34's 3-slot saved frame, once restored, weakens to the merely-owned frame
     slots the loop invariant carries. -/
@@ -768,6 +760,5 @@ theorem cvgulIterEntry (spC hdrBase lenBase validPtr firstBadPtr : Word)
       rw [show (BitVec.ofNat 64 i) <<< 3 = BitVec.ofNat 64 (8 * i) from shiftLeft3_ofNat i]
       xperm_hyp hp) hguardF hcallF)
 
-#print axioms cvgulIterEntry
 
 end EvmAsm.Codegen.ChainValidateGasUsedUnderLimitSpec

--- a/EvmAsm/Codegen/Programs/ChainValidateGasUsedUnderLimitLoopClose.lean
+++ b/EvmAsm/Codegen/Programs/ChainValidateGasUsedUnderLimitLoopClose.lean
@@ -582,7 +582,6 @@ theorem cvgulDispatch2
           (sepConj_mono (k34SavedFrame_implies_frameSlotsOwn _ _) (fun _ x => x))))) h hp1
         xperm_hyp hp2
 
-#print axioms cvgulDispatch2
 
 /-! ## Call block 2 with the consumed scratch registers owned
 
@@ -692,7 +691,6 @@ theorem cvgulCall2Owned (hbi lenBase spC iW : Word) (Li : Nat)
     (cvgulCall2 hbi lenBase spC iW Li nN s3 s4 oldOut oldOff oldLen v14 v1 v5 v10 v11 v12 v13
       v18 v21 v28 bytes csaved hsalign hslack hover hvalid)
 
-#print axioms cvgulCall2Owned
 
 /-! ## Dispatch from the first call (`D+128` onward): gas-used status + call 2
 
@@ -1029,7 +1027,6 @@ theorem cvgulDispatch1
           (sepConj_mono (k34SavedFrame_implies_frameSlotsOwn _ _) (fun _ x => x))))) h hp1
         xperm_hyp hp2
 
-#print axioms cvgulDispatch1
 
 /-! ## One full iteration: guard → call 1 → dispatch 1 (`D+68 → raIn`, `i < N`)
 
@@ -1126,7 +1123,6 @@ theorem cvgulIter (sp0 spC hdrBase lenBase validPtr firstBadPtr raIn : Word)
         oldOff oldLen oldLimit nTail hi hspC hraSaved hret halign hlen hsalign hslack hover
         hvalid hprefix htail))
 
-#print axioms cvgulIter
 
 /-- Step budget for the loop with `r = N − i` iterations remaining: each full
     iteration is `cvgulIter`'s cost (two K34 calls); the exhausted guard +
@@ -1273,7 +1269,6 @@ theorem cvgulLoop (sp0 spC hdrBase lenBase validPtr firstBadPtr raIn : Word)
         (hAllValid i hi) hpre
         (fun hpre' => ih (i + 1) (by omega) (by omega) hpre')
 
-#print axioms cvgulLoop
 
 set_option maxRecDepth 8000 in
 /-- **`chain_validate_gas_used_under_limit` caller contract.**  The 83-instruction
@@ -1367,6 +1362,5 @@ theorem chain_validate_gas_used_under_limit_spec_within
       (sepConj_mono (regIs_implies_regOwn .x14) (fun _ x => x))))))) h hp1
     xperm_hyp hp2) hpro hloop
 
-#print axioms chain_validate_gas_used_under_limit_spec_within
 
 end EvmAsm.Codegen.ChainValidateGasUsedUnderLimitSpec

--- a/EvmAsm/Codegen/Programs/ChainValidateGasUsedUnderLimitSpec.lean
+++ b/EvmAsm/Codegen/Programs/ChainValidateGasUsedUnderLimitSpec.lean
@@ -99,7 +99,6 @@ theorem cvgul_disjoint :
     · rw [EvmAsm.Rv64.RLP.rlp_content_to_u64_prog_length]; decide
     · left; rw [cvgul_length]; decide
 
-#print axioms cvgul_disjoint
 
 /-- K34's linked code is subsumed by the chain accessor's full closure. -/
 theorem k34_mono :
@@ -319,7 +318,6 @@ theorem cvgulPrologue
   have h16 := li_spec_gen_within .x21 cs5 (0 : Word) (D + 64) (by decide)
   runBlock h0 h1 h2 h3 h4 h5 h6 h7 h8 h9 h10 h11 h12 h13 h14 h15 h16
 
-#print axioms cvgulPrologue
 
 /-! ## Epilogue (instructions 74--82): restore + return -/
 
@@ -409,7 +407,6 @@ theorem cvgulEpilogue
   exact cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
     (fun _ hq => by xperm_hyp hq) hall
 
-#print axioms cvgulEpilogue
 
 /-! ## All-valid exit (instruction 73 → epilogue): `a0 := 0`, then return -/
 
@@ -454,7 +451,6 @@ theorem retAllValid
   exact cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
     (fun _ hq => by xperm_hyp hq) hall
 
-#print axioms retAllValid
 
 /-! ## Violation exit (instructions 67--70 → epilogue)
 
@@ -518,7 +514,6 @@ theorem retViolation
   exact cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
     (fun _ hq => by xperm_hyp hq) hall
 
-#print axioms retViolation
 
 /-! ## Parse-fail exit (instructions 71--72 → epilogue)
 
@@ -575,6 +570,5 @@ theorem retParseFail
   exact cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
     (fun _ hq => by xperm_hyp hq) hall
 
-#print axioms retParseFail
 
 end EvmAsm.Codegen.ChainValidateGasUsedUnderLimitSpec


### PR DESCRIPTION
Part of the deferred ChainValidate `#print axioms` cleanup lane (prover1 confirmed ChainValidate*.lean stable: all 6 chainValidate proofs merged, zero in-flight).

Removes `#print axioms` commands from 6 files (37 lines):
- ChainValidateExtraDataLengthLoop/LoopClose/Spec
- ChainValidateGasUsedUnderLimitLoop/LoopClose/Spec

Pure deletion (col-0 anchored); no proof-logic change.

Verified: `lake build` green; `scripts/check-axioms.sh` = 88 witnesses, classical axioms only.