### PR TITLE
refactor(codegen): split layout-free logs bloom arithmetic

### DIFF
--- a/EvmAsm/Codegen/Programs/HeaderExtractLogsBloomSpec.lean
+++ b/EvmAsm/Codegen/Programs/HeaderExtractLogsBloomSpec.lean
@@ -21,6 +21,7 @@
 import EvmAsm.Codegen.Programs.Bloom
 import EvmAsm.Codegen.Programs.RlpListNthItemCallSAsm
 import EvmAsm.Codegen.Programs.HeaderFieldsGenericInit
+import EvmAsm.Codegen.Programs.LogsBloomCopyArithmetic
 import EvmAsm.Rv64.SAsm.GlobalData
 import EvmAsm.Rv64.SAsm.AbiFrameCall
 import EvmAsm.Rv64.MemRegion
@@ -33,6 +34,7 @@ namespace EvmAsm.Codegen.HeaderExtractLogsBloomSpec
 open EvmAsm.Rv64 EvmAsm.Rv64.SAsm
 open EvmAsm.Rv64.Tactics
 open EvmAsm.Codegen.RlpListNthItemSAsm
+open EvmAsm.Codegen.LogsBloomCopyArithmetic
 open EvmAsm.Evm64.Terminating (copyIntoRegion copyIntoRegion_length)
 
 /-- Guest entry of `header_extract_logs_bloom`. -/
