### PR TITLE
chore: reduce GuestImage maxRecDepth to 8000

### DIFF
--- a/EvmAsm/Codegen/Proofs/GuestImage.lean
+++ b/EvmAsm/Codegen/Proofs/GuestImage.lean
@@ -49,7 +49,7 @@ def guestImageCodeReq : CodeReq := CodeReq.ofEntries guestImageEntries
 /-- End of the guest `.text` (by name, so layout regens flow through). -/
 def guestTextEnd : Nat := RegionMap.textRegion.base + RegionMap.textSizeBytes
 
-set_option maxRecDepth 100000 in
+set_option maxRecDepth 8000 in
 /-- The ONE kernel-checked disjointness fact for the whole image: the
     entries' byte extents are ascending and non-overlapping inside
     `.text = [0x80000000, guestTextEnd)`. -/


### PR DESCRIPTION
Follow-up to #10400, deferred until #10398 landed (bot regenerating GuestImage.lean) to avoid a merge collision — now done on clean main (ccf0648).

`GuestImage.lean`'s `set_option maxRecDepth` line is hand-maintained (not emitted by `scripts/guest_image_coverage.py`), so the reduction sticks. Reduces `100000` → `8000`, the policy ceiling from #10399. The entry list is only hundreds deep, well under 8000.

- **Build:** green (1252 jobs).
- **check-axioms:** 88 witnesses, only classical axioms.

Closes the last item from the maxRecDepth-reduction lane. After this, zero `maxRecDepth` raises above 8000 remain in `EvmAsm/`.