@@ -449,23 +451,6 @@ theorem helbEpilogue (newSp a0v v1 v8 v9 v18 : Word) (fsaved : HeaderFieldsSpec.
 
 /-! ## Copy-loop helpers -/
 
-private theorem helb_succ_dec (n : Nat) :
-    BitVec.ofNat 64 (n + 1) + signExtend12 (-1 : BitVec 12) = BitVec.ofNat 64 n := by
-  apply BitVec.eq_of_toNat_eq
-  have hs : (signExtend12 (-1 : BitVec 12) : Word).toNat = 18446744073709551615 := by decide
-  rw [BitVec.toNat_add, hs, BitVec.toNat_ofNat, BitVec.toNat_ofNat]
-  omega
-
-private theorem helb_succ_ne_zero (n : Nat) (h : n + 1 < 18446744073709551616) :
-    BitVec.ofNat 64 (n + 1) ≠ (0 : Word) := by
-  have ht : (BitVec.ofNat 64 (n + 1) : Word).toNat = n + 1 := by
-    rw [BitVec.toNat_ofNat]; omega
-  intro hc; rw [hc] at ht; simp at ht
-
-private theorem helb_advance (b : Word) (m : Nat) :
-    (b + BitVec.ofNat 64 m) + signExtend12 (1 : BitVec 12) = b + BitVec.ofNat 64 (m + 1) := by
-  rw [show signExtend12 (1 : BitVec 12) = (1 : Word) from by decide]; bv_omega
-
 set_option maxRecDepth 8000 in
 /-- One copy-loop body ([29]-[33], `helbBase+116 → helbBase+136`): copy one byte
     from `srcBase[srcOff+i]` to `dstBase[dstOff+i]` and decrement the counter. -/
@@ -538,7 +523,7 @@ private theorem helbCopyBody5 (srcBase dstBase x31old : Word)
   -- [31] addi x28, x28, 1
   have h3 := addi_spec_gen_same_within .x28
     (srcBase + BitVec.ofNat 64 (srcOff + i)) (1 : BitVec 12) (helbBase + 124) (by decide)
-  rw [helb_advance srcBase (srcOff + i),
+  rw [advance srcBase (srcOff + i),
       show srcOff + i + 1 = srcOff + (i + 1) from by omega,
       show (helbBase + 124 : Word) + 4 = helbBase + 128 from by bv_omega] at h3
   have h3e := cpsTripleWithin_extend_code
@@ -554,7 +539,7 @@ private theorem helbCopyBody5 (srcBase dstBase x31old : Word)
   -- [32] addi x29, x29, 1
   have h4 := addi_spec_gen_same_within .x29
     (dstBase + BitVec.ofNat 64 (dstOff + i)) (1 : BitVec 12) (helbBase + 128) (by decide)
-  rw [helb_advance dstBase (dstOff + i),
+  rw [advance dstBase (dstOff + i),
       show dstOff + i + 1 = dstOff + (i + 1) from by omega,
       show (helbBase + 128 : Word) + 4 = helbBase + 132 from by bv_omega] at h4
   have h4e := cpsTripleWithin_extend_code
@@ -570,7 +555,7 @@ private theorem helbCopyBody5 (srcBase dstBase x31old : Word)
   -- [33] addi x30, x30, -1
   have h5 := addi_spec_gen_same_within .x30 (BitVec.ofNat 64 (m + 1)) (-1 : BitVec 12)
     (helbBase + 132) (by decide)
-  rw [helb_succ_dec m, show (helbBase + 132 : Word) + 4 = helbBase + 136 from by bv_omega] at h5
+  rw [succ_dec m, show (helbBase + 132 : Word) + 4 = helbBase + 136 from by bv_omega] at h5
   have h5e := cpsTripleWithin_extend_code
     (helbMem Codegen.headerExtractLogsBloom_prog rfl (helbBase + 132) 33
       (.ADDI .x30 .x30 (-1 : BitVec 12)) (by rw [program_length]; norm_num) (by bv_omega) rfl) h5
@@ -662,7 +647,7 @@ private theorem helbCopyLoop (srcBase dstBase x31old : Word)
     have hbeqe := cpsBranchWithin_extend_code hbeqMem hbeq
     have hnt := cpsBranchWithin_ntakenStripPure2 hbeqe (fun hp hQt => by
       obtain ⟨_, _, _, _, _, hQ⟩ := hQt
-      exact helb_succ_ne_zero k (by omega) ((sepConj_pure_right _).1 hQ).2)
+      exact succ_ne_zero k (by omega) ((sepConj_pure_right _).1 hQ).2)
     have hntf := cpsTripleWithin_frameR
       (((.x28 : Reg) ↦ᵣ (srcBase + BitVec.ofNat 64 (srcOff + i))) **
        ((.x29 : Reg) ↦ᵣ (dstBase + BitVec.ofNat 64 (dstOff + i))) **
@@ -735,10 +720,6 @@ theorem helbLaOff88 (v : Word) :
     (by decide) (by decide) hau had
   rw [show (helbBase + 88 : Word) + 8 = helbBase + 96 from by bv_omega] at h
   exact h
-
-private theorem helb_ofNat_toNat (fo : Word) : (BitVec.ofNat 64 fo.toNat : Word) = fo := by
-  apply BitVec.eq_of_toNat_eq
-  rw [BitVec.toNat_ofNat]; exact Nat.mod_eq_of_lt fo.isLt
 
 /-! ## Terminal tails: set `a0`, jump to the epilogue, return -/
 
@@ -1003,7 +984,7 @@ private theorem helbCopyThenTail0
   simp only [Nat.add_zero, Nat.zero_add] at hcopy
   rw [show (outPtr + BitVec.ofNat 64 0 : Word) = outPtr from by bv_omega,
       show copyIntoRegion outBytes headerBytes 0 offset.toNat 0 = outBytes from rfl,
-      helb_ofNat_toNat offset,
+      ofNat_toNat offset,
       show (BitVec.ofNat 64 256 : Word) = (256 : Word) from by decide] at hcopy
   have hcopyF := cpsTripleWithin_frameR
     ((.x10 ↦ᵣ a0old) ** (.x2 ↦ᵣ newSp) ** (.x1 ↦ᵣ v1) ** (.x8 ↦ᵣ v8) ** (.x9 ↦ᵣ v9) **

--- a/EvmAsm/Codegen/Programs/LogsBloomCopyArithmetic.lean
+++ b/EvmAsm/Codegen/Programs/LogsBloomCopyArithmetic.lean
@@ -1,0 +1,42 @@
+/-
+  EvmAsm.Codegen.Programs.LogsBloomCopyArithmetic
+
+  Layout-independent arithmetic facts shared by the header and receipt
+  `logs_bloom` copy-loop proofs.  Keep this module free of `GuestAddrs`,
+  `RegionMap`, and emitted-program imports so guest-layout changes do not
+  rebuild these facts.
+-/
+
+import EvmAsm.Rv64.Instructions
+
+namespace EvmAsm.Codegen.LogsBloomCopyArithmetic
+
+open EvmAsm.Rv64
+
+theorem succ_dec (n : Nat) :
+    BitVec.ofNat 64 (n + 1) + signExtend12 (-1 : BitVec 12) = BitVec.ofNat 64 n := by
+  apply BitVec.eq_of_toNat_eq
+  have hs : (signExtend12 (-1 : BitVec 12) : Word).toNat = 18446744073709551615 := by decide
+  rw [BitVec.toNat_add, hs, BitVec.toNat_ofNat, BitVec.toNat_ofNat]
+  omega
+
+theorem succ_ne_zero (n : Nat) (h : n + 1 < 18446744073709551616) :
+    BitVec.ofNat 64 (n + 1) ≠ (0 : Word) := by
+  have ht : (BitVec.ofNat 64 (n + 1) : Word).toNat = n + 1 := by
+    rw [BitVec.toNat_ofNat]
+    omega
+  intro hc
+  rw [hc] at ht
+  simp at ht
+
+theorem advance (b : Word) (m : Nat) :
+    (b + BitVec.ofNat 64 m) + signExtend12 (1 : BitVec 12) = b + BitVec.ofNat 64 (m + 1) := by
+  rw [show signExtend12 (1 : BitVec 12) = (1 : Word) from by decide]
+  bv_omega
+
+theorem ofNat_toNat (fo : Word) : (BitVec.ofNat 64 fo.toNat : Word) = fo := by
+  apply BitVec.eq_of_toNat_eq
+  rw [BitVec.toNat_ofNat]
+  exact Nat.mod_eq_of_lt fo.isLt
+
+end EvmAsm.Codegen.LogsBloomCopyArithmetic

--- a/EvmAsm/Codegen/Programs/ReceiptExtractLogsBloomSpec.lean
+++ b/EvmAsm/Codegen/Programs/ReceiptExtractLogsBloomSpec.lean
@@ -22,6 +22,7 @@ import EvmAsm.Codegen.Programs.Bloom
 import EvmAsm.Codegen.Programs.RlpListNthItemCallSAsm
 import EvmAsm.Codegen.Programs.ReceiptExtractLogsBloomCallSAsm
 import EvmAsm.Codegen.Programs.HeaderFieldsGenericInit
+import EvmAsm.Codegen.Programs.LogsBloomCopyArithmetic
 import EvmAsm.Rv64.SAsm.GlobalData
 import EvmAsm.Rv64.SAsm.AbiFrameCall
 import EvmAsm.Rv64.MemRegion
@@ -34,6 +35,7 @@ namespace EvmAsm.Codegen.ReceiptExtractLogsBloomSpec
 open EvmAsm.Rv64 EvmAsm.Rv64.SAsm
 open EvmAsm.Rv64.Tactics
 open EvmAsm.Codegen.RlpListNthItemSAsm
+open EvmAsm.Codegen.LogsBloomCopyArithmetic
 open EvmAsm.Evm64.Terminating (copyIntoRegion copyIntoRegion_length)
 
 /-- Guest entry of `receipt_extract_logs_bloom`. -/
@@ -389,23 +391,6 @@ theorem relbEpilogue (newSp a0v v1 v8 v9 v18 : Word) (fsaved : HeaderFieldsSpec.
 
 /-! ## Copy-loop helpers -/
 
-private theorem relb_succ_dec (n : Nat) :
-    BitVec.ofNat 64 (n + 1) + signExtend12 (-1 : BitVec 12) = BitVec.ofNat 64 n := by
-  apply BitVec.eq_of_toNat_eq
-  have hs : (signExtend12 (-1 : BitVec 12) : Word).toNat = 18446744073709551615 := by decide
-  rw [BitVec.toNat_add, hs, BitVec.toNat_ofNat, BitVec.toNat_ofNat]
-  omega
-
-private theorem relb_succ_ne_zero (n : Nat) (h : n + 1 < 18446744073709551616) :
-    BitVec.ofNat 64 (n + 1) ≠ (0 : Word) := by
-  have ht : (BitVec.ofNat 64 (n + 1) : Word).toNat = n + 1 := by
-    rw [BitVec.toNat_ofNat]; omega
-  intro hc; rw [hc] at ht; simp at ht
-
-private theorem relb_advance (b : Word) (m : Nat) :
-    (b + BitVec.ofNat 64 m) + signExtend12 (1 : BitVec 12) = b + BitVec.ofNat 64 (m + 1) := by
-  rw [show signExtend12 (1 : BitVec 12) = (1 : Word) from by decide]; bv_omega
-
 set_option maxRecDepth 8000 in
 /-- One copy-loop body ([29]-[33], `relbBase+116 → relbBase+136`): copy one byte
     from `srcBase[srcOff+i]` to `dstBase[dstOff+i]` and decrement the counter. -/
@@ -478,7 +463,7 @@ private theorem relbCopyBody5 (srcBase dstBase x31old : Word)
   -- [31] addi x28, x28, 1
   have h3 := addi_spec_gen_same_within .x28
     (srcBase + BitVec.ofNat 64 (srcOff + i)) (1 : BitVec 12) (relbBase + 124) (by decide)
-  rw [relb_advance srcBase (srcOff + i),
+  rw [advance srcBase (srcOff + i),
       show srcOff + i + 1 = srcOff + (i + 1) from by omega,
       show (relbBase + 124 : Word) + 4 = relbBase + 128 from by bv_omega] at h3
   have h3e := cpsTripleWithin_extend_code
@@ -494,7 +479,7 @@ private theorem relbCopyBody5 (srcBase dstBase x31old : Word)
   -- [32] addi x29, x29, 1
   have h4 := addi_spec_gen_same_within .x29
     (dstBase + BitVec.ofNat 64 (dstOff + i)) (1 : BitVec 12) (relbBase + 128) (by decide)
-  rw [relb_advance dstBase (dstOff + i),
+  rw [advance dstBase (dstOff + i),
       show dstOff + i + 1 = dstOff + (i + 1) from by omega,
       show (relbBase + 128 : Word) + 4 = relbBase + 132 from by bv_omega] at h4
   have h4e := cpsTripleWithin_extend_code
@@ -510,7 +495,7 @@ private theorem relbCopyBody5 (srcBase dstBase x31old : Word)
   -- [33] addi x30, x30, -1
   have h5 := addi_spec_gen_same_within .x30 (BitVec.ofNat 64 (m + 1)) (-1 : BitVec 12)
     (relbBase + 132) (by decide)
-  rw [relb_succ_dec m, show (relbBase + 132 : Word) + 4 = relbBase + 136 from by bv_omega] at h5
+  rw [succ_dec m, show (relbBase + 132 : Word) + 4 = relbBase + 136 from by bv_omega] at h5
   have h5e := cpsTripleWithin_extend_code
     (relbMem Codegen.receiptExtractLogsBloom_prog rfl (relbBase + 132) 33
       (.ADDI .x30 .x30 (-1 : BitVec 12)) (by rw [program_length]; norm_num) (by bv_omega) rfl) h5
@@ -602,7 +587,7 @@ private theorem relbCopyLoop (srcBase dstBase x31old : Word)
     have hbeqe := cpsBranchWithin_extend_code hbeqMem hbeq
     have hnt := cpsBranchWithin_ntakenStripPure2 hbeqe (fun hp hQt => by
       obtain ⟨_, _, _, _, _, hQ⟩ := hQt
-      exact relb_succ_ne_zero k (by omega) ((sepConj_pure_right _).1 hQ).2)
+      exact succ_ne_zero k (by omega) ((sepConj_pure_right _).1 hQ).2)
     have hntf := cpsTripleWithin_frameR
       (((.x28 : Reg) ↦ᵣ (srcBase + BitVec.ofNat 64 (srcOff + i))) **
        ((.x29 : Reg) ↦ᵣ (dstBase + BitVec.ofNat 64 (dstOff + i))) **
@@ -675,10 +660,6 @@ theorem relbLaOff88 (v : Word) :
     (by decide) (by decide) hau had
   rw [show (relbBase + 88 : Word) + 8 = relbBase + 96 from by bv_omega] at h
   exact h
-
-private theorem relb_ofNat_toNat (fo : Word) : (BitVec.ofNat 64 fo.toNat : Word) = fo := by
-  apply BitVec.eq_of_toNat_eq
-  rw [BitVec.toNat_ofNat]; exact Nat.mod_eq_of_lt fo.isLt
 
 /-! ## Terminal tails: set `a0`, jump to the epilogue, return -/
 
@@ -943,7 +924,7 @@ private theorem relbCopyThenTail0
   simp only [Nat.add_zero, Nat.zero_add] at hcopy
   rw [show (outPtr + BitVec.ofNat 64 0 : Word) = outPtr from by bv_omega,
       show copyIntoRegion outBytes receiptBytes 0 offset.toNat 0 = outBytes from rfl,
-      relb_ofNat_toNat offset,
+      ofNat_toNat offset,
       show (BitVec.ofNat 64 256 : Word) = (256 : Word) from by decide] at hcopy
   have hcopyF := cpsTripleWithin_frameR
     ((.x10 ↦ᵣ a0old) ** (.x2 ↦ᵣ newSp) ** (.x1 ↦ᵣ v1) ** (.x8 ↦ᵣ v8) ** (.x9 ↦ᵣ v9) **

--- a/docs/agents/layout-independent-codegen-splits.md
+++ b/docs/agents/layout-independent-codegen-splits.md
@@ -1,0 +1,64 @@
+# Layout-independent Codegen splits
+
+Guest layout changes regenerate `GuestAddrs` and linked address facts.  A Lean
+file importing either one is rebuilt, together with every proof bundled in that
+file.  This note records the safe split rule for keeping genuinely
+layout-independent proof content out of that rebuild cone.
+
+## Rule for a safe split
+
+Move a declaration into a sibling module only when all of the following hold:
+
+1. Its type and proof body mention neither `GuestAddrs`, `RegionMap`, a linked
+   program entry/base, `laHi`/`laLo`/`jalOff`, nor an emitted-program
+   `CodeReq` tied to a linked address.
+2. Every import needed by the sibling is itself outside the layout cone.  A
+   declaration can look address-free while depending on a helper from a file
+   that imports `GuestAddrs`; that is **not** a useful split.
+3. The sibling imports only the smallest core/RV64/EL modules it needs; do not
+   import the original layout-dependent parent merely for convenience.
+4. Preserve the declaration statement and proof verbatim.  The parent imports
+   the sibling and rewrites only its local qualified name/open declaration.
+5. Build the sibling and parent together, run `check-unimported.sh`, and run
+   the affected byte/layout gates.  This is a build-graph refactor, not a
+   semantics or emitted-byte change.
+
+## Completed exemplar: logs-bloom copy arithmetic
+
+`LogsBloomCopyArithmetic.lean` contains the four Word/Nat facts shared by:
+
+- `HeaderExtractLogsBloomSpec.lean` (1,421 lines): `helb_succ_dec`,
+  `helb_succ_ne_zero`, `helb_advance`, and `helb_ofNat_toNat`;
+- `ReceiptExtractLogsBloomSpec.lean` (1,362 lines): their `relb_*`
+  counterparts.
+
+The sibling imports only `EvmAsm.Rv64.Instructions`; it has no Codegen layout
+or emitted-program import.  Both former layout-dependent proof files now only
+import the sibling for those facts.  This is also a useful template for paired
+header/receipt helpers: make the shared arithmetic generic rather than moving
+two renamed copies.
+
+## Candidate queue for mechanical follow-up
+
+| Source file | Proposed sibling | Layout-free content | Caution |
+| --- | --- | --- | --- |
+| `Programs/RlpListNthItemSAsmBase.lean` (1,356 lines) | `RlpListNthItemStrictList.lean` | `StrictListPayload` plus its structural lemmas through `long_view` (before the first `BalAccountNonstorageFinalsSpec` use) | Stop before `noStrictList_of_long_nonminimal`: it uses a helper from the layout-dependent BAL proof chain. |
+| `Programs/RlpSpliceHelperSpec.lean` (1,380 lines) | `RlpSpliceHelperArithmetic.lean` | `toNat_zx`, `ult_zx_of_lt`, `not_ult_zx_of_ge`, `ris_result_128`, `ris_result_192` | The following `∀ base` triples still import `RlpRead`, which is layout-dependent; do not move them without first splitting `RlpRead`. |
+| `Programs/HeaderExtractLogsBloomSpec.lean` | `LogsBloomCopyArithmetic.lean` | Completed exemplar | Keep `helbMem`, `helbBase`, LA/JAL proofs, and all `CodeReq` facts in the parent. |
+| `Programs/ReceiptExtractLogsBloomSpec.lean` | `LogsBloomCopyArithmetic.lean` | Completed exemplar | Same boundary as header. |
+
+## Explicit non-candidates until dependencies are split
+
+- `RlpFieldToU64SAsm.Result` is syntactically semantic, but it refers to
+  `RlpListNthItemSAsm.Failure` and `Success`; splitting it alone retains the
+  layout-dependent import edge.
+- `RlpSpliceHelperSpec`'s linked `rlp_item_size` and
+  `rlp_encode_list_prefix` wrappers, and `AccountAccessorTopSpec`, are pinned
+  to concrete `GuestAddrs` bases or JAL/LA facts.
+- The remaining `RlpListNthItemSAsmBase` strict-walk construction and prefix
+  lemmas import `BalAccountNonstorageFinalsSpec` helpers.  They need a core
+  replacement for those helpers before a split buys rebuild isolation.
+
+The mechanical bulk should apply this rule one sibling at a time, preserve
+file-local namespaces, and use a build gate after each batch rather than a
+global textual extraction.


### PR DESCRIPTION
Summary: moves the layout-free Word/Nat copy-loop facts shared by the header and receipt logs-bloom proofs into LogsBloomCopyArithmetic.lean. The sibling imports only EvmAsm.Rv64.Instructions, outside the GuestAddrs/RegionMap rebuild cone. Adds docs/agents/layout-independent-codegen-splits.md with the safe split rule, completed exemplar, candidate queue, and explicit non-candidates for glm-5.\n\nValidation: lake build; scripts/check-unimported.sh (2738 reachable, 0 orphans); scripts/check-asm-to-program.sh (386 converted defs / 146 files); git diff --check.\n\nBehavior and emitted bytes are unchanged; this only relocates proofs.