### PR TITLE
proof(account): accountDecode caller Fn.Spec (pkljc-unblocked, multi-field decoder)

### DIFF
--- a/EvmAsm/Codegen/Programs/AccountDecodeBalanceLoop.lean
+++ b/EvmAsm/Codegen/Programs/AccountDecodeBalanceLoop.lean
@@ -1,0 +1,311 @@
+/-
+  The balance right-aligned copy loop of `accountDecode_prog`
+  (`Programs/State.lean`, field 1, instrs [65]-[71], `AB+260 → AB+288`).
+
+  After the 32-byte output slot is zeroed and the destination cursor is set to
+  `out + (32-len)` (instrs [55]-[64]), the `len` content bytes are copied
+  forward into that cursor by a top-tested `BEQ`/`JAL` loop:
+
+    [65] BEQ  x6, x0, +28   -- exit to AB+288 when x6 = 0
+    [66] LBU  x30, 0(x28)
+    [67] SB   x30, 0(x29)   -- store x30's byte at [x29]
+    [68] ADDI x28, x28, 1
+    [69] ADDI x29, x29, 1
+    [70] ADDI x6,  x6, -1
+    [71] JAL  x0, -24       -- back to AB+260
+
+  The byte-copy reasoning is the same `copyIntoRegion` accumulator used by
+  `AccountDecodeLoop.adCopyLoop` (byte temp `x30`, destination cursor `x29`,
+  source cursor `x28`), re-derived here with the top-tested loop structure of
+  `AccountDecodeNonceLoop.adNonceLoop`.  Starting from the fully-zeroed 32-byte
+  buffer with destination offset `32-len`, the closure produces exactly
+  `AccountDecodeSpec.balanceCopied`.
+
+  No `sorry`/`admit`/`native_decide`/`bv_decide`; classical-3 axioms only.
+-/
+
+import EvmAsm.Codegen.Programs.AccountDecodeSpec
+import EvmAsm.Rv64.Tactics.XPerm
+import EvmAsm.Rv64.Tactics.XPermChunked
+
+namespace EvmAsm.Codegen.AccountDecodeSpec
+
+open EvmAsm.Rv64
+open EvmAsm.Rv64.SAsm
+open EvmAsm.Rv64.Tactics
+open EvmAsm.Evm64.Terminating (copyIntoRegion copyIntoRegion_length)
+
+set_option maxRecDepth 8000
+
+/-- Discharge a `.pcFree` side goal over frames of `bytesRegion`/`regIs` cells. -/
+local macro "pcFreeR" : tactic =>
+  `(tactic| repeat' first
+    | exact bytesRegion_pcFree _ _
+    | exact pcFree_regIs
+    | exact pcFree_regOwn
+    | exact pcFree_memIs
+    | exact pcFree_memOwn
+    | apply pcFree_sepConj
+    | pcFree)
+
+/-- `k`-th instruction membership of `accountDecode_prog` into `fullCode`. -/
+local macro "adMemF" k:term ", " A:term ", " ins:term : term =>
+  `((fun a i h => ad_mono a i
+      (CodeReq.ofProg_mem_at AB $A accountDecode_prog $k $ins (by bv_omega)
+        (by rw [ad_length]; omega) rfl (by rw [ad_length]; norm_num) a i h)))
+
+/-! ## Address / counter arithmetic helpers -/
+
+private theorem adb_succ_dec (n : Nat) :
+    BitVec.ofNat 64 (n + 1) + signExtend12 (-1 : BitVec 12) = BitVec.ofNat 64 n := by
+  apply BitVec.eq_of_toNat_eq
+  have hs : (signExtend12 (-1 : BitVec 12) : Word).toNat = 18446744073709551615 := by decide
+  rw [BitVec.toNat_add, hs, BitVec.toNat_ofNat, BitVec.toNat_ofNat]
+  omega
+
+private theorem adb_succ_ne_zero (n : Nat) (h : n + 1 < 18446744073709551616) :
+    BitVec.ofNat 64 (n + 1) ≠ (0 : Word) := by
+  have ht : (BitVec.ofNat 64 (n + 1) : Word).toNat = n + 1 := by
+    rw [BitVec.toNat_ofNat]; omega
+  intro hc; rw [hc] at ht; simp at ht
+
+private theorem adb_advance (b : Word) (m : Nat) :
+    (b + BitVec.ofNat 64 m) + signExtend12 (1 : BitVec 12) = b + BitVec.ofNat 64 (m + 1) := by
+  rw [show signExtend12 (1 : BitVec 12) = (1 : Word) from by decide]; bv_omega
+
+/-! ## Balance right-align copy loop ([65]-[71], `AB+260 → AB+288`) -/
+
+/-- **One balance-copy iteration** ([66]-[71], `AB+264 → AB+260`): load
+    `srcBytes[srcOff+i]` into `x30`, store it at `dstBase[dstOff+i]`, advance
+    both cursors, decrement the countdown, and take the back-edge `JAL`; the
+    destination content grows by one byte in the `copyIntoRegion` accumulator. -/
+private theorem adBalBody (srcBase dstBase x30old : Word)
+    (srcBytes dstBytes : List (BitVec 8)) (srcOff dstOff i m : Nat)
+    (h_src_align : srcBase.toNat % 8 = 0)
+    (h_dst_align : dstBase.toNat % 8 = 0)
+    (h_src_lt : srcOff + i < srcBytes.length)
+    (h_dst_lt : dstOff + i < dstBytes.length)
+    (h_src_over : srcBase.toNat + srcBytes.length < 2 ^ 64)
+    (h_dst_over : dstBase.toNat + dstBytes.length < 2 ^ 64)
+    (h_src_valid : ∀ k, k < srcBytes.length →
+      isValidByteAccess (srcBase + BitVec.ofNat 64 k) = true)
+    (h_dst_valid : ∀ k, k < dstBytes.length →
+      isValidByteAccess (dstBase + BitVec.ofNat 64 k) = true) :
+    cpsTripleWithin 6 (AB + 264) (AB + 260) fullCode
+      (((.x6 : Reg) ↦ᵣ BitVec.ofNat 64 (m + 1)) **
+       ((.x28 : Reg) ↦ᵣ (srcBase + BitVec.ofNat 64 (srcOff + i))) **
+       ((.x29 : Reg) ↦ᵣ (dstBase + BitVec.ofNat 64 (dstOff + i))) **
+       ((.x30 : Reg) ↦ᵣ x30old) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+       bytesRegion srcBase srcBytes **
+       bytesRegion dstBase (copyIntoRegion dstBytes srcBytes dstOff srcOff i))
+      (((.x6 : Reg) ↦ᵣ BitVec.ofNat 64 m) **
+       ((.x28 : Reg) ↦ᵣ (srcBase + BitVec.ofNat 64 (srcOff + (i + 1)))) **
+       ((.x29 : Reg) ↦ᵣ (dstBase + BitVec.ofNat 64 (dstOff + (i + 1)))) **
+       ((.x30 : Reg) ↦ᵣ ((srcBytes.getD (srcOff + i) 0).zeroExtend 64)) **
+       ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+       bytesRegion srcBase srcBytes **
+       bytesRegion dstBase (copyIntoRegion dstBytes srcBytes dstOff srcOff (i + 1))) := by
+  set bval := srcBytes[srcOff + i]'h_src_lt with hbval
+  have htrunc : (bval.zeroExtend 64).truncate 8 = bval := by
+    apply BitVec.eq_of_toNat_eq
+    rw [BitVec.toNat_setWidth, BitVec.toNat_setWidth]
+    have := bval.isLt
+    rw [Nat.mod_eq_of_lt (by omega), Nat.mod_eq_of_lt (by omega)]
+  have hgetd : srcBytes.getD (srcOff + i) 0 = bval := by
+    rw [hbval, List.getD_eq_getElem?_getD, List.getElem?_eq_getElem h_src_lt]; rfl
+  have hstep : copyIntoRegion dstBytes srcBytes dstOff srcOff (i + 1)
+      = (copyIntoRegion dstBytes srcBytes dstOff srcOff i).set (dstOff + i) bval := by
+    simp only [copyIntoRegion, hgetd]
+  -- [66] LBU x30, 0(x28)
+  have hlbu := bytesRegion_lbu_within .x30 .x28 srcBase x30old (AB + 264)
+    srcBytes (srcOff + i) (by decide) h_src_align h_src_lt (by omega)
+    (h_src_valid (srcOff + i) h_src_lt)
+  rw [← hbval, show (AB + 264 : Word) + 4 = AB + 268 from by bv_omega] at hlbu
+  have e66 := cpsTripleWithin_extend_code
+    (adMemF 66, (AB + 264), (.LBU .x30 .x28 (0 : BitVec 12))) hlbu
+  have f66 := cpsTripleWithin_frameR
+    (((.x6 : Reg) ↦ᵣ BitVec.ofNat 64 (m + 1)) **
+     ((.x29 : Reg) ↦ᵣ (dstBase + BitVec.ofNat 64 (dstOff + i))) **
+     ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+     bytesRegion dstBase (copyIntoRegion dstBytes srcBytes dstOff srcOff i))
+    (by pcFreeR) e66
+  -- [67] SB x30, 0(x29)  (store x30's byte at [x29])
+  have hsb := bytesRegion_sb_within .x29 .x30 dstBase (bval.zeroExtend 64) (AB + 268)
+    (copyIntoRegion dstBytes srcBytes dstOff srcOff i) (dstOff + i) h_dst_align
+    (by rw [copyIntoRegion_length]; omega) (by omega)
+    (h_dst_valid (dstOff + i) h_dst_lt)
+  rw [htrunc, ← hstep, show (AB + 268 : Word) + 4 = AB + 272 from by bv_omega] at hsb
+  have e67 := cpsTripleWithin_extend_code
+    (adMemF 67, (AB + 268), (.SB .x29 .x30 (0 : BitVec 12))) hsb
+  have f67 := cpsTripleWithin_frameR
+    (((.x6 : Reg) ↦ᵣ BitVec.ofNat 64 (m + 1)) **
+     ((.x28 : Reg) ↦ᵣ (srcBase + BitVec.ofNat 64 (srcOff + i))) **
+     ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+     bytesRegion srcBase srcBytes)
+    (by pcFreeR) e67
+  -- [68] ADDI x28, x28, 1
+  have h68 := addi_spec_gen_same_within .x28
+    (srcBase + BitVec.ofNat 64 (srcOff + i)) (1 : BitVec 12) (AB + 272) (by decide)
+  rw [adb_advance srcBase (srcOff + i),
+      show srcOff + i + 1 = srcOff + (i + 1) from by omega,
+      show (AB + 272 : Word) + 4 = AB + 276 from by bv_omega] at h68
+  have e68 := cpsTripleWithin_extend_code
+    (adMemF 68, (AB + 272), (.ADDI .x28 .x28 (1 : BitVec 12))) h68
+  have f68 := cpsTripleWithin_frameR
+    (((.x6 : Reg) ↦ᵣ BitVec.ofNat 64 (m + 1)) **
+     ((.x29 : Reg) ↦ᵣ (dstBase + BitVec.ofNat 64 (dstOff + i))) **
+     ((.x30 : Reg) ↦ᵣ (bval.zeroExtend 64)) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+     bytesRegion srcBase srcBytes **
+     bytesRegion dstBase (copyIntoRegion dstBytes srcBytes dstOff srcOff (i + 1)))
+    (by pcFreeR) e68
+  -- [69] ADDI x29, x29, 1
+  have h69 := addi_spec_gen_same_within .x29
+    (dstBase + BitVec.ofNat 64 (dstOff + i)) (1 : BitVec 12) (AB + 276) (by decide)
+  rw [adb_advance dstBase (dstOff + i),
+      show dstOff + i + 1 = dstOff + (i + 1) from by omega,
+      show (AB + 276 : Word) + 4 = AB + 280 from by bv_omega] at h69
+  have e69 := cpsTripleWithin_extend_code
+    (adMemF 69, (AB + 276), (.ADDI .x29 .x29 (1 : BitVec 12))) h69
+  have f69 := cpsTripleWithin_frameR
+    (((.x6 : Reg) ↦ᵣ BitVec.ofNat 64 (m + 1)) **
+     ((.x28 : Reg) ↦ᵣ (srcBase + BitVec.ofNat 64 (srcOff + (i + 1)))) **
+     ((.x30 : Reg) ↦ᵣ (bval.zeroExtend 64)) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+     bytesRegion srcBase srcBytes **
+     bytesRegion dstBase (copyIntoRegion dstBytes srcBytes dstOff srcOff (i + 1)))
+    (by pcFreeR) e69
+  -- [70] ADDI x6, x6, -1
+  have h70 := addi_spec_gen_same_within .x6 (BitVec.ofNat 64 (m + 1)) (-1 : BitVec 12)
+    (AB + 280) (by decide)
+  rw [adb_succ_dec m, show (AB + 280 : Word) + 4 = AB + 284 from by bv_omega] at h70
+  have e70 := cpsTripleWithin_extend_code
+    (adMemF 70, (AB + 280), (.ADDI .x6 .x6 (-1 : BitVec 12))) h70
+  have f70 := cpsTripleWithin_frameR
+    (((.x28 : Reg) ↦ᵣ (srcBase + BitVec.ofNat 64 (srcOff + (i + 1)))) **
+     ((.x29 : Reg) ↦ᵣ (dstBase + BitVec.ofNat 64 (dstOff + (i + 1)))) **
+     ((.x30 : Reg) ↦ᵣ (bval.zeroExtend 64)) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+     bytesRegion srcBase srcBytes **
+     bytesRegion dstBase (copyIntoRegion dstBytes srcBytes dstOff srcOff (i + 1)))
+    (by pcFreeR) e70
+  -- [71] JAL x0, -24  → AB+260
+  have h71 := jal_x0_spec_gen_within (-24 : BitVec 21) (AB + 284)
+  rw [show AB + 284 + signExtend21 (-24 : BitVec 21) = AB + 260 from by
+      rw [show signExtend21 (-24 : BitVec 21) = (-24 : Word) from by decide]; bv_omega] at h71
+  have e71 := cpsTripleWithin_extend_code
+    (adMemF 71, (AB + 284), (.JAL .x0 (-24 : BitVec 21))) h71
+  have f71 := cpsTripleWithin_frameR
+    (((.x6 : Reg) ↦ᵣ BitVec.ofNat 64 m) **
+     ((.x28 : Reg) ↦ᵣ (srcBase + BitVec.ofNat 64 (srcOff + (i + 1)))) **
+     ((.x29 : Reg) ↦ᵣ (dstBase + BitVec.ofNat 64 (dstOff + (i + 1)))) **
+     ((.x30 : Reg) ↦ᵣ (bval.zeroExtend 64)) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+     bytesRegion srcBase srcBytes **
+     bytesRegion dstBase (copyIntoRegion dstBytes srcBytes dstOff srcOff (i + 1)))
+    (by pcFreeR) e71
+  rw [sepConj_emp_left'] at f71
+  -- compose the six body steps ([66]-[71])
+  have s1 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_chunked hp) f66 f67
+  have s2 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_chunked hp) s1 f68
+  have s3 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_chunked hp) s2 f69
+  have s4 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_chunked hp) s3 f70
+  have s5 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_chunked hp) s4 f71
+  refine cpsTripleWithin_mono_nSteps (by omega)
+    (cpsTripleWithin_weaken (fun _ hp => by xperm_chunked hp)
+      (fun _ hq => by rw [hgetd]; xperm_chunked hq) s5)
+
+/-- **The balance right-align copy loop closure** ([65]-[71], `AB+260 → AB+288`):
+    by induction on the byte countdown `n`, copy the remaining `n` content bytes
+    forward into the destination and exit through the top `BEQ` with `x6 = 0`.
+    Grows the `copyIntoRegion` accumulator; starting from the zeroed buffer with
+    `dstOff = 32-len` this yields `balanceCopied`. -/
+theorem adBalLoop (srcBase dstBase x30old : Word)
+    (srcBytes dstBytes : List (BitVec 8)) (srcOff dstOff i n : Nat)
+    (h_src_align : srcBase.toNat % 8 = 0)
+    (h_dst_align : dstBase.toNat % 8 = 0)
+    (h_src_bound : srcOff + i + n ≤ srcBytes.length)
+    (h_dst_bound : dstOff + i + n ≤ dstBytes.length)
+    (h_src_over : srcBase.toNat + srcBytes.length < 2 ^ 64)
+    (h_dst_over : dstBase.toNat + dstBytes.length < 2 ^ 64)
+    (h_src_valid : ∀ k, k < srcBytes.length →
+      isValidByteAccess (srcBase + BitVec.ofNat 64 k) = true)
+    (h_dst_valid : ∀ k, k < dstBytes.length →
+      isValidByteAccess (dstBase + BitVec.ofNat 64 k) = true) :
+    cpsTripleWithin (7 * n + 1) (AB + 260) (AB + 288) fullCode
+      (((.x6 : Reg) ↦ᵣ BitVec.ofNat 64 n) **
+       ((.x28 : Reg) ↦ᵣ (srcBase + BitVec.ofNat 64 (srcOff + i))) **
+       ((.x29 : Reg) ↦ᵣ (dstBase + BitVec.ofNat 64 (dstOff + i))) **
+       ((.x30 : Reg) ↦ᵣ x30old) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+       bytesRegion srcBase srcBytes **
+       bytesRegion dstBase (copyIntoRegion dstBytes srcBytes dstOff srcOff i))
+      (((.x6 : Reg) ↦ᵣ (0 : Word)) **
+       ((.x28 : Reg) ↦ᵣ (srcBase + BitVec.ofNat 64 (srcOff + (i + n)))) **
+       ((.x29 : Reg) ↦ᵣ (dstBase + BitVec.ofNat 64 (dstOff + (i + n)))) **
+       regOwn .x30 ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+       bytesRegion srcBase srcBytes **
+       bytesRegion dstBase (copyIntoRegion dstBytes srcBytes dstOff srcOff (i + n))) := by
+  have hbeq : (AB + 260 : Word) + signExtend13 (28 : BitVec 13) = AB + 288 := by
+    rw [show signExtend13 (28 : BitVec 13) = (28 : Word) from by decide]; bv_omega
+  induction n generalizing i x30old with
+  | zero =>
+    -- x6 = 0 : BEQ taken → AB+288
+    have hb := beq_spec_gen_within .x6 .x0 (28 : BitVec 13) (BitVec.ofNat 64 0)
+      (0 : Word) (AB + 260)
+    rw [hbeq] at hb
+    have hbe := cpsBranchWithin_extend_code
+      (adMemF 65, (AB + 260), (.BEQ .x6 .x0 (28 : BitVec 13))) hb
+    have htaken := cpsBranchWithin_takenStripPure2 hbe (fun hp hQf => by
+      obtain ⟨_, _, _, _, _, hQ⟩ := hQf
+      exact ((sepConj_pure_right _).1 hQ).2 (by decide))
+    have htf := cpsTripleWithin_frameR
+      (((.x28 : Reg) ↦ᵣ (srcBase + BitVec.ofNat 64 (srcOff + i))) **
+       ((.x29 : Reg) ↦ᵣ (dstBase + BitVec.ofNat 64 (dstOff + i))) **
+       ((.x30 : Reg) ↦ᵣ x30old) ** bytesRegion srcBase srcBytes **
+       bytesRegion dstBase (copyIntoRegion dstBytes srcBytes dstOff srcOff i))
+      (by pcFreeR) htaken
+    refine cpsTripleWithin_mono_nSteps (by omega)
+      (cpsTripleWithin_weaken (fun _ hp => by xperm_chunked hp)
+        (fun sState hq => by
+          simp only [show i + 0 = i from by omega]
+          rw [show (BitVec.ofNat 64 0 : Word) = 0 from by decide] at hq
+          have hq2 : (((.x6 : Reg) ↦ᵣ (0 : Word)) **
+              ((.x28 : Reg) ↦ᵣ (srcBase + BitVec.ofNat 64 (srcOff + i))) **
+              ((.x29 : Reg) ↦ᵣ (dstBase + BitVec.ofNat 64 (dstOff + i))) **
+              ((.x30 : Reg) ↦ᵣ x30old) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+              bytesRegion srcBase srcBytes **
+              bytesRegion dstBase (copyIntoRegion dstBytes srcBytes dstOff srcOff i))
+              sState := by xperm_chunked hq
+          have hq3 := sepConj_mono_right (sepConj_mono_right (sepConj_mono_right
+            (sepConj_mono_left (regIs_implies_regOwn .x30)))) _ hq2
+          xperm_chunked hq3) htf)
+  | succ k ih =>
+    -- x6 = k+1 ≠ 0 : BEQ not-taken → AB+264, then body, then IH
+    have hb := beq_spec_gen_within .x6 .x0 (28 : BitVec 13) (BitVec.ofNat 64 (k + 1))
+      (0 : Word) (AB + 260)
+    rw [hbeq] at hb
+    have hbe := cpsBranchWithin_extend_code
+      (adMemF 65, (AB + 260), (.BEQ .x6 .x0 (28 : BitVec 13))) hb
+    have hnt := cpsBranchWithin_ntakenStripPure2 hbe (fun hp hQt => by
+      obtain ⟨_, _, _, _, _, hQ⟩ := hQt
+      exact adb_succ_ne_zero k (by omega) ((sepConj_pure_right _).1 hQ).2)
+    have hntf := cpsTripleWithin_frameR
+      (((.x28 : Reg) ↦ᵣ (srcBase + BitVec.ofNat 64 (srcOff + i))) **
+       ((.x29 : Reg) ↦ᵣ (dstBase + BitVec.ofNat 64 (dstOff + i))) **
+       ((.x30 : Reg) ↦ᵣ x30old) ** bytesRegion srcBase srcBytes **
+       bytesRegion dstBase (copyIntoRegion dstBytes srcBytes dstOff srcOff i))
+      (by pcFreeR) hnt
+    have hbody := adBalBody srcBase dstBase x30old srcBytes dstBytes srcOff dstOff i k
+      h_src_align h_dst_align (by omega) (by omega) h_src_over h_dst_over
+      h_src_valid h_dst_valid
+    have hih := ih ((srcBytes.getD (srcOff + i) 0).zeroExtend 64) (i + 1)
+      (by omega) (by omega)
+    have s1 := cpsTripleWithin_seq_perm_same_cr
+      (fun _ hp => by xperm_chunked hp) hntf hbody
+    have sfull := cpsTripleWithin_seq_perm_same_cr
+      (fun _ hp => by xperm_chunked hp) s1 hih
+    refine cpsTripleWithin_mono_nSteps (by omega)
+      (cpsTripleWithin_weaken (fun _ hp => by xperm_chunked hp)
+        (fun _ hq => by
+          simp only [show i + 1 + k = i + (k + 1) from by omega] at hq
+          xperm_chunked hq) sfull)
+
+#print axioms adBalLoop
+
+end EvmAsm.Codegen.AccountDecodeSpec

--- a/EvmAsm/Codegen/Programs/AccountDecodeBalanceSetup.lean
+++ b/EvmAsm/Codegen/Programs/AccountDecodeBalanceSetup.lean
@@ -1,0 +1,213 @@
+/-
+  The balance right-align setup block of `accountDecode_prog`
+  (`Programs/State.lean`, PR-K27), instructions [55]-[64] (`AB+220 → AB+260`),
+  run after field 1's length check accepts `len ≤ 32`:
+
+    [55]-[58]  sd x0, 0/8/16/24(x19)   -- zero the 32-byte balance slot
+    [59]       sub  x7, x7, x6         -- x7 := 32 - len
+    [60]       add  x29, x19, x7       -- dst cursor = balanceOut + (32 - len)
+    [61]-[62]  la   x5, ad_offset
+    [63]       ld   x28, 0(x5)         -- offset
+    [64]       add  x28, x8, x28       -- src cursor = listBase + offset
+
+  The four `sd x0` stores collapse the four dwords of the output slot to the
+  zeroed 32-byte `bytesRegion` (`bytesRegion_replicate32_zero`), and the two
+  cursors feed `adBalLoop` with `dstOff = 32 - len`, `srcOff = offset`.
+
+  No `sorry`/`admit`/`native_decide`/`bv_decide`; classical-3 axioms only.
+-/
+
+import EvmAsm.Codegen.Programs.AccountDecodeCall
+import EvmAsm.Rv64.LaResolve
+import EvmAsm.Rv64.RLP.ContentToU256Be
+
+namespace EvmAsm.Codegen.AccountDecodeSpec
+
+open EvmAsm.Rv64 EvmAsm.Rv64.SAsm
+open EvmAsm.Rv64.RLP (bytesRegion_replicate32_zero)
+
+/-- `la x5, ad_offset` at balance setup [61]-[62] (`AB+244 → AB+252`). -/
+private theorem adLaOffX5_244 (v : Word) :
+    cpsTripleWithin 2 (AB + 244) (AB + 252) fullCode
+      (.x5 ↦ᵣ v) (.x5 ↦ᵣ adOffsetAddr) := by
+  have hau : ∀ a i, CodeReq.singleton (AB + 244)
+      (.AUIPC .x5 (Codegen.laHi GuestAddrs.ad_offset (GuestAddrs.account_decode + 244)))
+        a = some i → fullCode a = some i := fun a i hi => ad_mono a i
+    (CodeReq.ofProg_mem_at AB (AB + 244) accountDecode_prog 61
+      (.AUIPC .x5 (Codegen.laHi GuestAddrs.ad_offset (GuestAddrs.account_decode + 244)))
+      (by bv_omega) (by rw [ad_length]; decide) rfl (by rw [ad_length]; decide) a i hi)
+  have had : ∀ a i, CodeReq.singleton (AB + 248)
+      (.ADDI .x5 .x5 (Codegen.laLo GuestAddrs.ad_offset (GuestAddrs.account_decode + 244)))
+        a = some i → fullCode a = some i := fun a i hi => ad_mono a i
+    (CodeReq.ofProg_mem_at AB (AB + 248) accountDecode_prog 62
+      (.ADDI .x5 .x5 (Codegen.laLo GuestAddrs.ad_offset (GuestAddrs.account_decode + 244)))
+      (by bv_omega) (by rw [ad_length]; decide) rfl (by rw [ad_length]; decide) a i hi)
+  have h := la_materialize_within .x5 v (AB + 244) adOffsetAddr (by decide) (by decide) hau had
+  rw [show (AB + 244 : Word) + 8 = AB + 252 from by bv_omega] at h
+  exact h
+
+set_option maxRecDepth 8000 in
+/-- The balance right-align setup [55]-[64] (`AB+220 → AB+260`): zero the 32-byte
+    output slot, compute `x7 = 32 - len`, the destination cursor
+    `x29 = balanceOut + (32 - len)`, load the content `offset`, and the source
+    cursor `x28 = listBase + offset`.  Feeds `adBalLoop`. -/
+theorem adBalanceSetup (balanceOut listBase len offset v5 v28 v29 ob0 ob1 ob2 ob3 : Word) :
+    cpsTripleWithin 10 (AB + 220) (AB + 260) fullCode
+      (((.x19 : Reg) ↦ᵣ balanceOut) ** ((.x8 : Reg) ↦ᵣ listBase) **
+       ((.x6 : Reg) ↦ᵣ len) ** ((.x7 : Reg) ↦ᵣ (32 : Word)) **
+       ((.x5 : Reg) ↦ᵣ v5) ** ((.x28 : Reg) ↦ᵣ v28) ** ((.x29 : Reg) ↦ᵣ v29) **
+       (balanceOut ↦ₘ ob0) ** ((balanceOut + 8) ↦ₘ ob1) **
+       ((balanceOut + 16) ↦ₘ ob2) ** ((balanceOut + 24) ↦ₘ ob3) **
+       (adOffsetAddr ↦ₘ offset))
+      (((.x19 : Reg) ↦ᵣ balanceOut) ** ((.x8 : Reg) ↦ᵣ listBase) **
+       ((.x6 : Reg) ↦ᵣ len) ** ((.x7 : Reg) ↦ᵣ ((32 : Word) - len)) **
+       ((.x5 : Reg) ↦ᵣ adOffsetAddr) ** ((.x28 : Reg) ↦ᵣ (listBase + offset)) **
+       ((.x29 : Reg) ↦ᵣ (balanceOut + ((32 : Word) - len))) **
+       bytesRegion balanceOut (List.replicate 32 (0 : BitVec 8)) **
+       (adOffsetAddr ↦ₘ offset)) := by
+  have hz0 : balanceOut + signExtend12 (0 : BitVec 12) = balanceOut := by
+    rw [show signExtend12 (0 : BitVec 12) = (0 : Word) from by decide]; bv_omega
+  have hz8 : balanceOut + signExtend12 (8 : BitVec 12) = balanceOut + 8 := by
+    rw [show signExtend12 (8 : BitVec 12) = (8 : Word) from by decide]
+  have hz16 : balanceOut + signExtend12 (16 : BitVec 12) = balanceOut + 16 := by
+    rw [show signExtend12 (16 : BitVec 12) = (16 : Word) from by decide]
+  have hz24 : balanceOut + signExtend12 (24 : BitVec 12) = balanceOut + 24 := by
+    rw [show signExtend12 (24 : BitVec 12) = (24 : Word) from by decide]
+  -- [55] sd x0, 0(x19)
+  have h55 := sd_x0_spec_gen_within .x19 balanceOut ob0 (0 : BitVec 12) (AB + 220)
+  rw [hz0, show (AB + 220 : Word) + 4 = AB + 224 from by bv_omega] at h55
+  have h55e := cpsTripleWithin_extend_code ad_mono
+    (cpsTripleWithin_extend_code
+      (CodeReq.ofProg_mem_at AB (AB + 220) accountDecode_prog 55 (.SD .x19 .x0 (0 : BitVec 12))
+        (by bv_omega) (by rw [ad_length]; decide) rfl (by rw [ad_length]; decide)) h55)
+  -- [56] sd x0, 8(x19)
+  have h56 := sd_x0_spec_gen_within .x19 balanceOut ob1 (8 : BitVec 12) (AB + 224)
+  rw [hz8, show (AB + 224 : Word) + 4 = AB + 228 from by bv_omega] at h56
+  have h56e := cpsTripleWithin_extend_code ad_mono
+    (cpsTripleWithin_extend_code
+      (CodeReq.ofProg_mem_at AB (AB + 224) accountDecode_prog 56 (.SD .x19 .x0 (8 : BitVec 12))
+        (by bv_omega) (by rw [ad_length]; decide) rfl (by rw [ad_length]; decide)) h56)
+  -- [57] sd x0, 16(x19)
+  have h57 := sd_x0_spec_gen_within .x19 balanceOut ob2 (16 : BitVec 12) (AB + 228)
+  rw [hz16, show (AB + 228 : Word) + 4 = AB + 232 from by bv_omega] at h57
+  have h57e := cpsTripleWithin_extend_code ad_mono
+    (cpsTripleWithin_extend_code
+      (CodeReq.ofProg_mem_at AB (AB + 228) accountDecode_prog 57 (.SD .x19 .x0 (16 : BitVec 12))
+        (by bv_omega) (by rw [ad_length]; decide) rfl (by rw [ad_length]; decide)) h57)
+  -- [58] sd x0, 24(x19)
+  have h58 := sd_x0_spec_gen_within .x19 balanceOut ob3 (24 : BitVec 12) (AB + 232)
+  rw [hz24, show (AB + 232 : Word) + 4 = AB + 236 from by bv_omega] at h58
+  have h58e := cpsTripleWithin_extend_code ad_mono
+    (cpsTripleWithin_extend_code
+      (CodeReq.ofProg_mem_at AB (AB + 232) accountDecode_prog 58 (.SD .x19 .x0 (24 : BitVec 12))
+        (by bv_omega) (by rw [ad_length]; decide) rfl (by rw [ad_length]; decide)) h58)
+  -- [59] sub x7, x7, x6
+  have h59 := sub_spec_gen_rd_eq_rs1_within .x7 .x6 (32 : Word) len (AB + 236) (by decide)
+  rw [show (AB + 236 : Word) + 4 = AB + 240 from by bv_omega] at h59
+  have h59e := cpsTripleWithin_extend_code ad_mono
+    (cpsTripleWithin_extend_code
+      (CodeReq.ofProg_mem_at AB (AB + 236) accountDecode_prog 59 (.SUB .x7 .x7 .x6)
+        (by bv_omega) (by rw [ad_length]; decide) rfl (by rw [ad_length]; decide)) h59)
+  -- [60] add x29, x19, x7
+  have h60 := add_spec_gen_within .x29 .x19 .x7 balanceOut ((32 : Word) - len) v29 (AB + 240)
+    (by decide)
+  rw [show (AB + 240 : Word) + 4 = AB + 244 from by bv_omega] at h60
+  have h60e := cpsTripleWithin_extend_code ad_mono
+    (cpsTripleWithin_extend_code
+      (CodeReq.ofProg_mem_at AB (AB + 240) accountDecode_prog 60 (.ADD .x29 .x19 .x7)
+        (by bv_omega) (by rw [ad_length]; decide) rfl (by rw [ad_length]; decide)) h60)
+  -- [61]-[62] la x5, ad_offset
+  have h61 := adLaOffX5_244 v5
+  -- [63] ld x28, 0(x5)
+  have h63 := ld_spec_gen_within .x28 .x5 adOffsetAddr v28 offset (0 : BitVec 12)
+    (AB + 252) (by decide)
+  rw [show adOffsetAddr + signExtend12 (0 : BitVec 12) = adOffsetAddr from by
+    rw [show signExtend12 (0 : BitVec 12) = (0 : Word) from by decide]; bv_omega,
+    show (AB + 252 : Word) + 4 = AB + 256 from by bv_omega] at h63
+  have h63e := cpsTripleWithin_extend_code ad_mono
+    (cpsTripleWithin_extend_code
+      (CodeReq.ofProg_mem_at AB (AB + 252) accountDecode_prog 63 (.LD .x28 .x5 (0 : BitVec 12))
+        (by bv_omega) (by rw [ad_length]; decide) rfl (by rw [ad_length]; decide)) h63)
+  -- [64] add x28, x8, x28
+  have h64 := add_spec_gen_rd_eq_rs2_within .x28 .x8 listBase offset (AB + 256) (by decide)
+  rw [show (AB + 256 : Word) + 4 = AB + 260 from by bv_omega] at h64
+  have h64e := cpsTripleWithin_extend_code ad_mono
+    (cpsTripleWithin_extend_code
+      (CodeReq.ofProg_mem_at AB (AB + 256) accountDecode_prog 64 (.ADD .x28 .x8 .x28)
+        (by bv_omega) (by rw [ad_length]; decide) rfl (by rw [ad_length]; decide)) h64)
+  -- Frame each store/op with the untouched carriers and compose.
+  have f55 := cpsTripleWithin_frameR
+    (((.x8 : Reg) ↦ᵣ listBase) ** ((.x6 : Reg) ↦ᵣ len) ** ((.x7 : Reg) ↦ᵣ (32 : Word)) **
+     ((.x5 : Reg) ↦ᵣ v5) ** ((.x28 : Reg) ↦ᵣ v28) ** ((.x29 : Reg) ↦ᵣ v29) **
+     ((balanceOut + 8) ↦ₘ ob1) ** ((balanceOut + 16) ↦ₘ ob2) **
+     ((balanceOut + 24) ↦ₘ ob3) ** (adOffsetAddr ↦ₘ offset))
+    (by repeat' first | exact pcFree_regIs | exact pcFree_memIs | apply pcFree_sepConj) h55e
+  have f56 := cpsTripleWithin_frameR
+    (((.x8 : Reg) ↦ᵣ listBase) ** ((.x6 : Reg) ↦ᵣ len) ** ((.x7 : Reg) ↦ᵣ (32 : Word)) **
+     ((.x5 : Reg) ↦ᵣ v5) ** ((.x28 : Reg) ↦ᵣ v28) ** ((.x29 : Reg) ↦ᵣ v29) **
+     (balanceOut ↦ₘ (0 : Word)) ** ((balanceOut + 16) ↦ₘ ob2) **
+     ((balanceOut + 24) ↦ₘ ob3) ** (adOffsetAddr ↦ₘ offset))
+    (by repeat' first | exact pcFree_regIs | exact pcFree_memIs | apply pcFree_sepConj) h56e
+  have f57 := cpsTripleWithin_frameR
+    (((.x8 : Reg) ↦ᵣ listBase) ** ((.x6 : Reg) ↦ᵣ len) ** ((.x7 : Reg) ↦ᵣ (32 : Word)) **
+     ((.x5 : Reg) ↦ᵣ v5) ** ((.x28 : Reg) ↦ᵣ v28) ** ((.x29 : Reg) ↦ᵣ v29) **
+     (balanceOut ↦ₘ (0 : Word)) ** ((balanceOut + 8) ↦ₘ (0 : Word)) **
+     ((balanceOut + 24) ↦ₘ ob3) ** (adOffsetAddr ↦ₘ offset))
+    (by repeat' first | exact pcFree_regIs | exact pcFree_memIs | apply pcFree_sepConj) h57e
+  have f58 := cpsTripleWithin_frameR
+    (((.x8 : Reg) ↦ᵣ listBase) ** ((.x6 : Reg) ↦ᵣ len) ** ((.x7 : Reg) ↦ᵣ (32 : Word)) **
+     ((.x5 : Reg) ↦ᵣ v5) ** ((.x28 : Reg) ↦ᵣ v28) ** ((.x29 : Reg) ↦ᵣ v29) **
+     (balanceOut ↦ₘ (0 : Word)) ** ((balanceOut + 8) ↦ₘ (0 : Word)) **
+     ((balanceOut + 16) ↦ₘ (0 : Word)) ** (adOffsetAddr ↦ₘ offset))
+    (by repeat' first | exact pcFree_regIs | exact pcFree_memIs | apply pcFree_sepConj) h58e
+  have f59 := cpsTripleWithin_frameR
+    (((.x19 : Reg) ↦ᵣ balanceOut) ** ((.x8 : Reg) ↦ᵣ listBase) ** ((.x5 : Reg) ↦ᵣ v5) **
+     ((.x28 : Reg) ↦ᵣ v28) ** ((.x29 : Reg) ↦ᵣ v29) **
+     (balanceOut ↦ₘ (0 : Word)) ** ((balanceOut + 8) ↦ₘ (0 : Word)) **
+     ((balanceOut + 16) ↦ₘ (0 : Word)) ** ((balanceOut + 24) ↦ₘ (0 : Word)) **
+     (adOffsetAddr ↦ₘ offset))
+    (by repeat' first | exact pcFree_regIs | exact pcFree_memIs | apply pcFree_sepConj) h59e
+  have f60 := cpsTripleWithin_frameR
+    (((.x8 : Reg) ↦ᵣ listBase) ** ((.x6 : Reg) ↦ᵣ len) ** ((.x5 : Reg) ↦ᵣ v5) **
+     ((.x28 : Reg) ↦ᵣ v28) **
+     (balanceOut ↦ₘ (0 : Word)) ** ((balanceOut + 8) ↦ₘ (0 : Word)) **
+     ((balanceOut + 16) ↦ₘ (0 : Word)) ** ((balanceOut + 24) ↦ₘ (0 : Word)) **
+     (adOffsetAddr ↦ₘ offset))
+    (by repeat' first | exact pcFree_regIs | exact pcFree_memIs | apply pcFree_sepConj) h60e
+  have f61 := cpsTripleWithin_frameR
+    (((.x19 : Reg) ↦ᵣ balanceOut) ** ((.x8 : Reg) ↦ᵣ listBase) ** ((.x6 : Reg) ↦ᵣ len) **
+     ((.x7 : Reg) ↦ᵣ ((32 : Word) - len)) ** ((.x28 : Reg) ↦ᵣ v28) **
+     ((.x29 : Reg) ↦ᵣ (balanceOut + ((32 : Word) - len))) **
+     (balanceOut ↦ₘ (0 : Word)) ** ((balanceOut + 8) ↦ₘ (0 : Word)) **
+     ((balanceOut + 16) ↦ₘ (0 : Word)) ** ((balanceOut + 24) ↦ₘ (0 : Word)) **
+     (adOffsetAddr ↦ₘ offset))
+    (by repeat' first | exact pcFree_regIs | exact pcFree_memIs | apply pcFree_sepConj) h61
+  have f63 := cpsTripleWithin_frameR
+    (((.x19 : Reg) ↦ᵣ balanceOut) ** ((.x8 : Reg) ↦ᵣ listBase) ** ((.x6 : Reg) ↦ᵣ len) **
+     ((.x7 : Reg) ↦ᵣ ((32 : Word) - len)) **
+     ((.x29 : Reg) ↦ᵣ (balanceOut + ((32 : Word) - len))) **
+     (balanceOut ↦ₘ (0 : Word)) ** ((balanceOut + 8) ↦ₘ (0 : Word)) **
+     ((balanceOut + 16) ↦ₘ (0 : Word)) ** ((balanceOut + 24) ↦ₘ (0 : Word)))
+    (by repeat' first | exact pcFree_regIs | exact pcFree_memIs | apply pcFree_sepConj) h63e
+  have f64 := cpsTripleWithin_frameR
+    (((.x19 : Reg) ↦ᵣ balanceOut) ** ((.x6 : Reg) ↦ᵣ len) **
+     ((.x7 : Reg) ↦ᵣ ((32 : Word) - len)) ** ((.x5 : Reg) ↦ᵣ adOffsetAddr) **
+     ((.x29 : Reg) ↦ᵣ (balanceOut + ((32 : Word) - len))) **
+     (balanceOut ↦ₘ (0 : Word)) ** ((balanceOut + 8) ↦ₘ (0 : Word)) **
+     ((balanceOut + 16) ↦ₘ (0 : Word)) ** ((balanceOut + 24) ↦ₘ (0 : Word)) **
+     (adOffsetAddr ↦ₘ offset))
+    (by repeat' first | exact pcFree_regIs | exact pcFree_memIs | apply pcFree_sepConj) h64e
+  have c1 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) f55 f56
+  have c2 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) c1 f57
+  have c3 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) c2 f58
+  have c4 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) c3 f59
+  have c5 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) c4 f60
+  have c6 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) c5 f61
+  have c7 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) c6 f63
+  have c8 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) c7 f64
+  exact cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
+    (fun _ hq => by rw [bytesRegion_replicate32_zero]; xperm_hyp hq) c8
+
+#print axioms adBalanceSetup
+
+end EvmAsm.Codegen.AccountDecodeSpec

--- a/EvmAsm/Codegen/Programs/AccountDecodeCall.lean
+++ b/EvmAsm/Codegen/Programs/AccountDecodeCall.lean
@@ -1,0 +1,233 @@
+/-
+  The four `rlp_list_nth_item` (K20) call blocks of `accountDecode_prog`
+  (`Programs/State.lean`, PR-K27).  Each field 0/1/2/3 is decoded by the same
+  strict selector, differing only in the immediate `LI x12 = N`, the guest
+  `la` immediates for the shared `ad_offset`/`ad_length` output cells, and the
+  return address linked by the field's `jal`.
+
+  Each call block is `arg-shuffle ;; jal ;; rlpListNthItem_flat_spec_within`:
+
+    * arg shuffle (`adFieldNSetup`, 7 instrs): `mv a0,s0 ; mv a1,s1 ; li a2,N ;
+      la a3,ad_offset ; la a4,ad_length` establishes K20's `entryRest`
+      (`rlp_list_nth_item(listBase, len, N, &ad_offset, &ad_length)`).
+    * the `jal` links `ra := return PC` and enters K20 at `B`.
+    * K20's `flatReturnResult` (offset/length cells written, the field-`N`
+      `Result` pinned) is returned.
+
+  Mirrors `WithdrawalDecodeSpec.wdField2Call` (the K20 call site).
+
+  No `sorry`/`admit`/`native_decide`/`bv_decide`; classical-3 axioms only.
+-/
+
+import EvmAsm.Codegen.Programs.AccountDecodeSpec
+import EvmAsm.Codegen.Programs.RlpListNthItemCallSAsm
+import EvmAsm.Rv64.LaResolve
+
+namespace EvmAsm.Codegen.AccountDecodeSpec
+
+open EvmAsm.Rv64 EvmAsm.Rv64.SAsm
+open EvmAsm.Codegen.RlpListNthItemSAsm (Saved entryRest flatReturnResult
+  rlpListNthItem_flat_spec_within regsAt_listNthFrame savedVals listNthFrame B)
+
+/-! ## Guest data-section cells written by every field's K20 call -/
+
+/-- The `ad_offset` data cell (holds the selected content's relative offset). -/
+abbrev adOffsetAddr : Word := (GuestAddrs.ad_offset : Word)
+/-- The `ad_length` data cell (holds the selected content's length). -/
+abbrev adLengthAddr : Word := (GuestAddrs.ad_length : Word)
+
+/-! ## `la` materialisers for the four call sites -/
+
+/-- `la x13, ad_offset` at field 0 [17]-[18] (`AB+68 → AB+76`). -/
+theorem adLaOff68 (v : Word) :
+    cpsTripleWithin 2 (AB + 68) (AB + 76) fullCode
+      (.x13 ↦ᵣ v) (.x13 ↦ᵣ adOffsetAddr) := by
+  have hau : ∀ a i, CodeReq.singleton (AB + 68)
+      (.AUIPC .x13 (Codegen.laHi GuestAddrs.ad_offset (GuestAddrs.account_decode + 68)))
+        a = some i → fullCode a = some i := fun a i hi => ad_mono a i
+    (CodeReq.ofProg_mem_at AB (AB + 68) accountDecode_prog 17
+      (.AUIPC .x13 (Codegen.laHi GuestAddrs.ad_offset (GuestAddrs.account_decode + 68)))
+      (by bv_omega) (by rw [ad_length]; decide) rfl (by rw [ad_length]; decide) a i hi)
+  have had : ∀ a i, CodeReq.singleton (AB + 72)
+      (.ADDI .x13 .x13 (Codegen.laLo GuestAddrs.ad_offset (GuestAddrs.account_decode + 68)))
+        a = some i → fullCode a = some i := fun a i hi => ad_mono a i
+    (CodeReq.ofProg_mem_at AB (AB + 72) accountDecode_prog 18
+      (.ADDI .x13 .x13 (Codegen.laLo GuestAddrs.ad_offset (GuestAddrs.account_decode + 68)))
+      (by bv_omega) (by rw [ad_length]; decide) rfl (by rw [ad_length]; decide) a i hi)
+  have h := la_materialize_within .x13 v (AB + 68) adOffsetAddr (by decide) (by decide) hau had
+  rw [show (AB + 68 : Word) + 8 = AB + 76 from by bv_omega] at h
+  exact h
+
+/-- `la x14, ad_length` at field 0 [19]-[20] (`AB+76 → AB+84`). -/
+theorem adLaLen76 (v : Word) :
+    cpsTripleWithin 2 (AB + 76) (AB + 84) fullCode
+      (.x14 ↦ᵣ v) (.x14 ↦ᵣ adLengthAddr) := by
+  have hau : ∀ a i, CodeReq.singleton (AB + 76)
+      (.AUIPC .x14 (Codegen.laHi GuestAddrs.ad_length (GuestAddrs.account_decode + 76)))
+        a = some i → fullCode a = some i := fun a i hi => ad_mono a i
+    (CodeReq.ofProg_mem_at AB (AB + 76) accountDecode_prog 19
+      (.AUIPC .x14 (Codegen.laHi GuestAddrs.ad_length (GuestAddrs.account_decode + 76)))
+      (by bv_omega) (by rw [ad_length]; decide) rfl (by rw [ad_length]; decide) a i hi)
+  have had : ∀ a i, CodeReq.singleton (AB + 80)
+      (.ADDI .x14 .x14 (Codegen.laLo GuestAddrs.ad_length (GuestAddrs.account_decode + 76)))
+        a = some i → fullCode a = some i := fun a i hi => ad_mono a i
+    (CodeReq.ofProg_mem_at AB (AB + 80) accountDecode_prog 20
+      (.ADDI .x14 .x14 (Codegen.laLo GuestAddrs.ad_length (GuestAddrs.account_decode + 76)))
+      (by bv_omega) (by rw [ad_length]; decide) rfl (by rw [ad_length]; decide) a i hi)
+  have h := la_materialize_within .x14 v (AB + 76) adLengthAddr (by decide) (by decide) hau had
+  rw [show (AB + 76 : Word) + 8 = AB + 84 from by bv_omega] at h
+  exact h
+
+set_option maxRecDepth 8000 in
+/-- Field-0 call setup [14]-[20] (`AB+56 → AB+84`): `mv a0,s0 ; mv a1,s1 ;
+    li a2,0 ; la a3,ad_offset ; la a4,ad_length` — arrange
+    `rlp_list_nth_item(listBase, len, 0, &ad_offset, &ad_length)`. -/
+theorem adField0Setup (v10 v11 v12 v13 v14 listBase len : Word) :
+    cpsTripleWithin 7 (AB + 56) (AB + 84) fullCode
+      (((.x10 : Reg) ↦ᵣ v10) ** ((.x11 : Reg) ↦ᵣ v11) ** ((.x12 : Reg) ↦ᵣ v12) **
+       ((.x13 : Reg) ↦ᵣ v13) ** ((.x14 : Reg) ↦ᵣ v14) ** ((.x8 : Reg) ↦ᵣ listBase) **
+       ((.x9 : Reg) ↦ᵣ len))
+      (((.x10 : Reg) ↦ᵣ listBase) ** ((.x11 : Reg) ↦ᵣ len) **
+       ((.x12 : Reg) ↦ᵣ (0 : Word)) ** ((.x13 : Reg) ↦ᵣ adOffsetAddr) **
+       ((.x14 : Reg) ↦ᵣ adLengthAddr) ** ((.x8 : Reg) ↦ᵣ listBase) **
+       ((.x9 : Reg) ↦ᵣ len)) := by
+  have h14 := mv_spec_gen_within .x10 .x8 listBase v10 (AB + 56) (by decide)
+  have h14e := cpsTripleWithin_extend_code ad_mono
+    (cpsTripleWithin_extend_code
+      (CodeReq.ofProg_mem_at AB (AB + 56) accountDecode_prog 14 (.MV .x10 .x8)
+        (by bv_omega) (by rw [ad_length]; decide) rfl (by rw [ad_length]; decide)) h14)
+  have h15 := mv_spec_gen_within .x11 .x9 len v11 (AB + 60) (by decide)
+  have h15e := cpsTripleWithin_extend_code ad_mono
+    (cpsTripleWithin_extend_code
+      (CodeReq.ofProg_mem_at AB (AB + 60) accountDecode_prog 15 (.MV .x11 .x9)
+        (by bv_omega) (by rw [ad_length]; decide) rfl (by rw [ad_length]; decide)) h15)
+  have h16 := li_spec_gen_within .x12 v12 (0 : Word) (AB + 64) (by decide)
+  have h16e := cpsTripleWithin_extend_code ad_mono
+    (cpsTripleWithin_extend_code
+      (CodeReq.ofProg_mem_at AB (AB + 64) accountDecode_prog 16 (.LI .x12 (0 : Word))
+        (by bv_omega) (by rw [ad_length]; decide) rfl (by rw [ad_length]; decide)) h16)
+  have h17 := adLaOff68 v13
+  have h19 := adLaLen76 v14
+  have f14 := cpsTripleWithin_frameR
+    (((.x11 : Reg) ↦ᵣ v11) ** ((.x12 : Reg) ↦ᵣ v12) ** ((.x13 : Reg) ↦ᵣ v13) **
+     ((.x14 : Reg) ↦ᵣ v14) ** ((.x9 : Reg) ↦ᵣ len))
+    (by repeat' first | exact pcFree_regIs | apply pcFree_sepConj) h14e
+  have f15 := cpsTripleWithin_frameR
+    (((.x10 : Reg) ↦ᵣ listBase) ** ((.x12 : Reg) ↦ᵣ v12) ** ((.x13 : Reg) ↦ᵣ v13) **
+     ((.x14 : Reg) ↦ᵣ v14) ** ((.x8 : Reg) ↦ᵣ listBase))
+    (by repeat' first | exact pcFree_regIs | apply pcFree_sepConj) h15e
+  have f16 := cpsTripleWithin_frameR
+    (((.x10 : Reg) ↦ᵣ listBase) ** ((.x11 : Reg) ↦ᵣ len) ** ((.x13 : Reg) ↦ᵣ v13) **
+     ((.x14 : Reg) ↦ᵣ v14) ** ((.x8 : Reg) ↦ᵣ listBase) ** ((.x9 : Reg) ↦ᵣ len))
+    (by repeat' first | exact pcFree_regIs | apply pcFree_sepConj) h16e
+  have f17 := cpsTripleWithin_frameR
+    (((.x10 : Reg) ↦ᵣ listBase) ** ((.x11 : Reg) ↦ᵣ len) ** ((.x12 : Reg) ↦ᵣ (0 : Word)) **
+     ((.x14 : Reg) ↦ᵣ v14) ** ((.x8 : Reg) ↦ᵣ listBase) ** ((.x9 : Reg) ↦ᵣ len))
+    (by repeat' first | exact pcFree_regIs | apply pcFree_sepConj) h17
+  have f19 := cpsTripleWithin_frameR
+    (((.x10 : Reg) ↦ᵣ listBase) ** ((.x11 : Reg) ↦ᵣ len) ** ((.x12 : Reg) ↦ᵣ (0 : Word)) **
+     ((.x13 : Reg) ↦ᵣ adOffsetAddr) ** ((.x8 : Reg) ↦ᵣ listBase) ** ((.x9 : Reg) ↦ᵣ len))
+    (by repeat' first | exact pcFree_regIs | apply pcFree_sepConj) h19
+  have s1 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) f14 f15
+  have s2 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) s1 f16
+  have s3 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) s2 f17
+  have s4 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) s3 f19
+  exact cpsTripleWithin_mono_nSteps (by omega)
+    (cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
+      (fun _ hq => by xperm_hyp hq) s4)
+
+#print axioms adField0Setup
+
+open EvmAsm.Codegen.RlpListNthItemSAsm in
+set_option maxRecDepth 8000 in
+/-- Field-0 RLP call adapter [14]-[21] + the strict `rlp_list_nth_item` selector
+    (index 0, outputs `ad_offset`/`ad_length`), `ra := AB+88`.  The post is
+    K20's `flatReturnResult` (its offset/length cells written, its `Result`
+    pinned). -/
+theorem adField0Call
+    (spW raIn listBase len s2v s3 s4 s5 oldOffset oldLen v10 v11 v12 v13 v14 : Word)
+    (bytes : List (BitVec 8)) (listLen : Nat)
+    (hlenW : len = BitVec.ofNat 64 listLen)
+    (hsalign : listBase.toNat % 8 = 0)
+    (hslack : listLen + 9 ≤ bytes.length)
+    (hover : listBase.toNat + bytes.length < 2 ^ 64)
+    (hvalid : ∀ k, k < bytes.length →
+      isValidByteAccess (listBase + BitVec.ofNat 64 k) = true) :
+    let saved : Saved :=
+      { ra := AB + 88, s0 := listBase, s1 := len, s2 := s2v, s3 := s3, s4 := s4,
+        s5 := s5 }
+    let n20 := (12 + ((85 + 93 * (0 + 2)) + 6)) + 9
+    cpsTripleWithin (7 + (1 + n20)) (AB + 56) (AB + 88) fullCode
+      (((.x1 : Reg) ↦ᵣ raIn) ** (.x2 ↦ᵣ spW) ** (.x8 ↦ᵣ listBase) ** (.x9 ↦ᵣ len) **
+        (.x18 ↦ᵣ s2v) ** (.x19 ↦ᵣ s3) ** (.x20 ↦ᵣ s4) ** (.x21 ↦ᵣ s5) **
+        (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ v11) ** (.x12 ↦ᵣ v12) ** (.x13 ↦ᵣ v13) **
+        (.x14 ↦ᵣ v14) ** stackFree spW 8 ** regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+        regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+        (.x0 ↦ᵣ (0 : Word)) ** bytesRegion listBase bytes **
+        (adOffsetAddr ↦ₘ oldOffset) ** (adLengthAddr ↦ₘ oldLen))
+      (flatReturnResult spW listBase (0 : Word) adOffsetAddr adLengthAddr oldOffset
+        oldLen saved bytes listLen 0) := by
+  intro saved n20
+  have hsetup := adField0Setup v10 v11 v12 v13 v14 listBase len
+  have hsetupF := cpsTripleWithin_frameR
+    ((.x1 ↦ᵣ raIn) ** (.x2 ↦ᵣ spW) ** (.x18 ↦ᵣ s2v) ** (.x19 ↦ᵣ s3) **
+     (.x20 ↦ᵣ s4) ** (.x21 ↦ᵣ s5) ** stackFree spW 8 ** regOwn .x5 ** regOwn .x6 **
+     regOwn .x7 ** regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+     (.x0 ↦ᵣ (0 : Word)) ** bytesRegion listBase bytes **
+     (adOffsetAddr ↦ₘ oldOffset) ** (adLengthAddr ↦ₘ oldLen))
+    (by repeat' first
+        | exact pcFree_regIs | exact pcFree_memIs | exact bytesRegion_pcFree _ _
+        | exact pcFree_regOwn | exact pcFree_stackFree _ _ | apply pcFree_sepConj) hsetup
+  have hhead : cpsTripleWithin 7 (AB + 56) (AB + 84) fullCode
+      (((.x1 : Reg) ↦ᵣ raIn) ** (.x2 ↦ᵣ spW) ** (.x8 ↦ᵣ listBase) ** (.x9 ↦ᵣ len) **
+        (.x18 ↦ᵣ s2v) ** (.x19 ↦ᵣ s3) ** (.x20 ↦ᵣ s4) ** (.x21 ↦ᵣ s5) **
+        (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ v11) ** (.x12 ↦ᵣ v12) ** (.x13 ↦ᵣ v13) **
+        (.x14 ↦ᵣ v14) ** stackFree spW 8 ** regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+        regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+        (.x0 ↦ᵣ (0 : Word)) ** bytesRegion listBase bytes **
+        (adOffsetAddr ↦ₘ oldOffset) ** (adLengthAddr ↦ₘ oldLen))
+      ((.x1 ↦ᵣ raIn) ** (.x2 ↦ᵣ spW) ** (.x8 ↦ᵣ listBase) ** (.x9 ↦ᵣ len) **
+       (.x18 ↦ᵣ s2v) ** (.x19 ↦ᵣ s3) ** (.x20 ↦ᵣ s4) ** (.x21 ↦ᵣ s5) **
+       stackFree spW 8 **
+       entryRest listBase len (0 : Word) adOffsetAddr adLengthAddr oldOffset oldLen bytes) :=
+    cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
+      (fun _ hq => by unfold entryRest; xperm_hyp hq) hsetupF
+  have hjal := jal_link_spec_within
+    (jalOff GuestAddrs.rlp_list_nth_item (GuestAddrs.account_decode + 84)) (AB + 84) raIn
+  rw [show (AB + 84) + signExtend21 (jalOff GuestAddrs.rlp_list_nth_item
+      (GuestAddrs.account_decode + 84)) = B from by decide,
+    show (AB + 84 + 4 : Word) = AB + 88 from by bv_omega] at hjal
+  have hjale := cpsTripleWithin_extend_code ad_mono
+    (cpsTripleWithin_extend_code
+      (CodeReq.ofProg_mem_at AB (AB + 84) accountDecode_prog 21
+        (.JAL .x1 (jalOff GuestAddrs.rlp_list_nth_item (GuestAddrs.account_decode + 84)))
+        (by bv_omega) (by rw [ad_length]; decide) rfl (by rw [ad_length]; decide)) hjal)
+  have hjalF := cpsTripleWithin_frameR
+    ((.x2 ↦ᵣ spW) ** (.x8 ↦ᵣ listBase) ** (.x9 ↦ᵣ len) ** (.x18 ↦ᵣ s2v) **
+     (.x19 ↦ᵣ s3) ** (.x20 ↦ᵣ s4) ** (.x21 ↦ᵣ s5) ** stackFree spW 8 **
+     entryRest listBase len (0 : Word) adOffsetAddr adLengthAddr oldOffset oldLen bytes)
+    (by repeat' first
+        | exact pcFree_regIs | exact pcFree_stackFree _ _
+        | exact (by unfold entryRest; repeat' first
+            | exact pcFree_regIs | exact pcFree_memIs | exact bytesRegion_pcFree _ _
+            | exact pcFree_regOwn | apply pcFree_sepConj : (entryRest listBase len (0 : Word)
+              adOffsetAddr adLengthAddr oldOffset oldLen bytes).pcFree)
+        | apply pcFree_sepConj) hjale
+  have hk20 := rlpListNthItem_flat_spec_within spW listBase len (0 : Word) adOffsetAddr
+    adLengthAddr oldOffset oldLen saved bytes listLen 0 hlenW (by decide) (by decide)
+    hsalign hslack hover hvalid (by show (AB + 88) &&& ~~~(1 : Word) = AB + 88; decide)
+  have hk20C := cpsTripleWithin_extend_code k20_mono hk20
+  have s1 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) hhead hjalF
+  have s2 := cpsTripleWithin_seq_perm_same_cr
+    (fun _ hp => by
+      rw [regsAt_listNthFrame]
+      simp only [show saved.ra = AB + 88 from rfl, show saved.s0 = listBase from rfl,
+        show saved.s1 = len from rfl, show saved.s2 = s2v from rfl,
+        show saved.s3 = s3 from rfl, show saved.s4 = s4 from rfl,
+        show saved.s5 = s5 from rfl]
+      xperm_hyp hp) s1 hk20C
+  exact cpsTripleWithin_mono_nSteps (by omega) s2
+
+#print axioms adField0Call
+
+end EvmAsm.Codegen.AccountDecodeSpec

--- a/EvmAsm/Codegen/Programs/AccountDecodeCall.lean
+++ b/EvmAsm/Codegen/Programs/AccountDecodeCall.lean
@@ -230,4 +230,563 @@ theorem adField0Call
 
 #print axioms adField0Call
 
+/-! ## Field 1 call block [41]-[48] (`AB+164 → AB+196`), index 1, `ra := AB+196` -/
+
+/-- `la x13, ad_offset` at field 1 [44]-[45] (`AB+176 → AB+184`). -/
+theorem adLaOff176 (v : Word) :
+    cpsTripleWithin 2 (AB + 176) (AB + 184) fullCode
+      (.x13 ↦ᵣ v) (.x13 ↦ᵣ adOffsetAddr) := by
+  have hau : ∀ a i, CodeReq.singleton (AB + 176)
+      (.AUIPC .x13 (Codegen.laHi GuestAddrs.ad_offset (GuestAddrs.account_decode + 176)))
+        a = some i → fullCode a = some i := fun a i hi => ad_mono a i
+    (CodeReq.ofProg_mem_at AB (AB + 176) accountDecode_prog 44
+      (.AUIPC .x13 (Codegen.laHi GuestAddrs.ad_offset (GuestAddrs.account_decode + 176)))
+      (by bv_omega) (by rw [ad_length]; decide) rfl (by rw [ad_length]; decide) a i hi)
+  have had : ∀ a i, CodeReq.singleton (AB + 180)
+      (.ADDI .x13 .x13 (Codegen.laLo GuestAddrs.ad_offset (GuestAddrs.account_decode + 176)))
+        a = some i → fullCode a = some i := fun a i hi => ad_mono a i
+    (CodeReq.ofProg_mem_at AB (AB + 180) accountDecode_prog 45
+      (.ADDI .x13 .x13 (Codegen.laLo GuestAddrs.ad_offset (GuestAddrs.account_decode + 176)))
+      (by bv_omega) (by rw [ad_length]; decide) rfl (by rw [ad_length]; decide) a i hi)
+  have h := la_materialize_within .x13 v (AB + 176) adOffsetAddr (by decide) (by decide) hau had
+  rw [show (AB + 176 : Word) + 8 = AB + 184 from by bv_omega] at h
+  exact h
+
+/-- `la x14, ad_length` at field 1 [46]-[47] (`AB+184 → AB+192`). -/
+theorem adLaLen184 (v : Word) :
+    cpsTripleWithin 2 (AB + 184) (AB + 192) fullCode
+      (.x14 ↦ᵣ v) (.x14 ↦ᵣ adLengthAddr) := by
+  have hau : ∀ a i, CodeReq.singleton (AB + 184)
+      (.AUIPC .x14 (Codegen.laHi GuestAddrs.ad_length (GuestAddrs.account_decode + 184)))
+        a = some i → fullCode a = some i := fun a i hi => ad_mono a i
+    (CodeReq.ofProg_mem_at AB (AB + 184) accountDecode_prog 46
+      (.AUIPC .x14 (Codegen.laHi GuestAddrs.ad_length (GuestAddrs.account_decode + 184)))
+      (by bv_omega) (by rw [ad_length]; decide) rfl (by rw [ad_length]; decide) a i hi)
+  have had : ∀ a i, CodeReq.singleton (AB + 188)
+      (.ADDI .x14 .x14 (Codegen.laLo GuestAddrs.ad_length (GuestAddrs.account_decode + 184)))
+        a = some i → fullCode a = some i := fun a i hi => ad_mono a i
+    (CodeReq.ofProg_mem_at AB (AB + 188) accountDecode_prog 47
+      (.ADDI .x14 .x14 (Codegen.laLo GuestAddrs.ad_length (GuestAddrs.account_decode + 184)))
+      (by bv_omega) (by rw [ad_length]; decide) rfl (by rw [ad_length]; decide) a i hi)
+  have h := la_materialize_within .x14 v (AB + 184) adLengthAddr (by decide) (by decide) hau had
+  rw [show (AB + 184 : Word) + 8 = AB + 192 from by bv_omega] at h
+  exact h
+
+set_option maxRecDepth 8000 in
+/-- Field-1 call setup [41]-[47] (`AB+164 → AB+192`): `li a2,1`. -/
+theorem adField1Setup (v10 v11 v12 v13 v14 listBase len : Word) :
+    cpsTripleWithin 7 (AB + 164) (AB + 192) fullCode
+      (((.x10 : Reg) ↦ᵣ v10) ** ((.x11 : Reg) ↦ᵣ v11) ** ((.x12 : Reg) ↦ᵣ v12) **
+       ((.x13 : Reg) ↦ᵣ v13) ** ((.x14 : Reg) ↦ᵣ v14) ** ((.x8 : Reg) ↦ᵣ listBase) **
+       ((.x9 : Reg) ↦ᵣ len))
+      (((.x10 : Reg) ↦ᵣ listBase) ** ((.x11 : Reg) ↦ᵣ len) **
+       ((.x12 : Reg) ↦ᵣ (1 : Word)) ** ((.x13 : Reg) ↦ᵣ adOffsetAddr) **
+       ((.x14 : Reg) ↦ᵣ adLengthAddr) ** ((.x8 : Reg) ↦ᵣ listBase) **
+       ((.x9 : Reg) ↦ᵣ len)) := by
+  have h41 := mv_spec_gen_within .x10 .x8 listBase v10 (AB + 164) (by decide)
+  have h41e := cpsTripleWithin_extend_code ad_mono
+    (cpsTripleWithin_extend_code
+      (CodeReq.ofProg_mem_at AB (AB + 164) accountDecode_prog 41 (.MV .x10 .x8)
+        (by bv_omega) (by rw [ad_length]; decide) rfl (by rw [ad_length]; decide)) h41)
+  have h42 := mv_spec_gen_within .x11 .x9 len v11 (AB + 168) (by decide)
+  have h42e := cpsTripleWithin_extend_code ad_mono
+    (cpsTripleWithin_extend_code
+      (CodeReq.ofProg_mem_at AB (AB + 168) accountDecode_prog 42 (.MV .x11 .x9)
+        (by bv_omega) (by rw [ad_length]; decide) rfl (by rw [ad_length]; decide)) h42)
+  have h43 := li_spec_gen_within .x12 v12 (1 : Word) (AB + 172) (by decide)
+  have h43e := cpsTripleWithin_extend_code ad_mono
+    (cpsTripleWithin_extend_code
+      (CodeReq.ofProg_mem_at AB (AB + 172) accountDecode_prog 43 (.LI .x12 (1 : Word))
+        (by bv_omega) (by rw [ad_length]; decide) rfl (by rw [ad_length]; decide)) h43)
+  have h44 := adLaOff176 v13
+  have h46 := adLaLen184 v14
+  have f41 := cpsTripleWithin_frameR
+    (((.x11 : Reg) ↦ᵣ v11) ** ((.x12 : Reg) ↦ᵣ v12) ** ((.x13 : Reg) ↦ᵣ v13) **
+     ((.x14 : Reg) ↦ᵣ v14) ** ((.x9 : Reg) ↦ᵣ len))
+    (by repeat' first | exact pcFree_regIs | apply pcFree_sepConj) h41e
+  have f42 := cpsTripleWithin_frameR
+    (((.x10 : Reg) ↦ᵣ listBase) ** ((.x12 : Reg) ↦ᵣ v12) ** ((.x13 : Reg) ↦ᵣ v13) **
+     ((.x14 : Reg) ↦ᵣ v14) ** ((.x8 : Reg) ↦ᵣ listBase))
+    (by repeat' first | exact pcFree_regIs | apply pcFree_sepConj) h42e
+  have f43 := cpsTripleWithin_frameR
+    (((.x10 : Reg) ↦ᵣ listBase) ** ((.x11 : Reg) ↦ᵣ len) ** ((.x13 : Reg) ↦ᵣ v13) **
+     ((.x14 : Reg) ↦ᵣ v14) ** ((.x8 : Reg) ↦ᵣ listBase) ** ((.x9 : Reg) ↦ᵣ len))
+    (by repeat' first | exact pcFree_regIs | apply pcFree_sepConj) h43e
+  have f44 := cpsTripleWithin_frameR
+    (((.x10 : Reg) ↦ᵣ listBase) ** ((.x11 : Reg) ↦ᵣ len) ** ((.x12 : Reg) ↦ᵣ (1 : Word)) **
+     ((.x14 : Reg) ↦ᵣ v14) ** ((.x8 : Reg) ↦ᵣ listBase) ** ((.x9 : Reg) ↦ᵣ len))
+    (by repeat' first | exact pcFree_regIs | apply pcFree_sepConj) h44
+  have f46 := cpsTripleWithin_frameR
+    (((.x10 : Reg) ↦ᵣ listBase) ** ((.x11 : Reg) ↦ᵣ len) ** ((.x12 : Reg) ↦ᵣ (1 : Word)) **
+     ((.x13 : Reg) ↦ᵣ adOffsetAddr) ** ((.x8 : Reg) ↦ᵣ listBase) ** ((.x9 : Reg) ↦ᵣ len))
+    (by repeat' first | exact pcFree_regIs | apply pcFree_sepConj) h46
+  have s1 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) f41 f42
+  have s2 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) s1 f43
+  have s3 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) s2 f44
+  have s4 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) s3 f46
+  exact cpsTripleWithin_mono_nSteps (by omega)
+    (cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
+      (fun _ hq => by xperm_hyp hq) s4)
+
+open EvmAsm.Codegen.RlpListNthItemSAsm in
+set_option maxRecDepth 8000 in
+/-- Field-1 RLP call adapter [41]-[48] + `rlp_list_nth_item` (index 1), `ra := AB+196`. -/
+theorem adField1Call
+    (spW raIn listBase len s2v s3 s4 s5 oldOffset oldLen v10 v11 v12 v13 v14 : Word)
+    (bytes : List (BitVec 8)) (listLen : Nat)
+    (hlenW : len = BitVec.ofNat 64 listLen)
+    (hsalign : listBase.toNat % 8 = 0)
+    (hslack : listLen + 9 ≤ bytes.length)
+    (hover : listBase.toNat + bytes.length < 2 ^ 64)
+    (hvalid : ∀ k, k < bytes.length →
+      isValidByteAccess (listBase + BitVec.ofNat 64 k) = true) :
+    let saved : Saved :=
+      { ra := AB + 196, s0 := listBase, s1 := len, s2 := s2v, s3 := s3, s4 := s4,
+        s5 := s5 }
+    let n20 := (12 + ((85 + 93 * (1 + 2)) + 6)) + 9
+    cpsTripleWithin (7 + (1 + n20)) (AB + 164) (AB + 196) fullCode
+      (((.x1 : Reg) ↦ᵣ raIn) ** (.x2 ↦ᵣ spW) ** (.x8 ↦ᵣ listBase) ** (.x9 ↦ᵣ len) **
+        (.x18 ↦ᵣ s2v) ** (.x19 ↦ᵣ s3) ** (.x20 ↦ᵣ s4) ** (.x21 ↦ᵣ s5) **
+        (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ v11) ** (.x12 ↦ᵣ v12) ** (.x13 ↦ᵣ v13) **
+        (.x14 ↦ᵣ v14) ** stackFree spW 8 ** regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+        regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+        (.x0 ↦ᵣ (0 : Word)) ** bytesRegion listBase bytes **
+        (adOffsetAddr ↦ₘ oldOffset) ** (adLengthAddr ↦ₘ oldLen))
+      (flatReturnResult spW listBase (1 : Word) adOffsetAddr adLengthAddr oldOffset
+        oldLen saved bytes listLen 1) := by
+  intro saved n20
+  have hsetup := adField1Setup v10 v11 v12 v13 v14 listBase len
+  have hsetupF := cpsTripleWithin_frameR
+    ((.x1 ↦ᵣ raIn) ** (.x2 ↦ᵣ spW) ** (.x18 ↦ᵣ s2v) ** (.x19 ↦ᵣ s3) **
+     (.x20 ↦ᵣ s4) ** (.x21 ↦ᵣ s5) ** stackFree spW 8 ** regOwn .x5 ** regOwn .x6 **
+     regOwn .x7 ** regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+     (.x0 ↦ᵣ (0 : Word)) ** bytesRegion listBase bytes **
+     (adOffsetAddr ↦ₘ oldOffset) ** (adLengthAddr ↦ₘ oldLen))
+    (by repeat' first
+        | exact pcFree_regIs | exact pcFree_memIs | exact bytesRegion_pcFree _ _
+        | exact pcFree_regOwn | exact pcFree_stackFree _ _ | apply pcFree_sepConj) hsetup
+  have hhead : cpsTripleWithin 7 (AB + 164) (AB + 192) fullCode
+      (((.x1 : Reg) ↦ᵣ raIn) ** (.x2 ↦ᵣ spW) ** (.x8 ↦ᵣ listBase) ** (.x9 ↦ᵣ len) **
+        (.x18 ↦ᵣ s2v) ** (.x19 ↦ᵣ s3) ** (.x20 ↦ᵣ s4) ** (.x21 ↦ᵣ s5) **
+        (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ v11) ** (.x12 ↦ᵣ v12) ** (.x13 ↦ᵣ v13) **
+        (.x14 ↦ᵣ v14) ** stackFree spW 8 ** regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+        regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+        (.x0 ↦ᵣ (0 : Word)) ** bytesRegion listBase bytes **
+        (adOffsetAddr ↦ₘ oldOffset) ** (adLengthAddr ↦ₘ oldLen))
+      ((.x1 ↦ᵣ raIn) ** (.x2 ↦ᵣ spW) ** (.x8 ↦ᵣ listBase) ** (.x9 ↦ᵣ len) **
+       (.x18 ↦ᵣ s2v) ** (.x19 ↦ᵣ s3) ** (.x20 ↦ᵣ s4) ** (.x21 ↦ᵣ s5) **
+       stackFree spW 8 **
+       entryRest listBase len (1 : Word) adOffsetAddr adLengthAddr oldOffset oldLen bytes) :=
+    cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
+      (fun _ hq => by unfold entryRest; xperm_hyp hq) hsetupF
+  have hjal := jal_link_spec_within
+    (jalOff GuestAddrs.rlp_list_nth_item (GuestAddrs.account_decode + 192)) (AB + 192) raIn
+  rw [show (AB + 192) + signExtend21 (jalOff GuestAddrs.rlp_list_nth_item
+      (GuestAddrs.account_decode + 192)) = B from by decide,
+    show (AB + 192 + 4 : Word) = AB + 196 from by bv_omega] at hjal
+  have hjale := cpsTripleWithin_extend_code ad_mono
+    (cpsTripleWithin_extend_code
+      (CodeReq.ofProg_mem_at AB (AB + 192) accountDecode_prog 48
+        (.JAL .x1 (jalOff GuestAddrs.rlp_list_nth_item (GuestAddrs.account_decode + 192)))
+        (by bv_omega) (by rw [ad_length]; decide) rfl (by rw [ad_length]; decide)) hjal)
+  have hjalF := cpsTripleWithin_frameR
+    ((.x2 ↦ᵣ spW) ** (.x8 ↦ᵣ listBase) ** (.x9 ↦ᵣ len) ** (.x18 ↦ᵣ s2v) **
+     (.x19 ↦ᵣ s3) ** (.x20 ↦ᵣ s4) ** (.x21 ↦ᵣ s5) ** stackFree spW 8 **
+     entryRest listBase len (1 : Word) adOffsetAddr adLengthAddr oldOffset oldLen bytes)
+    (by repeat' first
+        | exact pcFree_regIs | exact pcFree_stackFree _ _
+        | exact (by unfold entryRest; repeat' first
+            | exact pcFree_regIs | exact pcFree_memIs | exact bytesRegion_pcFree _ _
+            | exact pcFree_regOwn | apply pcFree_sepConj : (entryRest listBase len (1 : Word)
+              adOffsetAddr adLengthAddr oldOffset oldLen bytes).pcFree)
+        | apply pcFree_sepConj) hjale
+  have hk20 := rlpListNthItem_flat_spec_within spW listBase len (1 : Word) adOffsetAddr
+    adLengthAddr oldOffset oldLen saved bytes listLen 1 hlenW (by decide) (by decide)
+    hsalign hslack hover hvalid (by show (AB + 196) &&& ~~~(1 : Word) = AB + 196; decide)
+  have hk20C := cpsTripleWithin_extend_code k20_mono hk20
+  have s1 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) hhead hjalF
+  have s2 := cpsTripleWithin_seq_perm_same_cr
+    (fun _ hp => by
+      rw [regsAt_listNthFrame]
+      simp only [show saved.ra = AB + 196 from rfl, show saved.s0 = listBase from rfl,
+        show saved.s1 = len from rfl, show saved.s2 = s2v from rfl,
+        show saved.s3 = s3 from rfl, show saved.s4 = s4 from rfl,
+        show saved.s5 = s5 from rfl]
+      xperm_hyp hp) s1 hk20C
+  exact cpsTripleWithin_mono_nSteps (by omega) s2
+
+/-! ## Field 2 call block [72]-[79] (`AB+288 → AB+320`), index 2, `ra := AB+320` -/
+
+/-- `la x13, ad_offset` at field 2 [75]-[76] (`AB+300 → AB+308`). -/
+theorem adLaOff300 (v : Word) :
+    cpsTripleWithin 2 (AB + 300) (AB + 308) fullCode
+      (.x13 ↦ᵣ v) (.x13 ↦ᵣ adOffsetAddr) := by
+  have hau : ∀ a i, CodeReq.singleton (AB + 300)
+      (.AUIPC .x13 (Codegen.laHi GuestAddrs.ad_offset (GuestAddrs.account_decode + 300)))
+        a = some i → fullCode a = some i := fun a i hi => ad_mono a i
+    (CodeReq.ofProg_mem_at AB (AB + 300) accountDecode_prog 75
+      (.AUIPC .x13 (Codegen.laHi GuestAddrs.ad_offset (GuestAddrs.account_decode + 300)))
+      (by bv_omega) (by rw [ad_length]; decide) rfl (by rw [ad_length]; decide) a i hi)
+  have had : ∀ a i, CodeReq.singleton (AB + 304)
+      (.ADDI .x13 .x13 (Codegen.laLo GuestAddrs.ad_offset (GuestAddrs.account_decode + 300)))
+        a = some i → fullCode a = some i := fun a i hi => ad_mono a i
+    (CodeReq.ofProg_mem_at AB (AB + 304) accountDecode_prog 76
+      (.ADDI .x13 .x13 (Codegen.laLo GuestAddrs.ad_offset (GuestAddrs.account_decode + 300)))
+      (by bv_omega) (by rw [ad_length]; decide) rfl (by rw [ad_length]; decide) a i hi)
+  have h := la_materialize_within .x13 v (AB + 300) adOffsetAddr (by decide) (by decide) hau had
+  rw [show (AB + 300 : Word) + 8 = AB + 308 from by bv_omega] at h
+  exact h
+
+/-- `la x14, ad_length` at field 2 [77]-[78] (`AB+308 → AB+316`). -/
+theorem adLaLen308 (v : Word) :
+    cpsTripleWithin 2 (AB + 308) (AB + 316) fullCode
+      (.x14 ↦ᵣ v) (.x14 ↦ᵣ adLengthAddr) := by
+  have hau : ∀ a i, CodeReq.singleton (AB + 308)
+      (.AUIPC .x14 (Codegen.laHi GuestAddrs.ad_length (GuestAddrs.account_decode + 308)))
+        a = some i → fullCode a = some i := fun a i hi => ad_mono a i
+    (CodeReq.ofProg_mem_at AB (AB + 308) accountDecode_prog 77
+      (.AUIPC .x14 (Codegen.laHi GuestAddrs.ad_length (GuestAddrs.account_decode + 308)))
+      (by bv_omega) (by rw [ad_length]; decide) rfl (by rw [ad_length]; decide) a i hi)
+  have had : ∀ a i, CodeReq.singleton (AB + 312)
+      (.ADDI .x14 .x14 (Codegen.laLo GuestAddrs.ad_length (GuestAddrs.account_decode + 308)))
+        a = some i → fullCode a = some i := fun a i hi => ad_mono a i
+    (CodeReq.ofProg_mem_at AB (AB + 312) accountDecode_prog 78
+      (.ADDI .x14 .x14 (Codegen.laLo GuestAddrs.ad_length (GuestAddrs.account_decode + 308)))
+      (by bv_omega) (by rw [ad_length]; decide) rfl (by rw [ad_length]; decide) a i hi)
+  have h := la_materialize_within .x14 v (AB + 308) adLengthAddr (by decide) (by decide) hau had
+  rw [show (AB + 308 : Word) + 8 = AB + 316 from by bv_omega] at h
+  exact h
+
+set_option maxRecDepth 8000 in
+/-- Field-2 call setup [72]-[78] (`AB+288 → AB+316`): `li a2,2`. -/
+theorem adField2Setup (v10 v11 v12 v13 v14 listBase len : Word) :
+    cpsTripleWithin 7 (AB + 288) (AB + 316) fullCode
+      (((.x10 : Reg) ↦ᵣ v10) ** ((.x11 : Reg) ↦ᵣ v11) ** ((.x12 : Reg) ↦ᵣ v12) **
+       ((.x13 : Reg) ↦ᵣ v13) ** ((.x14 : Reg) ↦ᵣ v14) ** ((.x8 : Reg) ↦ᵣ listBase) **
+       ((.x9 : Reg) ↦ᵣ len))
+      (((.x10 : Reg) ↦ᵣ listBase) ** ((.x11 : Reg) ↦ᵣ len) **
+       ((.x12 : Reg) ↦ᵣ (2 : Word)) ** ((.x13 : Reg) ↦ᵣ adOffsetAddr) **
+       ((.x14 : Reg) ↦ᵣ adLengthAddr) ** ((.x8 : Reg) ↦ᵣ listBase) **
+       ((.x9 : Reg) ↦ᵣ len)) := by
+  have h72 := mv_spec_gen_within .x10 .x8 listBase v10 (AB + 288) (by decide)
+  have h72e := cpsTripleWithin_extend_code ad_mono
+    (cpsTripleWithin_extend_code
+      (CodeReq.ofProg_mem_at AB (AB + 288) accountDecode_prog 72 (.MV .x10 .x8)
+        (by bv_omega) (by rw [ad_length]; decide) rfl (by rw [ad_length]; decide)) h72)
+  have h73 := mv_spec_gen_within .x11 .x9 len v11 (AB + 292) (by decide)
+  have h73e := cpsTripleWithin_extend_code ad_mono
+    (cpsTripleWithin_extend_code
+      (CodeReq.ofProg_mem_at AB (AB + 292) accountDecode_prog 73 (.MV .x11 .x9)
+        (by bv_omega) (by rw [ad_length]; decide) rfl (by rw [ad_length]; decide)) h73)
+  have h74 := li_spec_gen_within .x12 v12 (2 : Word) (AB + 296) (by decide)
+  have h74e := cpsTripleWithin_extend_code ad_mono
+    (cpsTripleWithin_extend_code
+      (CodeReq.ofProg_mem_at AB (AB + 296) accountDecode_prog 74 (.LI .x12 (2 : Word))
+        (by bv_omega) (by rw [ad_length]; decide) rfl (by rw [ad_length]; decide)) h74)
+  have h75 := adLaOff300 v13
+  have h77 := adLaLen308 v14
+  have f72 := cpsTripleWithin_frameR
+    (((.x11 : Reg) ↦ᵣ v11) ** ((.x12 : Reg) ↦ᵣ v12) ** ((.x13 : Reg) ↦ᵣ v13) **
+     ((.x14 : Reg) ↦ᵣ v14) ** ((.x9 : Reg) ↦ᵣ len))
+    (by repeat' first | exact pcFree_regIs | apply pcFree_sepConj) h72e
+  have f73 := cpsTripleWithin_frameR
+    (((.x10 : Reg) ↦ᵣ listBase) ** ((.x12 : Reg) ↦ᵣ v12) ** ((.x13 : Reg) ↦ᵣ v13) **
+     ((.x14 : Reg) ↦ᵣ v14) ** ((.x8 : Reg) ↦ᵣ listBase))
+    (by repeat' first | exact pcFree_regIs | apply pcFree_sepConj) h73e
+  have f74 := cpsTripleWithin_frameR
+    (((.x10 : Reg) ↦ᵣ listBase) ** ((.x11 : Reg) ↦ᵣ len) ** ((.x13 : Reg) ↦ᵣ v13) **
+     ((.x14 : Reg) ↦ᵣ v14) ** ((.x8 : Reg) ↦ᵣ listBase) ** ((.x9 : Reg) ↦ᵣ len))
+    (by repeat' first | exact pcFree_regIs | apply pcFree_sepConj) h74e
+  have f75 := cpsTripleWithin_frameR
+    (((.x10 : Reg) ↦ᵣ listBase) ** ((.x11 : Reg) ↦ᵣ len) ** ((.x12 : Reg) ↦ᵣ (2 : Word)) **
+     ((.x14 : Reg) ↦ᵣ v14) ** ((.x8 : Reg) ↦ᵣ listBase) ** ((.x9 : Reg) ↦ᵣ len))
+    (by repeat' first | exact pcFree_regIs | apply pcFree_sepConj) h75
+  have f77 := cpsTripleWithin_frameR
+    (((.x10 : Reg) ↦ᵣ listBase) ** ((.x11 : Reg) ↦ᵣ len) ** ((.x12 : Reg) ↦ᵣ (2 : Word)) **
+     ((.x13 : Reg) ↦ᵣ adOffsetAddr) ** ((.x8 : Reg) ↦ᵣ listBase) ** ((.x9 : Reg) ↦ᵣ len))
+    (by repeat' first | exact pcFree_regIs | apply pcFree_sepConj) h77
+  have s1 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) f72 f73
+  have s2 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) s1 f74
+  have s3 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) s2 f75
+  have s4 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) s3 f77
+  exact cpsTripleWithin_mono_nSteps (by omega)
+    (cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
+      (fun _ hq => by xperm_hyp hq) s4)
+
+open EvmAsm.Codegen.RlpListNthItemSAsm in
+set_option maxRecDepth 8000 in
+/-- Field-2 RLP call adapter [72]-[79] + `rlp_list_nth_item` (index 2), `ra := AB+320`. -/
+theorem adField2Call
+    (spW raIn listBase len s2v s3 s4 s5 oldOffset oldLen v10 v11 v12 v13 v14 : Word)
+    (bytes : List (BitVec 8)) (listLen : Nat)
+    (hlenW : len = BitVec.ofNat 64 listLen)
+    (hsalign : listBase.toNat % 8 = 0)
+    (hslack : listLen + 9 ≤ bytes.length)
+    (hover : listBase.toNat + bytes.length < 2 ^ 64)
+    (hvalid : ∀ k, k < bytes.length →
+      isValidByteAccess (listBase + BitVec.ofNat 64 k) = true) :
+    let saved : Saved :=
+      { ra := AB + 320, s0 := listBase, s1 := len, s2 := s2v, s3 := s3, s4 := s4,
+        s5 := s5 }
+    let n20 := (12 + ((85 + 93 * (2 + 2)) + 6)) + 9
+    cpsTripleWithin (7 + (1 + n20)) (AB + 288) (AB + 320) fullCode
+      (((.x1 : Reg) ↦ᵣ raIn) ** (.x2 ↦ᵣ spW) ** (.x8 ↦ᵣ listBase) ** (.x9 ↦ᵣ len) **
+        (.x18 ↦ᵣ s2v) ** (.x19 ↦ᵣ s3) ** (.x20 ↦ᵣ s4) ** (.x21 ↦ᵣ s5) **
+        (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ v11) ** (.x12 ↦ᵣ v12) ** (.x13 ↦ᵣ v13) **
+        (.x14 ↦ᵣ v14) ** stackFree spW 8 ** regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+        regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+        (.x0 ↦ᵣ (0 : Word)) ** bytesRegion listBase bytes **
+        (adOffsetAddr ↦ₘ oldOffset) ** (adLengthAddr ↦ₘ oldLen))
+      (flatReturnResult spW listBase (2 : Word) adOffsetAddr adLengthAddr oldOffset
+        oldLen saved bytes listLen 2) := by
+  intro saved n20
+  have hsetup := adField2Setup v10 v11 v12 v13 v14 listBase len
+  have hsetupF := cpsTripleWithin_frameR
+    ((.x1 ↦ᵣ raIn) ** (.x2 ↦ᵣ spW) ** (.x18 ↦ᵣ s2v) ** (.x19 ↦ᵣ s3) **
+     (.x20 ↦ᵣ s4) ** (.x21 ↦ᵣ s5) ** stackFree spW 8 ** regOwn .x5 ** regOwn .x6 **
+     regOwn .x7 ** regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+     (.x0 ↦ᵣ (0 : Word)) ** bytesRegion listBase bytes **
+     (adOffsetAddr ↦ₘ oldOffset) ** (adLengthAddr ↦ₘ oldLen))
+    (by repeat' first
+        | exact pcFree_regIs | exact pcFree_memIs | exact bytesRegion_pcFree _ _
+        | exact pcFree_regOwn | exact pcFree_stackFree _ _ | apply pcFree_sepConj) hsetup
+  have hhead : cpsTripleWithin 7 (AB + 288) (AB + 316) fullCode
+      (((.x1 : Reg) ↦ᵣ raIn) ** (.x2 ↦ᵣ spW) ** (.x8 ↦ᵣ listBase) ** (.x9 ↦ᵣ len) **
+        (.x18 ↦ᵣ s2v) ** (.x19 ↦ᵣ s3) ** (.x20 ↦ᵣ s4) ** (.x21 ↦ᵣ s5) **
+        (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ v11) ** (.x12 ↦ᵣ v12) ** (.x13 ↦ᵣ v13) **
+        (.x14 ↦ᵣ v14) ** stackFree spW 8 ** regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+        regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+        (.x0 ↦ᵣ (0 : Word)) ** bytesRegion listBase bytes **
+        (adOffsetAddr ↦ₘ oldOffset) ** (adLengthAddr ↦ₘ oldLen))
+      ((.x1 ↦ᵣ raIn) ** (.x2 ↦ᵣ spW) ** (.x8 ↦ᵣ listBase) ** (.x9 ↦ᵣ len) **
+       (.x18 ↦ᵣ s2v) ** (.x19 ↦ᵣ s3) ** (.x20 ↦ᵣ s4) ** (.x21 ↦ᵣ s5) **
+       stackFree spW 8 **
+       entryRest listBase len (2 : Word) adOffsetAddr adLengthAddr oldOffset oldLen bytes) :=
+    cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
+      (fun _ hq => by unfold entryRest; xperm_hyp hq) hsetupF
+  have hjal := jal_link_spec_within
+    (jalOff GuestAddrs.rlp_list_nth_item (GuestAddrs.account_decode + 316)) (AB + 316) raIn
+  rw [show (AB + 316) + signExtend21 (jalOff GuestAddrs.rlp_list_nth_item
+      (GuestAddrs.account_decode + 316)) = B from by decide,
+    show (AB + 316 + 4 : Word) = AB + 320 from by bv_omega] at hjal
+  have hjale := cpsTripleWithin_extend_code ad_mono
+    (cpsTripleWithin_extend_code
+      (CodeReq.ofProg_mem_at AB (AB + 316) accountDecode_prog 79
+        (.JAL .x1 (jalOff GuestAddrs.rlp_list_nth_item (GuestAddrs.account_decode + 316)))
+        (by bv_omega) (by rw [ad_length]; decide) rfl (by rw [ad_length]; decide)) hjal)
+  have hjalF := cpsTripleWithin_frameR
+    ((.x2 ↦ᵣ spW) ** (.x8 ↦ᵣ listBase) ** (.x9 ↦ᵣ len) ** (.x18 ↦ᵣ s2v) **
+     (.x19 ↦ᵣ s3) ** (.x20 ↦ᵣ s4) ** (.x21 ↦ᵣ s5) ** stackFree spW 8 **
+     entryRest listBase len (2 : Word) adOffsetAddr adLengthAddr oldOffset oldLen bytes)
+    (by repeat' first
+        | exact pcFree_regIs | exact pcFree_stackFree _ _
+        | exact (by unfold entryRest; repeat' first
+            | exact pcFree_regIs | exact pcFree_memIs | exact bytesRegion_pcFree _ _
+            | exact pcFree_regOwn | apply pcFree_sepConj : (entryRest listBase len (2 : Word)
+              adOffsetAddr adLengthAddr oldOffset oldLen bytes).pcFree)
+        | apply pcFree_sepConj) hjale
+  have hk20 := rlpListNthItem_flat_spec_within spW listBase len (2 : Word) adOffsetAddr
+    adLengthAddr oldOffset oldLen saved bytes listLen 2 hlenW (by decide) (by decide)
+    hsalign hslack hover hvalid (by show (AB + 320) &&& ~~~(1 : Word) = AB + 320; decide)
+  have hk20C := cpsTripleWithin_extend_code k20_mono hk20
+  have s1 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) hhead hjalF
+  have s2 := cpsTripleWithin_seq_perm_same_cr
+    (fun _ hp => by
+      rw [regsAt_listNthFrame]
+      simp only [show saved.ra = AB + 320 from rfl, show saved.s0 = listBase from rfl,
+        show saved.s1 = len from rfl, show saved.s2 = s2v from rfl,
+        show saved.s3 = s3 from rfl, show saved.s4 = s4 from rfl,
+        show saved.s5 = s5 from rfl]
+      xperm_hyp hp) s1 hk20C
+  exact cpsTripleWithin_mono_nSteps (by omega) s2
+
+/-! ## Field 3 call block [98]-[105] (`AB+392 → AB+424`), index 3, `ra := AB+424` -/
+
+/-- `la x13, ad_offset` at field 3 [101]-[102] (`AB+404 → AB+412`). -/
+theorem adLaOff404 (v : Word) :
+    cpsTripleWithin 2 (AB + 404) (AB + 412) fullCode
+      (.x13 ↦ᵣ v) (.x13 ↦ᵣ adOffsetAddr) := by
+  have hau : ∀ a i, CodeReq.singleton (AB + 404)
+      (.AUIPC .x13 (Codegen.laHi GuestAddrs.ad_offset (GuestAddrs.account_decode + 404)))
+        a = some i → fullCode a = some i := fun a i hi => ad_mono a i
+    (CodeReq.ofProg_mem_at AB (AB + 404) accountDecode_prog 101
+      (.AUIPC .x13 (Codegen.laHi GuestAddrs.ad_offset (GuestAddrs.account_decode + 404)))
+      (by bv_omega) (by rw [ad_length]; decide) rfl (by rw [ad_length]; decide) a i hi)
+  have had : ∀ a i, CodeReq.singleton (AB + 408)
+      (.ADDI .x13 .x13 (Codegen.laLo GuestAddrs.ad_offset (GuestAddrs.account_decode + 404)))
+        a = some i → fullCode a = some i := fun a i hi => ad_mono a i
+    (CodeReq.ofProg_mem_at AB (AB + 408) accountDecode_prog 102
+      (.ADDI .x13 .x13 (Codegen.laLo GuestAddrs.ad_offset (GuestAddrs.account_decode + 404)))
+      (by bv_omega) (by rw [ad_length]; decide) rfl (by rw [ad_length]; decide) a i hi)
+  have h := la_materialize_within .x13 v (AB + 404) adOffsetAddr (by decide) (by decide) hau had
+  rw [show (AB + 404 : Word) + 8 = AB + 412 from by bv_omega] at h
+  exact h
+
+/-- `la x14, ad_length` at field 3 [103]-[104] (`AB+412 → AB+420`). -/
+theorem adLaLen412 (v : Word) :
+    cpsTripleWithin 2 (AB + 412) (AB + 420) fullCode
+      (.x14 ↦ᵣ v) (.x14 ↦ᵣ adLengthAddr) := by
+  have hau : ∀ a i, CodeReq.singleton (AB + 412)
+      (.AUIPC .x14 (Codegen.laHi GuestAddrs.ad_length (GuestAddrs.account_decode + 412)))
+        a = some i → fullCode a = some i := fun a i hi => ad_mono a i
+    (CodeReq.ofProg_mem_at AB (AB + 412) accountDecode_prog 103
+      (.AUIPC .x14 (Codegen.laHi GuestAddrs.ad_length (GuestAddrs.account_decode + 412)))
+      (by bv_omega) (by rw [ad_length]; decide) rfl (by rw [ad_length]; decide) a i hi)
+  have had : ∀ a i, CodeReq.singleton (AB + 416)
+      (.ADDI .x14 .x14 (Codegen.laLo GuestAddrs.ad_length (GuestAddrs.account_decode + 412)))
+        a = some i → fullCode a = some i := fun a i hi => ad_mono a i
+    (CodeReq.ofProg_mem_at AB (AB + 416) accountDecode_prog 104
+      (.ADDI .x14 .x14 (Codegen.laLo GuestAddrs.ad_length (GuestAddrs.account_decode + 412)))
+      (by bv_omega) (by rw [ad_length]; decide) rfl (by rw [ad_length]; decide) a i hi)
+  have h := la_materialize_within .x14 v (AB + 412) adLengthAddr (by decide) (by decide) hau had
+  rw [show (AB + 412 : Word) + 8 = AB + 420 from by bv_omega] at h
+  exact h
+
+set_option maxRecDepth 8000 in
+/-- Field-3 call setup [98]-[104] (`AB+392 → AB+420`): `li a2,3`. -/
+theorem adField3Setup (v10 v11 v12 v13 v14 listBase len : Word) :
+    cpsTripleWithin 7 (AB + 392) (AB + 420) fullCode
+      (((.x10 : Reg) ↦ᵣ v10) ** ((.x11 : Reg) ↦ᵣ v11) ** ((.x12 : Reg) ↦ᵣ v12) **
+       ((.x13 : Reg) ↦ᵣ v13) ** ((.x14 : Reg) ↦ᵣ v14) ** ((.x8 : Reg) ↦ᵣ listBase) **
+       ((.x9 : Reg) ↦ᵣ len))
+      (((.x10 : Reg) ↦ᵣ listBase) ** ((.x11 : Reg) ↦ᵣ len) **
+       ((.x12 : Reg) ↦ᵣ (3 : Word)) ** ((.x13 : Reg) ↦ᵣ adOffsetAddr) **
+       ((.x14 : Reg) ↦ᵣ adLengthAddr) ** ((.x8 : Reg) ↦ᵣ listBase) **
+       ((.x9 : Reg) ↦ᵣ len)) := by
+  have h98 := mv_spec_gen_within .x10 .x8 listBase v10 (AB + 392) (by decide)
+  have h98e := cpsTripleWithin_extend_code ad_mono
+    (cpsTripleWithin_extend_code
+      (CodeReq.ofProg_mem_at AB (AB + 392) accountDecode_prog 98 (.MV .x10 .x8)
+        (by bv_omega) (by rw [ad_length]; decide) rfl (by rw [ad_length]; decide)) h98)
+  have h99 := mv_spec_gen_within .x11 .x9 len v11 (AB + 396) (by decide)
+  have h99e := cpsTripleWithin_extend_code ad_mono
+    (cpsTripleWithin_extend_code
+      (CodeReq.ofProg_mem_at AB (AB + 396) accountDecode_prog 99 (.MV .x11 .x9)
+        (by bv_omega) (by rw [ad_length]; decide) rfl (by rw [ad_length]; decide)) h99)
+  have h100 := li_spec_gen_within .x12 v12 (3 : Word) (AB + 400) (by decide)
+  have h100e := cpsTripleWithin_extend_code ad_mono
+    (cpsTripleWithin_extend_code
+      (CodeReq.ofProg_mem_at AB (AB + 400) accountDecode_prog 100 (.LI .x12 (3 : Word))
+        (by bv_omega) (by rw [ad_length]; decide) rfl (by rw [ad_length]; decide)) h100)
+  have h101 := adLaOff404 v13
+  have h103 := adLaLen412 v14
+  have f98 := cpsTripleWithin_frameR
+    (((.x11 : Reg) ↦ᵣ v11) ** ((.x12 : Reg) ↦ᵣ v12) ** ((.x13 : Reg) ↦ᵣ v13) **
+     ((.x14 : Reg) ↦ᵣ v14) ** ((.x9 : Reg) ↦ᵣ len))
+    (by repeat' first | exact pcFree_regIs | apply pcFree_sepConj) h98e
+  have f99 := cpsTripleWithin_frameR
+    (((.x10 : Reg) ↦ᵣ listBase) ** ((.x12 : Reg) ↦ᵣ v12) ** ((.x13 : Reg) ↦ᵣ v13) **
+     ((.x14 : Reg) ↦ᵣ v14) ** ((.x8 : Reg) ↦ᵣ listBase))
+    (by repeat' first | exact pcFree_regIs | apply pcFree_sepConj) h99e
+  have f100 := cpsTripleWithin_frameR
+    (((.x10 : Reg) ↦ᵣ listBase) ** ((.x11 : Reg) ↦ᵣ len) ** ((.x13 : Reg) ↦ᵣ v13) **
+     ((.x14 : Reg) ↦ᵣ v14) ** ((.x8 : Reg) ↦ᵣ listBase) ** ((.x9 : Reg) ↦ᵣ len))
+    (by repeat' first | exact pcFree_regIs | apply pcFree_sepConj) h100e
+  have f101 := cpsTripleWithin_frameR
+    (((.x10 : Reg) ↦ᵣ listBase) ** ((.x11 : Reg) ↦ᵣ len) ** ((.x12 : Reg) ↦ᵣ (3 : Word)) **
+     ((.x14 : Reg) ↦ᵣ v14) ** ((.x8 : Reg) ↦ᵣ listBase) ** ((.x9 : Reg) ↦ᵣ len))
+    (by repeat' first | exact pcFree_regIs | apply pcFree_sepConj) h101
+  have f103 := cpsTripleWithin_frameR
+    (((.x10 : Reg) ↦ᵣ listBase) ** ((.x11 : Reg) ↦ᵣ len) ** ((.x12 : Reg) ↦ᵣ (3 : Word)) **
+     ((.x13 : Reg) ↦ᵣ adOffsetAddr) ** ((.x8 : Reg) ↦ᵣ listBase) ** ((.x9 : Reg) ↦ᵣ len))
+    (by repeat' first | exact pcFree_regIs | apply pcFree_sepConj) h103
+  have s1 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) f98 f99
+  have s2 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) s1 f100
+  have s3 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) s2 f101
+  have s4 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) s3 f103
+  exact cpsTripleWithin_mono_nSteps (by omega)
+    (cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
+      (fun _ hq => by xperm_hyp hq) s4)
+
+open EvmAsm.Codegen.RlpListNthItemSAsm in
+set_option maxRecDepth 8000 in
+/-- Field-3 RLP call adapter [98]-[105] + `rlp_list_nth_item` (index 3), `ra := AB+424`. -/
+theorem adField3Call
+    (spW raIn listBase len s2v s3 s4 s5 oldOffset oldLen v10 v11 v12 v13 v14 : Word)
+    (bytes : List (BitVec 8)) (listLen : Nat)
+    (hlenW : len = BitVec.ofNat 64 listLen)
+    (hsalign : listBase.toNat % 8 = 0)
+    (hslack : listLen + 9 ≤ bytes.length)
+    (hover : listBase.toNat + bytes.length < 2 ^ 64)
+    (hvalid : ∀ k, k < bytes.length →
+      isValidByteAccess (listBase + BitVec.ofNat 64 k) = true) :
+    let saved : Saved :=
+      { ra := AB + 424, s0 := listBase, s1 := len, s2 := s2v, s3 := s3, s4 := s4,
+        s5 := s5 }
+    let n20 := (12 + ((85 + 93 * (3 + 2)) + 6)) + 9
+    cpsTripleWithin (7 + (1 + n20)) (AB + 392) (AB + 424) fullCode
+      (((.x1 : Reg) ↦ᵣ raIn) ** (.x2 ↦ᵣ spW) ** (.x8 ↦ᵣ listBase) ** (.x9 ↦ᵣ len) **
+        (.x18 ↦ᵣ s2v) ** (.x19 ↦ᵣ s3) ** (.x20 ↦ᵣ s4) ** (.x21 ↦ᵣ s5) **
+        (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ v11) ** (.x12 ↦ᵣ v12) ** (.x13 ↦ᵣ v13) **
+        (.x14 ↦ᵣ v14) ** stackFree spW 8 ** regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+        regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+        (.x0 ↦ᵣ (0 : Word)) ** bytesRegion listBase bytes **
+        (adOffsetAddr ↦ₘ oldOffset) ** (adLengthAddr ↦ₘ oldLen))
+      (flatReturnResult spW listBase (3 : Word) adOffsetAddr adLengthAddr oldOffset
+        oldLen saved bytes listLen 3) := by
+  intro saved n20
+  have hsetup := adField3Setup v10 v11 v12 v13 v14 listBase len
+  have hsetupF := cpsTripleWithin_frameR
+    ((.x1 ↦ᵣ raIn) ** (.x2 ↦ᵣ spW) ** (.x18 ↦ᵣ s2v) ** (.x19 ↦ᵣ s3) **
+     (.x20 ↦ᵣ s4) ** (.x21 ↦ᵣ s5) ** stackFree spW 8 ** regOwn .x5 ** regOwn .x6 **
+     regOwn .x7 ** regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+     (.x0 ↦ᵣ (0 : Word)) ** bytesRegion listBase bytes **
+     (adOffsetAddr ↦ₘ oldOffset) ** (adLengthAddr ↦ₘ oldLen))
+    (by repeat' first
+        | exact pcFree_regIs | exact pcFree_memIs | exact bytesRegion_pcFree _ _
+        | exact pcFree_regOwn | exact pcFree_stackFree _ _ | apply pcFree_sepConj) hsetup
+  have hhead : cpsTripleWithin 7 (AB + 392) (AB + 420) fullCode
+      (((.x1 : Reg) ↦ᵣ raIn) ** (.x2 ↦ᵣ spW) ** (.x8 ↦ᵣ listBase) ** (.x9 ↦ᵣ len) **
+        (.x18 ↦ᵣ s2v) ** (.x19 ↦ᵣ s3) ** (.x20 ↦ᵣ s4) ** (.x21 ↦ᵣ s5) **
+        (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ v11) ** (.x12 ↦ᵣ v12) ** (.x13 ↦ᵣ v13) **
+        (.x14 ↦ᵣ v14) ** stackFree spW 8 ** regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+        regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+        (.x0 ↦ᵣ (0 : Word)) ** bytesRegion listBase bytes **
+        (adOffsetAddr ↦ₘ oldOffset) ** (adLengthAddr ↦ₘ oldLen))
+      ((.x1 ↦ᵣ raIn) ** (.x2 ↦ᵣ spW) ** (.x8 ↦ᵣ listBase) ** (.x9 ↦ᵣ len) **
+       (.x18 ↦ᵣ s2v) ** (.x19 ↦ᵣ s3) ** (.x20 ↦ᵣ s4) ** (.x21 ↦ᵣ s5) **
+       stackFree spW 8 **
+       entryRest listBase len (3 : Word) adOffsetAddr adLengthAddr oldOffset oldLen bytes) :=
+    cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
+      (fun _ hq => by unfold entryRest; xperm_hyp hq) hsetupF
+  have hjal := jal_link_spec_within
+    (jalOff GuestAddrs.rlp_list_nth_item (GuestAddrs.account_decode + 420)) (AB + 420) raIn
+  rw [show (AB + 420) + signExtend21 (jalOff GuestAddrs.rlp_list_nth_item
+      (GuestAddrs.account_decode + 420)) = B from by decide,
+    show (AB + 420 + 4 : Word) = AB + 424 from by bv_omega] at hjal
+  have hjale := cpsTripleWithin_extend_code ad_mono
+    (cpsTripleWithin_extend_code
+      (CodeReq.ofProg_mem_at AB (AB + 420) accountDecode_prog 105
+        (.JAL .x1 (jalOff GuestAddrs.rlp_list_nth_item (GuestAddrs.account_decode + 420)))
+        (by bv_omega) (by rw [ad_length]; decide) rfl (by rw [ad_length]; decide)) hjal)
+  have hjalF := cpsTripleWithin_frameR
+    ((.x2 ↦ᵣ spW) ** (.x8 ↦ᵣ listBase) ** (.x9 ↦ᵣ len) ** (.x18 ↦ᵣ s2v) **
+     (.x19 ↦ᵣ s3) ** (.x20 ↦ᵣ s4) ** (.x21 ↦ᵣ s5) ** stackFree spW 8 **
+     entryRest listBase len (3 : Word) adOffsetAddr adLengthAddr oldOffset oldLen bytes)
+    (by repeat' first
+        | exact pcFree_regIs | exact pcFree_stackFree _ _
+        | exact (by unfold entryRest; repeat' first
+            | exact pcFree_regIs | exact pcFree_memIs | exact bytesRegion_pcFree _ _
+            | exact pcFree_regOwn | apply pcFree_sepConj : (entryRest listBase len (3 : Word)
+              adOffsetAddr adLengthAddr oldOffset oldLen bytes).pcFree)
+        | apply pcFree_sepConj) hjale
+  have hk20 := rlpListNthItem_flat_spec_within spW listBase len (3 : Word) adOffsetAddr
+    adLengthAddr oldOffset oldLen saved bytes listLen 3 hlenW (by decide) (by decide)
+    hsalign hslack hover hvalid (by show (AB + 424) &&& ~~~(1 : Word) = AB + 424; decide)
+  have hk20C := cpsTripleWithin_extend_code k20_mono hk20
+  have s1 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) hhead hjalF
+  have s2 := cpsTripleWithin_seq_perm_same_cr
+    (fun _ hp => by
+      rw [regsAt_listNthFrame]
+      simp only [show saved.ra = AB + 424 from rfl, show saved.s0 = listBase from rfl,
+        show saved.s1 = len from rfl, show saved.s2 = s2v from rfl,
+        show saved.s3 = s3 from rfl, show saved.s4 = s4 from rfl,
+        show saved.s5 = s5 from rfl]
+      xperm_hyp hp) s1 hk20C
+  exact cpsTripleWithin_mono_nSteps (by omega) s2
+
+#print axioms adField1Call
+#print axioms adField2Call
+#print axioms adField3Call
+
 end EvmAsm.Codegen.AccountDecodeSpec

--- a/EvmAsm/Codegen/Programs/AccountDecodeClose.lean
+++ b/EvmAsm/Codegen/Programs/AccountDecodeClose.lean
@@ -1,0 +1,346 @@
+/-
+  `accountDecode_prog` caller-contract composition, part 1 — the K20 content
+  bound and the small glue leaves that connect the length checks / calls to
+  the per-field materialisers and the status tails.
+
+  Ported / mirrored from `WithdrawalDecodeSpec` (the `strictNthItem_content_le`
+  content span bound and the `wdSuccessTail`/`wdFailTail` status tails).
+
+    * `strictNthItem_content_le` / `adSuccessContentBound` — a K20 `Success`'s
+      selected content span (offset + length) fits inside the declared list
+      length.
+    * `adNonceSetup` [28]-[32] — `la ad_offset ; ld ; add x28=listBase+offset ;
+      li x7,0`, feeding `adNonceLoop`.
+    * `adRootCopySetup` [86]-[89] / `adCodeCopySetup` [112]-[115] — the fixed-32
+      copy source-cursor setups (`la ad_offset ; ld ; add x28=listBase+offset`).
+    * `adNonceStore` [40] — `sd x18, x7`, storing the accumulated LE u64 nonce.
+    * `adSuccessTail` [124]-[125] / `adFailTail` [126] — the `a0 := 0`/`a0 := 1`
+      status writes converging on the epilogue entry (`AB+508`).
+
+  No `sorry`/`admit`/`native_decide`/`bv_decide`; classical-3 axioms only.
+-/
+
+import EvmAsm.Codegen.Programs.AccountDecodeBalanceSetup
+
+namespace EvmAsm.Codegen.AccountDecodeSpec
+
+open EvmAsm.Rv64 EvmAsm.Rv64.SAsm
+
+/-! ## K20 content-span bound (all four fields)
+
+    The selected item's content span (offset + length) fits inside the declared
+    list window `endOff`.  Induction on the `StrictNthItem` chain: each
+    non-final decode strictly advances the cursor but stays `≤ endOff`
+    (`rlpItemDecode_advance`); the final decode's span is bounded by
+    `rlpItemDecode_field0_content_span`.  Mirrors
+    `WithdrawalDecodeSpec.strictNthItem_content_le`. -/
+
+open EvmAsm.Codegen.RlpListNthItemSAsm in
+theorem strictNthItem_content_le {bytes : List (BitVec 8)} {base : Word}
+    {endOff : Nat} : ∀ {index cursorOff : Nat} {next len : Word},
+    StrictNthItem bytes base (base + BitVec.ofNat 64 endOff) index cursorOff next len →
+    cursorOff ≤ endOff →
+    base.toNat + endOff + 9 < 2 ^ 64 →
+    (next - len - base).toNat + len.toNat ≤ endOff := by
+  intro index cursorOff next len h
+  induction h with
+  | zero off n l hitem =>
+      intro hcursor hover
+      exact (EvmAsm.Rv64.RLP.rlpItemDecode_field0_content_span hitem hcursor hover).2.2
+  | succ idx off n l fn fl hitem hrest ih =>
+      intro hcursor hover
+      have hadv := EvmAsm.Codegen.BalAccountNonstorageFinalsSpec.rlpItemDecode_advance
+        hitem hcursor hover
+      exact ih hadv.2.2 hover
+
+#print axioms strictNthItem_content_le
+
+open EvmAsm.Codegen.RlpListNthItemSAsm in
+/-- From a K20 `Success` (any index), the selected content offset plus length
+    fits inside the declared list length.  Mirrors `wdSuccessContentBound`
+    (generalised over the field index). -/
+theorem adSuccessContentBound (bytes : List (BitVec 8)) (listBase : Word)
+    (listLen index : Nat) (offset len' : Word)
+    (hslack : listLen + 9 ≤ bytes.length)
+    (hover : listBase.toNat + bytes.length < 2 ^ 64)
+    (hsucc : EvmAsm.Codegen.RlpListNthItemSAsm.Success bytes listBase listLen index offset len') :
+    offset.toNat + len'.toNat ≤ listLen := by
+  obtain ⟨cursorOff, endPtr, next, hpay, hnth, hoff⟩ := hsucc
+  have hend := hpay.end_eq
+  have hcur := hpay.cursor_le
+  subst hend
+  subst hoff
+  exact strictNthItem_content_le hnth hcur (by omega)
+
+#print axioms adSuccessContentBound
+
+/-! ## `la x5, ad_offset` materialisers for the setup sites -/
+
+/-- `la x5, ad_offset` at nonce setup [28]-[29] (`AB+112 → AB+120`). -/
+private theorem adLaOffX5_112 (v : Word) :
+    cpsTripleWithin 2 (AB + 112) (AB + 120) fullCode
+      (.x5 ↦ᵣ v) (.x5 ↦ᵣ adOffsetAddr) := by
+  have hau : ∀ a i, CodeReq.singleton (AB + 112)
+      (.AUIPC .x5 (Codegen.laHi GuestAddrs.ad_offset (GuestAddrs.account_decode + 112)))
+        a = some i → fullCode a = some i := fun a i hi => ad_mono a i
+    (CodeReq.ofProg_mem_at AB (AB + 112) accountDecode_prog 28
+      (.AUIPC .x5 (Codegen.laHi GuestAddrs.ad_offset (GuestAddrs.account_decode + 112)))
+      (by bv_omega) (by rw [ad_length]; decide) rfl (by rw [ad_length]; decide) a i hi)
+  have had : ∀ a i, CodeReq.singleton (AB + 116)
+      (.ADDI .x5 .x5 (Codegen.laLo GuestAddrs.ad_offset (GuestAddrs.account_decode + 112)))
+        a = some i → fullCode a = some i := fun a i hi => ad_mono a i
+    (CodeReq.ofProg_mem_at AB (AB + 116) accountDecode_prog 29
+      (.ADDI .x5 .x5 (Codegen.laLo GuestAddrs.ad_offset (GuestAddrs.account_decode + 112)))
+      (by bv_omega) (by rw [ad_length]; decide) rfl (by rw [ad_length]; decide) a i hi)
+  have h := la_materialize_within .x5 v (AB + 112) adOffsetAddr (by decide) (by decide) hau had
+  rw [show (AB + 112 : Word) + 8 = AB + 120 from by bv_omega] at h
+  exact h
+
+/-- `la x5, ad_offset` at root copy setup [86]-[87] (`AB+344 → AB+352`). -/
+private theorem adLaOffX5_344 (v : Word) :
+    cpsTripleWithin 2 (AB + 344) (AB + 352) fullCode
+      (.x5 ↦ᵣ v) (.x5 ↦ᵣ adOffsetAddr) := by
+  have hau : ∀ a i, CodeReq.singleton (AB + 344)
+      (.AUIPC .x5 (Codegen.laHi GuestAddrs.ad_offset (GuestAddrs.account_decode + 344)))
+        a = some i → fullCode a = some i := fun a i hi => ad_mono a i
+    (CodeReq.ofProg_mem_at AB (AB + 344) accountDecode_prog 86
+      (.AUIPC .x5 (Codegen.laHi GuestAddrs.ad_offset (GuestAddrs.account_decode + 344)))
+      (by bv_omega) (by rw [ad_length]; decide) rfl (by rw [ad_length]; decide) a i hi)
+  have had : ∀ a i, CodeReq.singleton (AB + 348)
+      (.ADDI .x5 .x5 (Codegen.laLo GuestAddrs.ad_offset (GuestAddrs.account_decode + 344)))
+        a = some i → fullCode a = some i := fun a i hi => ad_mono a i
+    (CodeReq.ofProg_mem_at AB (AB + 348) accountDecode_prog 87
+      (.ADDI .x5 .x5 (Codegen.laLo GuestAddrs.ad_offset (GuestAddrs.account_decode + 344)))
+      (by bv_omega) (by rw [ad_length]; decide) rfl (by rw [ad_length]; decide) a i hi)
+  have h := la_materialize_within .x5 v (AB + 344) adOffsetAddr (by decide) (by decide) hau had
+  rw [show (AB + 344 : Word) + 8 = AB + 352 from by bv_omega] at h
+  exact h
+
+/-- `la x5, ad_offset` at code copy setup [112]-[113] (`AB+448 → AB+456`). -/
+private theorem adLaOffX5_448 (v : Word) :
+    cpsTripleWithin 2 (AB + 448) (AB + 456) fullCode
+      (.x5 ↦ᵣ v) (.x5 ↦ᵣ adOffsetAddr) := by
+  have hau : ∀ a i, CodeReq.singleton (AB + 448)
+      (.AUIPC .x5 (Codegen.laHi GuestAddrs.ad_offset (GuestAddrs.account_decode + 448)))
+        a = some i → fullCode a = some i := fun a i hi => ad_mono a i
+    (CodeReq.ofProg_mem_at AB (AB + 448) accountDecode_prog 112
+      (.AUIPC .x5 (Codegen.laHi GuestAddrs.ad_offset (GuestAddrs.account_decode + 448)))
+      (by bv_omega) (by rw [ad_length]; decide) rfl (by rw [ad_length]; decide) a i hi)
+  have had : ∀ a i, CodeReq.singleton (AB + 452)
+      (.ADDI .x5 .x5 (Codegen.laLo GuestAddrs.ad_offset (GuestAddrs.account_decode + 448)))
+        a = some i → fullCode a = some i := fun a i hi => ad_mono a i
+    (CodeReq.ofProg_mem_at AB (AB + 452) accountDecode_prog 113
+      (.ADDI .x5 .x5 (Codegen.laLo GuestAddrs.ad_offset (GuestAddrs.account_decode + 448)))
+      (by bv_omega) (by rw [ad_length]; decide) rfl (by rw [ad_length]; decide) a i hi)
+  have h := la_materialize_within .x5 v (AB + 448) adOffsetAddr (by decide) (by decide) hau had
+  rw [show (AB + 448 : Word) + 8 = AB + 456 from by bv_omega] at h
+  exact h
+
+/-! ## Glue leaf: nonce loop setup [28]-[32] (`AB+112 → AB+132`) -/
+
+set_option maxRecDepth 8000 in
+/-- Nonce source-cursor setup [28]-[32] (`AB+112 → AB+132`): `la x5,ad_offset ;
+    ld x28 ; add x28=listBase+offset ; li x7,0`.  Feeds `adNonceLoop` with the
+    initial accumulator `x7 = 0` and source cursor `x28 = listBase + offset`. -/
+theorem adNonceSetup (listBase offset v5 v28 v7 : Word) :
+    cpsTripleWithin 5 (AB + 112) (AB + 132) fullCode
+      (((.x5 : Reg) ↦ᵣ v5) ** ((.x8 : Reg) ↦ᵣ listBase) **
+       ((.x28 : Reg) ↦ᵣ v28) ** ((.x7 : Reg) ↦ᵣ v7) **
+       (adOffsetAddr ↦ₘ offset))
+      (((.x5 : Reg) ↦ᵣ adOffsetAddr) ** ((.x8 : Reg) ↦ᵣ listBase) **
+       ((.x28 : Reg) ↦ᵣ (listBase + offset)) ** ((.x7 : Reg) ↦ᵣ (0 : Word)) **
+       (adOffsetAddr ↦ₘ offset)) := by
+  have h28 := adLaOffX5_112 v5
+  have h28f := cpsTripleWithin_frameR
+    (((.x8 : Reg) ↦ᵣ listBase) ** ((.x28 : Reg) ↦ᵣ v28) ** ((.x7 : Reg) ↦ᵣ v7) **
+     (adOffsetAddr ↦ₘ offset))
+    (by repeat' first | exact pcFree_regIs | exact pcFree_memIs | apply pcFree_sepConj) h28
+  -- [30] ld x28, 0(x5)
+  have h30 := ld_spec_gen_within .x28 .x5 adOffsetAddr v28 offset (0 : BitVec 12)
+    (AB + 120) (by decide)
+  rw [show adOffsetAddr + signExtend12 (0 : BitVec 12) = adOffsetAddr from by
+    rw [show signExtend12 (0 : BitVec 12) = (0 : Word) from by decide]; bv_omega,
+    show (AB + 120 : Word) + 4 = AB + 124 from by bv_omega] at h30
+  have h30e := cpsTripleWithin_extend_code ad_mono
+    (cpsTripleWithin_extend_code
+      (CodeReq.ofProg_mem_at AB (AB + 120) accountDecode_prog 30 (.LD .x28 .x5 (0 : BitVec 12))
+        (by bv_omega) (by rw [ad_length]; decide) rfl (by rw [ad_length]; decide)) h30)
+  have h30f := cpsTripleWithin_frameR
+    (((.x8 : Reg) ↦ᵣ listBase) ** ((.x7 : Reg) ↦ᵣ v7))
+    (by repeat' first | exact pcFree_regIs | apply pcFree_sepConj) h30e
+  -- [31] add x28, x8, x28
+  have h31 := add_spec_gen_rd_eq_rs2_within .x28 .x8 listBase offset (AB + 124) (by decide)
+  rw [show (AB + 124 : Word) + 4 = AB + 128 from by bv_omega] at h31
+  have h31e := cpsTripleWithin_extend_code ad_mono
+    (cpsTripleWithin_extend_code
+      (CodeReq.ofProg_mem_at AB (AB + 124) accountDecode_prog 31 (.ADD .x28 .x8 .x28)
+        (by bv_omega) (by rw [ad_length]; decide) rfl (by rw [ad_length]; decide)) h31)
+  have h31f := cpsTripleWithin_frameR
+    (((.x5 : Reg) ↦ᵣ adOffsetAddr) ** ((.x7 : Reg) ↦ᵣ v7) ** (adOffsetAddr ↦ₘ offset))
+    (by repeat' first | exact pcFree_regIs | exact pcFree_memIs | apply pcFree_sepConj) h31e
+  -- [32] li x7, 0
+  have h32 := li_spec_gen_within .x7 v7 (0 : Word) (AB + 128) (by decide)
+  rw [show (AB + 128 : Word) + 4 = AB + 132 from by bv_omega] at h32
+  have h32e := cpsTripleWithin_extend_code ad_mono
+    (cpsTripleWithin_extend_code
+      (CodeReq.ofProg_mem_at AB (AB + 128) accountDecode_prog 32 (.LI .x7 (0 : Word))
+        (by bv_omega) (by rw [ad_length]; decide) rfl (by rw [ad_length]; decide)) h32)
+  have h32f := cpsTripleWithin_frameR
+    (((.x5 : Reg) ↦ᵣ adOffsetAddr) ** ((.x8 : Reg) ↦ᵣ listBase) **
+     ((.x28 : Reg) ↦ᵣ (listBase + offset)) ** (adOffsetAddr ↦ₘ offset))
+    (by repeat' first | exact pcFree_regIs | exact pcFree_memIs | apply pcFree_sepConj) h32e
+  have c1 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) h28f h30f
+  have c2 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) c1 h31f
+  have c3 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) c2 h32f
+  exact cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
+    (fun _ hq => by xperm_hyp hq) c3
+
+#print axioms adNonceSetup
+
+/-! ## Glue leaf: nonce store [40] (`AB+160 → AB+164`) -/
+
+set_option maxRecDepth 8000 in
+/-- Nonce store [40] (`AB+160 → AB+164`): `sd x18, x7` — write the accumulated
+    big-endian u64 (as a little-endian dword) into the 8-byte nonce slot. -/
+theorem adNonceStore (nonceOut nonceVal oldVal : Word) :
+    cpsTripleWithin 1 (AB + 160) (AB + 164) fullCode
+      (((.x18 : Reg) ↦ᵣ nonceOut) ** ((.x7 : Reg) ↦ᵣ nonceVal) ** (nonceOut ↦ₘ oldVal))
+      (((.x18 : Reg) ↦ᵣ nonceOut) ** ((.x7 : Reg) ↦ᵣ nonceVal) ** (nonceOut ↦ₘ nonceVal)) := by
+  have h := sd_spec_gen_within .x18 .x7 nonceOut nonceVal oldVal (0 : BitVec 12) (AB + 160)
+  rw [show nonceOut + signExtend12 (0 : BitVec 12) = nonceOut from by
+    rw [show signExtend12 (0 : BitVec 12) = (0 : Word) from by decide]; bv_omega,
+    show (AB + 160 : Word) + 4 = AB + 164 from by bv_omega] at h
+  exact cpsTripleWithin_extend_code ad_mono
+    (cpsTripleWithin_extend_code
+      (CodeReq.ofProg_mem_at AB (AB + 160) accountDecode_prog 40 (.SD .x18 .x7 (0 : BitVec 12))
+        (by bv_omega) (by rw [ad_length]; decide) rfl (by rw [ad_length]; decide)) h)
+
+#print axioms adNonceStore
+
+/-! ## Glue leaves: the fixed-32 copy source-cursor setups -/
+
+set_option maxRecDepth 8000 in
+/-- Root copy source-cursor setup [86]-[89] (`AB+344 → AB+360`):
+    `la x5,ad_offset ; ld x28 ; add x28=listBase+offset`.  Feeds `adCopyLoop`. -/
+theorem adRootCopySetup (listBase offset v5 v28 : Word) :
+    cpsTripleWithin 4 (AB + 344) (AB + 360) fullCode
+      (((.x5 : Reg) ↦ᵣ v5) ** ((.x8 : Reg) ↦ᵣ listBase) **
+       ((.x28 : Reg) ↦ᵣ v28) ** (adOffsetAddr ↦ₘ offset))
+      (((.x5 : Reg) ↦ᵣ adOffsetAddr) ** ((.x8 : Reg) ↦ᵣ listBase) **
+       ((.x28 : Reg) ↦ᵣ (listBase + offset)) ** (adOffsetAddr ↦ₘ offset)) := by
+  have h86 := adLaOffX5_344 v5
+  have h86f := cpsTripleWithin_frameR
+    (((.x8 : Reg) ↦ᵣ listBase) ** ((.x28 : Reg) ↦ᵣ v28) ** (adOffsetAddr ↦ₘ offset))
+    (by repeat' first | exact pcFree_regIs | exact pcFree_memIs | apply pcFree_sepConj) h86
+  have h88 := ld_spec_gen_within .x28 .x5 adOffsetAddr v28 offset (0 : BitVec 12)
+    (AB + 352) (by decide)
+  rw [show adOffsetAddr + signExtend12 (0 : BitVec 12) = adOffsetAddr from by
+    rw [show signExtend12 (0 : BitVec 12) = (0 : Word) from by decide]; bv_omega,
+    show (AB + 352 : Word) + 4 = AB + 356 from by bv_omega] at h88
+  have h88e := cpsTripleWithin_extend_code ad_mono
+    (cpsTripleWithin_extend_code
+      (CodeReq.ofProg_mem_at AB (AB + 352) accountDecode_prog 88 (.LD .x28 .x5 (0 : BitVec 12))
+        (by bv_omega) (by rw [ad_length]; decide) rfl (by rw [ad_length]; decide)) h88)
+  have h88f := cpsTripleWithin_frameR ((.x8 : Reg) ↦ᵣ listBase) pcFree_regIs h88e
+  have h89 := add_spec_gen_rd_eq_rs2_within .x28 .x8 listBase offset (AB + 356) (by decide)
+  rw [show (AB + 356 : Word) + 4 = AB + 360 from by bv_omega] at h89
+  have h89e := cpsTripleWithin_extend_code ad_mono
+    (cpsTripleWithin_extend_code
+      (CodeReq.ofProg_mem_at AB (AB + 356) accountDecode_prog 89 (.ADD .x28 .x8 .x28)
+        (by bv_omega) (by rw [ad_length]; decide) rfl (by rw [ad_length]; decide)) h89)
+  have h89f := cpsTripleWithin_frameR
+    (((.x5 : Reg) ↦ᵣ adOffsetAddr) ** (adOffsetAddr ↦ₘ offset))
+    (by repeat' first | exact pcFree_regIs | exact pcFree_memIs | apply pcFree_sepConj) h89e
+  have c1 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) h86f h88f
+  have c2 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) c1 h89f
+  exact cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
+    (fun _ hq => by xperm_hyp hq) c2
+
+#print axioms adRootCopySetup
+
+set_option maxRecDepth 8000 in
+/-- Code copy source-cursor setup [112]-[115] (`AB+448 → AB+464`):
+    `la x5,ad_offset ; ld x28 ; add x28=listBase+offset`.  Feeds `adCopyLoop`. -/
+theorem adCodeCopySetup (listBase offset v5 v28 : Word) :
+    cpsTripleWithin 4 (AB + 448) (AB + 464) fullCode
+      (((.x5 : Reg) ↦ᵣ v5) ** ((.x8 : Reg) ↦ᵣ listBase) **
+       ((.x28 : Reg) ↦ᵣ v28) ** (adOffsetAddr ↦ₘ offset))
+      (((.x5 : Reg) ↦ᵣ adOffsetAddr) ** ((.x8 : Reg) ↦ᵣ listBase) **
+       ((.x28 : Reg) ↦ᵣ (listBase + offset)) ** (adOffsetAddr ↦ₘ offset)) := by
+  have h112 := adLaOffX5_448 v5
+  have h112f := cpsTripleWithin_frameR
+    (((.x8 : Reg) ↦ᵣ listBase) ** ((.x28 : Reg) ↦ᵣ v28) ** (adOffsetAddr ↦ₘ offset))
+    (by repeat' first | exact pcFree_regIs | exact pcFree_memIs | apply pcFree_sepConj) h112
+  have h114 := ld_spec_gen_within .x28 .x5 adOffsetAddr v28 offset (0 : BitVec 12)
+    (AB + 456) (by decide)
+  rw [show adOffsetAddr + signExtend12 (0 : BitVec 12) = adOffsetAddr from by
+    rw [show signExtend12 (0 : BitVec 12) = (0 : Word) from by decide]; bv_omega,
+    show (AB + 456 : Word) + 4 = AB + 460 from by bv_omega] at h114
+  have h114e := cpsTripleWithin_extend_code ad_mono
+    (cpsTripleWithin_extend_code
+      (CodeReq.ofProg_mem_at AB (AB + 456) accountDecode_prog 114 (.LD .x28 .x5 (0 : BitVec 12))
+        (by bv_omega) (by rw [ad_length]; decide) rfl (by rw [ad_length]; decide)) h114)
+  have h114f := cpsTripleWithin_frameR ((.x8 : Reg) ↦ᵣ listBase) pcFree_regIs h114e
+  have h115 := add_spec_gen_rd_eq_rs2_within .x28 .x8 listBase offset (AB + 460) (by decide)
+  rw [show (AB + 460 : Word) + 4 = AB + 464 from by bv_omega] at h115
+  have h115e := cpsTripleWithin_extend_code ad_mono
+    (cpsTripleWithin_extend_code
+      (CodeReq.ofProg_mem_at AB (AB + 460) accountDecode_prog 115 (.ADD .x28 .x8 .x28)
+        (by bv_omega) (by rw [ad_length]; decide) rfl (by rw [ad_length]; decide)) h115)
+  have h115f := cpsTripleWithin_frameR
+    (((.x5 : Reg) ↦ᵣ adOffsetAddr) ** (adOffsetAddr ↦ₘ offset))
+    (by repeat' first | exact pcFree_regIs | exact pcFree_memIs | apply pcFree_sepConj) h115e
+  have c1 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) h112f h114f
+  have c2 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) c1 h115f
+  exact cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
+    (fun _ hq => by xperm_hyp hq) c2
+
+#print axioms adCodeCopySetup
+
+/-! ## Status tails [124]-[126] -/
+
+set_option maxRecDepth 8000 in
+/-- Success tail [124]-[125] (`AB+496 → AB+508`): `li a0,0 ; jal +8` — set the
+    success status and jump past the failure `li` to the epilogue entry.
+    Generic over the untouched frame `G`. -/
+theorem adSuccessTail (v10old : Word) (G : Assertion) (hG : G.pcFree) :
+    cpsTripleWithin 2 (AB + 496) (AB + 508) fullCode
+      (((.x10 : Reg) ↦ᵣ v10old) ** G)
+      (((.x10 : Reg) ↦ᵣ (0 : Word)) ** G) := by
+  have h0 := li_spec_gen_within .x10 v10old (0 : Word) (AB + 496) (by decide)
+  rw [show (AB + 496 : Word) + 4 = AB + 500 from by bv_omega] at h0
+  have h0e := cpsTripleWithin_extend_code ad_mono
+    (cpsTripleWithin_extend_code
+      (CodeReq.ofProg_mem_at AB (AB + 496) accountDecode_prog 124 (.LI .x10 (0 : Word))
+        (by bv_omega) (by rw [ad_length]; decide) rfl (by rw [ad_length]; decide)) h0)
+  have h1 := jal0_spec_pcFree (P := ((.x10 : Reg) ↦ᵣ (0 : Word)) ** G) (8 : BitVec 21)
+    (AB + 500) (pcFree_sepConj pcFree_regIs hG)
+  rw [show AB + 500 + signExtend21 (8 : BitVec 21) = AB + 508 from by
+    rw [show signExtend21 (8 : BitVec 21) = (8 : Word) from by decide]; bv_omega] at h1
+  have h1e := cpsTripleWithin_extend_code ad_mono
+    (cpsTripleWithin_extend_code
+      (CodeReq.ofProg_mem_at AB (AB + 500) accountDecode_prog 125 (.JAL .x0 (8 : BitVec 21))
+        (by bv_omega) (by rw [ad_length]; decide) rfl (by rw [ad_length]; decide)) h1)
+  have f0 := cpsTripleWithin_frameR G hG h0e
+  exact cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) f0 h1e
+
+#print axioms adSuccessTail
+
+set_option maxRecDepth 8000 in
+/-- Failure tail [126] (`AB+504 → AB+508`): `li a0,1` then fall through to the
+    epilogue entry.  Generic over the untouched frame `G`. -/
+theorem adFailTail (v10old : Word) (G : Assertion) (hG : G.pcFree) :
+    cpsTripleWithin 1 (AB + 504) (AB + 508) fullCode
+      (((.x10 : Reg) ↦ᵣ v10old) ** G)
+      (((.x10 : Reg) ↦ᵣ (1 : Word)) ** G) := by
+  have h0 := li_spec_gen_within .x10 v10old (1 : Word) (AB + 504) (by decide)
+  rw [show (AB + 504 : Word) + 4 = AB + 508 from by bv_omega] at h0
+  have h0e := cpsTripleWithin_extend_code ad_mono
+    (cpsTripleWithin_extend_code
+      (CodeReq.ofProg_mem_at AB (AB + 504) accountDecode_prog 126 (.LI .x10 (1 : Word))
+        (by bv_omega) (by rw [ad_length]; decide) rfl (by rw [ad_length]; decide)) h0)
+  exact cpsTripleWithin_frameR G hG h0e
+
+#print axioms adFailTail
+
+end EvmAsm.Codegen.AccountDecodeSpec

--- a/EvmAsm/Codegen/Programs/AccountDecodeClose2.lean
+++ b/EvmAsm/Codegen/Programs/AccountDecodeClose2.lean
@@ -1,0 +1,181 @@
+/-
+  `accountDecode_prog` caller-contract composition, part 2 — the four per-field
+  "stages": each field's K20 call composed with its post-call status dispatch
+  (`adFieldNCall ;; adK20Dispatch`), yielding a `cpsBranchWithin` from the call
+  entry with the shared failure edge (`AB+504`) and the field's continue edge
+  (the length-check entry `dispatchPC + 4`).
+
+  Mirrors `WithdrawalDecodeSpec.wdFieldNStage` (uniform here: all four fields
+  are K20, so the four stages share one shape).
+
+  No `sorry`/`admit`/`native_decide`/`bv_decide`; classical-3 axioms only.
+-/
+
+import EvmAsm.Codegen.Programs.AccountDecodeClose
+import EvmAsm.Codegen.Programs.AccountDecodeDispatch
+
+namespace EvmAsm.Codegen.AccountDecodeSpec
+
+open EvmAsm.Rv64 EvmAsm.Rv64.SAsm
+open EvmAsm.Codegen.RlpListNthItemSAsm (Saved flatReturnResult)
+
+/-- The shared field-call precondition, parameterised by the call entry and the
+    field's saved-`s2` slot value.  Identical register/memory footprint across
+    all four fields (only the `ra`/index differ, tracked in the call/dispatch
+    lemmas). -/
+def adCallPre (raIn spW listBase len s2v s3 s4 s5 oldOffset oldLen
+    v10 v11 v12 v13 v14 : Word) (bytes : List (BitVec 8)) : Assertion :=
+  ((.x1 : Reg) ↦ᵣ raIn) ** (.x2 ↦ᵣ spW) ** (.x8 ↦ᵣ listBase) ** (.x9 ↦ᵣ len) **
+  (.x18 ↦ᵣ s2v) ** (.x19 ↦ᵣ s3) ** (.x20 ↦ᵣ s4) ** (.x21 ↦ᵣ s5) **
+  (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ v11) ** (.x12 ↦ᵣ v12) ** (.x13 ↦ᵣ v13) **
+  (.x14 ↦ᵣ v14) ** stackFree spW 8 ** regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+  regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+  (.x0 ↦ᵣ (0 : Word)) ** bytesRegion listBase bytes **
+  (adOffsetAddr ↦ₘ oldOffset) ** (adLengthAddr ↦ₘ oldLen)
+
+set_option maxRecDepth 8000 in
+/-- Field-0 stage [14]-[22] (`AB+56 → 504/92`): the nonce K20 call composed with
+    its post-call dispatch.  Fail edge `AB+504`, continue edge `AB+92` (nonce
+    length check). -/
+theorem adField0Stage
+    (spW raIn listBase len nonceOut s3 s4 s5 oldOffset oldLen v10 v11 v12 v13 v14 : Word)
+    (bytes : List (BitVec 8)) (listLen : Nat)
+    (hlenW : len = BitVec.ofNat 64 listLen)
+    (hsalign : listBase.toNat % 8 = 0)
+    (hslack : listLen + 9 ≤ bytes.length)
+    (hover : listBase.toNat + bytes.length < 2 ^ 64)
+    (hvalid : ∀ k, k < bytes.length →
+      isValidByteAccess (listBase + BitVec.ofNat 64 k) = true) :
+    let saved : Saved :=
+      { ra := AB + 88, s0 := listBase, s1 := len, s2 := nonceOut, s3 := s3, s4 := s4,
+        s5 := s5 }
+    let n20 := (12 + ((85 + 93 * (0 + 2)) + 6)) + 9
+    cpsBranchWithin ((7 + (1 + n20)) + 1) (AB + 56) fullCode
+      (adCallPre raIn spW listBase len nonceOut s3 s4 s5 oldOffset oldLen
+        v10 v11 v12 v13 v14 bytes)
+      (AB + 504) (adK20FailPost spW listBase oldOffset oldLen 0 saved bytes listLen)
+      (AB + 92) (adK20ContPost spW listBase 0 saved bytes listLen) := by
+  intro saved n20
+  have hcall := adField0Call spW raIn listBase len nonceOut s3 s4 s5 oldOffset oldLen
+    v10 v11 v12 v13 v14 bytes listLen hlenW hsalign hslack hover hvalid
+  have hdisp := adK20Dispatch spW listBase oldOffset oldLen (AB + 88) (416 : BitVec 13) 0
+    saved bytes listLen
+    (by rw [show signExtend13 (416 : BitVec 13) = (416 : Word) from by decide]; bv_omega)
+    (fun a i hi => ad_mono a i
+      (CodeReq.ofProg_mem_at AB (AB + 88) accountDecode_prog 22
+        (.BNE .x10 .x0 (416 : BitVec 13)) (by bv_omega) (by rw [ad_length]; decide) rfl
+        (by rw [ad_length]; decide) a i hi))
+  rw [show (AB + 88 : Word) + 4 = AB + 92 from by bv_omega] at hdisp
+  exact cpsTripleWithin_seq_cpsBranchWithin_perm_same_cr (fun _ hq => hq) hcall hdisp
+
+#print axioms adField0Stage
+
+set_option maxRecDepth 8000 in
+/-- Field-1 stage [41]-[49] (`AB+164 → 504/200`): the balance K20 call composed
+    with its dispatch.  Fail edge `AB+504`, continue edge `AB+200`. -/
+theorem adField1Stage
+    (spW raIn listBase len nonceOut s3 s4 s5 oldOffset oldLen v10 v11 v12 v13 v14 : Word)
+    (bytes : List (BitVec 8)) (listLen : Nat)
+    (hlenW : len = BitVec.ofNat 64 listLen)
+    (hsalign : listBase.toNat % 8 = 0)
+    (hslack : listLen + 9 ≤ bytes.length)
+    (hover : listBase.toNat + bytes.length < 2 ^ 64)
+    (hvalid : ∀ k, k < bytes.length →
+      isValidByteAccess (listBase + BitVec.ofNat 64 k) = true) :
+    let saved : Saved :=
+      { ra := AB + 196, s0 := listBase, s1 := len, s2 := nonceOut, s3 := s3, s4 := s4,
+        s5 := s5 }
+    let n20 := (12 + ((85 + 93 * (1 + 2)) + 6)) + 9
+    cpsBranchWithin ((7 + (1 + n20)) + 1) (AB + 164) fullCode
+      (adCallPre raIn spW listBase len nonceOut s3 s4 s5 oldOffset oldLen
+        v10 v11 v12 v13 v14 bytes)
+      (AB + 504) (adK20FailPost spW listBase oldOffset oldLen 1 saved bytes listLen)
+      (AB + 200) (adK20ContPost spW listBase 1 saved bytes listLen) := by
+  intro saved n20
+  have hcall := adField1Call spW raIn listBase len nonceOut s3 s4 s5 oldOffset oldLen
+    v10 v11 v12 v13 v14 bytes listLen hlenW hsalign hslack hover hvalid
+  have hdisp := adK20Dispatch spW listBase oldOffset oldLen (AB + 196) (308 : BitVec 13) 1
+    saved bytes listLen
+    (by rw [show signExtend13 (308 : BitVec 13) = (308 : Word) from by decide]; bv_omega)
+    (fun a i hi => ad_mono a i
+      (CodeReq.ofProg_mem_at AB (AB + 196) accountDecode_prog 49
+        (.BNE .x10 .x0 (308 : BitVec 13)) (by bv_omega) (by rw [ad_length]; decide) rfl
+        (by rw [ad_length]; decide) a i hi))
+  rw [show (AB + 196 : Word) + 4 = AB + 200 from by bv_omega] at hdisp
+  exact cpsTripleWithin_seq_cpsBranchWithin_perm_same_cr (fun _ hq => hq) hcall hdisp
+
+#print axioms adField1Stage
+
+set_option maxRecDepth 8000 in
+/-- Field-2 stage [72]-[80] (`AB+288 → 504/324`): the storage-root K20 call
+    composed with its dispatch.  Fail edge `AB+504`, continue edge `AB+324`. -/
+theorem adField2Stage
+    (spW raIn listBase len nonceOut s3 s4 s5 oldOffset oldLen v10 v11 v12 v13 v14 : Word)
+    (bytes : List (BitVec 8)) (listLen : Nat)
+    (hlenW : len = BitVec.ofNat 64 listLen)
+    (hsalign : listBase.toNat % 8 = 0)
+    (hslack : listLen + 9 ≤ bytes.length)
+    (hover : listBase.toNat + bytes.length < 2 ^ 64)
+    (hvalid : ∀ k, k < bytes.length →
+      isValidByteAccess (listBase + BitVec.ofNat 64 k) = true) :
+    let saved : Saved :=
+      { ra := AB + 320, s0 := listBase, s1 := len, s2 := nonceOut, s3 := s3, s4 := s4,
+        s5 := s5 }
+    let n20 := (12 + ((85 + 93 * (2 + 2)) + 6)) + 9
+    cpsBranchWithin ((7 + (1 + n20)) + 1) (AB + 288) fullCode
+      (adCallPre raIn spW listBase len nonceOut s3 s4 s5 oldOffset oldLen
+        v10 v11 v12 v13 v14 bytes)
+      (AB + 504) (adK20FailPost spW listBase oldOffset oldLen 2 saved bytes listLen)
+      (AB + 324) (adK20ContPost spW listBase 2 saved bytes listLen) := by
+  intro saved n20
+  have hcall := adField2Call spW raIn listBase len nonceOut s3 s4 s5 oldOffset oldLen
+    v10 v11 v12 v13 v14 bytes listLen hlenW hsalign hslack hover hvalid
+  have hdisp := adK20Dispatch spW listBase oldOffset oldLen (AB + 320) (184 : BitVec 13) 2
+    saved bytes listLen
+    (by rw [show signExtend13 (184 : BitVec 13) = (184 : Word) from by decide]; bv_omega)
+    (fun a i hi => ad_mono a i
+      (CodeReq.ofProg_mem_at AB (AB + 320) accountDecode_prog 80
+        (.BNE .x10 .x0 (184 : BitVec 13)) (by bv_omega) (by rw [ad_length]; decide) rfl
+        (by rw [ad_length]; decide) a i hi))
+  rw [show (AB + 320 : Word) + 4 = AB + 324 from by bv_omega] at hdisp
+  exact cpsTripleWithin_seq_cpsBranchWithin_perm_same_cr (fun _ hq => hq) hcall hdisp
+
+#print axioms adField2Stage
+
+set_option maxRecDepth 8000 in
+/-- Field-3 stage [98]-[106] (`AB+392 → 504/428`): the code-hash K20 call
+    composed with its dispatch.  Fail edge `AB+504`, continue edge `AB+428`. -/
+theorem adField3Stage
+    (spW raIn listBase len nonceOut s3 s4 s5 oldOffset oldLen v10 v11 v12 v13 v14 : Word)
+    (bytes : List (BitVec 8)) (listLen : Nat)
+    (hlenW : len = BitVec.ofNat 64 listLen)
+    (hsalign : listBase.toNat % 8 = 0)
+    (hslack : listLen + 9 ≤ bytes.length)
+    (hover : listBase.toNat + bytes.length < 2 ^ 64)
+    (hvalid : ∀ k, k < bytes.length →
+      isValidByteAccess (listBase + BitVec.ofNat 64 k) = true) :
+    let saved : Saved :=
+      { ra := AB + 424, s0 := listBase, s1 := len, s2 := nonceOut, s3 := s3, s4 := s4,
+        s5 := s5 }
+    let n20 := (12 + ((85 + 93 * (3 + 2)) + 6)) + 9
+    cpsBranchWithin ((7 + (1 + n20)) + 1) (AB + 392) fullCode
+      (adCallPre raIn spW listBase len nonceOut s3 s4 s5 oldOffset oldLen
+        v10 v11 v12 v13 v14 bytes)
+      (AB + 504) (adK20FailPost spW listBase oldOffset oldLen 3 saved bytes listLen)
+      (AB + 428) (adK20ContPost spW listBase 3 saved bytes listLen) := by
+  intro saved n20
+  have hcall := adField3Call spW raIn listBase len nonceOut s3 s4 s5 oldOffset oldLen
+    v10 v11 v12 v13 v14 bytes listLen hlenW hsalign hslack hover hvalid
+  have hdisp := adK20Dispatch spW listBase oldOffset oldLen (AB + 424) (80 : BitVec 13) 3
+    saved bytes listLen
+    (by rw [show signExtend13 (80 : BitVec 13) = (80 : Word) from by decide]; bv_omega)
+    (fun a i hi => ad_mono a i
+      (CodeReq.ofProg_mem_at AB (AB + 424) accountDecode_prog 106
+        (.BNE .x10 .x0 (80 : BitVec 13)) (by bv_omega) (by rw [ad_length]; decide) rfl
+        (by rw [ad_length]; decide) a i hi))
+  rw [show (AB + 424 : Word) + 4 = AB + 428 from by bv_omega] at hdisp
+  exact cpsTripleWithin_seq_cpsBranchWithin_perm_same_cr (fun _ hq => hq) hcall hdisp
+
+#print axioms adField3Stage
+
+end EvmAsm.Codegen.AccountDecodeSpec

--- a/EvmAsm/Codegen/Programs/AccountDecodeClose3.lean
+++ b/EvmAsm/Codegen/Programs/AccountDecodeClose3.lean
@@ -1,0 +1,69 @@
+/-
+  `accountDecode_prog` caller-contract composition, part 3 — the return-edge
+  tails: each status store (`a0 := 0`/`a0 := 1`) stitched to the shared ABI
+  epilogue (`adEpilogue`, `AB+508 → saved.ra`).  Both land the restored
+  caller-register/frame state with the appropriate `a0`.
+
+  Mirrors `WithdrawalDecodeSpec.wdSuccessEpi`/`wdFailEpi`, but uses the 7-slot
+  `adEpilogue` (account decode restores `x1/x8/x9/x18/x19/x20/x21`).
+
+  No `sorry`/`admit`/`native_decide`/`bv_decide`; classical-3 axioms only.
+-/
+
+import EvmAsm.Codegen.Programs.AccountDecodeClose2
+import EvmAsm.Codegen.Programs.AccountDecodeFrame
+
+namespace EvmAsm.Codegen.AccountDecodeSpec
+
+open EvmAsm.Rv64 EvmAsm.Rv64.SAsm
+open EvmAsm.Codegen.RlpListNthItemSAsm (Saved savedVals listNthFrame savedFrame)
+
+set_option maxRecDepth 8000 in
+/-- Failure return `AB+504 → saved.ra`: store `a0 := 1` and run the epilogue.
+    Generic over the caller's remaining footprint `F`. -/
+theorem adFailEpi (sp0 newSp v10old : Word) (saved : Saved) (F : Assertion) (hF : F.pcFree)
+    (hnewSp : newSp = sp0 + signExtend12 (-64 : BitVec 12))
+    (hret : saved.ra &&& ~~~(1 : Word) = saved.ra) :
+    cpsTripleWithin (1 + 9) (AB + 504) saved.ra fullCode
+      (((.x10 : Reg) ↦ᵣ v10old) **
+       (((.x2 : Reg) ↦ᵣ newSp) ** regsOwnAt listNthFrame ** savedFrame newSp saved) ** F)
+      (((.x10 : Reg) ↦ᵣ (1 : Word)) **
+       (((.x2 : Reg) ↦ᵣ sp0) ** regsAt listNthFrame (savedVals saved) **
+        savedFrame newSp saved) ** F) := by
+  have hft := adFailTail v10old
+    ((((.x2 : Reg) ↦ᵣ newSp) ** regsOwnAt listNthFrame ** savedFrame newSp saved) ** F)
+    (by unfold savedFrame; repeat' first
+        | exact hF | exact pcFree_regIs | exact pcFree_regOwn | exact pcFree_memIs
+        | exact pcFree_regsOwnAt _ | apply pcFree_sepConj)
+  have hepi := adEpilogue sp0 newSp saved (((.x10 : Reg) ↦ᵣ (1 : Word)) ** F)
+    (by exact pcFree_sepConj pcFree_regIs hF) hnewSp hret
+  exact cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp) (fun _ hq => by xperm_hyp hq)
+    (cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) hft hepi)
+
+#print axioms adFailEpi
+
+set_option maxRecDepth 8000 in
+/-- Success return `AB+496 → saved.ra`: store `a0 := 0`, jump past the failure
+    `li`, and run the epilogue.  Generic over the caller's footprint `F`. -/
+theorem adSuccessEpi (sp0 newSp v10old : Word) (saved : Saved) (F : Assertion) (hF : F.pcFree)
+    (hnewSp : newSp = sp0 + signExtend12 (-64 : BitVec 12))
+    (hret : saved.ra &&& ~~~(1 : Word) = saved.ra) :
+    cpsTripleWithin (2 + 9) (AB + 496) saved.ra fullCode
+      (((.x10 : Reg) ↦ᵣ v10old) **
+       (((.x2 : Reg) ↦ᵣ newSp) ** regsOwnAt listNthFrame ** savedFrame newSp saved) ** F)
+      (((.x10 : Reg) ↦ᵣ (0 : Word)) **
+       (((.x2 : Reg) ↦ᵣ sp0) ** regsAt listNthFrame (savedVals saved) **
+        savedFrame newSp saved) ** F) := by
+  have hst := adSuccessTail v10old
+    ((((.x2 : Reg) ↦ᵣ newSp) ** regsOwnAt listNthFrame ** savedFrame newSp saved) ** F)
+    (by unfold savedFrame; repeat' first
+        | exact hF | exact pcFree_regIs | exact pcFree_regOwn | exact pcFree_memIs
+        | exact pcFree_regsOwnAt _ | apply pcFree_sepConj)
+  have hepi := adEpilogue sp0 newSp saved (((.x10 : Reg) ↦ᵣ (0 : Word)) ** F)
+    (by exact pcFree_sepConj pcFree_regIs hF) hnewSp hret
+  exact cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp) (fun _ hq => by xperm_hyp hq)
+    (cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) hst hepi)
+
+#print axioms adSuccessEpi
+
+end EvmAsm.Codegen.AccountDecodeSpec

--- a/EvmAsm/Codegen/Programs/AccountDecodeClose4.lean
+++ b/EvmAsm/Codegen/Programs/AccountDecodeClose4.lean
@@ -1,0 +1,189 @@
+/-
+  `accountDecode_prog` caller-contract composition, part 4 — the whole-program
+  post-condition model and the two generic edge reshapes.
+
+  All four account fields decode via the same `rlp_list_nth_item` (K20) callee
+  and share the outer frame (`spW = newSp = sp0 - 64`), so — unlike the
+  withdrawal decoder — there is no K34↔K20 stack transform: ONE failure arm
+  (`adFailArm`) and ONE continue reshape (`adContReshape`) cover every field
+  boundary.
+
+    * `adCommon`/`adScratch`/`adFailLeftover`/`adSuccessOut`/`adWholePost` —
+      the whole-program success/failure outcome (mirrors `wdWholePost`).
+    * `adFailArm` — the shared failure tail (`AB+504 → saved.ra`) landing the
+      whole-program failure post from any reshaped fail pre.
+    * `adContReshape` — a field's K20 continue post (`adK20ContPost`, with the
+      three length-check temporaries exposed as values) reshaped into the
+      length-check pre plus the ambient continue frame `adContFrame`.
+
+  No `sorry`/`admit`/`native_decide`/`bv_decide`; classical-3 axioms only.
+-/
+
+import EvmAsm.Codegen.Programs.AccountDecodeClose3
+
+namespace EvmAsm.Codegen.AccountDecodeSpec
+
+open EvmAsm.Rv64 EvmAsm.Rv64.SAsm
+open EvmAsm.Codegen.RlpListNthItemSAsm (Saved savedVals listNthFrame savedFrame regsAt_listNthFrame
+  Success Result)
+
+/-! ## Whole-program post-condition pieces -/
+
+/-- The registers/slots common to both the success and the failure return: the
+    restored caller registers (`x1/x8/x9/x18/x19/x20/x21`) reloaded from their
+    (untouched) frame slots and `sp := sp0`.  Exactly `adEpilogue`'s non-`F`
+    post. -/
+def adCommon (sp0 spW : Word) (saved : Saved) : Assertion :=
+  ((.x2 : Reg) ↦ᵣ sp0) ** regsAt listNthFrame (savedVals saved) ** savedFrame spW saved
+
+theorem pcFree_adCommon (sp0 spW : Word) (saved : Saved) :
+    (adCommon sp0 spW saved).pcFree := by
+  unfold adCommon savedFrame
+  rw [regsAt_listNthFrame]
+  repeat' first | exact pcFree_regIs | exact pcFree_memIs | apply pcFree_sepConj
+
+/-- The clobbered temporaries left owned on return, plus the zero register and
+    the still-live `x15` (the `code_hash` output pointer `a5`, framed ambient
+    from the prologue and never restored).  Common to both returns. -/
+def adScratch (codeOut : Word) : Assertion :=
+  regOwn .x5 ** regOwn .x6 ** regOwn .x7 ** regOwn .x11 ** regOwn .x12 **
+  regOwn .x13 ** regOwn .x14 ** regOwn .x28 ** regOwn .x29 ** regOwn .x30 **
+  regOwn .x31 ** ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x15 : Reg) ↦ᵣ codeOut)
+
+theorem pcFree_adScratch (codeOut : Word) : (adScratch codeOut).pcFree := by
+  unfold adScratch
+  repeat' first | exact pcFree_regIs | exact pcFree_regOwn | apply pcFree_sepConj
+
+/-- The mutable leftover after a failure return: the whole output struct
+    (contents forgotten, ownership retained: the 8-byte nonce cell and the three
+    32-byte regions), the input region, the two guest data cells, the clobbered
+    temporaries, and the reclaimed 8-cell K20 scratch stack. -/
+def adFailLeftover (spW nonceOut balanceOut rootOut codeOut listBase : Word)
+    (bytes : List (BitVec 8)) : Assertion :=
+  fun h => ∃ (n roff rlen : Word) (bal root code : List (BitVec 8)),
+    ((nonceOut ↦ₘ n) ** bytesRegion balanceOut bal ** bytesRegion rootOut root **
+     bytesRegion codeOut code ** bytesRegion listBase bytes **
+     (adOffsetAddr ↦ₘ roff) ** (adLengthAddr ↦ₘ rlen) ** stackFree spW 8 **
+     adScratch codeOut) h
+
+theorem pcFree_adFailLeftover (spW nonceOut balanceOut rootOut codeOut listBase : Word)
+    (bytes : List (BitVec 8)) :
+    (adFailLeftover spW nonceOut balanceOut rootOut codeOut listBase bytes).pcFree := by
+  intro h hp
+  obtain ⟨_, _, _, _, _, _, hbody⟩ := hp
+  revert h hbody
+  show Assertion.pcFree _
+  repeat' first
+    | exact pcFree_memIs | exact bytesRegion_pcFree _ _ | exact pcFree_stackFree _ _
+    | exact pcFree_adScratch _ | apply pcFree_sepConj
+
+/-- The output-struct leftover after a success return: each cell tied to the
+    genuinely decoded field value (`outputSuccess`), the untouched input region,
+    the two guest data cells, the clobbered temporaries, and the reclaimed
+    scratch stack. -/
+def adSuccessOut (spW nonceOut balanceOut rootOut codeOut listBase o0 o1 o2 o3 : Word)
+    (l0 l1 : Nat) (bytes oldRoot oldCode : List (BitVec 8)) : Assertion :=
+  fun h => ∃ (roff rlen : Word),
+    (outputSuccess nonceOut balanceOut rootOut codeOut o0 o1 o2 o3 l0 l1 bytes oldRoot oldCode **
+     bytesRegion listBase bytes ** (adOffsetAddr ↦ₘ roff) ** (adLengthAddr ↦ₘ rlen) **
+     stackFree spW 8 ** adScratch codeOut) h
+
+/-- The whole-program post: `a0 = 0` with the genuine decoded output struct, or
+    `a0 = 1` with a witnessed `DecodeFailure` and the owned leftover. -/
+def adWholePost (sp0 spW : Word) (saved : Saved) (listBase : Word)
+    (listLen : Nat) (bytes oldRoot oldCode : List (BitVec 8)) : Assertion :=
+  fun h =>
+    (∃ (o0 l0 o1 l1 o2 l2 o3 l3 : Word),
+      ((⌜Decoded bytes listBase listLen o0 l0 o1 l1 o2 l2 o3 l3⌝ : Assertion) **
+       (((.x10 : Reg) ↦ᵣ (0 : Word)) ** adCommon sp0 spW saved **
+        adSuccessOut spW saved.s2 saved.s3 saved.s4 saved.s5 listBase o0 o1 o2 o3
+          l0.toNat l1.toNat bytes oldRoot oldCode)) h) ∨
+    (((⌜DecodeFailure bytes listBase listLen⌝ : Assertion) **
+      (((.x10 : Reg) ↦ᵣ (1 : Word)) ** adCommon sp0 spW saved **
+       adFailLeftover spW saved.s2 saved.s3 saved.s4 saved.s5 listBase bytes)) h)
+
+/-! ## Failure-tail arm -/
+
+set_option maxRecDepth 8000 in
+/-- Generic fail arm: from a reshaped fail-pre — the restored-caller frame
+    (`x2 ↦ spW`, `regsOwnAt` and the saved frame slots), the pure `⌜DecodeFailure⌝`
+    and the owned leftover as the preserved footprint, and an owned `x10` — the
+    failure tail (`AB+504 → saved.ra`) lands the whole-program failure post.
+    Every fail edge (all four K20 dispatch fails and all four length-check fails)
+    reduces to this after its own PRE reshape. -/
+theorem adFailArm (sp0 spW : Word) (saved : Saved) (listBase : Word)
+    (bytes oldRoot oldCode : List (BitVec 8)) (listLen : Nat)
+    (hspW : spW = sp0 + signExtend12 (-64 : BitVec 12))
+    (hret : saved.ra &&& ~~~(1 : Word) = saved.ra) :
+    cpsTripleWithin (1 + 9) (AB + 504) saved.ra fullCode
+      (((((.x2 : Reg) ↦ᵣ spW) ** regsOwnAt listNthFrame ** savedFrame spW saved) **
+        ((⌜DecodeFailure bytes listBase listLen⌝ : Assertion) **
+         adFailLeftover spW saved.s2 saved.s3 saved.s4 saved.s5 listBase bytes)) **
+       regOwn .x10)
+      (adWholePost sp0 spW saved listBase listLen bytes oldRoot oldCode) := by
+  refine cpsTripleWithin_of_forall_regIs_to_regOwn (fun v10 => ?_)
+  have hepi := adFailEpi sp0 spW v10 saved
+    ((⌜DecodeFailure bytes listBase listLen⌝ : Assertion) **
+      adFailLeftover spW saved.s2 saved.s3 saved.s4 saved.s5 listBase bytes)
+    (pcFree_sepConj pcFree_pure (pcFree_adFailLeftover _ _ _ _ _ _ _)) hspW hret
+  refine cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp) (fun h hq => Or.inr ?_) hepi
+  -- hq : ((x10↦1) ** ((x2↦sp0) ** regsAt ** savedFrame) ** (⌜DF⌝ ** adFailLeftover)) h
+  -- goal : (⌜DF⌝ ** ((x10↦1) ** adCommon ** adFailLeftover)) h
+  unfold adCommon
+  xperm_hyp hq
+
+#print axioms adFailArm
+
+/-! ## Continue-edge reshape (K20 boundary)
+
+    A field's K20 dispatch continue exit (`adK20ContPost`, status `0`) keeps a
+    genuine `Success` decode.  The reshape below exposes the length-check pre
+    (the three temporaries `x5/x6/x7` and the `ad_length` cell) and folds
+    everything else — the seven saved registers, the K20 scratch stack, the
+    still-live status/temporaries, the input region and the `ad_offset` cell,
+    together with the pinned field `Success` — into the ambient frame
+    `adContFrame`, threaded unchanged through the length check. -/
+
+/-- The ambient continue frame carried across a field's length check. -/
+def adContFrame (spW listBase : Word) (index : Nat) (saved : Saved)
+    (bytes : List (BitVec 8)) (listLen : Nat) (offset len v11 v12 : Word) : Assertion :=
+  (⌜Success bytes listBase listLen index offset len⌝ : Assertion) **
+  ((.x2 : Reg) ↦ᵣ spW) ** regsAt listNthFrame (savedVals saved) ** stackFree spW 8 **
+  ((.x10 : Reg) ↦ᵣ (0 : Word)) ** ((.x11 : Reg) ↦ᵣ v11) ** ((.x12 : Reg) ↦ᵣ v12) **
+  regOwn .x13 ** regOwn .x14 ** regOwn .x28 ** regOwn .x29 ** regOwn .x30 **
+  regOwn .x31 ** ((.x0 : Reg) ↦ᵣ (0 : Word)) ** bytesRegion listBase bytes **
+  (adOffsetAddr ↦ₘ offset)
+
+theorem pcFree_adContFrame (spW listBase : Word) (index : Nat) (saved : Saved)
+    (bytes : List (BitVec 8)) (listLen : Nat) (offset len v11 v12 : Word) :
+    (adContFrame spW listBase index saved bytes listLen offset len v11 v12).pcFree := by
+  unfold adContFrame
+  rw [regsAt_listNthFrame]
+  repeat' first
+    | exact pcFree_pure | exact pcFree_regIs | exact pcFree_memIs | exact pcFree_regOwn
+    | exact pcFree_stackFree _ _ | exact bytesRegion_pcFree _ _ | apply pcFree_sepConj
+
+set_option maxRecDepth 8000 in
+/-- CONT reshape: a field's `adK20ContPost` body (a status-`0` `Success` payload,
+    with the three length-check temporaries `x5/x6/x7` already exposed as the
+    fresh values `v5/v6/v7`) reshapes into the length-check pre plus the ambient
+    continue frame.  Generic over the field index — every continue edge uses it. -/
+theorem adContReshape (spW listBase : Word) (index : Nat) (saved : Saved)
+    (bytes : List (BitVec 8)) (listLen : Nat) (offset len v11 v12 v5 v6 v7 : Word) : ∀ h,
+    ((⌜Success bytes listBase listLen index offset len⌝ : Assertion) **
+     ((((.x2 : Reg) ↦ᵣ spW) ** regsAt listNthFrame (savedVals saved) ** stackFree spW 8) **
+      (((.x10 : Reg) ↦ᵣ (0 : Word)) ** ((.x5 : Reg) ↦ᵣ v5) ** ((.x6 : Reg) ↦ᵣ v6) **
+       ((.x7 : Reg) ↦ᵣ v7) ** ((.x11 : Reg) ↦ᵣ v11) ** ((.x12 : Reg) ↦ᵣ v12) **
+       regOwn .x13 ** regOwn .x14 ** regOwn .x28 ** regOwn .x29 ** regOwn .x30 **
+       regOwn .x31 ** ((.x0 : Reg) ↦ᵣ (0 : Word)) ** bytesRegion listBase bytes **
+       (adOffsetAddr ↦ₘ offset) ** (adLengthAddr ↦ₘ len)))) h →
+    ((((.x5 : Reg) ↦ᵣ v5) ** ((.x6 : Reg) ↦ᵣ v6) ** ((.x7 : Reg) ↦ᵣ v7) **
+      (adLengthAddr ↦ₘ len)) **
+     adContFrame spW listBase index saved bytes listLen offset len v11 v12) h := by
+  intro h hp
+  unfold adContFrame
+  xperm_hyp hp
+
+#print axioms adContReshape
+
+end EvmAsm.Codegen.AccountDecodeSpec

--- a/EvmAsm/Codegen/Programs/AccountDecodeClose5.lean
+++ b/EvmAsm/Codegen/Programs/AccountDecodeClose5.lean
@@ -24,10 +24,23 @@ namespace EvmAsm.Codegen.AccountDecodeSpec
 
 open EvmAsm.Rv64 EvmAsm.Rv64.SAsm
 open EvmAsm.Codegen.RlpListNthItemSAsm (Saved savedVals listNthFrame savedFrame regsAt_listNthFrame
-  Success Result Failure)
+  listNthFrameRegs_implies_owned Success Result Failure)
 open EvmAsm.Evm64.Terminating (copyIntoRegion)
 
 /-! ## Local register-ownership introduction helpers -/
+
+/-- Introduce TWO owned registers' values at once (trailing `regOwn` chain). -/
+theorem cpsTripleWithin_of_forall_regIs_to_regOwn2
+    {nSteps : Nat} {entry exit_ : Word} {r1 r2 : Reg} {P Q : Assertion} {cr : CodeReq}
+    (h : ∀ v1 v2, cpsTripleWithin nSteps entry exit_ cr
+      (P ** (r1 ↦ᵣ v1) ** (r2 ↦ᵣ v2)) Q) :
+    cpsTripleWithin nSteps entry exit_ cr (P ** regOwn r1 ** regOwn r2) Q := by
+  intro R hR s hcr hPR hpc
+  obtain ⟨hp, hcompat, h1, h2, hd, hu, hPP, hRb⟩ := hPR
+  obtain ⟨g0, g1, d1, u1, hP0, hO1⟩ := hPP
+  obtain ⟨g2, g3, d2, u2, ⟨v1, hv1⟩, ⟨v2, hv2⟩⟩ := hO1
+  exact h v1 v2 R hR s hcr
+    ⟨hp, hcompat, h1, h2, hd, hu, ⟨g0, g1, d1, u1, hP0, g2, g3, d2, u2, hv1, hv2⟩, hRb⟩ hpc
 
 /-- Introduce THREE owned registers' values at once (trailing `regOwn` chain). -/
 theorem cpsTripleWithin_of_forall_regIs_to_regOwn3
@@ -90,5 +103,439 @@ def adCopyFetchCode : CopyFetch .x21 (AB + 464) where
   bne := fun a i hi => CodeReq.ofProg_mem_at AB (AB + 464 + 20) accountDecode_prog 121
     (.BNE .x6 .x0 (-20 : BitVec 13)) (by bv_omega) (by rw [ad_length]; decide) rfl
     (by rw [ad_length]; decide) a i hi
+
+/-! ## `pcFree` discharge macro for the continue-frame reshapes -/
+
+local macro "pcfa" : tactic =>
+  `(tactic| repeat' first
+    | exact bytesRegion_pcFree _ _
+    | exact pcFree_regIs
+    | exact pcFree_regOwn
+    | exact pcFree_memIs
+    | exact pcFree_memOwn
+    | exact pcFree_pure
+    | exact pcFree_stackFree _ _
+    | exact pcFree_adContFrame _ _ _ _ _ _ _ _ _ _
+    | exact pcFree_adScratch _
+    | exact pcFree_adCommon _ _ _
+    | apply pcFree_sepConj)
+
+/-- The clobbered temporaries (a mix of concrete `regIs` and already-owned
+    `regOwn` cells) weaken into `adScratch`; `x0`/`x15` are kept as concrete. -/
+theorem adScratch_of_regs (codeOut v5 v6 v7 v11 v12 v28 : Word) : ∀ h,
+    (((.x5 : Reg) ↦ᵣ v5) ** ((.x6 : Reg) ↦ᵣ v6) ** ((.x7 : Reg) ↦ᵣ v7) **
+     ((.x11 : Reg) ↦ᵣ v11) ** ((.x12 : Reg) ↦ᵣ v12) ** regOwn .x13 ** regOwn .x14 **
+     ((.x28 : Reg) ↦ᵣ v28) ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+     ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x15 : Reg) ↦ᵣ codeOut)) h →
+    adScratch codeOut h := by
+  intro h hp
+  unfold adScratch
+  exact sepConj_mono (regIs_implies_regOwn .x5) (sepConj_mono (regIs_implies_regOwn .x6)
+    (sepConj_mono (regIs_implies_regOwn .x7) (sepConj_mono (regIs_implies_regOwn .x11)
+    (sepConj_mono (regIs_implies_regOwn .x12) (sepConj_mono_right (sepConj_mono_right
+    (sepConj_mono_left (regIs_implies_regOwn .x28)))))))) h hp
+
+/-- Variant of `adScratch_of_regs` for the fail edge, where `x28` is already
+    owned (never materialised to a concrete cursor). -/
+theorem adScratch_of_regs_own (codeOut v5 v6 v7 v11 v12 : Word) : ∀ h,
+    (((.x5 : Reg) ↦ᵣ v5) ** ((.x6 : Reg) ↦ᵣ v6) ** ((.x7 : Reg) ↦ᵣ v7) **
+     ((.x11 : Reg) ↦ᵣ v11) ** ((.x12 : Reg) ↦ᵣ v12) ** regOwn .x13 ** regOwn .x14 **
+     regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+     ((.x0 : Reg) ↦ᵣ (0 : Word)) ** ((.x15 : Reg) ↦ᵣ codeOut)) h →
+    adScratch codeOut h := by
+  intro h hp
+  unfold adScratch
+  exact sepConj_mono (regIs_implies_regOwn .x5) (sepConj_mono (regIs_implies_regOwn .x6)
+    (sepConj_mono (regIs_implies_regOwn .x7) (sepConj_mono (regIs_implies_regOwn .x11)
+    (sepConj_mono_left (regIs_implies_regOwn .x12))))) h hp
+
+/-! ## Field-3 success tail (`AB+448 → raIn`): code copy + `Decoded` tie
+
+    On the `len = 32` continue edge of field 3's length check, the 20-... (32-)
+    byte code hash is copied into the final output cell, then `adSuccessEpi`
+    stores `a0 := 0` and returns.  The `Decoded` verdict, assembled from the four
+    field `Success` facts, is carried through the epilogue and unpacked into the
+    whole-program success post. -/
+
+set_option maxRecDepth 8000 in
+theorem adField3Success
+    (sp0 spW raIn listBase len nonceOut balanceOut rootOut codeOut o0 o1 o2 o3 l0 l1 l2 l3
+      x28v x29v v11 v12 : Word)
+    (bytes oldRoot oldCode : List (BitVec 8)) (listLen : Nat)
+    (hspW : spW = sp0 + signExtend12 (-64 : BitVec 12))
+    (hret : raIn &&& ~~~(1 : Word) = raIn)
+    (hsalign : listBase.toNat % 8 = 0)
+    (hslack : listLen + 9 ≤ bytes.length)
+    (hover : listBase.toNat + bytes.length < 2 ^ 64)
+    (hvalid : ∀ k, k < bytes.length →
+      isValidByteAccess (listBase + BitVec.ofNat 64 k) = true)
+    (hcalign : codeOut.toNat % 8 = 0)
+    (hcover : codeOut.toNat + 32 < 2 ^ 64)
+    (hcodelen : oldCode.length = 32)
+    (hcvalid : ∀ k, k < 32 → isValidByteAccess (codeOut + BitVec.ofNat 64 k) = true)
+    (hDecoded : Decoded bytes listBase listLen o0 l0 o1 l1 o2 l2 o3 l3)
+    (hf3 : Success bytes listBase listLen 3 o3 l3)
+    (hl3 : l3 = (32 : Word)) :
+    let savedCaller : Saved :=
+      { ra := raIn, s0 := listBase, s1 := len, s2 := nonceOut, s3 := balanceOut,
+        s4 := rootOut, s5 := codeOut }
+    cpsTripleWithin (4 + (192 + (1 + (1 + 11)))) (AB + 448) raIn fullCode
+      (((.x6 : Reg) ↦ᵣ l3) ** ((.x7 : Reg) ↦ᵣ (32 : Word)) ** ((.x5 : Reg) ↦ᵣ adLengthAddr) **
+       (adLengthAddr ↦ₘ l3) ** ((.x2 : Reg) ↦ᵣ spW) ** ((.x1 : Reg) ↦ᵣ (AB + 424)) **
+       ((.x8 : Reg) ↦ᵣ listBase) ** ((.x9 : Reg) ↦ᵣ len) ** ((.x18 : Reg) ↦ᵣ nonceOut) **
+       ((.x19 : Reg) ↦ᵣ balanceOut) ** ((.x20 : Reg) ↦ᵣ s4v) ** ((.x21 : Reg) ↦ᵣ codeOut) **
+       stackFree spW 8 ** ((.x10 : Reg) ↦ᵣ (0 : Word)) ** ((.x11 : Reg) ↦ᵣ v11) **
+       ((.x12 : Reg) ↦ᵣ v12) ** ((.x28 : Reg) ↦ᵣ x28v) ** ((.x29 : Reg) ↦ᵣ x29v) **
+       regOwn .x13 ** regOwn .x14 ** regOwn .x30 ** regOwn .x31 ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+       bytesRegion listBase bytes ** (adOffsetAddr ↦ₘ o3) ** ((.x15 : Reg) ↦ᵣ codeOut) **
+       savedFrame spW savedCaller ** (nonceOut ↦ₘ beAccum bytes o0.toNat l0.toNat) **
+       bytesRegion balanceOut (balanceCopied bytes o1 l1.toNat) **
+       bytesRegion rootOut (fixed32Copied bytes oldRoot o2) ** bytesRegion codeOut oldCode)
+      (adWholePost sp0 spW savedCaller listBase listLen bytes oldRoot oldCode) := by
+  intro savedCaller
+  have hoffnorm : listBase + o3 = listBase + BitVec.ofNat 64 (o3.toNat + 0) := by
+    rw [Nat.add_zero]; congr 1
+    apply BitVec.eq_of_toNat_eq; rw [BitVec.toNat_ofNat, Nat.mod_eq_of_lt o3.isLt]
+  have hsrcbound : o3.toNat + 0 + (31 + 1) ≤ bytes.length := by
+    have hcb := adSuccessContentBound bytes listBase listLen 3 o3 l3 hslack hover hf3
+    rw [hl3] at hcb; simp only [show (32 : Word).toNat = 32 from by decide] at hcb; omega
+  -- code copy source-cursor setup [112]-[115].
+  have hcs := cpsTripleWithin_frameR
+    (((.x6 : Reg) ↦ᵣ l3) ** ((.x7 : Reg) ↦ᵣ (32 : Word)) ** (adLengthAddr ↦ₘ l3) **
+     ((.x2 : Reg) ↦ᵣ spW) ** ((.x1 : Reg) ↦ᵣ (AB + 424)) ** ((.x9 : Reg) ↦ᵣ len) **
+     ((.x18 : Reg) ↦ᵣ nonceOut) ** ((.x19 : Reg) ↦ᵣ balanceOut) ** ((.x20 : Reg) ↦ᵣ s4v) **
+     ((.x21 : Reg) ↦ᵣ codeOut) ** stackFree spW 8 ** ((.x10 : Reg) ↦ᵣ (0 : Word)) **
+     ((.x11 : Reg) ↦ᵣ v11) ** ((.x12 : Reg) ↦ᵣ v12) ** ((.x29 : Reg) ↦ᵣ x29v) **
+     regOwn .x13 ** regOwn .x14 ** regOwn .x30 ** regOwn .x31 ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+     ((.x15 : Reg) ↦ᵣ codeOut) ** savedFrame spW savedCaller ** bytesRegion listBase bytes **
+     (nonceOut ↦ₘ beAccum bytes o0.toNat l0.toNat) **
+     bytesRegion balanceOut (balanceCopied bytes o1 l1.toNat) **
+     bytesRegion rootOut (fixed32Copied bytes oldRoot o2) ** bytesRegion codeOut oldCode)
+    (by pcfa) (adCodeCopySetup listBase o3 adLengthAddr x28v)
+  -- code copy loop [116]-[121].
+  have hcl := cpsTripleWithin_frameR
+    (((.x5 : Reg) ↦ᵣ adOffsetAddr) ** ((.x7 : Reg) ↦ᵣ (32 : Word)) ** (adLengthAddr ↦ₘ l3) **
+     ((.x2 : Reg) ↦ᵣ spW) ** ((.x1 : Reg) ↦ᵣ (AB + 424)) ** ((.x8 : Reg) ↦ᵣ listBase) **
+     ((.x9 : Reg) ↦ᵣ len) **
+     ((.x18 : Reg) ↦ᵣ nonceOut) ** ((.x19 : Reg) ↦ᵣ balanceOut) ** ((.x20 : Reg) ↦ᵣ s4v) **
+     stackFree spW 8 ** ((.x10 : Reg) ↦ᵣ (0 : Word)) ** ((.x11 : Reg) ↦ᵣ v11) **
+     ((.x12 : Reg) ↦ᵣ v12) ** regOwn .x13 ** regOwn .x14 ** regOwn .x30 ** regOwn .x31 **
+     ((.x15 : Reg) ↦ᵣ codeOut) ** savedFrame spW savedCaller **
+     (nonceOut ↦ₘ beAccum bytes o0.toNat l0.toNat) **
+     bytesRegion balanceOut (balanceCopied bytes o1 l1.toNat) **
+     bytesRegion rootOut (fixed32Copied bytes oldRoot o2) ** (adOffsetAddr ↦ₘ o3))
+    (by pcfa)
+    (adCopyLoop .x21 (AB + 464) listBase codeOut x29v bytes oldCode o3.toNat 0 0 31
+      (by decide) adCopyFetchCode hsalign hcalign hsrcbound (by rw [hcodelen])
+      hover (by rw [hcodelen]; exact hcover) hvalid
+      (by intro k hk; rw [hcodelen] at hk; exact hcvalid k hk))
+  -- bridge copysetup → copyloop.
+  have c1 := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by
+      rw [show (BitVec.ofNat 64 (31 + 1) : Word) = l3 from by rw [hl3]; decide,
+        show listBase + BitVec.ofNat 64 (o3.toNat + 0) = listBase + o3 from hoffnorm.symm,
+        show codeOut + BitVec.ofNat 64 (0 + 0) = codeOut from by bv_omega,
+        show copyIntoRegion oldCode bytes 0 o3.toNat 0 = oldCode from rfl]
+      xperm_hyp hp)
+    hcs hcl
+  -- the two trailing NOPs [122]-[123] (`AB+488 → AB+496`).
+  have hnop1 := cpsTripleWithin_extend_code ad_mono
+    (cpsTripleWithin_extend_code
+      (CodeReq.ofProg_mem_at AB (AB + 488) accountDecode_prog 122 .NOP (by bv_omega)
+        (by rw [ad_length]; decide) rfl (by rw [ad_length]; decide)) (nop_spec_within (AB + 488)))
+  have hnop2 := cpsTripleWithin_extend_code ad_mono
+    (cpsTripleWithin_extend_code
+      (CodeReq.ofProg_mem_at AB (AB + 492) accountDecode_prog 123 .NOP (by bv_omega)
+        (by rw [ad_length]; decide) rfl (by rw [ad_length]; decide)) (nop_spec_within (AB + 492)))
+  -- success tail F: the four output cells, the input, the two data cells, the
+  -- reclaimed scratch stack and the clobbered temporaries.
+  set F : Assertion :=
+    (nonceOut ↦ₘ beAccum bytes o0.toNat l0.toNat) **
+    bytesRegion balanceOut (balanceCopied bytes o1 l1.toNat) **
+    bytesRegion rootOut (fixed32Copied bytes oldRoot o2) **
+    bytesRegion codeOut (fixed32Copied bytes oldCode o3) ** bytesRegion listBase bytes **
+    (adOffsetAddr ↦ₘ o3) ** (adLengthAddr ↦ₘ l3) ** stackFree spW 8 ** adScratch codeOut
+    with hFdef
+  have hF : F.pcFree := by rw [hFdef]; unfold adScratch; pcfa
+  have hepi := adSuccessEpi sp0 spW (0 : Word) savedCaller F hF hspW
+    (show savedCaller.ra &&& ~~~(1 : Word) = savedCaller.ra from hret)
+  -- frame the NOPs by the ambient state at AB+488 / AB+492.
+  have hnop1f := cpsTripleWithin_frameR
+    ((.x6 ↦ᵣ (0 : Word)) ** ((.x28 : Reg) ↦ᵣ (listBase + BitVec.ofNat 64 (o3.toNat + (0 + (31 + 1))))) **
+     ((.x21 : Reg) ↦ᵣ (codeOut + BitVec.ofNat 64 (0 + (0 + (31 + 1))))) ** regOwn .x29 **
+     ((.x0 : Reg) ↦ᵣ (0 : Word)) ** bytesRegion listBase bytes **
+     bytesRegion codeOut (copyIntoRegion oldCode bytes 0 o3.toNat (0 + (31 + 1))) **
+     (.x5 ↦ᵣ adOffsetAddr) ** (.x7 ↦ᵣ (32 : Word)) ** (adLengthAddr ↦ₘ l3) ** (.x2 ↦ᵣ spW) **
+     (.x1 ↦ᵣ (AB + 424)) ** (.x8 ↦ᵣ listBase) ** (.x9 ↦ᵣ len) ** (.x18 ↦ᵣ nonceOut) **
+     (.x19 ↦ᵣ balanceOut) **
+     (.x20 ↦ᵣ s4v) ** stackFree spW 8 ** (.x10 ↦ᵣ (0 : Word)) ** (.x11 ↦ᵣ v11) **
+     (.x12 ↦ᵣ v12) ** regOwn .x13 ** regOwn .x14 ** regOwn .x30 ** regOwn .x31 **
+     (.x15 ↦ᵣ codeOut) ** savedFrame spW savedCaller **
+     (nonceOut ↦ₘ beAccum bytes o0.toNat l0.toNat) **
+     bytesRegion balanceOut (balanceCopied bytes o1 l1.toNat) **
+     bytesRegion rootOut (fixed32Copied bytes oldRoot o2) ** (adOffsetAddr ↦ₘ o3))
+    (by pcfa) hnop1
+  rw [sepConj_emp_left'] at hnop1f
+  have hnop2f := cpsTripleWithin_frameR
+    ((.x6 ↦ᵣ (0 : Word)) ** ((.x28 : Reg) ↦ᵣ (listBase + BitVec.ofNat 64 (o3.toNat + (0 + (31 + 1))))) **
+     ((.x21 : Reg) ↦ᵣ (codeOut + BitVec.ofNat 64 (0 + (0 + (31 + 1))))) ** regOwn .x29 **
+     ((.x0 : Reg) ↦ᵣ (0 : Word)) ** bytesRegion listBase bytes **
+     bytesRegion codeOut (copyIntoRegion oldCode bytes 0 o3.toNat (0 + (31 + 1))) **
+     (.x5 ↦ᵣ adOffsetAddr) ** (.x7 ↦ᵣ (32 : Word)) ** (adLengthAddr ↦ₘ l3) ** (.x2 ↦ᵣ spW) **
+     (.x1 ↦ᵣ (AB + 424)) ** (.x8 ↦ᵣ listBase) ** (.x9 ↦ᵣ len) ** (.x18 ↦ᵣ nonceOut) **
+     (.x19 ↦ᵣ balanceOut) **
+     (.x20 ↦ᵣ s4v) ** stackFree spW 8 ** (.x10 ↦ᵣ (0 : Word)) ** (.x11 ↦ᵣ v11) **
+     (.x12 ↦ᵣ v12) ** regOwn .x13 ** regOwn .x14 ** regOwn .x30 ** regOwn .x31 **
+     (.x15 ↦ᵣ codeOut) ** savedFrame spW savedCaller **
+     (nonceOut ↦ₘ beAccum bytes o0.toNat l0.toNat) **
+     bytesRegion balanceOut (balanceCopied bytes o1 l1.toNat) **
+     bytesRegion rootOut (fixed32Copied bytes oldRoot o2) ** (adOffsetAddr ↦ₘ o3))
+    (by pcfa) hnop2
+  rw [sepConj_emp_left'] at hnop2f
+  -- compose copy ;; nop ;; nop ;; success epilogue.
+  have c2 := cpsTripleWithin_seq_perm_same_cr (fun h hp => by xperm_hyp hp) c1 hnop1f
+  have c3 := cpsTripleWithin_seq_perm_same_cr (fun h hp => by xperm_hyp hp) c2 hnop2f
+  have c4 := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by
+      rw [hFdef]
+      have hg : (((.x10 : Reg) ↦ᵣ (0 : Word)) **
+          (((.x2 : Reg) ↦ᵣ spW) **
+           (((.x1 : Reg) ↦ᵣ (AB + 424)) ** ((.x8 : Reg) ↦ᵣ listBase) ** ((.x9 : Reg) ↦ᵣ len) **
+            ((.x18 : Reg) ↦ᵣ nonceOut) ** ((.x19 : Reg) ↦ᵣ balanceOut) **
+            ((.x20 : Reg) ↦ᵣ s4v) **
+            ((.x21 : Reg) ↦ᵣ (codeOut + BitVec.ofNat 64 (0 + (0 + (31 + 1)))))) **
+           savedFrame spW savedCaller) **
+          ((nonceOut ↦ₘ beAccum bytes o0.toNat l0.toNat) **
+           bytesRegion balanceOut (balanceCopied bytes o1 l1.toNat) **
+           bytesRegion rootOut (fixed32Copied bytes oldRoot o2) **
+           bytesRegion codeOut (fixed32Copied bytes oldCode o3) ** bytesRegion listBase bytes **
+           (adOffsetAddr ↦ₘ o3) ** (adLengthAddr ↦ₘ l3) ** stackFree spW 8 **
+           (((.x5 : Reg) ↦ᵣ adOffsetAddr) ** ((.x6 : Reg) ↦ᵣ (0 : Word)) **
+            ((.x7 : Reg) ↦ᵣ (32 : Word)) ** ((.x11 : Reg) ↦ᵣ v11) ** ((.x12 : Reg) ↦ᵣ v12) **
+            regOwn .x13 ** regOwn .x14 **
+            ((.x28 : Reg) ↦ᵣ (listBase + BitVec.ofNat 64 (o3.toNat + (0 + (31 + 1))))) **
+            regOwn .x29 ** regOwn .x30 ** regOwn .x31 ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+            ((.x15 : Reg) ↦ᵣ codeOut)))) h := by
+        rw [show copyIntoRegion oldCode bytes 0 o3.toNat (0 + (31 + 1))
+            = fixed32Copied bytes oldCode o3 from rfl] at hp
+        xperm_hyp hp
+      exact sepConj_mono_right (sepConj_mono
+        (sepConj_mono_right (sepConj_mono_left (fun h' hr => listNthFrameRegs_implies_owned
+          listBase len nonceOut balanceOut s4v
+          (codeOut + BitVec.ofNat 64 (0 + (0 + (31 + 1)))) h'
+          (sepConj_mono_left (regIs_implies_regOwn .x1) h' hr))))
+        (sepConj_mono_right (sepConj_mono_right (sepConj_mono_right (sepConj_mono_right
+          (sepConj_mono_right (sepConj_mono_right (sepConj_mono_right (sepConj_mono_right
+            (adScratch_of_regs codeOut adOffsetAddr (0 : Word) (32 : Word) v11 v12
+              (listBase + BitVec.ofNat 64 (o3.toNat + (0 + (31 + 1)))))))))))))) h hg)
+    c3 hepi
+  -- weaken pre (stated → copysetup pre) and post (epilogue post → whole-program success).
+  refine cpsTripleWithin_mono_nSteps (by omega)
+    (cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp) (fun h hq => ?_) c4)
+  refine Or.inl ⟨o0, l0, o1, l1, o2, l2, o3, l3, ?_⟩
+  refine (sepConj_pure_left h).2 ⟨hDecoded, ?_⟩
+  rw [hFdef] at hq
+  unfold adSuccessOut
+  exact sepConj_mono_right (sepConj_mono_right
+    (fun h' hF => ⟨o3, l3, by unfold outputSuccess; xperm_hyp hF⟩)) h hq
+
+#print axioms adField3Success
+
+/-! ## Field-3 continue: the success-content tie (`AB+428 → raIn`)
+
+    Field 3's K20 continue exit is the all-fields-decoded success path.  The
+    upstream decode facts (fields 0/1/2 `Success` with their length bounds)
+    arrive as hypotheses; combined with field 3's own pinned `Success` (from the
+    reshape) and the `len = 32` length check they assemble `Decoded`.  The code
+    copy loop writes the fourth output cell, then the success tail (`adSuccessEpi`,
+    `AB+496 → raIn`) stores `a0 := 0` and returns. -/
+
+set_option maxRecDepth 8000 in
+theorem adField3ContEpi
+    (sp0 spW raIn listBase len nonceOut balanceOut rootOut codeOut o0 o1 o2 l0 l1 l2 s4reg
+      : Word)
+    (bytes oldRoot oldCode : List (BitVec 8)) (listLen : Nat)
+    (hspW : spW = sp0 + signExtend12 (-64 : BitVec 12))
+    (hret : raIn &&& ~~~(1 : Word) = raIn)
+    (hsalign : listBase.toNat % 8 = 0)
+    (hslack : listLen + 9 ≤ bytes.length)
+    (hover : listBase.toNat + bytes.length < 2 ^ 64)
+    (hvalid : ∀ k, k < bytes.length →
+      isValidByteAccess (listBase + BitVec.ofNat 64 k) = true)
+    (hcalign : codeOut.toNat % 8 = 0)
+    (hcover : codeOut.toNat + 32 < 2 ^ 64)
+    (hcodelen : oldCode.length = 32)
+    (hcvalid : ∀ k, k < 32 → isValidByteAccess (codeOut + BitVec.ofNat 64 k) = true)
+    (hf0 : Success bytes listBase listLen 0 o0 l0)
+    (hf1 : Success bytes listBase listLen 1 o1 l1)
+    (hf2 : Success bytes listBase listLen 2 o2 l2)
+    (hl0 : l0.toNat ≤ 8) (hl1 : l1.toNat ≤ 32) (hl2 : l2.toNat = 32) :
+    let saved3 : Saved :=
+      { ra := AB + 424, s0 := listBase, s1 := len, s2 := nonceOut, s3 := balanceOut,
+        s4 := s4reg, s5 := codeOut }
+    let savedCaller : Saved :=
+      { ra := raIn, s0 := listBase, s1 := len, s2 := nonceOut, s3 := balanceOut,
+        s4 := rootOut, s5 := codeOut }
+    cpsTripleWithin (5 + 210) (AB + 428) raIn fullCode
+      (adK20ContPost spW listBase 3 saved3 bytes listLen **
+       (savedFrame spW savedCaller ** (nonceOut ↦ₘ beAccum bytes o0.toNat l0.toNat) **
+        bytesRegion balanceOut (balanceCopied bytes o1 l1.toNat) **
+        bytesRegion rootOut (fixed32Copied bytes oldRoot o2) ** bytesRegion codeOut oldCode **
+        ((.x15 : Reg) ↦ᵣ codeOut)))
+      (adWholePost sp0 spW savedCaller listBase listLen bytes oldRoot oldCode) := by
+  intro saved3 savedCaller
+  -- (1) expose the K20 continue existentials, keeping x5/x6/x7 owned.
+  refine cpsTripleWithin_weaken
+    (P := fun h => ∃ offset len' v11 v12,
+      (((⌜Success bytes listBase listLen 3 offset len'⌝ : Assertion) **
+        ((.x2 : Reg) ↦ᵣ spW) ** regsAt listNthFrame (savedVals saved3) ** stackFree spW 8 **
+        ((.x10 : Reg) ↦ᵣ (0 : Word)) ** ((.x11 : Reg) ↦ᵣ v11) ** ((.x12 : Reg) ↦ᵣ v12) **
+        regOwn .x13 ** regOwn .x14 ** regOwn .x28 ** regOwn .x29 ** regOwn .x30 **
+        regOwn .x31 ** ((.x0 : Reg) ↦ᵣ (0 : Word)) ** bytesRegion listBase bytes **
+        (adOffsetAddr ↦ₘ offset) ** (adLengthAddr ↦ₘ len') ** savedFrame spW savedCaller **
+        (nonceOut ↦ₘ beAccum bytes o0.toNat l0.toNat) **
+        bytesRegion balanceOut (balanceCopied bytes o1 l1.toNat) **
+        bytesRegion rootOut (fixed32Copied bytes oldRoot o2) ** bytesRegion codeOut oldCode **
+        ((.x15 : Reg) ↦ᵣ codeOut)) ** regOwn .x5 ** regOwn .x6 ** regOwn .x7) h)
+    (fun h hp => by
+      obtain ⟨h1, h2, hd, hu, hcont, hacc⟩ := hp
+      unfold adK20ContPost at hcont
+      obtain ⟨offset, len', v11, v12, hbody⟩ := hcont
+      refine ⟨offset, len', v11, v12, ?_⟩
+      have hcomb : (_ ** _) h := ⟨h1, h2, hd, hu, hbody, hacc⟩
+      xperm_hyp hcomb)
+    (fun _ hq => hq) ?_
+  refine cpsTripleWithin_exists_pre_gen (fun offset => ?_)
+  refine cpsTripleWithin_exists_pre_gen (fun len' => ?_)
+  refine cpsTripleWithin_exists_pre_gen (fun v11 => ?_)
+  refine cpsTripleWithin_exists_pre_gen (fun v12 => ?_)
+  refine cpsTripleWithin_of_forall_regIs_to_regOwn3 (fun v5 v6 v7 => ?_)
+  -- (2) continue reshape into length-check pre plus the ambient continue frame.
+  refine cpsTripleWithin_weaken
+    (P := (((.x5 : Reg) ↦ᵣ v5) ** ((.x6 : Reg) ↦ᵣ v6) ** ((.x7 : Reg) ↦ᵣ v7) **
+        (adLengthAddr ↦ₘ len')) **
+       (adContFrame spW listBase 3 saved3 bytes listLen offset len' v11 v12 **
+        savedFrame spW savedCaller ** (nonceOut ↦ₘ beAccum bytes o0.toNat l0.toNat) **
+        bytesRegion balanceOut (balanceCopied bytes o1 l1.toNat) **
+        bytesRegion rootOut (fixed32Copied bytes oldRoot o2) ** bytesRegion codeOut oldCode **
+        ((.x15 : Reg) ↦ᵣ codeOut)))
+    (fun h hp => by
+      have hin : (((⌜Success bytes listBase listLen 3 offset len'⌝ : Assertion) **
+          ((((.x2 : Reg) ↦ᵣ spW) ** regsAt listNthFrame (savedVals saved3) ** stackFree spW 8) **
+           (((.x10 : Reg) ↦ᵣ (0 : Word)) ** ((.x5 : Reg) ↦ᵣ v5) ** ((.x6 : Reg) ↦ᵣ v6) **
+            ((.x7 : Reg) ↦ᵣ v7) ** ((.x11 : Reg) ↦ᵣ v11) ** ((.x12 : Reg) ↦ᵣ v12) **
+            regOwn .x13 ** regOwn .x14 ** regOwn .x28 ** regOwn .x29 ** regOwn .x30 **
+            regOwn .x31 ** ((.x0 : Reg) ↦ᵣ (0 : Word)) ** bytesRegion listBase bytes **
+            (adOffsetAddr ↦ₘ offset) ** (adLengthAddr ↦ₘ len')))) **
+          (savedFrame spW savedCaller ** (nonceOut ↦ₘ beAccum bytes o0.toNat l0.toNat) **
+           bytesRegion balanceOut (balanceCopied bytes o1 l1.toNat) **
+           bytesRegion rootOut (fixed32Copied bytes oldRoot o2) ** bytesRegion codeOut oldCode **
+           ((.x15 : Reg) ↦ᵣ codeOut))) h := by xperm_hyp hp
+      have hout := sepConj_mono_left (adContReshape spW listBase 3 saved3 bytes listLen offset len'
+        v11 v12 v5 v6 v7) h hin
+      xperm_hyp hout)
+    (fun _ hq => hq) ?_
+  -- (3) length-check branch, framed by the continue frame plus the output cells.
+  have hbr := cpsBranchWithin_frameR
+    (adContFrame spW listBase 3 saved3 bytes listLen offset len' v11 v12 **
+     savedFrame spW savedCaller ** (nonceOut ↦ₘ beAccum bytes o0.toNat l0.toNat) **
+     bytesRegion balanceOut (balanceCopied bytes o1 l1.toNat) **
+     bytesRegion rootOut (fixed32Copied bytes oldRoot o2) ** bytesRegion codeOut oldCode **
+     ((.x15 : Reg) ↦ᵣ codeOut))
+    (by pcfa) (adCodeLenCheck v5 v6 v7 len')
+  refine cpsBranchWithin_merge_same_cr hbr ?fail ?cont
+  case fail =>
+    -- len ≠ 32: field3Len failure through the shared fail arm.
+    refine cpsTripleWithin_weaken (fun h hp => ?_) (fun _ hq => hq)
+      (cpsTripleWithin_mono_nSteps (show (1 + 9) ≤ 210 from by omega)
+        (adFailArm sp0 spW savedCaller listBase bytes oldRoot oldCode listLen hspW
+          (show savedCaller.ra &&& ~~~(1 : Word) = savedCaller.ra from hret)))
+    unfold adContFrame at hp
+    rw [regsAt_listNthFrame] at hp
+    have hf3 : Success bytes listBase listLen 3 offset len' := by
+      obtain ⟨_, _, _, _, _, hr⟩ := hp
+      obtain ⟨_, _, _, _, hcf, _⟩ := hr
+      exact ((sepConj_pure_left _).1 hcf).1
+    have hne32 : len'.toNat ≠ 32 := by
+      have hne : len' ≠ (32 : Word) := by
+        obtain ⟨_, _, _, _, hfp, _⟩ := hp
+        obtain ⟨_, _, _, _, hAgrp, _⟩ := hfp
+        obtain ⟨_, _, _, _, _, hA2⟩ := hAgrp
+        exact ((sepConj_pure_right _).1 hA2).2
+      intro heq; exact hne (by apply BitVec.eq_of_toNat_eq; rw [heq]; decide)
+    have hDF : DecodeFailure bytes listBase listLen := DecodeFailure.field3Len offset len' hf3 hne32
+    have hgP : ((⌜Success bytes listBase listLen 3 offset len'⌝ : Assertion) **
+        (⌜len' ≠ (32 : Word)⌝ : Assertion) **
+        ((((.x2 : Reg) ↦ᵣ spW) **
+         (((.x1 : Reg) ↦ᵣ (AB + 424)) ** ((.x8 : Reg) ↦ᵣ listBase) ** ((.x9 : Reg) ↦ᵣ len) **
+          ((.x18 : Reg) ↦ᵣ nonceOut) ** ((.x19 : Reg) ↦ᵣ balanceOut) **
+          ((.x20 : Reg) ↦ᵣ saved3.s4) ** ((.x21 : Reg) ↦ᵣ codeOut)) **
+         savedFrame spW savedCaller) **
+        ((nonceOut ↦ₘ beAccum bytes o0.toNat l0.toNat) **
+         bytesRegion balanceOut (balanceCopied bytes o1 l1.toNat) **
+         bytesRegion rootOut (fixed32Copied bytes oldRoot o2) ** bytesRegion codeOut oldCode **
+         bytesRegion listBase bytes ** (adOffsetAddr ↦ₘ offset) ** (adLengthAddr ↦ₘ len') **
+         stackFree spW 8 **
+         (((.x5 : Reg) ↦ᵣ adLengthAddr) ** ((.x6 : Reg) ↦ᵣ len') ** ((.x7 : Reg) ↦ᵣ (32 : Word)) **
+          ((.x11 : Reg) ↦ᵣ v11) ** ((.x12 : Reg) ↦ᵣ v12) ** regOwn .x13 ** regOwn .x14 **
+          regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+          ((.x15 : Reg) ↦ᵣ codeOut)))) ** ((.x10 : Reg) ↦ᵣ (0 : Word))) h := by xperm_hyp hp
+    have hg := ((sepConj_pure_left h).1 (((sepConj_pure_left h).1 hgP).2)).2
+    exact sepConj_mono (sepConj_mono
+      (sepConj_mono_right (sepConj_mono_left (fun h' hr => listNthFrameRegs_implies_owned
+        listBase len nonceOut balanceOut saved3.s4 codeOut h'
+        (sepConj_mono_left (regIs_implies_regOwn .x1) h' hr))))
+      (fun h' hc => (sepConj_pure_left h').2
+        ⟨hDF, beAccum bytes o0.toNat l0.toNat, offset, len', balanceCopied bytes o1 l1.toNat,
+          fixed32Copied bytes oldRoot o2, oldCode,
+          sepConj_mono_right (sepConj_mono_right (sepConj_mono_right (sepConj_mono_right
+            (sepConj_mono_right (sepConj_mono_right (sepConj_mono_right (sepConj_mono_right
+              (adScratch_of_regs_own codeOut adLengthAddr len' (32 : Word) v11 v12)))))))) h' hc⟩))
+      (regIs_implies_regOwn .x10) h hg
+  case cont =>
+    -- len = 32: the success tie.  Introduce x28/x29 witnesses, extract facts.
+    refine cpsTripleWithin_weaken
+      (P := ((⌜Success bytes listBase listLen 3 offset len'⌝ : Assertion) **
+        (⌜len' = (32 : Word)⌝ : Assertion) **
+        ((.x6 : Reg) ↦ᵣ len') ** ((.x7 : Reg) ↦ᵣ (32 : Word)) ** ((.x5 : Reg) ↦ᵣ adLengthAddr) **
+        (adLengthAddr ↦ₘ len') ** ((.x2 : Reg) ↦ᵣ spW) ** ((.x1 : Reg) ↦ᵣ (AB + 424)) **
+        ((.x8 : Reg) ↦ᵣ listBase) ** ((.x9 : Reg) ↦ᵣ len) ** ((.x18 : Reg) ↦ᵣ nonceOut) **
+        ((.x19 : Reg) ↦ᵣ balanceOut) ** ((.x20 : Reg) ↦ᵣ saved3.s4) ** ((.x21 : Reg) ↦ᵣ codeOut) **
+        stackFree spW 8 ** ((.x10 : Reg) ↦ᵣ (0 : Word)) ** ((.x11 : Reg) ↦ᵣ v11) **
+        ((.x12 : Reg) ↦ᵣ v12) ** regOwn .x13 ** regOwn .x14 ** regOwn .x30 ** regOwn .x31 **
+        ((.x0 : Reg) ↦ᵣ (0 : Word)) ** bytesRegion listBase bytes **
+        (adOffsetAddr ↦ₘ offset) ** ((.x15 : Reg) ↦ᵣ codeOut) ** savedFrame spW savedCaller **
+        (nonceOut ↦ₘ beAccum bytes o0.toNat l0.toNat) **
+        bytesRegion balanceOut (balanceCopied bytes o1 l1.toNat) **
+        bytesRegion rootOut (fixed32Copied bytes oldRoot o2) ** bytesRegion codeOut oldCode) **
+        regOwn .x28 ** regOwn .x29)
+      (fun h hp => by unfold adContFrame at hp; rw [regsAt_listNthFrame] at hp; xperm_hyp hp)
+      (fun _ hq => hq) ?_
+    refine cpsTripleWithin_of_forall_regIs_to_regOwn2 (fun x28v x29v => ?_)
+    refine cpsTripleWithin_weaken
+      (P := (⌜Success bytes listBase listLen 3 offset len'⌝ : Assertion) **
+        (⌜len' = (32 : Word)⌝ : Assertion) **
+        (((.x6 : Reg) ↦ᵣ len') ** ((.x7 : Reg) ↦ᵣ (32 : Word)) ** ((.x5 : Reg) ↦ᵣ adLengthAddr) **
+         (adLengthAddr ↦ₘ len') ** ((.x2 : Reg) ↦ᵣ spW) ** ((.x1 : Reg) ↦ᵣ (AB + 424)) **
+         ((.x8 : Reg) ↦ᵣ listBase) ** ((.x9 : Reg) ↦ᵣ len) ** ((.x18 : Reg) ↦ᵣ nonceOut) **
+         ((.x19 : Reg) ↦ᵣ balanceOut) ** ((.x20 : Reg) ↦ᵣ saved3.s4) ** ((.x21 : Reg) ↦ᵣ codeOut) **
+         stackFree spW 8 ** ((.x10 : Reg) ↦ᵣ (0 : Word)) ** ((.x11 : Reg) ↦ᵣ v11) **
+         ((.x12 : Reg) ↦ᵣ v12) ** ((.x28 : Reg) ↦ᵣ x28v) ** ((.x29 : Reg) ↦ᵣ x29v) **
+         regOwn .x13 ** regOwn .x14 ** regOwn .x30 ** regOwn .x31 ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+         bytesRegion listBase bytes ** (adOffsetAddr ↦ₘ offset) ** ((.x15 : Reg) ↦ᵣ codeOut) **
+         savedFrame spW savedCaller ** (nonceOut ↦ₘ beAccum bytes o0.toNat l0.toNat) **
+         bytesRegion balanceOut (balanceCopied bytes o1 l1.toNat) **
+         bytesRegion rootOut (fixed32Copied bytes oldRoot o2) ** bytesRegion codeOut oldCode))
+      (fun h hp => by xperm_hyp hp) (fun _ hq => hq) ?_
+    refine cpsTripleWithin_pure_pre (fun hf3 => ?_)
+    refine cpsTripleWithin_pure_pre (fun hl3 => ?_)
+    have hDecoded : Decoded bytes listBase listLen o0 l0 o1 l1 o2 l2 offset len' :=
+      ⟨hf0, hl0, hf1, hl1, hf2, hl2, hf3, by rw [hl3]; decide⟩
+    exact cpsTripleWithin_mono_nSteps (by omega)
+      (adField3Success (s4v := saved3.s4) sp0 spW raIn listBase len nonceOut balanceOut rootOut
+        codeOut o0 o1 o2 offset l0 l1 l2 len' x28v x29v v11 v12 bytes oldRoot oldCode listLen hspW
+        hret hsalign hslack hover hvalid hcalign hcover hcodelen hcvalid hDecoded hf3 hl3)
+
+#print axioms adField3ContEpi
 
 end EvmAsm.Codegen.AccountDecodeSpec

--- a/EvmAsm/Codegen/Programs/AccountDecodeClose5.lean
+++ b/EvmAsm/Codegen/Programs/AccountDecodeClose5.lean
@@ -149,6 +149,20 @@ theorem adScratch_of_regs_own (codeOut v5 v6 v7 v11 v12 : Word) : ∀ h,
     (sepConj_mono (regIs_implies_regOwn .x7) (sepConj_mono (regIs_implies_regOwn .x11)
     (sepConj_mono_left (regIs_implies_regOwn .x12))))) h hp
 
+/-- Variant of `adScratch_of_regs` for a stage fail edge, where `x5/x6/x7` and
+    `x28` are all already owned; only `x11`/`x12` are concrete. -/
+theorem adScratch_of_regs_own2 (codeOut v11 v12 : Word) : ∀ h,
+    (regOwn .x5 ** regOwn .x6 ** regOwn .x7 ** ((.x11 : Reg) ↦ᵣ v11) **
+     ((.x12 : Reg) ↦ᵣ v12) ** regOwn .x13 ** regOwn .x14 ** regOwn .x28 ** regOwn .x29 **
+     regOwn .x30 ** regOwn .x31 ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+     ((.x15 : Reg) ↦ᵣ codeOut)) h →
+    adScratch codeOut h := by
+  intro h hp
+  unfold adScratch
+  exact sepConj_mono_right (sepConj_mono_right (sepConj_mono_right
+    (sepConj_mono (regIs_implies_regOwn .x11) (sepConj_mono_left (regIs_implies_regOwn .x12)))))
+    h hp
+
 /-! ## Field-3 success tail (`AB+448 → raIn`): code copy + `Decoded` tie
 
     On the `len = 32` continue edge of field 3's length check, the 20-... (32-)
@@ -537,5 +551,108 @@ theorem adField3ContEpi
         hret hsalign hslack hover hvalid hcalign hcover hcodelen hcvalid hDecoded hf3 hl3)
 
 #print axioms adField3ContEpi
+
+/-! ## Field-3 backbone (`AB+392 → raSaved`)
+
+    Merge the field-3 stage's two exits: the parse-fail edge routes through the
+    shared `adFailArm` (constructor `DecodeFailure.field3List`), the continue edge
+    through `adField3ContEpi` (the success tie).  Both land the whole-program post;
+    the four saved slots, the three already-written output cells, the code output
+    cell and the live `x15` code pointer are framed ambient across both. -/
+
+set_option maxRecDepth 8000 in
+theorem adBBField3
+    (sp0 spW raEntry raSaved listBase len nonceOut balanceOut rootOut codeOut s4reg
+      oldOffset oldLen v10 v11 v12 v13 v14 o0 o1 o2 l0 l1 l2 : Word)
+    (bytes oldRoot oldCode : List (BitVec 8)) (listLen : Nat)
+    (hspW : spW = sp0 + signExtend12 (-64 : BitVec 12))
+    (hret : raSaved &&& ~~~(1 : Word) = raSaved)
+    (hlenW : len = BitVec.ofNat 64 listLen)
+    (hsalign : listBase.toNat % 8 = 0)
+    (hslack : listLen + 9 ≤ bytes.length)
+    (hover : listBase.toNat + bytes.length < 2 ^ 64)
+    (hvalid : ∀ k, k < bytes.length →
+      isValidByteAccess (listBase + BitVec.ofNat 64 k) = true)
+    (hcalign : codeOut.toNat % 8 = 0)
+    (hcover : codeOut.toNat + 32 < 2 ^ 64)
+    (hcodelen : oldCode.length = 32)
+    (hcvalid : ∀ k, k < 32 → isValidByteAccess (codeOut + BitVec.ofNat 64 k) = true)
+    (hf0 : Success bytes listBase listLen 0 o0 l0)
+    (hf1 : Success bytes listBase listLen 1 o1 l1)
+    (hf2 : Success bytes listBase listLen 2 o2 l2)
+    (hl0 : l0.toNat ≤ 8) (hl1 : l1.toNat ≤ 32) (hl2 : l2.toNat = 32) :
+    let savedCaller : Saved :=
+      { ra := raSaved, s0 := listBase, s1 := len, s2 := nonceOut, s3 := balanceOut,
+        s4 := rootOut, s5 := codeOut }
+    cpsTripleWithin (((7 + (1 + ((12 + ((85 + 93 * (3 + 2)) + 6)) + 9))) + 1) + 215)
+      (AB + 392) raSaved fullCode
+      (adCallPre raEntry spW listBase len nonceOut balanceOut s4reg codeOut oldOffset oldLen
+        v10 v11 v12 v13 v14 bytes **
+       (savedFrame spW savedCaller ** (nonceOut ↦ₘ beAccum bytes o0.toNat l0.toNat) **
+        bytesRegion balanceOut (balanceCopied bytes o1 l1.toNat) **
+        bytesRegion rootOut (fixed32Copied bytes oldRoot o2) ** bytesRegion codeOut oldCode **
+        ((.x15 : Reg) ↦ᵣ codeOut)))
+      (adWholePost sp0 spW savedCaller listBase listLen bytes oldRoot oldCode) := by
+  intro savedCaller
+  have hstage := adField3Stage spW raEntry listBase len nonceOut balanceOut s4reg codeOut
+    oldOffset oldLen v10 v11 v12 v13 v14 bytes listLen hlenW hsalign hslack hover hvalid
+  have hbr := cpsBranchWithin_frameR
+    (savedFrame spW savedCaller ** (nonceOut ↦ₘ beAccum bytes o0.toNat l0.toNat) **
+     bytesRegion balanceOut (balanceCopied bytes o1 l1.toNat) **
+     bytesRegion rootOut (fixed32Copied bytes oldRoot o2) ** bytesRegion codeOut oldCode **
+     ((.x15 : Reg) ↦ᵣ codeOut))
+    (by pcfa) hstage
+  refine cpsBranchWithin_merge_same_cr hbr ?fail ?cont
+  case cont =>
+    exact cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp) (fun _ hq => hq)
+      (adField3ContEpi sp0 spW raSaved listBase len nonceOut balanceOut rootOut codeOut o0 o1 o2
+        l0 l1 l2 s4reg bytes oldRoot oldCode listLen hspW hret hsalign hslack hover hvalid hcalign
+        hcover hcodelen hcvalid hf0 hf1 hf2 hl0 hl1 hl2)
+  case fail =>
+    refine cpsTripleWithin_weaken (fun h hp => ?_) (fun _ hq => hq)
+      (cpsTripleWithin_mono_nSteps (show (1 + 9) ≤ 215 from by omega)
+        (adFailArm sp0 spW savedCaller listBase bytes oldRoot oldCode listLen hspW
+          (show savedCaller.ra &&& ~~~(1 : Word) = savedCaller.ra from hret)))
+    obtain ⟨h1, h2, hd, hu, hfail, hacc⟩ := hp
+    unfold adK20FailPost at hfail
+    obtain ⟨status, offset', len', v11', v12', hbody⟩ := hfail
+    have hResPair : Result bytes listBase listLen 3 oldOffset oldLen status offset' len' ∧
+        status ≠ (0 : Word) := ((sepConj_pure_left h1).1 hbody).1
+    have hFail : Failure bytes listBase listLen 3 := by
+      cases hResPair.1 with
+      | ok o l hs => exact absurd rfl hResPair.2
+      | fail hf => exact hf
+    have hDF : DecodeFailure bytes listBase listLen := DecodeFailure.field3List hFail
+    have hbig := ((sepConj_pure_left h1).1 hbody).2
+    rw [regsAt_listNthFrame] at hbig
+    have hgP : (((((.x2 : Reg) ↦ᵣ spW) **
+        (((.x1 : Reg) ↦ᵣ (AB + 424)) ** ((.x8 : Reg) ↦ᵣ listBase) ** ((.x9 : Reg) ↦ᵣ len) **
+         ((.x18 : Reg) ↦ᵣ nonceOut) ** ((.x19 : Reg) ↦ᵣ balanceOut) **
+         ((.x20 : Reg) ↦ᵣ s4reg) ** ((.x21 : Reg) ↦ᵣ codeOut)) **
+        savedFrame spW savedCaller) **
+       ((nonceOut ↦ₘ beAccum bytes o0.toNat l0.toNat) **
+        bytesRegion balanceOut (balanceCopied bytes o1 l1.toNat) **
+        bytesRegion rootOut (fixed32Copied bytes oldRoot o2) ** bytesRegion codeOut oldCode **
+        bytesRegion listBase bytes ** (adOffsetAddr ↦ₘ offset') ** (adLengthAddr ↦ₘ len') **
+        stackFree spW 8 **
+        (regOwn .x5 ** regOwn .x6 ** regOwn .x7 ** ((.x11 : Reg) ↦ᵣ v11') **
+         ((.x12 : Reg) ↦ᵣ v12') ** regOwn .x13 ** regOwn .x14 **
+         regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+         ((.x15 : Reg) ↦ᵣ codeOut)))) ** ((.x10 : Reg) ↦ᵣ status)) h := by
+      have hcomb : (_ ** _) h := ⟨h1, h2, hd, hu, hbig, hacc⟩
+      xperm_hyp hcomb
+    exact sepConj_mono (sepConj_mono
+      (sepConj_mono_right (sepConj_mono_left (fun h' hr => listNthFrameRegs_implies_owned
+        listBase len nonceOut balanceOut s4reg codeOut h'
+        (sepConj_mono_left (regIs_implies_regOwn .x1) h' hr))))
+      (fun h' hc => (sepConj_pure_left h').2
+        ⟨hDF, beAccum bytes o0.toNat l0.toNat, offset', len', balanceCopied bytes o1 l1.toNat,
+          fixed32Copied bytes oldRoot o2, oldCode,
+          sepConj_mono_right (sepConj_mono_right (sepConj_mono_right (sepConj_mono_right
+            (sepConj_mono_right (sepConj_mono_right (sepConj_mono_right (sepConj_mono_right
+              (adScratch_of_regs_own2 codeOut v11' v12')))))))) h' hc⟩))
+      (regIs_implies_regOwn .x10) h hgP
+
+#print axioms adBBField3
 
 end EvmAsm.Codegen.AccountDecodeSpec

--- a/EvmAsm/Codegen/Programs/AccountDecodeClose5.lean
+++ b/EvmAsm/Codegen/Programs/AccountDecodeClose5.lean
@@ -655,4 +655,558 @@ theorem adBBField3
 
 #print axioms adBBField3
 
+/-! ## Field-2 (storage_root) backbone
+
+    Mirror of the field-3 trio, split one step further (`adField2Copy` +
+    `adField2Success` + `adField2ContEpi` + `adBBField2`).  The `len = 32`
+    continue edge copies the 32 root bytes into the third output cell and hands
+    the register state off to the field-3 backbone `adBBField3`. -/
+
+/-- Introduce FOUR owned registers' values at once (trailing `regOwn` chain). -/
+theorem cpsTripleWithin_of_forall_regIs_to_regOwn4
+    {nSteps : Nat} {entry exit_ : Word} {r1 r2 r3 r4 : Reg} {P Q : Assertion} {cr : CodeReq}
+    (h : ∀ v1 v2 v3 v4, cpsTripleWithin nSteps entry exit_ cr
+      (P ** (r1 ↦ᵣ v1) ** (r2 ↦ᵣ v2) ** (r3 ↦ᵣ v3) ** (r4 ↦ᵣ v4)) Q) :
+    cpsTripleWithin nSteps entry exit_ cr
+      (P ** regOwn r1 ** regOwn r2 ** regOwn r3 ** regOwn r4) Q := by
+  intro R hR s hcr hPR hpc
+  obtain ⟨hp, hcompat, h1, h2, hd, hu, hPP, hRb⟩ := hPR
+  obtain ⟨g0, g1, d1, u1, hP0, hO1⟩ := hPP
+  obtain ⟨g2, g3, d2, u2, ⟨v1, hv1⟩, hO2⟩ := hO1
+  obtain ⟨g4, g5, d3, u3, ⟨v2, hv2⟩, hO3⟩ := hO2
+  obtain ⟨g6, g7, d4, u4, ⟨v3, hv3⟩, ⟨v4, hv4⟩⟩ := hO3
+  exact h v1 v2 v3 v4 R hR s hcr
+    ⟨hp, hcompat, h1, h2, hd, hu,
+      ⟨g0, g1, d1, u1, hP0, g2, g3, d2, u2, hv1, g4, g5, d3, u3, hv2,
+        g6, g7, d4, u4, hv3, hv4⟩, hRb⟩ hpc
+
+/-- Package the regIs→regOwn weakening of the four scratch temporaries
+    `x5/x6/x7/x28` into `adCallPre`: the handoff of a field materialiser into the
+    next field's call precondition. -/
+theorem adCallPre_weaken (raIn spW listBase len s2v s3 s4 s5 oldOffset oldLen
+    v10 v11 v12 v13 v14 v5 v6 v7 v28 : Word) (bytes : List (BitVec 8)) : ∀ h,
+    (((.x1 : Reg) ↦ᵣ raIn) ** ((.x2 : Reg) ↦ᵣ spW) ** ((.x8 : Reg) ↦ᵣ listBase) **
+     ((.x9 : Reg) ↦ᵣ len) ** ((.x18 : Reg) ↦ᵣ s2v) ** ((.x19 : Reg) ↦ᵣ s3) **
+     ((.x20 : Reg) ↦ᵣ s4) ** ((.x21 : Reg) ↦ᵣ s5) ** ((.x10 : Reg) ↦ᵣ v10) **
+     ((.x11 : Reg) ↦ᵣ v11) ** ((.x12 : Reg) ↦ᵣ v12) ** ((.x13 : Reg) ↦ᵣ v13) **
+     ((.x14 : Reg) ↦ᵣ v14) ** stackFree spW 8 ** ((.x5 : Reg) ↦ᵣ v5) **
+     ((.x6 : Reg) ↦ᵣ v6) ** ((.x7 : Reg) ↦ᵣ v7) ** ((.x28 : Reg) ↦ᵣ v28) **
+     regOwn .x29 ** regOwn .x30 ** regOwn .x31 ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+     bytesRegion listBase bytes ** (adOffsetAddr ↦ₘ oldOffset) **
+     (adLengthAddr ↦ₘ oldLen)) h →
+    adCallPre raIn spW listBase len s2v s3 s4 s5 oldOffset oldLen
+      v10 v11 v12 v13 v14 bytes h := by
+  intro h hp
+  unfold adCallPre
+  exact sepConj_mono_right (sepConj_mono_right (sepConj_mono_right (sepConj_mono_right
+    (sepConj_mono_right (sepConj_mono_right (sepConj_mono_right (sepConj_mono_right
+    (sepConj_mono_right (sepConj_mono_right (sepConj_mono_right (sepConj_mono_right
+    (sepConj_mono_right (sepConj_mono_right
+      (sepConj_mono (regIs_implies_regOwn .x5) (sepConj_mono (regIs_implies_regOwn .x6)
+        (sepConj_mono (regIs_implies_regOwn .x7)
+          (sepConj_mono_left (regIs_implies_regOwn .x28))))))))))))))))))
+    h hp
+
+set_option maxRecDepth 8000 in
+/-- Field-2 root copy tail (`AB+344 → AB+392`): the 32-byte storage-root copy
+    loop plus the two trailing NOPs, reshaping the `len = 32` continue state into
+    the field-3 call precondition (`adBBField3`'s `adCallPre`) plus the ambient
+    accumulator with the third output cell now written (`fixed32Copied`). -/
+theorem adField2Copy
+    (spW raSaved listBase len nonceOut balanceOut rootOut codeOut o0 o1 o2 l0 l1
+      x28v x29v v11 v12 v13 v14 : Word)
+    (bytes oldRoot oldCode : List (BitVec 8)) (listLen : Nat)
+    (hsalign : listBase.toNat % 8 = 0)
+    (hslack : listLen + 9 ≤ bytes.length)
+    (hover : listBase.toNat + bytes.length < 2 ^ 64)
+    (hvalid : ∀ k, k < bytes.length →
+      isValidByteAccess (listBase + BitVec.ofNat 64 k) = true)
+    (hralign : rootOut.toNat % 8 = 0)
+    (hrover : rootOut.toNat + 32 < 2 ^ 64)
+    (hrootlen : oldRoot.length = 32)
+    (hrvalid : ∀ k, k < 32 → isValidByteAccess (rootOut + BitVec.ofNat 64 k) = true)
+    (hf2 : Success bytes listBase listLen 2 o2 l2)
+    (hl2 : l2 = (32 : Word)) :
+    let savedCaller : Saved :=
+      { ra := raSaved, s0 := listBase, s1 := len, s2 := nonceOut, s3 := balanceOut,
+        s4 := rootOut, s5 := codeOut }
+    cpsTripleWithin (4 + (192 + (1 + 1))) (AB + 344) (AB + 392) fullCode
+      (((.x6 : Reg) ↦ᵣ l2) ** ((.x7 : Reg) ↦ᵣ (32 : Word)) ** ((.x5 : Reg) ↦ᵣ adLengthAddr) **
+       (adLengthAddr ↦ₘ l2) ** ((.x2 : Reg) ↦ᵣ spW) ** ((.x1 : Reg) ↦ᵣ (AB + 320)) **
+       ((.x8 : Reg) ↦ᵣ listBase) ** ((.x9 : Reg) ↦ᵣ len) ** ((.x18 : Reg) ↦ᵣ nonceOut) **
+       ((.x19 : Reg) ↦ᵣ balanceOut) ** ((.x20 : Reg) ↦ᵣ rootOut) ** ((.x21 : Reg) ↦ᵣ codeOut) **
+       stackFree spW 8 ** ((.x10 : Reg) ↦ᵣ (0 : Word)) ** ((.x11 : Reg) ↦ᵣ v11) **
+       ((.x12 : Reg) ↦ᵣ v12) ** ((.x13 : Reg) ↦ᵣ v13) ** ((.x14 : Reg) ↦ᵣ v14) **
+       ((.x28 : Reg) ↦ᵣ x28v) ** ((.x29 : Reg) ↦ᵣ x29v) **
+       regOwn .x30 ** regOwn .x31 ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+       bytesRegion listBase bytes ** (adOffsetAddr ↦ₘ o2) ** ((.x15 : Reg) ↦ᵣ codeOut) **
+       savedFrame spW savedCaller ** (nonceOut ↦ₘ beAccum bytes o0.toNat l0.toNat) **
+       bytesRegion balanceOut (balanceCopied bytes o1 l1.toNat) **
+       bytesRegion codeOut oldCode ** bytesRegion rootOut oldRoot)
+      (adCallPre (AB + 320) spW listBase len nonceOut balanceOut
+        (rootOut + BitVec.ofNat 64 32) codeOut o2 l2 (0 : Word) v11 v12 v13 v14 bytes **
+       (savedFrame spW savedCaller ** (nonceOut ↦ₘ beAccum bytes o0.toNat l0.toNat) **
+        bytesRegion balanceOut (balanceCopied bytes o1 l1.toNat) **
+        bytesRegion rootOut (fixed32Copied bytes oldRoot o2) ** bytesRegion codeOut oldCode **
+        ((.x15 : Reg) ↦ᵣ codeOut))) := by
+  intro savedCaller
+  have hoffnorm : listBase + o2 = listBase + BitVec.ofNat 64 (o2.toNat + 0) := by
+    rw [Nat.add_zero]; congr 1
+    apply BitVec.eq_of_toNat_eq; rw [BitVec.toNat_ofNat, Nat.mod_eq_of_lt o2.isLt]
+  have hsrcbound : o2.toNat + 0 + (31 + 1) ≤ bytes.length := by
+    have hcb := adSuccessContentBound bytes listBase listLen 2 o2 l2 hslack hover hf2
+    rw [hl2] at hcb; simp only [show (32 : Word).toNat = 32 from by decide] at hcb; omega
+  -- root copy source-cursor setup [86]-[89].
+  have hcs := cpsTripleWithin_frameR
+    (((.x6 : Reg) ↦ᵣ l2) ** ((.x7 : Reg) ↦ᵣ (32 : Word)) ** (adLengthAddr ↦ₘ l2) **
+     ((.x2 : Reg) ↦ᵣ spW) ** ((.x1 : Reg) ↦ᵣ (AB + 320)) ** ((.x9 : Reg) ↦ᵣ len) **
+     ((.x18 : Reg) ↦ᵣ nonceOut) ** ((.x19 : Reg) ↦ᵣ balanceOut) ** ((.x20 : Reg) ↦ᵣ rootOut) **
+     ((.x21 : Reg) ↦ᵣ codeOut) ** stackFree spW 8 ** ((.x10 : Reg) ↦ᵣ (0 : Word)) **
+     ((.x11 : Reg) ↦ᵣ v11) ** ((.x12 : Reg) ↦ᵣ v12) ** ((.x13 : Reg) ↦ᵣ v13) **
+     ((.x14 : Reg) ↦ᵣ v14) ** ((.x29 : Reg) ↦ᵣ x29v) **
+     regOwn .x30 ** regOwn .x31 ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+     ((.x15 : Reg) ↦ᵣ codeOut) ** savedFrame spW savedCaller ** bytesRegion listBase bytes **
+     (nonceOut ↦ₘ beAccum bytes o0.toNat l0.toNat) **
+     bytesRegion balanceOut (balanceCopied bytes o1 l1.toNat) **
+     bytesRegion codeOut oldCode ** bytesRegion rootOut oldRoot)
+    (by pcfa) (adRootCopySetup listBase o2 adLengthAddr x28v)
+  -- root copy loop [90]-[95].
+  have hcl := cpsTripleWithin_frameR
+    (((.x5 : Reg) ↦ᵣ adOffsetAddr) ** ((.x7 : Reg) ↦ᵣ (32 : Word)) ** (adLengthAddr ↦ₘ l2) **
+     ((.x2 : Reg) ↦ᵣ spW) ** ((.x1 : Reg) ↦ᵣ (AB + 320)) ** ((.x8 : Reg) ↦ᵣ listBase) **
+     ((.x9 : Reg) ↦ᵣ len) **
+     ((.x18 : Reg) ↦ᵣ nonceOut) ** ((.x19 : Reg) ↦ᵣ balanceOut) ** ((.x21 : Reg) ↦ᵣ codeOut) **
+     stackFree spW 8 ** ((.x10 : Reg) ↦ᵣ (0 : Word)) ** ((.x11 : Reg) ↦ᵣ v11) **
+     ((.x12 : Reg) ↦ᵣ v12) ** ((.x13 : Reg) ↦ᵣ v13) ** ((.x14 : Reg) ↦ᵣ v14) **
+     regOwn .x30 ** regOwn .x31 **
+     ((.x15 : Reg) ↦ᵣ codeOut) ** savedFrame spW savedCaller **
+     (nonceOut ↦ₘ beAccum bytes o0.toNat l0.toNat) **
+     bytesRegion balanceOut (balanceCopied bytes o1 l1.toNat) **
+     bytesRegion codeOut oldCode ** (adOffsetAddr ↦ₘ o2))
+    (by pcfa)
+    (adCopyLoop .x20 (AB + 360) listBase rootOut x29v bytes oldRoot o2.toNat 0 0 31
+      (by decide) adCopyFetchRoot hsalign hralign hsrcbound (by rw [hrootlen])
+      hover (by rw [hrootlen]; exact hrover) hvalid
+      (by intro k hk; rw [hrootlen] at hk; exact hrvalid k hk))
+  -- bridge copysetup → copyloop.
+  have c1 := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by
+      rw [show (BitVec.ofNat 64 (31 + 1) : Word) = l2 from by rw [hl2]; decide,
+        show listBase + BitVec.ofNat 64 (o2.toNat + 0) = listBase + o2 from hoffnorm.symm,
+        show rootOut + BitVec.ofNat 64 (0 + 0) = rootOut from by bv_omega,
+        show copyIntoRegion oldRoot bytes 0 o2.toNat 0 = oldRoot from rfl]
+      xperm_hyp hp)
+    hcs hcl
+  -- the two trailing NOPs [96]-[97] (`AB+384 → AB+392`).
+  have hnop1 := cpsTripleWithin_extend_code ad_mono
+    (cpsTripleWithin_extend_code
+      (CodeReq.ofProg_mem_at AB (AB + 384) accountDecode_prog 96 .NOP (by bv_omega)
+        (by rw [ad_length]; decide) rfl (by rw [ad_length]; decide)) (nop_spec_within (AB + 384)))
+  have hnop2 := cpsTripleWithin_extend_code ad_mono
+    (cpsTripleWithin_extend_code
+      (CodeReq.ofProg_mem_at AB (AB + 388) accountDecode_prog 97 .NOP (by bv_omega)
+        (by rw [ad_length]; decide) rfl (by rw [ad_length]; decide)) (nop_spec_within (AB + 388)))
+  have hnop1f := cpsTripleWithin_frameR
+    ((.x6 ↦ᵣ (0 : Word)) ** ((.x28 : Reg) ↦ᵣ (listBase + BitVec.ofNat 64 (o2.toNat + (0 + (31 + 1))))) **
+     ((.x20 : Reg) ↦ᵣ (rootOut + BitVec.ofNat 64 (0 + (0 + (31 + 1))))) ** regOwn .x29 **
+     ((.x0 : Reg) ↦ᵣ (0 : Word)) ** bytesRegion listBase bytes **
+     bytesRegion rootOut (copyIntoRegion oldRoot bytes 0 o2.toNat (0 + (31 + 1))) **
+     (.x5 ↦ᵣ adOffsetAddr) ** (.x7 ↦ᵣ (32 : Word)) ** (adLengthAddr ↦ₘ l2) ** (.x2 ↦ᵣ spW) **
+     (.x1 ↦ᵣ (AB + 320)) ** (.x8 ↦ᵣ listBase) ** (.x9 ↦ᵣ len) ** (.x18 ↦ᵣ nonceOut) **
+     (.x19 ↦ᵣ balanceOut) ** (.x21 ↦ᵣ codeOut) ** stackFree spW 8 ** (.x10 ↦ᵣ (0 : Word)) **
+     (.x11 ↦ᵣ v11) ** (.x12 ↦ᵣ v12) ** (.x13 ↦ᵣ v13) ** (.x14 ↦ᵣ v14) **
+     regOwn .x30 ** regOwn .x31 **
+     (.x15 ↦ᵣ codeOut) ** savedFrame spW savedCaller **
+     (nonceOut ↦ₘ beAccum bytes o0.toNat l0.toNat) **
+     bytesRegion balanceOut (balanceCopied bytes o1 l1.toNat) **
+     bytesRegion codeOut oldCode ** (adOffsetAddr ↦ₘ o2))
+    (by pcfa) hnop1
+  rw [sepConj_emp_left'] at hnop1f
+  have hnop2f := cpsTripleWithin_frameR
+    ((.x6 ↦ᵣ (0 : Word)) ** ((.x28 : Reg) ↦ᵣ (listBase + BitVec.ofNat 64 (o2.toNat + (0 + (31 + 1))))) **
+     ((.x20 : Reg) ↦ᵣ (rootOut + BitVec.ofNat 64 (0 + (0 + (31 + 1))))) ** regOwn .x29 **
+     ((.x0 : Reg) ↦ᵣ (0 : Word)) ** bytesRegion listBase bytes **
+     bytesRegion rootOut (copyIntoRegion oldRoot bytes 0 o2.toNat (0 + (31 + 1))) **
+     (.x5 ↦ᵣ adOffsetAddr) ** (.x7 ↦ᵣ (32 : Word)) ** (adLengthAddr ↦ₘ l2) ** (.x2 ↦ᵣ spW) **
+     (.x1 ↦ᵣ (AB + 320)) ** (.x8 ↦ᵣ listBase) ** (.x9 ↦ᵣ len) ** (.x18 ↦ᵣ nonceOut) **
+     (.x19 ↦ᵣ balanceOut) ** (.x21 ↦ᵣ codeOut) ** stackFree spW 8 ** (.x10 ↦ᵣ (0 : Word)) **
+     (.x11 ↦ᵣ v11) ** (.x12 ↦ᵣ v12) ** (.x13 ↦ᵣ v13) ** (.x14 ↦ᵣ v14) **
+     regOwn .x30 ** regOwn .x31 **
+     (.x15 ↦ᵣ codeOut) ** savedFrame spW savedCaller **
+     (nonceOut ↦ₘ beAccum bytes o0.toNat l0.toNat) **
+     bytesRegion balanceOut (balanceCopied bytes o1 l1.toNat) **
+     bytesRegion codeOut oldCode ** (adOffsetAddr ↦ₘ o2))
+    (by pcfa) hnop2
+  rw [sepConj_emp_left'] at hnop2f
+  have c2 := cpsTripleWithin_seq_perm_same_cr (fun h hp => by xperm_hyp hp) c1 hnop1f
+  have c3 := cpsTripleWithin_seq_perm_same_cr (fun h hp => by xperm_hyp hp) c2 hnop2f
+  refine cpsTripleWithin_mono_nSteps (by omega)
+    (cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp) (fun h hq => ?_) c3)
+  rw [show copyIntoRegion oldRoot bytes 0 o2.toNat (0 + (31 + 1))
+      = fixed32Copied bytes oldRoot o2 from rfl,
+    show (rootOut + BitVec.ofNat 64 (0 + (0 + (31 + 1))) : Word) = rootOut + BitVec.ofNat 64 32
+      from by bv_omega] at hq
+  exact sepConj_mono_left
+    (adCallPre_weaken (AB + 320) spW listBase len nonceOut balanceOut
+      (rootOut + BitVec.ofNat 64 32) codeOut o2 l2 (0 : Word) v11 v12 v13 v14
+      adOffsetAddr (0 : Word) (32 : Word)
+      (listBase + BitVec.ofNat 64 (o2.toNat + (0 + (31 + 1)))) bytes)
+    h (by xperm_hyp hq)
+
+#print axioms adField2Copy
+
+set_option maxRecDepth 8000 in
+/-- Field-2 success tie (`AB+344 → raSaved`): the root copy (`adField2Copy`)
+    followed by the field-3 backbone (`adBBField3`).  Lands the whole-program
+    post directly. -/
+theorem adField2Success
+    (sp0 spW raSaved listBase len nonceOut balanceOut rootOut codeOut o0 o1 o2 l0 l1
+      x28v x29v v11 v12 v13 v14 : Word)
+    (bytes oldRoot oldCode : List (BitVec 8)) (listLen : Nat)
+    (hspW : spW = sp0 + signExtend12 (-64 : BitVec 12))
+    (hret : raSaved &&& ~~~(1 : Word) = raSaved)
+    (hlenW : len = BitVec.ofNat 64 listLen)
+    (hsalign : listBase.toNat % 8 = 0)
+    (hslack : listLen + 9 ≤ bytes.length)
+    (hover : listBase.toNat + bytes.length < 2 ^ 64)
+    (hvalid : ∀ k, k < bytes.length →
+      isValidByteAccess (listBase + BitVec.ofNat 64 k) = true)
+    (hralign : rootOut.toNat % 8 = 0)
+    (hrover : rootOut.toNat + 32 < 2 ^ 64)
+    (hrootlen : oldRoot.length = 32)
+    (hrvalid : ∀ k, k < 32 → isValidByteAccess (rootOut + BitVec.ofNat 64 k) = true)
+    (hcalign : codeOut.toNat % 8 = 0)
+    (hcover : codeOut.toNat + 32 < 2 ^ 64)
+    (hcodelen : oldCode.length = 32)
+    (hcvalid : ∀ k, k < 32 → isValidByteAccess (codeOut + BitVec.ofNat 64 k) = true)
+    (hf0 : Success bytes listBase listLen 0 o0 l0)
+    (hf1 : Success bytes listBase listLen 1 o1 l1)
+    (hf2 : Success bytes listBase listLen 2 o2 l2)
+    (hl0 : l0.toNat ≤ 8) (hl1 : l1.toNat ≤ 32) (hl2 : l2 = (32 : Word)) :
+    let savedCaller : Saved :=
+      { ra := raSaved, s0 := listBase, s1 := len, s2 := nonceOut, s3 := balanceOut,
+        s4 := rootOut, s5 := codeOut }
+    cpsTripleWithin 999 (AB + 344) raSaved fullCode
+      (((.x6 : Reg) ↦ᵣ l2) ** ((.x7 : Reg) ↦ᵣ (32 : Word)) ** ((.x5 : Reg) ↦ᵣ adLengthAddr) **
+       (adLengthAddr ↦ₘ l2) ** ((.x2 : Reg) ↦ᵣ spW) ** ((.x1 : Reg) ↦ᵣ (AB + 320)) **
+       ((.x8 : Reg) ↦ᵣ listBase) ** ((.x9 : Reg) ↦ᵣ len) ** ((.x18 : Reg) ↦ᵣ nonceOut) **
+       ((.x19 : Reg) ↦ᵣ balanceOut) ** ((.x20 : Reg) ↦ᵣ rootOut) ** ((.x21 : Reg) ↦ᵣ codeOut) **
+       stackFree spW 8 ** ((.x10 : Reg) ↦ᵣ (0 : Word)) ** ((.x11 : Reg) ↦ᵣ v11) **
+       ((.x12 : Reg) ↦ᵣ v12) ** ((.x13 : Reg) ↦ᵣ v13) ** ((.x14 : Reg) ↦ᵣ v14) **
+       ((.x28 : Reg) ↦ᵣ x28v) ** ((.x29 : Reg) ↦ᵣ x29v) **
+       regOwn .x30 ** regOwn .x31 ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+       bytesRegion listBase bytes ** (adOffsetAddr ↦ₘ o2) ** ((.x15 : Reg) ↦ᵣ codeOut) **
+       savedFrame spW savedCaller ** (nonceOut ↦ₘ beAccum bytes o0.toNat l0.toNat) **
+       bytesRegion balanceOut (balanceCopied bytes o1 l1.toNat) **
+       bytesRegion codeOut oldCode ** bytesRegion rootOut oldRoot)
+      (adWholePost sp0 spW savedCaller listBase listLen bytes oldRoot oldCode) := by
+  intro savedCaller
+  have hl2N : l2.toNat = 32 := by rw [hl2]; decide
+  have hcopy := adField2Copy spW raSaved listBase len nonceOut balanceOut rootOut codeOut
+    o0 o1 o2 l0 l1 x28v x29v v11 v12 v13 v14 bytes oldRoot oldCode listLen
+    hsalign hslack hover hvalid hralign hrover hrootlen hrvalid hf2 hl2
+  have hbb := adBBField3 sp0 spW (AB + 320) raSaved listBase len nonceOut balanceOut rootOut
+    codeOut (rootOut + BitVec.ofNat 64 32) o2 l2 (0 : Word) v11 v12 v13 v14 o0 o1 o2 l0 l1 l2
+    bytes oldRoot oldCode listLen hspW hret hlenW hsalign hslack hover hvalid hcalign hcover
+    hcodelen hcvalid hf0 hf1 hf2 hl0 hl1 hl2N
+  exact cpsTripleWithin_mono_nSteps (by omega)
+    (cpsTripleWithin_seq_perm_same_cr (fun h hp => by xperm_hyp hp) hcopy hbb)
+
+#print axioms adField2Success
+
+set_option maxRecDepth 8000 in
+/-- Field-2 continue (`AB+324 → raSaved`): the storage-root continue edge.  The
+    K20 `Success` is pinned; the `len = 32` length check gates the root copy
+    (`adField2Success`) or the `field2Len` failure. -/
+theorem adField2ContEpi
+    (sp0 spW raSaved listBase len nonceOut balanceOut rootOut codeOut o0 o1 l0 l1 : Word)
+    (bytes oldRoot oldCode : List (BitVec 8)) (listLen : Nat)
+    (hspW : spW = sp0 + signExtend12 (-64 : BitVec 12))
+    (hret : raSaved &&& ~~~(1 : Word) = raSaved)
+    (hlenW : len = BitVec.ofNat 64 listLen)
+    (hsalign : listBase.toNat % 8 = 0)
+    (hslack : listLen + 9 ≤ bytes.length)
+    (hover : listBase.toNat + bytes.length < 2 ^ 64)
+    (hvalid : ∀ k, k < bytes.length →
+      isValidByteAccess (listBase + BitVec.ofNat 64 k) = true)
+    (hralign : rootOut.toNat % 8 = 0)
+    (hrover : rootOut.toNat + 32 < 2 ^ 64)
+    (hrootlen : oldRoot.length = 32)
+    (hrvalid : ∀ k, k < 32 → isValidByteAccess (rootOut + BitVec.ofNat 64 k) = true)
+    (hcalign : codeOut.toNat % 8 = 0)
+    (hcover : codeOut.toNat + 32 < 2 ^ 64)
+    (hcodelen : oldCode.length = 32)
+    (hcvalid : ∀ k, k < 32 → isValidByteAccess (codeOut + BitVec.ofNat 64 k) = true)
+    (hf0 : Success bytes listBase listLen 0 o0 l0)
+    (hf1 : Success bytes listBase listLen 1 o1 l1)
+    (hl0 : l0.toNat ≤ 8) (hl1 : l1.toNat ≤ 32) :
+    let saved2 : Saved :=
+      { ra := AB + 320, s0 := listBase, s1 := len, s2 := nonceOut, s3 := balanceOut,
+        s4 := rootOut, s5 := codeOut }
+    let savedCaller : Saved :=
+      { ra := raSaved, s0 := listBase, s1 := len, s2 := nonceOut, s3 := balanceOut,
+        s4 := rootOut, s5 := codeOut }
+    cpsTripleWithin (5 + 999) (AB + 324) raSaved fullCode
+      (adK20ContPost spW listBase 2 saved2 bytes listLen **
+       (savedFrame spW savedCaller ** (nonceOut ↦ₘ beAccum bytes o0.toNat l0.toNat) **
+        bytesRegion balanceOut (balanceCopied bytes o1 l1.toNat) **
+        bytesRegion rootOut oldRoot ** bytesRegion codeOut oldCode **
+        ((.x15 : Reg) ↦ᵣ codeOut)))
+      (adWholePost sp0 spW savedCaller listBase listLen bytes oldRoot oldCode) := by
+  intro saved2 savedCaller
+  -- (1) expose the K20 continue existentials, keeping x5/x6/x7 owned.
+  refine cpsTripleWithin_weaken
+    (P := fun h => ∃ offset len' v11 v12,
+      (((⌜Success bytes listBase listLen 2 offset len'⌝ : Assertion) **
+        ((.x2 : Reg) ↦ᵣ spW) ** regsAt listNthFrame (savedVals saved2) ** stackFree spW 8 **
+        ((.x10 : Reg) ↦ᵣ (0 : Word)) ** ((.x11 : Reg) ↦ᵣ v11) ** ((.x12 : Reg) ↦ᵣ v12) **
+        regOwn .x13 ** regOwn .x14 ** regOwn .x28 ** regOwn .x29 ** regOwn .x30 **
+        regOwn .x31 ** ((.x0 : Reg) ↦ᵣ (0 : Word)) ** bytesRegion listBase bytes **
+        (adOffsetAddr ↦ₘ offset) ** (adLengthAddr ↦ₘ len') ** savedFrame spW savedCaller **
+        (nonceOut ↦ₘ beAccum bytes o0.toNat l0.toNat) **
+        bytesRegion balanceOut (balanceCopied bytes o1 l1.toNat) **
+        bytesRegion rootOut oldRoot ** bytesRegion codeOut oldCode **
+        ((.x15 : Reg) ↦ᵣ codeOut)) ** regOwn .x5 ** regOwn .x6 ** regOwn .x7) h)
+    (fun h hp => by
+      obtain ⟨h1, h2, hd, hu, hcont, hacc⟩ := hp
+      unfold adK20ContPost at hcont
+      obtain ⟨offset, len', v11, v12, hbody⟩ := hcont
+      refine ⟨offset, len', v11, v12, ?_⟩
+      have hcomb : (_ ** _) h := ⟨h1, h2, hd, hu, hbody, hacc⟩
+      xperm_hyp hcomb)
+    (fun _ hq => hq) ?_
+  refine cpsTripleWithin_exists_pre_gen (fun offset => ?_)
+  refine cpsTripleWithin_exists_pre_gen (fun len' => ?_)
+  refine cpsTripleWithin_exists_pre_gen (fun v11 => ?_)
+  refine cpsTripleWithin_exists_pre_gen (fun v12 => ?_)
+  refine cpsTripleWithin_of_forall_regIs_to_regOwn3 (fun v5 v6 v7 => ?_)
+  -- (2) continue reshape into length-check pre plus the ambient continue frame.
+  refine cpsTripleWithin_weaken
+    (P := (((.x5 : Reg) ↦ᵣ v5) ** ((.x6 : Reg) ↦ᵣ v6) ** ((.x7 : Reg) ↦ᵣ v7) **
+        (adLengthAddr ↦ₘ len')) **
+       (adContFrame spW listBase 2 saved2 bytes listLen offset len' v11 v12 **
+        savedFrame spW savedCaller ** (nonceOut ↦ₘ beAccum bytes o0.toNat l0.toNat) **
+        bytesRegion balanceOut (balanceCopied bytes o1 l1.toNat) **
+        bytesRegion rootOut oldRoot ** bytesRegion codeOut oldCode **
+        ((.x15 : Reg) ↦ᵣ codeOut)))
+    (fun h hp => by
+      have hin : (((⌜Success bytes listBase listLen 2 offset len'⌝ : Assertion) **
+          ((((.x2 : Reg) ↦ᵣ spW) ** regsAt listNthFrame (savedVals saved2) ** stackFree spW 8) **
+           (((.x10 : Reg) ↦ᵣ (0 : Word)) ** ((.x5 : Reg) ↦ᵣ v5) ** ((.x6 : Reg) ↦ᵣ v6) **
+            ((.x7 : Reg) ↦ᵣ v7) ** ((.x11 : Reg) ↦ᵣ v11) ** ((.x12 : Reg) ↦ᵣ v12) **
+            regOwn .x13 ** regOwn .x14 ** regOwn .x28 ** regOwn .x29 ** regOwn .x30 **
+            regOwn .x31 ** ((.x0 : Reg) ↦ᵣ (0 : Word)) ** bytesRegion listBase bytes **
+            (adOffsetAddr ↦ₘ offset) ** (adLengthAddr ↦ₘ len')))) **
+          (savedFrame spW savedCaller ** (nonceOut ↦ₘ beAccum bytes o0.toNat l0.toNat) **
+           bytesRegion balanceOut (balanceCopied bytes o1 l1.toNat) **
+           bytesRegion rootOut oldRoot ** bytesRegion codeOut oldCode **
+           ((.x15 : Reg) ↦ᵣ codeOut))) h := by xperm_hyp hp
+      have hout := sepConj_mono_left (adContReshape spW listBase 2 saved2 bytes listLen offset len'
+        v11 v12 v5 v6 v7) h hin
+      xperm_hyp hout)
+    (fun _ hq => hq) ?_
+  -- (3) length-check branch, framed by the continue frame plus the output cells.
+  have hbr := cpsBranchWithin_frameR
+    (adContFrame spW listBase 2 saved2 bytes listLen offset len' v11 v12 **
+     savedFrame spW savedCaller ** (nonceOut ↦ₘ beAccum bytes o0.toNat l0.toNat) **
+     bytesRegion balanceOut (balanceCopied bytes o1 l1.toNat) **
+     bytesRegion rootOut oldRoot ** bytesRegion codeOut oldCode **
+     ((.x15 : Reg) ↦ᵣ codeOut))
+    (by pcfa) (adRootLenCheck v5 v6 v7 len')
+  refine cpsBranchWithin_merge_same_cr hbr ?fail ?cont
+  case fail =>
+    -- len ≠ 32: field2Len failure through the shared fail arm.
+    refine cpsTripleWithin_weaken (fun h hp => ?_) (fun _ hq => hq)
+      (cpsTripleWithin_mono_nSteps (show (1 + 9) ≤ 999 from by omega)
+        (adFailArm sp0 spW savedCaller listBase bytes oldRoot oldCode listLen hspW
+          (show savedCaller.ra &&& ~~~(1 : Word) = savedCaller.ra from hret)))
+    unfold adContFrame at hp
+    rw [regsAt_listNthFrame] at hp
+    have hf2 : Success bytes listBase listLen 2 offset len' := by
+      obtain ⟨_, _, _, _, _, hr⟩ := hp
+      obtain ⟨_, _, _, _, hcf, _⟩ := hr
+      exact ((sepConj_pure_left _).1 hcf).1
+    have hne32 : len'.toNat ≠ 32 := by
+      have hne : len' ≠ (32 : Word) := by
+        obtain ⟨_, _, _, _, hfp, _⟩ := hp
+        obtain ⟨_, _, _, _, hAgrp, _⟩ := hfp
+        obtain ⟨_, _, _, _, _, hA2⟩ := hAgrp
+        exact ((sepConj_pure_right _).1 hA2).2
+      intro heq; exact hne (by apply BitVec.eq_of_toNat_eq; rw [heq]; decide)
+    have hDF : DecodeFailure bytes listBase listLen := DecodeFailure.field2Len offset len' hf2 hne32
+    have hgP : ((⌜Success bytes listBase listLen 2 offset len'⌝ : Assertion) **
+        (⌜len' ≠ (32 : Word)⌝ : Assertion) **
+        ((((.x2 : Reg) ↦ᵣ spW) **
+         (((.x1 : Reg) ↦ᵣ (AB + 320)) ** ((.x8 : Reg) ↦ᵣ listBase) ** ((.x9 : Reg) ↦ᵣ len) **
+          ((.x18 : Reg) ↦ᵣ nonceOut) ** ((.x19 : Reg) ↦ᵣ balanceOut) **
+          ((.x20 : Reg) ↦ᵣ saved2.s4) ** ((.x21 : Reg) ↦ᵣ codeOut)) **
+         savedFrame spW savedCaller) **
+        ((nonceOut ↦ₘ beAccum bytes o0.toNat l0.toNat) **
+         bytesRegion balanceOut (balanceCopied bytes o1 l1.toNat) **
+         bytesRegion rootOut oldRoot ** bytesRegion codeOut oldCode **
+         bytesRegion listBase bytes ** (adOffsetAddr ↦ₘ offset) ** (adLengthAddr ↦ₘ len') **
+         stackFree spW 8 **
+         (((.x5 : Reg) ↦ᵣ adLengthAddr) ** ((.x6 : Reg) ↦ᵣ len') ** ((.x7 : Reg) ↦ᵣ (32 : Word)) **
+          ((.x11 : Reg) ↦ᵣ v11) ** ((.x12 : Reg) ↦ᵣ v12) ** regOwn .x13 ** regOwn .x14 **
+          regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+          ((.x15 : Reg) ↦ᵣ codeOut)))) ** ((.x10 : Reg) ↦ᵣ (0 : Word))) h := by xperm_hyp hp
+    have hg := ((sepConj_pure_left h).1 (((sepConj_pure_left h).1 hgP).2)).2
+    exact sepConj_mono (sepConj_mono
+      (sepConj_mono_right (sepConj_mono_left (fun h' hr => listNthFrameRegs_implies_owned
+        listBase len nonceOut balanceOut saved2.s4 codeOut h'
+        (sepConj_mono_left (regIs_implies_regOwn .x1) h' hr))))
+      (fun h' hc => (sepConj_pure_left h').2
+        ⟨hDF, beAccum bytes o0.toNat l0.toNat, offset, len', balanceCopied bytes o1 l1.toNat,
+          oldRoot, oldCode,
+          sepConj_mono_right (sepConj_mono_right (sepConj_mono_right (sepConj_mono_right
+            (sepConj_mono_right (sepConj_mono_right (sepConj_mono_right (sepConj_mono_right
+              (adScratch_of_regs_own codeOut adLengthAddr len' (32 : Word) v11 v12)))))))) h' hc⟩))
+      (regIs_implies_regOwn .x10) h hg
+  case cont =>
+    -- len = 32: the root-copy success tie.  Introduce x13/x14/x28/x29 witnesses.
+    refine cpsTripleWithin_weaken
+      (P := ((⌜Success bytes listBase listLen 2 offset len'⌝ : Assertion) **
+        (⌜len' = (32 : Word)⌝ : Assertion) **
+        ((.x6 : Reg) ↦ᵣ len') ** ((.x7 : Reg) ↦ᵣ (32 : Word)) ** ((.x5 : Reg) ↦ᵣ adLengthAddr) **
+        (adLengthAddr ↦ₘ len') ** ((.x2 : Reg) ↦ᵣ spW) ** ((.x1 : Reg) ↦ᵣ (AB + 320)) **
+        ((.x8 : Reg) ↦ᵣ listBase) ** ((.x9 : Reg) ↦ᵣ len) ** ((.x18 : Reg) ↦ᵣ nonceOut) **
+        ((.x19 : Reg) ↦ᵣ balanceOut) ** ((.x20 : Reg) ↦ᵣ saved2.s4) ** ((.x21 : Reg) ↦ᵣ codeOut) **
+        stackFree spW 8 ** ((.x10 : Reg) ↦ᵣ (0 : Word)) ** ((.x11 : Reg) ↦ᵣ v11) **
+        ((.x12 : Reg) ↦ᵣ v12) ** regOwn .x30 ** regOwn .x31 **
+        ((.x0 : Reg) ↦ᵣ (0 : Word)) ** bytesRegion listBase bytes **
+        (adOffsetAddr ↦ₘ offset) ** ((.x15 : Reg) ↦ᵣ codeOut) ** savedFrame spW savedCaller **
+        (nonceOut ↦ₘ beAccum bytes o0.toNat l0.toNat) **
+        bytesRegion balanceOut (balanceCopied bytes o1 l1.toNat) **
+        bytesRegion rootOut oldRoot ** bytesRegion codeOut oldCode) **
+        regOwn .x13 ** regOwn .x14 ** regOwn .x28 ** regOwn .x29)
+      (fun h hp => by unfold adContFrame at hp; rw [regsAt_listNthFrame] at hp; xperm_hyp hp)
+      (fun _ hq => hq) ?_
+    refine cpsTripleWithin_of_forall_regIs_to_regOwn4 (fun v13 v14 x28v x29v => ?_)
+    refine cpsTripleWithin_weaken
+      (P := (⌜Success bytes listBase listLen 2 offset len'⌝ : Assertion) **
+        (⌜len' = (32 : Word)⌝ : Assertion) **
+        (((.x6 : Reg) ↦ᵣ len') ** ((.x7 : Reg) ↦ᵣ (32 : Word)) ** ((.x5 : Reg) ↦ᵣ adLengthAddr) **
+         (adLengthAddr ↦ₘ len') ** ((.x2 : Reg) ↦ᵣ spW) ** ((.x1 : Reg) ↦ᵣ (AB + 320)) **
+         ((.x8 : Reg) ↦ᵣ listBase) ** ((.x9 : Reg) ↦ᵣ len) ** ((.x18 : Reg) ↦ᵣ nonceOut) **
+         ((.x19 : Reg) ↦ᵣ balanceOut) ** ((.x20 : Reg) ↦ᵣ saved2.s4) ** ((.x21 : Reg) ↦ᵣ codeOut) **
+         stackFree spW 8 ** ((.x10 : Reg) ↦ᵣ (0 : Word)) ** ((.x11 : Reg) ↦ᵣ v11) **
+         ((.x12 : Reg) ↦ᵣ v12) ** ((.x13 : Reg) ↦ᵣ v13) ** ((.x14 : Reg) ↦ᵣ v14) **
+         ((.x28 : Reg) ↦ᵣ x28v) ** ((.x29 : Reg) ↦ᵣ x29v) **
+         regOwn .x30 ** regOwn .x31 ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+         bytesRegion listBase bytes ** (adOffsetAddr ↦ₘ offset) ** ((.x15 : Reg) ↦ᵣ codeOut) **
+         savedFrame spW savedCaller ** (nonceOut ↦ₘ beAccum bytes o0.toNat l0.toNat) **
+         bytesRegion balanceOut (balanceCopied bytes o1 l1.toNat) **
+         bytesRegion codeOut oldCode ** bytesRegion rootOut oldRoot))
+      (fun h hp => by xperm_hyp hp) (fun _ hq => hq) ?_
+    refine cpsTripleWithin_pure_pre (fun hf2 => ?_)
+    refine cpsTripleWithin_pure_pre (fun hl2 => ?_)
+    exact adField2Success sp0 spW raSaved listBase len nonceOut balanceOut rootOut codeOut
+      o0 o1 offset l0 l1 x28v x29v v11 v12 v13 v14 bytes oldRoot oldCode listLen hspW hret hlenW
+      hsalign hslack hover hvalid hralign hrover hrootlen hrvalid hcalign hcover hcodelen hcvalid
+      hf0 hf1 hf2 hl0 hl1 hl2
+
+#print axioms adField2ContEpi
+
+set_option maxRecDepth 8000 in
+/-- Field-2 (storage_root) backbone (`AB+288 → raSaved`): merge the field-2
+    stage's parse-fail edge (`field2List`) with the continue edge
+    (`adField2ContEpi`).  The storage-root output cell is untouched (`oldRoot`)
+    on entry. -/
+theorem adBBField2
+    (sp0 spW raEntry raSaved listBase len nonceOut balanceOut rootOut codeOut
+      oldOffset oldLen v10 v11 v12 v13 v14 o0 o1 l0 l1 : Word)
+    (bytes oldRoot oldCode : List (BitVec 8)) (listLen : Nat)
+    (hspW : spW = sp0 + signExtend12 (-64 : BitVec 12))
+    (hret : raSaved &&& ~~~(1 : Word) = raSaved)
+    (hlenW : len = BitVec.ofNat 64 listLen)
+    (hsalign : listBase.toNat % 8 = 0)
+    (hslack : listLen + 9 ≤ bytes.length)
+    (hover : listBase.toNat + bytes.length < 2 ^ 64)
+    (hvalid : ∀ k, k < bytes.length →
+      isValidByteAccess (listBase + BitVec.ofNat 64 k) = true)
+    (hralign : rootOut.toNat % 8 = 0)
+    (hrover : rootOut.toNat + 32 < 2 ^ 64)
+    (hrootlen : oldRoot.length = 32)
+    (hrvalid : ∀ k, k < 32 → isValidByteAccess (rootOut + BitVec.ofNat 64 k) = true)
+    (hcalign : codeOut.toNat % 8 = 0)
+    (hcover : codeOut.toNat + 32 < 2 ^ 64)
+    (hcodelen : oldCode.length = 32)
+    (hcvalid : ∀ k, k < 32 → isValidByteAccess (codeOut + BitVec.ofNat 64 k) = true)
+    (hf0 : Success bytes listBase listLen 0 o0 l0)
+    (hf1 : Success bytes listBase listLen 1 o1 l1)
+    (hl0 : l0.toNat ≤ 8) (hl1 : l1.toNat ≤ 32) :
+    let savedCaller : Saved :=
+      { ra := raSaved, s0 := listBase, s1 := len, s2 := nonceOut, s3 := balanceOut,
+        s4 := rootOut, s5 := codeOut }
+    cpsTripleWithin (((7 + (1 + ((12 + ((85 + 93 * (2 + 2)) + 6)) + 9))) + 1) + 1004)
+      (AB + 288) raSaved fullCode
+      (adCallPre raEntry spW listBase len nonceOut balanceOut rootOut codeOut oldOffset oldLen
+        v10 v11 v12 v13 v14 bytes **
+       (savedFrame spW savedCaller ** (nonceOut ↦ₘ beAccum bytes o0.toNat l0.toNat) **
+        bytesRegion balanceOut (balanceCopied bytes o1 l1.toNat) **
+        bytesRegion rootOut oldRoot ** bytesRegion codeOut oldCode **
+        ((.x15 : Reg) ↦ᵣ codeOut)))
+      (adWholePost sp0 spW savedCaller listBase listLen bytes oldRoot oldCode) := by
+  intro savedCaller
+  have hstage := adField2Stage spW raEntry listBase len nonceOut balanceOut rootOut codeOut
+    oldOffset oldLen v10 v11 v12 v13 v14 bytes listLen hlenW hsalign hslack hover hvalid
+  have hbr := cpsBranchWithin_frameR
+    (savedFrame spW savedCaller ** (nonceOut ↦ₘ beAccum bytes o0.toNat l0.toNat) **
+     bytesRegion balanceOut (balanceCopied bytes o1 l1.toNat) **
+     bytesRegion rootOut oldRoot ** bytesRegion codeOut oldCode **
+     ((.x15 : Reg) ↦ᵣ codeOut))
+    (by pcfa) hstage
+  refine cpsBranchWithin_merge_same_cr hbr ?fail ?cont
+  case cont =>
+    exact cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp) (fun _ hq => hq)
+      (adField2ContEpi sp0 spW raSaved listBase len nonceOut balanceOut rootOut codeOut o0 o1
+        l0 l1 bytes oldRoot oldCode listLen hspW hret hlenW hsalign hslack hover hvalid hralign
+        hrover hrootlen hrvalid hcalign hcover hcodelen hcvalid hf0 hf1 hl0 hl1)
+  case fail =>
+    refine cpsTripleWithin_weaken (fun h hp => ?_) (fun _ hq => hq)
+      (cpsTripleWithin_mono_nSteps (show (1 + 9) ≤ 1004 from by omega)
+        (adFailArm sp0 spW savedCaller listBase bytes oldRoot oldCode listLen hspW
+          (show savedCaller.ra &&& ~~~(1 : Word) = savedCaller.ra from hret)))
+    obtain ⟨h1, h2, hd, hu, hfail, hacc⟩ := hp
+    unfold adK20FailPost at hfail
+    obtain ⟨status, offset', len', v11', v12', hbody⟩ := hfail
+    have hResPair : Result bytes listBase listLen 2 oldOffset oldLen status offset' len' ∧
+        status ≠ (0 : Word) := ((sepConj_pure_left h1).1 hbody).1
+    have hFail : Failure bytes listBase listLen 2 := by
+      cases hResPair.1 with
+      | ok o l hs => exact absurd rfl hResPair.2
+      | fail hf => exact hf
+    have hDF : DecodeFailure bytes listBase listLen := DecodeFailure.field2List hFail
+    have hbig := ((sepConj_pure_left h1).1 hbody).2
+    rw [regsAt_listNthFrame] at hbig
+    have hgP : (((((.x2 : Reg) ↦ᵣ spW) **
+        (((.x1 : Reg) ↦ᵣ (AB + 320)) ** ((.x8 : Reg) ↦ᵣ listBase) ** ((.x9 : Reg) ↦ᵣ len) **
+         ((.x18 : Reg) ↦ᵣ nonceOut) ** ((.x19 : Reg) ↦ᵣ balanceOut) **
+         ((.x20 : Reg) ↦ᵣ rootOut) ** ((.x21 : Reg) ↦ᵣ codeOut)) **
+        savedFrame spW savedCaller) **
+       ((nonceOut ↦ₘ beAccum bytes o0.toNat l0.toNat) **
+        bytesRegion balanceOut (balanceCopied bytes o1 l1.toNat) **
+        bytesRegion rootOut oldRoot ** bytesRegion codeOut oldCode **
+        bytesRegion listBase bytes ** (adOffsetAddr ↦ₘ offset') ** (adLengthAddr ↦ₘ len') **
+        stackFree spW 8 **
+        (regOwn .x5 ** regOwn .x6 ** regOwn .x7 ** ((.x11 : Reg) ↦ᵣ v11') **
+         ((.x12 : Reg) ↦ᵣ v12') ** regOwn .x13 ** regOwn .x14 **
+         regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+         ((.x15 : Reg) ↦ᵣ codeOut)))) ** ((.x10 : Reg) ↦ᵣ status)) h := by
+      have hcomb : (_ ** _) h := ⟨h1, h2, hd, hu, hbig, hacc⟩
+      xperm_hyp hcomb
+    exact sepConj_mono (sepConj_mono
+      (sepConj_mono_right (sepConj_mono_left (fun h' hr => listNthFrameRegs_implies_owned
+        listBase len nonceOut balanceOut rootOut codeOut h'
+        (sepConj_mono_left (regIs_implies_regOwn .x1) h' hr))))
+      (fun h' hc => (sepConj_pure_left h').2
+        ⟨hDF, beAccum bytes o0.toNat l0.toNat, offset', len', balanceCopied bytes o1 l1.toNat,
+          oldRoot, oldCode,
+          sepConj_mono_right (sepConj_mono_right (sepConj_mono_right (sepConj_mono_right
+            (sepConj_mono_right (sepConj_mono_right (sepConj_mono_right (sepConj_mono_right
+              (adScratch_of_regs_own2 codeOut v11' v12')))))))) h' hc⟩))
+      (regIs_implies_regOwn .x10) h hgP
+
+#print axioms adBBField2
+
 end EvmAsm.Codegen.AccountDecodeSpec

--- a/EvmAsm/Codegen/Programs/AccountDecodeClose5.lean
+++ b/EvmAsm/Codegen/Programs/AccountDecodeClose5.lean
@@ -1,0 +1,94 @@
+/-
+  `accountDecode_prog` caller-contract composition, part 5 — the four per-field
+  backbone merges and the whole-program close.
+
+  Close4 supplied the whole-program outcome model (`adWholePost`), the shared
+  failure arm (`adFailArm`) and the generic continue reshape (`adContReshape`).
+  This module stitches the four field stages, their length checks and the field
+  materialisers into a single `AB+56 → raSaved` triple, then prepends the
+  prologue for the whole-program `account_decode_spec_within`.
+
+  Because every field decodes via the same `rlp_list_nth_item` (K20) callee and
+  shares the outer frame (`spW = newSp = sp0 - 64`), there is no stack transform:
+  ONE `adFailArm` and ONE `adContReshape` cover all four boundaries.
+
+  No `sorry`/`admit`/`native_decide`/`bv_decide`; classical-3 axioms only.
+-/
+
+import EvmAsm.Codegen.Programs.AccountDecodeClose4
+import EvmAsm.Codegen.Programs.AccountDecodeLoop
+import EvmAsm.Codegen.Programs.AccountDecodeNonceLoop
+import EvmAsm.Codegen.Programs.AccountDecodeBalanceLoop
+
+namespace EvmAsm.Codegen.AccountDecodeSpec
+
+open EvmAsm.Rv64 EvmAsm.Rv64.SAsm
+open EvmAsm.Codegen.RlpListNthItemSAsm (Saved savedVals listNthFrame savedFrame regsAt_listNthFrame
+  Success Result Failure)
+open EvmAsm.Evm64.Terminating (copyIntoRegion)
+
+/-! ## Local register-ownership introduction helpers -/
+
+/-- Introduce THREE owned registers' values at once (trailing `regOwn` chain). -/
+theorem cpsTripleWithin_of_forall_regIs_to_regOwn3
+    {nSteps : Nat} {entry exit_ : Word} {r1 r2 r3 : Reg} {P Q : Assertion} {cr : CodeReq}
+    (h : ∀ v1 v2 v3, cpsTripleWithin nSteps entry exit_ cr
+      (P ** (r1 ↦ᵣ v1) ** (r2 ↦ᵣ v2) ** (r3 ↦ᵣ v3)) Q) :
+    cpsTripleWithin nSteps entry exit_ cr
+      (P ** regOwn r1 ** regOwn r2 ** regOwn r3) Q := by
+  intro R hR s hcr hPR hpc
+  obtain ⟨hp, hcompat, h1, h2, hd, hu, hPP, hRb⟩ := hPR
+  obtain ⟨g0, g1, d1, u1, hP0, hO1⟩ := hPP
+  obtain ⟨g2, g3, d2, u2, ⟨v1, hv1⟩, hO2⟩ := hO1
+  obtain ⟨g4, g5, d3, u3, ⟨v2, hv2⟩, ⟨v3, hv3⟩⟩ := hO2
+  exact h v1 v2 v3 R hR s hcr
+    ⟨hp, hcompat, h1, h2, hd, hu,
+      ⟨g0, g1, d1, u1, hP0, g2, g3, d2, u2, hv1, g4, g5, d3, u3, hv2, hv3⟩, hRb⟩ hpc
+
+/-! ## Copy-loop instruction fetch bundles for the fixed-32 fields -/
+
+/-- The six fetch facts of the storage-root copy loop [90]-[95] (`GB = AB+360`,
+    destination register `x20`). -/
+def adCopyFetchRoot : CopyFetch .x20 (AB + 360) where
+  lbu := fun a i hi => CodeReq.ofProg_mem_at AB (AB + 360) accountDecode_prog 90
+    (.LBU .x29 .x28 (0 : BitVec 12)) (by bv_omega) (by rw [ad_length]; decide) rfl
+    (by rw [ad_length]; decide) a i hi
+  sb := fun a i hi => CodeReq.ofProg_mem_at AB (AB + 360 + 4) accountDecode_prog 91
+    (.SB .x20 .x29 (0 : BitVec 12)) (by bv_omega) (by rw [ad_length]; decide) rfl
+    (by rw [ad_length]; decide) a i hi
+  a28 := fun a i hi => CodeReq.ofProg_mem_at AB (AB + 360 + 8) accountDecode_prog 92
+    (.ADDI .x28 .x28 (1 : BitVec 12)) (by bv_omega) (by rw [ad_length]; decide) rfl
+    (by rw [ad_length]; decide) a i hi
+  ard := fun a i hi => CodeReq.ofProg_mem_at AB (AB + 360 + 12) accountDecode_prog 93
+    (.ADDI .x20 .x20 (1 : BitVec 12)) (by bv_omega) (by rw [ad_length]; decide) rfl
+    (by rw [ad_length]; decide) a i hi
+  a6 := fun a i hi => CodeReq.ofProg_mem_at AB (AB + 360 + 16) accountDecode_prog 94
+    (.ADDI .x6 .x6 (-1 : BitVec 12)) (by bv_omega) (by rw [ad_length]; decide) rfl
+    (by rw [ad_length]; decide) a i hi
+  bne := fun a i hi => CodeReq.ofProg_mem_at AB (AB + 360 + 20) accountDecode_prog 95
+    (.BNE .x6 .x0 (-20 : BitVec 13)) (by bv_omega) (by rw [ad_length]; decide) rfl
+    (by rw [ad_length]; decide) a i hi
+
+/-- The six fetch facts of the code-hash copy loop [116]-[121] (`GB = AB+464`,
+    destination register `x21`). -/
+def adCopyFetchCode : CopyFetch .x21 (AB + 464) where
+  lbu := fun a i hi => CodeReq.ofProg_mem_at AB (AB + 464) accountDecode_prog 116
+    (.LBU .x29 .x28 (0 : BitVec 12)) (by bv_omega) (by rw [ad_length]; decide) rfl
+    (by rw [ad_length]; decide) a i hi
+  sb := fun a i hi => CodeReq.ofProg_mem_at AB (AB + 464 + 4) accountDecode_prog 117
+    (.SB .x21 .x29 (0 : BitVec 12)) (by bv_omega) (by rw [ad_length]; decide) rfl
+    (by rw [ad_length]; decide) a i hi
+  a28 := fun a i hi => CodeReq.ofProg_mem_at AB (AB + 464 + 8) accountDecode_prog 118
+    (.ADDI .x28 .x28 (1 : BitVec 12)) (by bv_omega) (by rw [ad_length]; decide) rfl
+    (by rw [ad_length]; decide) a i hi
+  ard := fun a i hi => CodeReq.ofProg_mem_at AB (AB + 464 + 12) accountDecode_prog 119
+    (.ADDI .x21 .x21 (1 : BitVec 12)) (by bv_omega) (by rw [ad_length]; decide) rfl
+    (by rw [ad_length]; decide) a i hi
+  a6 := fun a i hi => CodeReq.ofProg_mem_at AB (AB + 464 + 16) accountDecode_prog 120
+    (.ADDI .x6 .x6 (-1 : BitVec 12)) (by bv_omega) (by rw [ad_length]; decide) rfl
+    (by rw [ad_length]; decide) a i hi
+  bne := fun a i hi => CodeReq.ofProg_mem_at AB (AB + 464 + 20) accountDecode_prog 121
+    (.BNE .x6 .x0 (-20 : BitVec 13)) (by bv_omega) (by rw [ad_length]; decide) rfl
+    (by rw [ad_length]; decide) a i hi
+
+end EvmAsm.Codegen.AccountDecodeSpec

--- a/EvmAsm/Codegen/Programs/AccountDecodeClose6.lean
+++ b/EvmAsm/Codegen/Programs/AccountDecodeClose6.lean
@@ -1059,4 +1059,80 @@ theorem adBBField0
 
 #print axioms adBBField0
 
+/-! ## Top-level whole-program caller contract (`AB → raSaved`) -/
+
+set_option maxRecDepth 8000 in
+/-- **Whole-program caller contract** for `accountDecode_prog`: the ABI prologue
+    (`adPrologue`) followed by the four field backbones (`adBBField0`), landing
+    the abstract decode outcome `adWholePost`.  On `a0 = 0` the four output cells
+    hold the genuine `Decoded` account fields; on `a0 = 1` a `DecodeFailure` is
+    witnessed and the owned leftover retained.
+
+    Honest preconditions: the caller passes the RLP pointer/length and the four
+    output pointers in the callee-saved registers `x8/x9/x18/x19/x20/x21` (also
+    mirrored into the argument registers `a0..a5`), owns the frame slots, the K20
+    scratch stack, the seven temporaries, the input region `bytesRegion listBase`,
+    the two guest scratch cells and the four output slots (nonce dword +
+    balance/root/code 32-byte regions); the buffer fits (`listLen + 9 ≤ length`),
+    `listBase`/output alignments, the return-address low-bit invariant, the
+    over-bounds and per-byte `isValidByteAccess` facts. -/
+theorem account_decode_spec_within
+    (sp0 spW raSaved listBase len nonceOut balanceOut rootOut codeOut oldOffset oldLen oldNonce
+      : Word)
+    (bytes oldBal oldRoot oldCode : List (BitVec 8)) (listLen : Nat)
+    (hspW : spW = sp0 + signExtend12 (-64 : BitVec 12))
+    (hret : raSaved &&& ~~~(1 : Word) = raSaved)
+    (hlenW : len = BitVec.ofNat 64 listLen)
+    (hsalign : listBase.toNat % 8 = 0)
+    (hslack : listLen + 9 ≤ bytes.length)
+    (hover : listBase.toNat + bytes.length < 2 ^ 64)
+    (hvalid : ∀ k, k < bytes.length →
+      isValidByteAccess (listBase + BitVec.ofNat 64 k) = true)
+    (hbalign : balanceOut.toNat % 8 = 0)
+    (hbover : balanceOut.toNat + 32 < 2 ^ 64)
+    (hballen : oldBal.length = 32)
+    (hbvalid : ∀ k, k < 32 → isValidByteAccess (balanceOut + BitVec.ofNat 64 k) = true)
+    (hralign : rootOut.toNat % 8 = 0)
+    (hrover : rootOut.toNat + 32 < 2 ^ 64)
+    (hrootlen : oldRoot.length = 32)
+    (hrvalid : ∀ k, k < 32 → isValidByteAccess (rootOut + BitVec.ofNat 64 k) = true)
+    (hcalign : codeOut.toNat % 8 = 0)
+    (hcover : codeOut.toNat + 32 < 2 ^ 64)
+    (hcodelen : oldCode.length = 32)
+    (hcvalid : ∀ k, k < 32 → isValidByteAccess (codeOut + BitVec.ofNat 64 k) = true) :
+    let savedCaller : Saved :=
+      { ra := raSaved, s0 := listBase, s1 := len, s2 := nonceOut, s3 := balanceOut,
+        s4 := rootOut, s5 := codeOut }
+    cpsTripleWithin (14 + (((7 + (1 + ((12 + ((85 + 93 * (0 + 2)) + 6)) + 9))) + 1) + 2205))
+      AB raSaved fullCode
+      ((((.x2 : Reg) ↦ᵣ sp0) ** regsAt listNthFrame (savedVals savedCaller) **
+       frameSlotsOwn listNthFrame spW **
+       (((.x10 : Reg) ↦ᵣ listBase) ** ((.x11 : Reg) ↦ᵣ len) ** ((.x12 : Reg) ↦ᵣ nonceOut) **
+        ((.x13 : Reg) ↦ᵣ balanceOut) ** ((.x14 : Reg) ↦ᵣ rootOut) ** ((.x15 : Reg) ↦ᵣ codeOut))) **
+       (stackFree spW 8 ** regOwn .x5 ** regOwn .x6 ** regOwn .x7 ** regOwn .x28 **
+        regOwn .x29 ** regOwn .x30 ** regOwn .x31 ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+        bytesRegion listBase bytes ** (adOffsetAddr ↦ₘ oldOffset) ** (adLengthAddr ↦ₘ oldLen) **
+        (nonceOut ↦ₘ oldNonce) ** bytesRegion balanceOut oldBal **
+        bytesRegion rootOut oldRoot ** bytesRegion codeOut oldCode))
+      (adWholePost sp0 spW savedCaller listBase listLen bytes oldRoot oldCode) := by
+  intro savedCaller
+  have hpro := adPrologue sp0 spW raSaved listBase len nonceOut balanceOut rootOut codeOut
+    listBase len nonceOut balanceOut rootOut codeOut hspW
+  have hproF := cpsTripleWithin_frameR
+    (stackFree spW 8 ** regOwn .x5 ** regOwn .x6 ** regOwn .x7 ** regOwn .x28 **
+     regOwn .x29 ** regOwn .x30 ** regOwn .x31 ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+     bytesRegion listBase bytes ** (adOffsetAddr ↦ₘ oldOffset) ** (adLengthAddr ↦ₘ oldLen) **
+     (nonceOut ↦ₘ oldNonce) ** bytesRegion balanceOut oldBal **
+     bytesRegion rootOut oldRoot ** bytesRegion codeOut oldCode)
+    (by pcfa) hpro
+  have hbb := adBBField0 sp0 spW raSaved raSaved listBase len nonceOut balanceOut rootOut codeOut
+    oldOffset oldLen listBase len nonceOut balanceOut rootOut oldNonce
+    bytes oldBal oldRoot oldCode listLen hspW hret hlenW hsalign hslack hover hvalid hbalign
+    hbover hballen hbvalid hralign hrover hrootlen hrvalid hcalign hcover hcodelen hcvalid
+  refine cpsTripleWithin_seq_perm_same_cr (fun h hp => ?_) hproF hbb
+  unfold adCallPre
+  xperm_hyp hp
+
+#print axioms account_decode_spec_within
+
 end EvmAsm.Codegen.AccountDecodeSpec

--- a/EvmAsm/Codegen/Programs/AccountDecodeClose6.lean
+++ b/EvmAsm/Codegen/Programs/AccountDecodeClose6.lean
@@ -1,0 +1,580 @@
+/-
+  `accountDecode_prog` caller-contract composition, part 6 — the field-1
+  (balance), field-0 (nonce) backbones and the whole-program close.
+
+  Mirrors the field-2/field-3 trios of `AccountDecodeClose5`.  The balance and
+  nonce materialisers differ (right-aligned 32-byte copy / big-endian u64
+  accumulate), but the backbone shape (stage merge → length check → materialiser
+  handoff) is uniform.  The whole program is `adPrologue ;; adBBField0`.
+
+  No `sorry`/`admit`/`native_decide`/`bv_decide`; classical-3 axioms only.
+-/
+
+import EvmAsm.Codegen.Programs.AccountDecodeClose5
+
+namespace EvmAsm.Codegen.AccountDecodeSpec
+
+open EvmAsm.Rv64 EvmAsm.Rv64.SAsm
+open EvmAsm.Codegen.RlpListNthItemSAsm (Saved savedVals listNthFrame savedFrame regsAt_listNthFrame
+  listNthFrameRegs_implies_owned Success Result Failure)
+open EvmAsm.Evm64.Terminating (copyIntoRegion)
+
+local macro "pcfa" : tactic =>
+  `(tactic| repeat' first
+    | exact bytesRegion_pcFree _ _
+    | exact pcFree_regIs
+    | exact pcFree_regOwn
+    | exact pcFree_memIs
+    | exact pcFree_memOwn
+    | exact pcFree_pure
+    | exact pcFree_stackFree _ _
+    | exact pcFree_adContFrame _ _ _ _ _ _ _ _ _ _
+    | exact pcFree_adScratch _
+    | exact pcFree_adCommon _ _ _
+    | apply pcFree_sepConj)
+
+/-! ## Extra owned-register introductions and the balance-copy handoff -/
+
+/-- Introduce FIVE owned registers' values at once (trailing `regOwn` chain). -/
+theorem cpsTripleWithin_of_forall_regIs_to_regOwn5
+    {nSteps : Nat} {entry exit_ : Word} {r1 r2 r3 r4 r5 : Reg} {P Q : Assertion} {cr : CodeReq}
+    (h : ∀ v1 v2 v3 v4 v5, cpsTripleWithin nSteps entry exit_ cr
+      (P ** (r1 ↦ᵣ v1) ** (r2 ↦ᵣ v2) ** (r3 ↦ᵣ v3) ** (r4 ↦ᵣ v4) ** (r5 ↦ᵣ v5)) Q) :
+    cpsTripleWithin nSteps entry exit_ cr
+      (P ** regOwn r1 ** regOwn r2 ** regOwn r3 ** regOwn r4 ** regOwn r5) Q := by
+  intro R hR s hcr hPR hpc
+  obtain ⟨hp, hcompat, h1, h2, hd, hu, hPP, hRb⟩ := hPR
+  obtain ⟨g0, g1, d1, u1, hP0, hO1⟩ := hPP
+  obtain ⟨g2, g3, d2, u2, ⟨v1, hv1⟩, hO2⟩ := hO1
+  obtain ⟨g4, g5, d3, u3, ⟨v2, hv2⟩, hO3⟩ := hO2
+  obtain ⟨g6, g7, d4, u4, ⟨v3, hv3⟩, hO4⟩ := hO3
+  obtain ⟨g8, g9, d5, u5, ⟨v4, hv4⟩, ⟨v5, hv5⟩⟩ := hO4
+  exact h v1 v2 v3 v4 v5 R hR s hcr
+    ⟨hp, hcompat, h1, h2, hd, hu,
+      ⟨g0, g1, d1, u1, hP0, g2, g3, d2, u2, hv1, g4, g5, d3, u3, hv2,
+        g6, g7, d4, u4, hv3, g8, g9, d5, u5, hv4, hv5⟩, hRb⟩ hpc
+
+/-- Variant of `adCallPre_weaken` weakening FIVE concrete scratch temporaries
+    `x5/x6/x7/x28/x29` (used after the balance/nonce loops, which leave the
+    destination cursor `x29` live). -/
+theorem adCallPre_weaken5 (raIn spW listBase len s2v s3 s4 s5 oldOffset oldLen
+    v10 v11 v12 v13 v14 w5 w6 w7 w28 w29 : Word) (bytes : List (BitVec 8)) : ∀ h,
+    (((.x1 : Reg) ↦ᵣ raIn) ** ((.x2 : Reg) ↦ᵣ spW) ** ((.x8 : Reg) ↦ᵣ listBase) **
+     ((.x9 : Reg) ↦ᵣ len) ** ((.x18 : Reg) ↦ᵣ s2v) ** ((.x19 : Reg) ↦ᵣ s3) **
+     ((.x20 : Reg) ↦ᵣ s4) ** ((.x21 : Reg) ↦ᵣ s5) ** ((.x10 : Reg) ↦ᵣ v10) **
+     ((.x11 : Reg) ↦ᵣ v11) ** ((.x12 : Reg) ↦ᵣ v12) ** ((.x13 : Reg) ↦ᵣ v13) **
+     ((.x14 : Reg) ↦ᵣ v14) ** stackFree spW 8 ** ((.x5 : Reg) ↦ᵣ w5) **
+     ((.x6 : Reg) ↦ᵣ w6) ** ((.x7 : Reg) ↦ᵣ w7) ** ((.x28 : Reg) ↦ᵣ w28) **
+     ((.x29 : Reg) ↦ᵣ w29) ** regOwn .x30 ** regOwn .x31 ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+     bytesRegion listBase bytes ** (adOffsetAddr ↦ₘ oldOffset) **
+     (adLengthAddr ↦ₘ oldLen)) h →
+    adCallPre raIn spW listBase len s2v s3 s4 s5 oldOffset oldLen
+      v10 v11 v12 v13 v14 bytes h := by
+  intro h hp
+  unfold adCallPre
+  exact sepConj_mono_right (sepConj_mono_right (sepConj_mono_right (sepConj_mono_right
+    (sepConj_mono_right (sepConj_mono_right (sepConj_mono_right (sepConj_mono_right
+    (sepConj_mono_right (sepConj_mono_right (sepConj_mono_right (sepConj_mono_right
+    (sepConj_mono_right (sepConj_mono_right
+      (sepConj_mono (regIs_implies_regOwn .x5) (sepConj_mono (regIs_implies_regOwn .x6)
+        (sepConj_mono (regIs_implies_regOwn .x7) (sepConj_mono (regIs_implies_regOwn .x28)
+          (sepConj_mono_left (regIs_implies_regOwn .x29)))))))))))))))))))
+    h hp
+
+/-- Split a 32-byte region into its four little-endian dword cells, as an
+    assertion equality (matching `adBalanceSetup`'s zeroing precondition). -/
+theorem bytesRegion32_dwords_eq (base : Word) (bs : List (BitVec 8)) (h_len : bs.length = 32) :
+    bytesRegion base bs =
+    ((base ↦ₘ packBytes (bs.take 8)) ** ((base + 8) ↦ₘ packBytes ((bs.drop 8).take 8)) **
+     ((base + 16) ↦ₘ packBytes (((bs.drop 8).drop 8).take 8)) **
+     ((base + 24) ↦ₘ packBytes ((((bs.drop 8).drop 8).drop 8).take 8))) := by
+  have hne0 : bs ≠ [] := List.ne_nil_of_length_pos (by omega)
+  have hne1 : bs.drop 8 ≠ [] := List.ne_nil_of_length_pos (by simp only [List.length_drop]; omega)
+  have hne2 : (bs.drop 8).drop 8 ≠ [] :=
+    List.ne_nil_of_length_pos (by simp only [List.length_drop]; omega)
+  have hne3 : ((bs.drop 8).drop 8).drop 8 ≠ [] :=
+    List.ne_nil_of_length_pos (by simp only [List.length_drop]; omega)
+  have hdrop : ((((bs.drop 8).drop 8).drop 8).drop 8) = [] :=
+    List.eq_nil_of_length_eq_zero (by simp only [List.length_drop]; omega)
+  rw [bytesRegion_eq_cons base bs hne0, bytesRegion_eq_cons (base + 8) (bs.drop 8) hne1,
+      bytesRegion_eq_cons (base + 8 + 8) ((bs.drop 8).drop 8) hne2,
+      bytesRegion_eq_cons (base + 8 + 8 + 8) (((bs.drop 8).drop 8).drop 8) hne3,
+      hdrop, bytesRegion_nil, sepConj_emp_right',
+      show base + 8 + 8 = base + 16 from by bv_omega,
+      show base + 16 + 8 = base + 24 from by bv_omega]
+
+set_option maxRecDepth 8000 in
+/-- Field-1 balance copy tail (`AB+220 → AB+288`): the right-aligned 32-byte
+    balance copy (zeroing setup + forward copy loop), reshaping the `len ≤ 32`
+    continue state into the field-2 call precondition (`adBBField2`'s
+    `adCallPre`) with the second output cell now written (`balanceCopied`). -/
+theorem adField1Copy
+    (spW raSaved listBase len nonceOut balanceOut rootOut codeOut o0 o1 l0
+      x28v x29v x30v v11 v12 v13 v14 : Word)
+    (bytes oldBal oldRoot oldCode : List (BitVec 8)) (listLen : Nat)
+    (hsalign : listBase.toNat % 8 = 0)
+    (hslack : listLen + 9 ≤ bytes.length)
+    (hover : listBase.toNat + bytes.length < 2 ^ 64)
+    (hvalid : ∀ k, k < bytes.length →
+      isValidByteAccess (listBase + BitVec.ofNat 64 k) = true)
+    (hbalign : balanceOut.toNat % 8 = 0)
+    (hbover : balanceOut.toNat + 32 < 2 ^ 64)
+    (hballen : oldBal.length = 32)
+    (hbvalid : ∀ k, k < 32 → isValidByteAccess (balanceOut + BitVec.ofNat 64 k) = true)
+    (hf1 : Success bytes listBase listLen 1 o1 l1)
+    (hl1 : l1.toNat ≤ 32) :
+    let savedCaller : Saved :=
+      { ra := raSaved, s0 := listBase, s1 := len, s2 := nonceOut, s3 := balanceOut,
+        s4 := rootOut, s5 := codeOut }
+    cpsTripleWithin (10 + (7 * l1.toNat + 1)) (AB + 220) (AB + 288) fullCode
+      (((.x6 : Reg) ↦ᵣ l1) ** ((.x7 : Reg) ↦ᵣ (32 : Word)) ** ((.x5 : Reg) ↦ᵣ adLengthAddr) **
+       (adLengthAddr ↦ₘ l1) ** ((.x2 : Reg) ↦ᵣ spW) ** ((.x1 : Reg) ↦ᵣ (AB + 196)) **
+       ((.x8 : Reg) ↦ᵣ listBase) ** ((.x9 : Reg) ↦ᵣ len) ** ((.x18 : Reg) ↦ᵣ nonceOut) **
+       ((.x19 : Reg) ↦ᵣ balanceOut) ** ((.x20 : Reg) ↦ᵣ rootOut) ** ((.x21 : Reg) ↦ᵣ codeOut) **
+       stackFree spW 8 ** ((.x10 : Reg) ↦ᵣ (0 : Word)) ** ((.x11 : Reg) ↦ᵣ v11) **
+       ((.x12 : Reg) ↦ᵣ v12) ** ((.x13 : Reg) ↦ᵣ v13) ** ((.x14 : Reg) ↦ᵣ v14) **
+       ((.x28 : Reg) ↦ᵣ x28v) ** ((.x29 : Reg) ↦ᵣ x29v) ** ((.x30 : Reg) ↦ᵣ x30v) **
+       regOwn .x31 ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+       bytesRegion listBase bytes ** (adOffsetAddr ↦ₘ o1) ** ((.x15 : Reg) ↦ᵣ codeOut) **
+       savedFrame spW savedCaller ** (nonceOut ↦ₘ beAccum bytes o0.toNat l0.toNat) **
+       bytesRegion balanceOut oldBal **
+       bytesRegion rootOut oldRoot ** bytesRegion codeOut oldCode)
+      (adCallPre (AB + 196) spW listBase len nonceOut balanceOut rootOut codeOut o1 l1
+        (0 : Word) v11 v12 v13 v14 bytes **
+       (savedFrame spW savedCaller ** (nonceOut ↦ₘ beAccum bytes o0.toNat l0.toNat) **
+        bytesRegion balanceOut (balanceCopied bytes o1 l1.toNat) **
+        bytesRegion rootOut oldRoot ** bytesRegion codeOut oldCode **
+        ((.x15 : Reg) ↦ᵣ codeOut))) := by
+  intro savedCaller
+  have hoffnorm : listBase + o1 = listBase + BitVec.ofNat 64 (o1.toNat + 0) := by
+    rw [Nat.add_zero]; congr 1
+    apply BitVec.eq_of_toNat_eq; rw [BitVec.toNat_ofNat, Nat.mod_eq_of_lt o1.isLt]
+  have hsrcbound : o1.toNat + 0 + l1.toNat ≤ bytes.length := by
+    have hcb := adSuccessContentBound bytes listBase listLen 1 o1 l1 hslack hover hf1
+    omega
+  -- balance setup [55]-[64]: zero the 32-byte cell, compute right-align cursors.
+  have hbs := cpsTripleWithin_frameR
+    (((.x1 : Reg) ↦ᵣ (AB + 196)) ** ((.x2 : Reg) ↦ᵣ spW) ** ((.x9 : Reg) ↦ᵣ len) **
+     ((.x18 : Reg) ↦ᵣ nonceOut) ** ((.x20 : Reg) ↦ᵣ rootOut) ** ((.x21 : Reg) ↦ᵣ codeOut) **
+     stackFree spW 8 ** ((.x10 : Reg) ↦ᵣ (0 : Word)) ** ((.x11 : Reg) ↦ᵣ v11) **
+     ((.x12 : Reg) ↦ᵣ v12) ** ((.x13 : Reg) ↦ᵣ v13) ** ((.x14 : Reg) ↦ᵣ v14) **
+     ((.x30 : Reg) ↦ᵣ x30v) ** regOwn .x31 ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+     bytesRegion listBase bytes ** ((.x15 : Reg) ↦ᵣ codeOut) ** savedFrame spW savedCaller **
+     (nonceOut ↦ₘ beAccum bytes o0.toNat l0.toNat) **
+     bytesRegion rootOut oldRoot ** bytesRegion codeOut oldCode **
+     (adLengthAddr ↦ₘ l1))
+    (by pcfa) (adBalanceSetup balanceOut listBase l1 o1 adLengthAddr x28v x29v
+      (packBytes (oldBal.take 8)) (packBytes ((oldBal.drop 8).take 8))
+      (packBytes (((oldBal.drop 8).drop 8).take 8))
+      (packBytes ((((oldBal.drop 8).drop 8).drop 8).take 8)))
+  -- balance copy loop [65]-[71].
+  have hbl := cpsTripleWithin_frameR
+    (((.x5 : Reg) ↦ᵣ adOffsetAddr) ** (adLengthAddr ↦ₘ l1) ** ((.x1 : Reg) ↦ᵣ (AB + 196)) **
+     ((.x2 : Reg) ↦ᵣ spW) ** ((.x7 : Reg) ↦ᵣ ((32 : Word) - l1)) ** ((.x8 : Reg) ↦ᵣ listBase) **
+     ((.x9 : Reg) ↦ᵣ len) ** ((.x18 : Reg) ↦ᵣ nonceOut) ** ((.x19 : Reg) ↦ᵣ balanceOut) **
+     ((.x20 : Reg) ↦ᵣ rootOut) ** ((.x21 : Reg) ↦ᵣ codeOut) ** stackFree spW 8 **
+     ((.x10 : Reg) ↦ᵣ (0 : Word)) ** ((.x11 : Reg) ↦ᵣ v11) ** ((.x12 : Reg) ↦ᵣ v12) **
+     ((.x13 : Reg) ↦ᵣ v13) ** ((.x14 : Reg) ↦ᵣ v14) ** regOwn .x31 **
+     ((.x15 : Reg) ↦ᵣ codeOut) ** savedFrame spW savedCaller **
+     (nonceOut ↦ₘ beAccum bytes o0.toNat l0.toNat) **
+     bytesRegion rootOut oldRoot ** bytesRegion codeOut oldCode ** (adOffsetAddr ↦ₘ o1))
+    (by pcfa)
+    (adBalLoop listBase balanceOut x30v bytes (List.replicate 32 (0 : BitVec 8))
+      o1.toNat (32 - l1.toNat) 0 l1.toNat hsalign hbalign hsrcbound
+      (by simp only [List.length_replicate]; omega) hover
+      (by simp only [List.length_replicate]; exact hbover) hvalid
+      (by simp only [List.length_replicate]; exact hbvalid))
+  -- bridge setup → loop (right-align cursor arithmetic).
+  have c1 := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by
+      rw [show BitVec.ofNat 64 l1.toNat = l1 from by bv_omega,
+        show listBase + BitVec.ofNat 64 (o1.toNat + 0) = listBase + o1 from hoffnorm.symm,
+        show balanceOut + BitVec.ofNat 64 ((32 - l1.toNat) + 0) = balanceOut + ((32 : Word) - l1)
+          from by bv_omega,
+        show copyIntoRegion (List.replicate 32 (0 : BitVec 8)) bytes (32 - l1.toNat) o1.toNat 0
+          = List.replicate 32 (0 : BitVec 8) from rfl]
+      xperm_hyp hp)
+    hbs hbl
+  -- weaken: outer bytesRegion pre → 4-dword setup pre ; loop post → field-2 call pre.
+  refine cpsTripleWithin_weaken (fun h hp => by
+      rw [bytesRegion32_dwords_eq balanceOut oldBal hballen] at hp
+      xperm_hyp hp)
+    (fun h hq => ?_) c1
+  rw [show copyIntoRegion (List.replicate 32 (0 : BitVec 8)) bytes (32 - l1.toNat) o1.toNat
+      (0 + l1.toNat) = balanceCopied bytes o1 l1.toNat from by rw [Nat.zero_add]; rfl] at hq
+  exact sepConj_mono_left
+    (adCallPre_weaken5 (AB + 196) spW listBase len nonceOut balanceOut rootOut codeOut o1 l1
+      (0 : Word) v11 v12 v13 v14 adOffsetAddr (0 : Word) ((32 : Word) - l1)
+      (listBase + BitVec.ofNat 64 (o1.toNat + (0 + l1.toNat)))
+      (balanceOut + BitVec.ofNat 64 ((32 - l1.toNat) + (0 + l1.toNat))) bytes)
+    h (by xperm_hyp hq)
+
+#print axioms adField1Copy
+
+set_option maxRecDepth 8000 in
+/-- Field-1 success tie (`AB+220 → raSaved`): the balance copy (`adField1Copy`)
+    followed by the field-2 backbone (`adBBField2`). -/
+theorem adField1Success
+    (sp0 spW raSaved listBase len nonceOut balanceOut rootOut codeOut o0 o1 l0
+      x28v x29v x30v v11 v12 v13 v14 : Word)
+    (bytes oldBal oldRoot oldCode : List (BitVec 8)) (listLen : Nat)
+    (hspW : spW = sp0 + signExtend12 (-64 : BitVec 12))
+    (hret : raSaved &&& ~~~(1 : Word) = raSaved)
+    (hlenW : len = BitVec.ofNat 64 listLen)
+    (hsalign : listBase.toNat % 8 = 0)
+    (hslack : listLen + 9 ≤ bytes.length)
+    (hover : listBase.toNat + bytes.length < 2 ^ 64)
+    (hvalid : ∀ k, k < bytes.length →
+      isValidByteAccess (listBase + BitVec.ofNat 64 k) = true)
+    (hbalign : balanceOut.toNat % 8 = 0)
+    (hbover : balanceOut.toNat + 32 < 2 ^ 64)
+    (hballen : oldBal.length = 32)
+    (hbvalid : ∀ k, k < 32 → isValidByteAccess (balanceOut + BitVec.ofNat 64 k) = true)
+    (hralign : rootOut.toNat % 8 = 0)
+    (hrover : rootOut.toNat + 32 < 2 ^ 64)
+    (hrootlen : oldRoot.length = 32)
+    (hrvalid : ∀ k, k < 32 → isValidByteAccess (rootOut + BitVec.ofNat 64 k) = true)
+    (hcalign : codeOut.toNat % 8 = 0)
+    (hcover : codeOut.toNat + 32 < 2 ^ 64)
+    (hcodelen : oldCode.length = 32)
+    (hcvalid : ∀ k, k < 32 → isValidByteAccess (codeOut + BitVec.ofNat 64 k) = true)
+    (hf0 : Success bytes listBase listLen 0 o0 l0)
+    (hf1 : Success bytes listBase listLen 1 o1 l1)
+    (hl0 : l0.toNat ≤ 8) (hl1 : l1.toNat ≤ 32) :
+    let savedCaller : Saved :=
+      { ra := raSaved, s0 := listBase, s1 := len, s2 := nonceOut, s3 := balanceOut,
+        s4 := rootOut, s5 := codeOut }
+    cpsTripleWithin (1508 + 7 * l1.toNat) (AB + 220) raSaved fullCode
+      (((.x6 : Reg) ↦ᵣ l1) ** ((.x7 : Reg) ↦ᵣ (32 : Word)) ** ((.x5 : Reg) ↦ᵣ adLengthAddr) **
+       (adLengthAddr ↦ₘ l1) ** ((.x2 : Reg) ↦ᵣ spW) ** ((.x1 : Reg) ↦ᵣ (AB + 196)) **
+       ((.x8 : Reg) ↦ᵣ listBase) ** ((.x9 : Reg) ↦ᵣ len) ** ((.x18 : Reg) ↦ᵣ nonceOut) **
+       ((.x19 : Reg) ↦ᵣ balanceOut) ** ((.x20 : Reg) ↦ᵣ rootOut) ** ((.x21 : Reg) ↦ᵣ codeOut) **
+       stackFree spW 8 ** ((.x10 : Reg) ↦ᵣ (0 : Word)) ** ((.x11 : Reg) ↦ᵣ v11) **
+       ((.x12 : Reg) ↦ᵣ v12) ** ((.x13 : Reg) ↦ᵣ v13) ** ((.x14 : Reg) ↦ᵣ v14) **
+       ((.x28 : Reg) ↦ᵣ x28v) ** ((.x29 : Reg) ↦ᵣ x29v) ** ((.x30 : Reg) ↦ᵣ x30v) **
+       regOwn .x31 ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+       bytesRegion listBase bytes ** (adOffsetAddr ↦ₘ o1) ** ((.x15 : Reg) ↦ᵣ codeOut) **
+       savedFrame spW savedCaller ** (nonceOut ↦ₘ beAccum bytes o0.toNat l0.toNat) **
+       bytesRegion balanceOut oldBal **
+       bytesRegion rootOut oldRoot ** bytesRegion codeOut oldCode)
+      (adWholePost sp0 spW savedCaller listBase listLen bytes oldRoot oldCode) := by
+  intro savedCaller
+  have hcopy := adField1Copy spW raSaved listBase len nonceOut balanceOut rootOut codeOut
+    o0 o1 l0 x28v x29v x30v v11 v12 v13 v14 bytes oldBal oldRoot oldCode listLen
+    hsalign hslack hover hvalid hbalign hbover hballen hbvalid hf1 hl1
+  have hbb := adBBField2 sp0 spW (AB + 196) raSaved listBase len nonceOut balanceOut rootOut
+    codeOut o1 l1 (0 : Word) v11 v12 v13 v14 o0 o1 l0 l1 bytes oldRoot oldCode listLen hspW hret
+    hlenW hsalign hslack hover hvalid hralign hrover hrootlen hrvalid hcalign hcover hcodelen
+    hcvalid hf0 hf1 hl0 hl1
+  exact cpsTripleWithin_mono_nSteps (by omega)
+    (cpsTripleWithin_seq_perm_same_cr (fun h hp => by xperm_hyp hp) hcopy hbb)
+
+#print axioms adField1Success
+
+set_option maxRecDepth 8000 in
+/-- Field-1 continue (`AB+200 → raSaved`): the balance continue edge.  The
+    `len ≤ 32` length check gates the balance copy (`adField1Success`) or the
+    `field1Len` failure. -/
+theorem adField1ContEpi
+    (sp0 spW raSaved listBase len nonceOut balanceOut rootOut codeOut o0 l0 : Word)
+    (bytes oldBal oldRoot oldCode : List (BitVec 8)) (listLen : Nat)
+    (hspW : spW = sp0 + signExtend12 (-64 : BitVec 12))
+    (hret : raSaved &&& ~~~(1 : Word) = raSaved)
+    (hlenW : len = BitVec.ofNat 64 listLen)
+    (hsalign : listBase.toNat % 8 = 0)
+    (hslack : listLen + 9 ≤ bytes.length)
+    (hover : listBase.toNat + bytes.length < 2 ^ 64)
+    (hvalid : ∀ k, k < bytes.length →
+      isValidByteAccess (listBase + BitVec.ofNat 64 k) = true)
+    (hbalign : balanceOut.toNat % 8 = 0)
+    (hbover : balanceOut.toNat + 32 < 2 ^ 64)
+    (hballen : oldBal.length = 32)
+    (hbvalid : ∀ k, k < 32 → isValidByteAccess (balanceOut + BitVec.ofNat 64 k) = true)
+    (hralign : rootOut.toNat % 8 = 0)
+    (hrover : rootOut.toNat + 32 < 2 ^ 64)
+    (hrootlen : oldRoot.length = 32)
+    (hrvalid : ∀ k, k < 32 → isValidByteAccess (rootOut + BitVec.ofNat 64 k) = true)
+    (hcalign : codeOut.toNat % 8 = 0)
+    (hcover : codeOut.toNat + 32 < 2 ^ 64)
+    (hcodelen : oldCode.length = 32)
+    (hcvalid : ∀ k, k < 32 → isValidByteAccess (codeOut + BitVec.ofNat 64 k) = true)
+    (hf0 : Success bytes listBase listLen 0 o0 l0)
+    (hl0 : l0.toNat ≤ 8) :
+    let saved1 : Saved :=
+      { ra := AB + 196, s0 := listBase, s1 := len, s2 := nonceOut, s3 := balanceOut,
+        s4 := rootOut, s5 := codeOut }
+    let savedCaller : Saved :=
+      { ra := raSaved, s0 := listBase, s1 := len, s2 := nonceOut, s3 := balanceOut,
+        s4 := rootOut, s5 := codeOut }
+    cpsTripleWithin (5 + 1732) (AB + 200) raSaved fullCode
+      (adK20ContPost spW listBase 1 saved1 bytes listLen **
+       (savedFrame spW savedCaller ** (nonceOut ↦ₘ beAccum bytes o0.toNat l0.toNat) **
+        bytesRegion balanceOut oldBal **
+        bytesRegion rootOut oldRoot ** bytesRegion codeOut oldCode **
+        ((.x15 : Reg) ↦ᵣ codeOut)))
+      (adWholePost sp0 spW savedCaller listBase listLen bytes oldRoot oldCode) := by
+  intro saved1 savedCaller
+  -- (1) expose the K20 continue existentials, keeping x5/x6/x7 owned.
+  refine cpsTripleWithin_weaken
+    (P := fun h => ∃ offset len' v11 v12,
+      (((⌜Success bytes listBase listLen 1 offset len'⌝ : Assertion) **
+        ((.x2 : Reg) ↦ᵣ spW) ** regsAt listNthFrame (savedVals saved1) ** stackFree spW 8 **
+        ((.x10 : Reg) ↦ᵣ (0 : Word)) ** ((.x11 : Reg) ↦ᵣ v11) ** ((.x12 : Reg) ↦ᵣ v12) **
+        regOwn .x13 ** regOwn .x14 ** regOwn .x28 ** regOwn .x29 ** regOwn .x30 **
+        regOwn .x31 ** ((.x0 : Reg) ↦ᵣ (0 : Word)) ** bytesRegion listBase bytes **
+        (adOffsetAddr ↦ₘ offset) ** (adLengthAddr ↦ₘ len') ** savedFrame spW savedCaller **
+        (nonceOut ↦ₘ beAccum bytes o0.toNat l0.toNat) **
+        bytesRegion balanceOut oldBal **
+        bytesRegion rootOut oldRoot ** bytesRegion codeOut oldCode **
+        ((.x15 : Reg) ↦ᵣ codeOut)) ** regOwn .x5 ** regOwn .x6 ** regOwn .x7) h)
+    (fun h hp => by
+      obtain ⟨h1, h2, hd, hu, hcont, hacc⟩ := hp
+      unfold adK20ContPost at hcont
+      obtain ⟨offset, len', v11, v12, hbody⟩ := hcont
+      refine ⟨offset, len', v11, v12, ?_⟩
+      have hcomb : (_ ** _) h := ⟨h1, h2, hd, hu, hbody, hacc⟩
+      xperm_hyp hcomb)
+    (fun _ hq => hq) ?_
+  refine cpsTripleWithin_exists_pre_gen (fun offset => ?_)
+  refine cpsTripleWithin_exists_pre_gen (fun len' => ?_)
+  refine cpsTripleWithin_exists_pre_gen (fun v11 => ?_)
+  refine cpsTripleWithin_exists_pre_gen (fun v12 => ?_)
+  refine cpsTripleWithin_of_forall_regIs_to_regOwn3 (fun v5 v6 v7 => ?_)
+  -- (2) continue reshape into length-check pre plus the ambient continue frame.
+  refine cpsTripleWithin_weaken
+    (P := (((.x5 : Reg) ↦ᵣ v5) ** ((.x6 : Reg) ↦ᵣ v6) ** ((.x7 : Reg) ↦ᵣ v7) **
+        (adLengthAddr ↦ₘ len')) **
+       (adContFrame spW listBase 1 saved1 bytes listLen offset len' v11 v12 **
+        savedFrame spW savedCaller ** (nonceOut ↦ₘ beAccum bytes o0.toNat l0.toNat) **
+        bytesRegion balanceOut oldBal **
+        bytesRegion rootOut oldRoot ** bytesRegion codeOut oldCode **
+        ((.x15 : Reg) ↦ᵣ codeOut)))
+    (fun h hp => by
+      have hin : (((⌜Success bytes listBase listLen 1 offset len'⌝ : Assertion) **
+          ((((.x2 : Reg) ↦ᵣ spW) ** regsAt listNthFrame (savedVals saved1) ** stackFree spW 8) **
+           (((.x10 : Reg) ↦ᵣ (0 : Word)) ** ((.x5 : Reg) ↦ᵣ v5) ** ((.x6 : Reg) ↦ᵣ v6) **
+            ((.x7 : Reg) ↦ᵣ v7) ** ((.x11 : Reg) ↦ᵣ v11) ** ((.x12 : Reg) ↦ᵣ v12) **
+            regOwn .x13 ** regOwn .x14 ** regOwn .x28 ** regOwn .x29 ** regOwn .x30 **
+            regOwn .x31 ** ((.x0 : Reg) ↦ᵣ (0 : Word)) ** bytesRegion listBase bytes **
+            (adOffsetAddr ↦ₘ offset) ** (adLengthAddr ↦ₘ len')))) **
+          (savedFrame spW savedCaller ** (nonceOut ↦ₘ beAccum bytes o0.toNat l0.toNat) **
+           bytesRegion balanceOut oldBal **
+           bytesRegion rootOut oldRoot ** bytesRegion codeOut oldCode **
+           ((.x15 : Reg) ↦ᵣ codeOut))) h := by xperm_hyp hp
+      have hout := sepConj_mono_left (adContReshape spW listBase 1 saved1 bytes listLen offset len'
+        v11 v12 v5 v6 v7) h hin
+      xperm_hyp hout)
+    (fun _ hq => hq) ?_
+  -- (3) length-check branch, framed by the continue frame plus the output cells.
+  have hbr := cpsBranchWithin_frameR
+    (adContFrame spW listBase 1 saved1 bytes listLen offset len' v11 v12 **
+     savedFrame spW savedCaller ** (nonceOut ↦ₘ beAccum bytes o0.toNat l0.toNat) **
+     bytesRegion balanceOut oldBal **
+     bytesRegion rootOut oldRoot ** bytesRegion codeOut oldCode **
+     ((.x15 : Reg) ↦ᵣ codeOut))
+    (by pcfa) (adBalLenCheck v5 v6 v7 len')
+  refine cpsBranchWithin_merge_same_cr hbr ?fail ?cont
+  case fail =>
+    -- 32 < len: field1Len failure through the shared fail arm.
+    refine cpsTripleWithin_weaken (fun h hp => ?_) (fun _ hq => hq)
+      (cpsTripleWithin_mono_nSteps (show (1 + 9) ≤ 1732 from by omega)
+        (adFailArm sp0 spW savedCaller listBase bytes oldRoot oldCode listLen hspW
+          (show savedCaller.ra &&& ~~~(1 : Word) = savedCaller.ra from hret)))
+    unfold adContFrame at hp
+    rw [regsAt_listNthFrame] at hp
+    have hf1 : Success bytes listBase listLen 1 offset len' := by
+      obtain ⟨_, _, _, _, _, hr⟩ := hp
+      obtain ⟨_, _, _, _, hcf, _⟩ := hr
+      exact ((sepConj_pure_left _).1 hcf).1
+    have hgt : 32 < len'.toNat := by
+      have hult : BitVec.ult (32 : Word) len' = true := by
+        obtain ⟨_, _, _, _, hfp, _⟩ := hp
+        obtain ⟨_, _, _, _, hAgrp, _⟩ := hfp
+        obtain ⟨_, _, _, _, _, hA2⟩ := hAgrp
+        exact ((sepConj_pure_right _).1 hA2).2
+      have h32 : ((32 : Word)).toNat = 32 := by decide
+      simp only [BitVec.ult, decide_eq_true_eq] at hult; omega
+    have hDF : DecodeFailure bytes listBase listLen := DecodeFailure.field1Len offset len' hf1 hgt
+    have hgP : ((⌜Success bytes listBase listLen 1 offset len'⌝ : Assertion) **
+        (⌜BitVec.ult (32 : Word) len' = true⌝ : Assertion) **
+        ((((.x2 : Reg) ↦ᵣ spW) **
+         (((.x1 : Reg) ↦ᵣ (AB + 196)) ** ((.x8 : Reg) ↦ᵣ listBase) ** ((.x9 : Reg) ↦ᵣ len) **
+          ((.x18 : Reg) ↦ᵣ nonceOut) ** ((.x19 : Reg) ↦ᵣ balanceOut) **
+          ((.x20 : Reg) ↦ᵣ saved1.s4) ** ((.x21 : Reg) ↦ᵣ codeOut)) **
+         savedFrame spW savedCaller) **
+        ((nonceOut ↦ₘ beAccum bytes o0.toNat l0.toNat) **
+         bytesRegion balanceOut oldBal **
+         bytesRegion rootOut oldRoot ** bytesRegion codeOut oldCode **
+         bytesRegion listBase bytes ** (adOffsetAddr ↦ₘ offset) ** (adLengthAddr ↦ₘ len') **
+         stackFree spW 8 **
+         (((.x5 : Reg) ↦ᵣ adLengthAddr) ** ((.x6 : Reg) ↦ᵣ len') ** ((.x7 : Reg) ↦ᵣ (32 : Word)) **
+          ((.x11 : Reg) ↦ᵣ v11) ** ((.x12 : Reg) ↦ᵣ v12) ** regOwn .x13 ** regOwn .x14 **
+          regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+          ((.x15 : Reg) ↦ᵣ codeOut)))) ** ((.x10 : Reg) ↦ᵣ (0 : Word))) h := by xperm_hyp hp
+    have hg := ((sepConj_pure_left h).1 (((sepConj_pure_left h).1 hgP).2)).2
+    exact sepConj_mono (sepConj_mono
+      (sepConj_mono_right (sepConj_mono_left (fun h' hr => listNthFrameRegs_implies_owned
+        listBase len nonceOut balanceOut saved1.s4 codeOut h'
+        (sepConj_mono_left (regIs_implies_regOwn .x1) h' hr))))
+      (fun h' hc => (sepConj_pure_left h').2
+        ⟨hDF, beAccum bytes o0.toNat l0.toNat, offset, len', oldBal,
+          oldRoot, oldCode,
+          sepConj_mono_right (sepConj_mono_right (sepConj_mono_right (sepConj_mono_right
+            (sepConj_mono_right (sepConj_mono_right (sepConj_mono_right (sepConj_mono_right
+              (adScratch_of_regs_own codeOut adLengthAddr len' (32 : Word) v11 v12)))))))) h' hc⟩))
+      (regIs_implies_regOwn .x10) h hg
+  case cont =>
+    -- len ≤ 32: the balance-copy success tie.  Introduce x13/x14/x28/x29/x30.
+    refine cpsTripleWithin_weaken
+      (P := ((⌜Success bytes listBase listLen 1 offset len'⌝ : Assertion) **
+        (⌜¬ BitVec.ult (32 : Word) len'⌝ : Assertion) **
+        ((.x6 : Reg) ↦ᵣ len') ** ((.x7 : Reg) ↦ᵣ (32 : Word)) ** ((.x5 : Reg) ↦ᵣ adLengthAddr) **
+        (adLengthAddr ↦ₘ len') ** ((.x2 : Reg) ↦ᵣ spW) ** ((.x1 : Reg) ↦ᵣ (AB + 196)) **
+        ((.x8 : Reg) ↦ᵣ listBase) ** ((.x9 : Reg) ↦ᵣ len) ** ((.x18 : Reg) ↦ᵣ nonceOut) **
+        ((.x19 : Reg) ↦ᵣ balanceOut) ** ((.x20 : Reg) ↦ᵣ saved1.s4) ** ((.x21 : Reg) ↦ᵣ codeOut) **
+        stackFree spW 8 ** ((.x10 : Reg) ↦ᵣ (0 : Word)) ** ((.x11 : Reg) ↦ᵣ v11) **
+        ((.x12 : Reg) ↦ᵣ v12) ** regOwn .x31 **
+        ((.x0 : Reg) ↦ᵣ (0 : Word)) ** bytesRegion listBase bytes **
+        (adOffsetAddr ↦ₘ offset) ** ((.x15 : Reg) ↦ᵣ codeOut) ** savedFrame spW savedCaller **
+        (nonceOut ↦ₘ beAccum bytes o0.toNat l0.toNat) **
+        bytesRegion balanceOut oldBal **
+        bytesRegion rootOut oldRoot ** bytesRegion codeOut oldCode) **
+        regOwn .x13 ** regOwn .x14 ** regOwn .x28 ** regOwn .x29 ** regOwn .x30)
+      (fun h hp => by unfold adContFrame at hp; rw [regsAt_listNthFrame] at hp; xperm_hyp hp)
+      (fun _ hq => hq) ?_
+    refine cpsTripleWithin_of_forall_regIs_to_regOwn5 (fun v13 v14 x28v x29v x30v => ?_)
+    refine cpsTripleWithin_weaken
+      (P := (⌜Success bytes listBase listLen 1 offset len'⌝ : Assertion) **
+        (⌜¬ BitVec.ult (32 : Word) len'⌝ : Assertion) **
+        (((.x6 : Reg) ↦ᵣ len') ** ((.x7 : Reg) ↦ᵣ (32 : Word)) ** ((.x5 : Reg) ↦ᵣ adLengthAddr) **
+         (adLengthAddr ↦ₘ len') ** ((.x2 : Reg) ↦ᵣ spW) ** ((.x1 : Reg) ↦ᵣ (AB + 196)) **
+         ((.x8 : Reg) ↦ᵣ listBase) ** ((.x9 : Reg) ↦ᵣ len) ** ((.x18 : Reg) ↦ᵣ nonceOut) **
+         ((.x19 : Reg) ↦ᵣ balanceOut) ** ((.x20 : Reg) ↦ᵣ saved1.s4) ** ((.x21 : Reg) ↦ᵣ codeOut) **
+         stackFree spW 8 ** ((.x10 : Reg) ↦ᵣ (0 : Word)) ** ((.x11 : Reg) ↦ᵣ v11) **
+         ((.x12 : Reg) ↦ᵣ v12) ** ((.x13 : Reg) ↦ᵣ v13) ** ((.x14 : Reg) ↦ᵣ v14) **
+         ((.x28 : Reg) ↦ᵣ x28v) ** ((.x29 : Reg) ↦ᵣ x29v) ** ((.x30 : Reg) ↦ᵣ x30v) **
+         regOwn .x31 ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+         bytesRegion listBase bytes ** (adOffsetAddr ↦ₘ offset) ** ((.x15 : Reg) ↦ᵣ codeOut) **
+         savedFrame spW savedCaller ** (nonceOut ↦ₘ beAccum bytes o0.toNat l0.toNat) **
+         bytesRegion balanceOut oldBal **
+         bytesRegion rootOut oldRoot ** bytesRegion codeOut oldCode))
+      (fun h hp => by xperm_hyp hp) (fun _ hq => hq) ?_
+    refine cpsTripleWithin_pure_pre (fun hf1 => ?_)
+    refine cpsTripleWithin_pure_pre (fun hult => ?_)
+    have hl1 : len'.toNat ≤ 32 := by
+      have h32 : ((32 : Word)).toNat = 32 := by decide
+      by_contra hc; exact hult (by simp only [BitVec.ult, decide_eq_true_eq]; omega)
+    exact cpsTripleWithin_mono_nSteps (show 1508 + 7 * len'.toNat ≤ 1732 from by omega)
+      (adField1Success sp0 spW raSaved listBase len nonceOut balanceOut rootOut codeOut
+        o0 offset l0 x28v x29v x30v v11 v12 v13 v14 bytes oldBal oldRoot oldCode listLen hspW hret
+        hlenW hsalign hslack hover hvalid hbalign hbover hballen hbvalid hralign hrover hrootlen
+        hrvalid hcalign hcover hcodelen hcvalid hf0 hf1 hl0 hl1)
+
+#print axioms adField1ContEpi
+
+set_option maxRecDepth 8000 in
+/-- Field-1 (balance) backbone (`AB+164 → raSaved`): merge the field-1 stage's
+    parse-fail edge (`field1List`) with the continue edge (`adField1ContEpi`).
+    The balance output cell is untouched (`oldBal`) on entry. -/
+theorem adBBField1
+    (sp0 spW raEntry raSaved listBase len nonceOut balanceOut rootOut codeOut
+      oldOffset oldLen v10 v11 v12 v13 v14 o0 l0 : Word)
+    (bytes oldBal oldRoot oldCode : List (BitVec 8)) (listLen : Nat)
+    (hspW : spW = sp0 + signExtend12 (-64 : BitVec 12))
+    (hret : raSaved &&& ~~~(1 : Word) = raSaved)
+    (hlenW : len = BitVec.ofNat 64 listLen)
+    (hsalign : listBase.toNat % 8 = 0)
+    (hslack : listLen + 9 ≤ bytes.length)
+    (hover : listBase.toNat + bytes.length < 2 ^ 64)
+    (hvalid : ∀ k, k < bytes.length →
+      isValidByteAccess (listBase + BitVec.ofNat 64 k) = true)
+    (hbalign : balanceOut.toNat % 8 = 0)
+    (hbover : balanceOut.toNat + 32 < 2 ^ 64)
+    (hballen : oldBal.length = 32)
+    (hbvalid : ∀ k, k < 32 → isValidByteAccess (balanceOut + BitVec.ofNat 64 k) = true)
+    (hralign : rootOut.toNat % 8 = 0)
+    (hrover : rootOut.toNat + 32 < 2 ^ 64)
+    (hrootlen : oldRoot.length = 32)
+    (hrvalid : ∀ k, k < 32 → isValidByteAccess (rootOut + BitVec.ofNat 64 k) = true)
+    (hcalign : codeOut.toNat % 8 = 0)
+    (hcover : codeOut.toNat + 32 < 2 ^ 64)
+    (hcodelen : oldCode.length = 32)
+    (hcvalid : ∀ k, k < 32 → isValidByteAccess (codeOut + BitVec.ofNat 64 k) = true)
+    (hf0 : Success bytes listBase listLen 0 o0 l0)
+    (hl0 : l0.toNat ≤ 8) :
+    let savedCaller : Saved :=
+      { ra := raSaved, s0 := listBase, s1 := len, s2 := nonceOut, s3 := balanceOut,
+        s4 := rootOut, s5 := codeOut }
+    cpsTripleWithin (((7 + (1 + ((12 + ((85 + 93 * (1 + 2)) + 6)) + 9))) + 1) + 1737)
+      (AB + 164) raSaved fullCode
+      (adCallPre raEntry spW listBase len nonceOut balanceOut rootOut codeOut oldOffset oldLen
+        v10 v11 v12 v13 v14 bytes **
+       (savedFrame spW savedCaller ** (nonceOut ↦ₘ beAccum bytes o0.toNat l0.toNat) **
+        bytesRegion balanceOut oldBal **
+        bytesRegion rootOut oldRoot ** bytesRegion codeOut oldCode **
+        ((.x15 : Reg) ↦ᵣ codeOut)))
+      (adWholePost sp0 spW savedCaller listBase listLen bytes oldRoot oldCode) := by
+  intro savedCaller
+  have hstage := adField1Stage spW raEntry listBase len nonceOut balanceOut rootOut codeOut
+    oldOffset oldLen v10 v11 v12 v13 v14 bytes listLen hlenW hsalign hslack hover hvalid
+  have hbr := cpsBranchWithin_frameR
+    (savedFrame spW savedCaller ** (nonceOut ↦ₘ beAccum bytes o0.toNat l0.toNat) **
+     bytesRegion balanceOut oldBal **
+     bytesRegion rootOut oldRoot ** bytesRegion codeOut oldCode **
+     ((.x15 : Reg) ↦ᵣ codeOut))
+    (by pcfa) hstage
+  refine cpsBranchWithin_merge_same_cr hbr ?fail ?cont
+  case cont =>
+    exact cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp) (fun _ hq => hq)
+      (adField1ContEpi sp0 spW raSaved listBase len nonceOut balanceOut rootOut codeOut o0 l0
+        bytes oldBal oldRoot oldCode listLen hspW hret hlenW hsalign hslack hover hvalid hbalign
+        hbover hballen hbvalid hralign hrover hrootlen hrvalid hcalign hcover hcodelen hcvalid
+        hf0 hl0)
+  case fail =>
+    refine cpsTripleWithin_weaken (fun h hp => ?_) (fun _ hq => hq)
+      (cpsTripleWithin_mono_nSteps (show (1 + 9) ≤ 1737 from by omega)
+        (adFailArm sp0 spW savedCaller listBase bytes oldRoot oldCode listLen hspW
+          (show savedCaller.ra &&& ~~~(1 : Word) = savedCaller.ra from hret)))
+    obtain ⟨h1, h2, hd, hu, hfail, hacc⟩ := hp
+    unfold adK20FailPost at hfail
+    obtain ⟨status, offset', len', v11', v12', hbody⟩ := hfail
+    have hResPair : Result bytes listBase listLen 1 oldOffset oldLen status offset' len' ∧
+        status ≠ (0 : Word) := ((sepConj_pure_left h1).1 hbody).1
+    have hFail : Failure bytes listBase listLen 1 := by
+      cases hResPair.1 with
+      | ok o l hs => exact absurd rfl hResPair.2
+      | fail hf => exact hf
+    have hDF : DecodeFailure bytes listBase listLen := DecodeFailure.field1List hFail
+    have hbig := ((sepConj_pure_left h1).1 hbody).2
+    rw [regsAt_listNthFrame] at hbig
+    have hgP : (((((.x2 : Reg) ↦ᵣ spW) **
+        (((.x1 : Reg) ↦ᵣ (AB + 196)) ** ((.x8 : Reg) ↦ᵣ listBase) ** ((.x9 : Reg) ↦ᵣ len) **
+         ((.x18 : Reg) ↦ᵣ nonceOut) ** ((.x19 : Reg) ↦ᵣ balanceOut) **
+         ((.x20 : Reg) ↦ᵣ rootOut) ** ((.x21 : Reg) ↦ᵣ codeOut)) **
+        savedFrame spW savedCaller) **
+       ((nonceOut ↦ₘ beAccum bytes o0.toNat l0.toNat) **
+        bytesRegion balanceOut oldBal **
+        bytesRegion rootOut oldRoot ** bytesRegion codeOut oldCode **
+        bytesRegion listBase bytes ** (adOffsetAddr ↦ₘ offset') ** (adLengthAddr ↦ₘ len') **
+        stackFree spW 8 **
+        (regOwn .x5 ** regOwn .x6 ** regOwn .x7 ** ((.x11 : Reg) ↦ᵣ v11') **
+         ((.x12 : Reg) ↦ᵣ v12') ** regOwn .x13 ** regOwn .x14 **
+         regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+         ((.x15 : Reg) ↦ᵣ codeOut)))) ** ((.x10 : Reg) ↦ᵣ status)) h := by
+      have hcomb : (_ ** _) h := ⟨h1, h2, hd, hu, hbig, hacc⟩
+      xperm_hyp hcomb
+    exact sepConj_mono (sepConj_mono
+      (sepConj_mono_right (sepConj_mono_left (fun h' hr => listNthFrameRegs_implies_owned
+        listBase len nonceOut balanceOut rootOut codeOut h'
+        (sepConj_mono_left (regIs_implies_regOwn .x1) h' hr))))
+      (fun h' hc => (sepConj_pure_left h').2
+        ⟨hDF, beAccum bytes o0.toNat l0.toNat, offset', len', oldBal,
+          oldRoot, oldCode,
+          sepConj_mono_right (sepConj_mono_right (sepConj_mono_right (sepConj_mono_right
+            (sepConj_mono_right (sepConj_mono_right (sepConj_mono_right (sepConj_mono_right
+              (adScratch_of_regs_own2 codeOut v11' v12')))))))) h' hc⟩))
+      (regIs_implies_regOwn .x10) h hgP
+
+#print axioms adBBField1
+
+end EvmAsm.Codegen.AccountDecodeSpec

--- a/EvmAsm/Codegen/Programs/AccountDecodeClose6.lean
+++ b/EvmAsm/Codegen/Programs/AccountDecodeClose6.lean
@@ -577,4 +577,486 @@ theorem adBBField1
 
 #print axioms adBBField1
 
+/-- Variant of `adCallPre_weaken` weakening THREE concrete scratch temporaries
+    `x5/x6/x7` (used after the nonce loop, which leaves `x28/x29` owned). -/
+theorem adCallPre_weaken3 (raIn spW listBase len s2v s3 s4 s5 oldOffset oldLen
+    v10 v11 v12 v13 v14 w5 w6 w7 : Word) (bytes : List (BitVec 8)) : ∀ h,
+    (((.x1 : Reg) ↦ᵣ raIn) ** ((.x2 : Reg) ↦ᵣ spW) ** ((.x8 : Reg) ↦ᵣ listBase) **
+     ((.x9 : Reg) ↦ᵣ len) ** ((.x18 : Reg) ↦ᵣ s2v) ** ((.x19 : Reg) ↦ᵣ s3) **
+     ((.x20 : Reg) ↦ᵣ s4) ** ((.x21 : Reg) ↦ᵣ s5) ** ((.x10 : Reg) ↦ᵣ v10) **
+     ((.x11 : Reg) ↦ᵣ v11) ** ((.x12 : Reg) ↦ᵣ v12) ** ((.x13 : Reg) ↦ᵣ v13) **
+     ((.x14 : Reg) ↦ᵣ v14) ** stackFree spW 8 ** ((.x5 : Reg) ↦ᵣ w5) **
+     ((.x6 : Reg) ↦ᵣ w6) ** ((.x7 : Reg) ↦ᵣ w7) ** regOwn .x28 ** regOwn .x29 **
+     regOwn .x30 ** regOwn .x31 ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+     bytesRegion listBase bytes ** (adOffsetAddr ↦ₘ oldOffset) **
+     (adLengthAddr ↦ₘ oldLen)) h →
+    adCallPre raIn spW listBase len s2v s3 s4 s5 oldOffset oldLen
+      v10 v11 v12 v13 v14 bytes h := by
+  intro h hp
+  unfold adCallPre
+  exact sepConj_mono_right (sepConj_mono_right (sepConj_mono_right (sepConj_mono_right
+    (sepConj_mono_right (sepConj_mono_right (sepConj_mono_right (sepConj_mono_right
+    (sepConj_mono_right (sepConj_mono_right (sepConj_mono_right (sepConj_mono_right
+    (sepConj_mono_right (sepConj_mono_right
+      (sepConj_mono (regIs_implies_regOwn .x5) (sepConj_mono (regIs_implies_regOwn .x6)
+        (sepConj_mono_left (regIs_implies_regOwn .x7)))))))))))))))))
+    h hp
+
+set_option maxRecDepth 8000 in
+/-- Field-0 nonce copy tail (`AB+112 → AB+164`): the big-endian accumulate scan
+    plus the dword store, reshaping the `len ≤ 8` continue state into the field-1
+    call precondition (`adBBField1`'s `adCallPre`) with the nonce output cell now
+    written (`beAccum`). -/
+theorem adField0Copy
+    (spW raSaved listBase len nonceOut balanceOut rootOut codeOut o0 oldNonce
+      x28v x29v v11 v12 v13 v14 : Word)
+    (bytes oldBal oldRoot oldCode : List (BitVec 8)) (listLen : Nat)
+    (hsalign : listBase.toNat % 8 = 0)
+    (hslack : listLen + 9 ≤ bytes.length)
+    (hover : listBase.toNat + bytes.length < 2 ^ 64)
+    (hvalid : ∀ k, k < bytes.length →
+      isValidByteAccess (listBase + BitVec.ofNat 64 k) = true)
+    (hf0 : Success bytes listBase listLen 0 o0 l0) :
+    let savedCaller : Saved :=
+      { ra := raSaved, s0 := listBase, s1 := len, s2 := nonceOut, s3 := balanceOut,
+        s4 := rootOut, s5 := codeOut }
+    cpsTripleWithin (5 + ((7 * l0.toNat + 1) + 1)) (AB + 112) (AB + 164) fullCode
+      (((.x6 : Reg) ↦ᵣ l0) ** ((.x7 : Reg) ↦ᵣ (8 : Word)) ** ((.x5 : Reg) ↦ᵣ adLengthAddr) **
+       (adLengthAddr ↦ₘ l0) ** ((.x2 : Reg) ↦ᵣ spW) ** ((.x1 : Reg) ↦ᵣ (AB + 88)) **
+       ((.x8 : Reg) ↦ᵣ listBase) ** ((.x9 : Reg) ↦ᵣ len) ** ((.x18 : Reg) ↦ᵣ nonceOut) **
+       ((.x19 : Reg) ↦ᵣ balanceOut) ** ((.x20 : Reg) ↦ᵣ rootOut) ** ((.x21 : Reg) ↦ᵣ codeOut) **
+       stackFree spW 8 ** ((.x10 : Reg) ↦ᵣ (0 : Word)) ** ((.x11 : Reg) ↦ᵣ v11) **
+       ((.x12 : Reg) ↦ᵣ v12) ** ((.x13 : Reg) ↦ᵣ v13) ** ((.x14 : Reg) ↦ᵣ v14) **
+       ((.x28 : Reg) ↦ᵣ x28v) ** ((.x29 : Reg) ↦ᵣ x29v) **
+       regOwn .x30 ** regOwn .x31 ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+       bytesRegion listBase bytes ** (adOffsetAddr ↦ₘ o0) ** ((.x15 : Reg) ↦ᵣ codeOut) **
+       savedFrame spW savedCaller ** (nonceOut ↦ₘ oldNonce) **
+       bytesRegion balanceOut oldBal **
+       bytesRegion rootOut oldRoot ** bytesRegion codeOut oldCode)
+      (adCallPre (AB + 88) spW listBase len nonceOut balanceOut rootOut codeOut o0 l0
+        (0 : Word) v11 v12 v13 v14 bytes **
+       (savedFrame spW savedCaller ** (nonceOut ↦ₘ beAccum bytes o0.toNat l0.toNat) **
+        bytesRegion balanceOut oldBal **
+        bytesRegion rootOut oldRoot ** bytesRegion codeOut oldCode **
+        ((.x15 : Reg) ↦ᵣ codeOut))) := by
+  intro savedCaller
+  have hoffnorm : listBase + o0 = listBase + BitVec.ofNat 64 (o0.toNat + 0) := by
+    rw [Nat.add_zero]; congr 1
+    apply BitVec.eq_of_toNat_eq; rw [BitVec.toNat_ofNat, Nat.mod_eq_of_lt o0.isLt]
+  have hbound : o0.toNat + 0 + l0.toNat ≤ bytes.length := by
+    have hcb := adSuccessContentBound bytes listBase listLen 0 o0 l0 hslack hover hf0
+    omega
+  -- nonce source-cursor setup [28]-[32].
+  have hns := cpsTripleWithin_frameR
+    (((.x6 : Reg) ↦ᵣ l0) ** (adLengthAddr ↦ₘ l0) ** ((.x2 : Reg) ↦ᵣ spW) **
+     ((.x1 : Reg) ↦ᵣ (AB + 88)) ** ((.x9 : Reg) ↦ᵣ len) ** ((.x18 : Reg) ↦ᵣ nonceOut) **
+     ((.x19 : Reg) ↦ᵣ balanceOut) ** ((.x20 : Reg) ↦ᵣ rootOut) ** ((.x21 : Reg) ↦ᵣ codeOut) **
+     stackFree spW 8 ** ((.x10 : Reg) ↦ᵣ (0 : Word)) ** ((.x11 : Reg) ↦ᵣ v11) **
+     ((.x12 : Reg) ↦ᵣ v12) ** ((.x13 : Reg) ↦ᵣ v13) ** ((.x14 : Reg) ↦ᵣ v14) **
+     ((.x29 : Reg) ↦ᵣ x29v) ** regOwn .x30 ** regOwn .x31 ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+     bytesRegion listBase bytes ** ((.x15 : Reg) ↦ᵣ codeOut) ** savedFrame spW savedCaller **
+     (nonceOut ↦ₘ oldNonce) ** bytesRegion balanceOut oldBal **
+     bytesRegion rootOut oldRoot ** bytesRegion codeOut oldCode)
+    (by pcfa) (adNonceSetup listBase o0 adLengthAddr x28v (8 : Word))
+  -- nonce accumulate loop [33]-[39].
+  have hnl := cpsTripleWithin_frameR
+    (((.x5 : Reg) ↦ᵣ adOffsetAddr) ** (adLengthAddr ↦ₘ l0) ** ((.x2 : Reg) ↦ᵣ spW) **
+     ((.x1 : Reg) ↦ᵣ (AB + 88)) ** ((.x8 : Reg) ↦ᵣ listBase) ** ((.x9 : Reg) ↦ᵣ len) **
+     ((.x18 : Reg) ↦ᵣ nonceOut) ** ((.x19 : Reg) ↦ᵣ balanceOut) ** ((.x20 : Reg) ↦ᵣ rootOut) **
+     ((.x21 : Reg) ↦ᵣ codeOut) ** stackFree spW 8 ** ((.x10 : Reg) ↦ᵣ (0 : Word)) **
+     ((.x11 : Reg) ↦ᵣ v11) ** ((.x12 : Reg) ↦ᵣ v12) ** ((.x13 : Reg) ↦ᵣ v13) **
+     ((.x14 : Reg) ↦ᵣ v14) ** regOwn .x30 ** regOwn .x31 ** ((.x15 : Reg) ↦ᵣ codeOut) **
+     savedFrame spW savedCaller ** (nonceOut ↦ₘ oldNonce) ** bytesRegion balanceOut oldBal **
+     bytesRegion rootOut oldRoot ** bytesRegion codeOut oldCode ** (adOffsetAddr ↦ₘ o0))
+    (by pcfa) (adNonceLoop listBase bytes o0.toNat l0.toNat 0 x29v hsalign hbound hover hvalid)
+  -- nonce store [40].
+  have hst := cpsTripleWithin_frameR
+    (((.x5 : Reg) ↦ᵣ adOffsetAddr) ** (adLengthAddr ↦ₘ l0) ** ((.x2 : Reg) ↦ᵣ spW) **
+     ((.x1 : Reg) ↦ᵣ (AB + 88)) ** ((.x8 : Reg) ↦ᵣ listBase) ** ((.x9 : Reg) ↦ᵣ len) **
+     ((.x6 : Reg) ↦ᵣ (0 : Word)) ** ((.x19 : Reg) ↦ᵣ balanceOut) ** ((.x20 : Reg) ↦ᵣ rootOut) **
+     ((.x21 : Reg) ↦ᵣ codeOut) ** stackFree spW 8 ** ((.x10 : Reg) ↦ᵣ (0 : Word)) **
+     ((.x11 : Reg) ↦ᵣ v11) ** ((.x12 : Reg) ↦ᵣ v12) ** ((.x13 : Reg) ↦ᵣ v13) **
+     ((.x14 : Reg) ↦ᵣ v14) ** regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+     ((.x0 : Reg) ↦ᵣ (0 : Word)) ** bytesRegion listBase bytes ** ((.x15 : Reg) ↦ᵣ codeOut) **
+     savedFrame spW savedCaller ** bytesRegion balanceOut oldBal **
+     bytesRegion rootOut oldRoot ** bytesRegion codeOut oldCode ** (adOffsetAddr ↦ₘ o0))
+    (by pcfa) (adNonceStore nonceOut (beAccum bytes o0.toNat (0 + l0.toNat)) oldNonce)
+  -- bridge setup → loop.
+  have c1 := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by
+      rw [show BitVec.ofNat 64 l0.toNat = l0 from by bv_omega,
+        show beAccum bytes o0.toNat 0 = (0 : Word) from rfl,
+        show listBase + BitVec.ofNat 64 (o0.toNat + 0) = listBase + o0 from hoffnorm.symm]
+      xperm_hyp hp)
+    hns hnl
+  -- bridge loop → store.
+  have c2 := cpsTripleWithin_seq_perm_same_cr (fun h hp => by xperm_hyp hp) c1 hst
+  -- reshape store post into the field-1 call precondition.
+  refine cpsTripleWithin_mono_nSteps (by omega)
+    (cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp) (fun h hq => ?_) c2)
+  rw [show beAccum bytes o0.toNat (0 + l0.toNat) = beAccum bytes o0.toNat l0.toNat
+      from by rw [Nat.zero_add]] at hq
+  exact sepConj_mono_left
+    (adCallPre_weaken3 (AB + 88) spW listBase len nonceOut balanceOut rootOut codeOut o0 l0
+      (0 : Word) v11 v12 v13 v14 adOffsetAddr (0 : Word) (beAccum bytes o0.toNat l0.toNat) bytes)
+    h (by xperm_hyp hq)
+
+#print axioms adField0Copy
+
+set_option maxRecDepth 8000 in
+/-- Field-0 success tie (`AB+112 → raSaved`): the nonce copy (`adField0Copy`)
+    followed by the field-1 backbone (`adBBField1`). -/
+theorem adField0Success
+    (sp0 spW raSaved listBase len nonceOut balanceOut rootOut codeOut o0 oldNonce
+      x28v x29v v11 v12 v13 v14 : Word)
+    (bytes oldBal oldRoot oldCode : List (BitVec 8)) (listLen : Nat)
+    (hspW : spW = sp0 + signExtend12 (-64 : BitVec 12))
+    (hret : raSaved &&& ~~~(1 : Word) = raSaved)
+    (hlenW : len = BitVec.ofNat 64 listLen)
+    (hsalign : listBase.toNat % 8 = 0)
+    (hslack : listLen + 9 ≤ bytes.length)
+    (hover : listBase.toNat + bytes.length < 2 ^ 64)
+    (hvalid : ∀ k, k < bytes.length →
+      isValidByteAccess (listBase + BitVec.ofNat 64 k) = true)
+    (hbalign : balanceOut.toNat % 8 = 0)
+    (hbover : balanceOut.toNat + 32 < 2 ^ 64)
+    (hballen : oldBal.length = 32)
+    (hbvalid : ∀ k, k < 32 → isValidByteAccess (balanceOut + BitVec.ofNat 64 k) = true)
+    (hralign : rootOut.toNat % 8 = 0)
+    (hrover : rootOut.toNat + 32 < 2 ^ 64)
+    (hrootlen : oldRoot.length = 32)
+    (hrvalid : ∀ k, k < 32 → isValidByteAccess (rootOut + BitVec.ofNat 64 k) = true)
+    (hcalign : codeOut.toNat % 8 = 0)
+    (hcover : codeOut.toNat + 32 < 2 ^ 64)
+    (hcodelen : oldCode.length = 32)
+    (hcvalid : ∀ k, k < 32 → isValidByteAccess (codeOut + BitVec.ofNat 64 k) = true)
+    (hf0 : Success bytes listBase listLen 0 o0 l0)
+    (hl0 : l0.toNat ≤ 8) :
+    let savedCaller : Saved :=
+      { ra := raSaved, s0 := listBase, s1 := len, s2 := nonceOut, s3 := balanceOut,
+        s4 := rootOut, s5 := codeOut }
+    cpsTripleWithin (2144 + 7 * l0.toNat) (AB + 112) raSaved fullCode
+      (((.x6 : Reg) ↦ᵣ l0) ** ((.x7 : Reg) ↦ᵣ (8 : Word)) ** ((.x5 : Reg) ↦ᵣ adLengthAddr) **
+       (adLengthAddr ↦ₘ l0) ** ((.x2 : Reg) ↦ᵣ spW) ** ((.x1 : Reg) ↦ᵣ (AB + 88)) **
+       ((.x8 : Reg) ↦ᵣ listBase) ** ((.x9 : Reg) ↦ᵣ len) ** ((.x18 : Reg) ↦ᵣ nonceOut) **
+       ((.x19 : Reg) ↦ᵣ balanceOut) ** ((.x20 : Reg) ↦ᵣ rootOut) ** ((.x21 : Reg) ↦ᵣ codeOut) **
+       stackFree spW 8 ** ((.x10 : Reg) ↦ᵣ (0 : Word)) ** ((.x11 : Reg) ↦ᵣ v11) **
+       ((.x12 : Reg) ↦ᵣ v12) ** ((.x13 : Reg) ↦ᵣ v13) ** ((.x14 : Reg) ↦ᵣ v14) **
+       ((.x28 : Reg) ↦ᵣ x28v) ** ((.x29 : Reg) ↦ᵣ x29v) **
+       regOwn .x30 ** regOwn .x31 ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+       bytesRegion listBase bytes ** (adOffsetAddr ↦ₘ o0) ** ((.x15 : Reg) ↦ᵣ codeOut) **
+       savedFrame spW savedCaller ** (nonceOut ↦ₘ oldNonce) **
+       bytesRegion balanceOut oldBal **
+       bytesRegion rootOut oldRoot ** bytesRegion codeOut oldCode)
+      (adWholePost sp0 spW savedCaller listBase listLen bytes oldRoot oldCode) := by
+  intro savedCaller
+  have hcopy := adField0Copy spW raSaved listBase len nonceOut balanceOut rootOut codeOut
+    o0 oldNonce x28v x29v v11 v12 v13 v14 bytes oldBal oldRoot oldCode listLen
+    hsalign hslack hover hvalid hf0
+  have hbb := adBBField1 sp0 spW (AB + 88) raSaved listBase len nonceOut balanceOut rootOut
+    codeOut o0 l0 (0 : Word) v11 v12 v13 v14 o0 l0 bytes oldBal oldRoot oldCode listLen hspW hret
+    hlenW hsalign hslack hover hvalid hbalign hbover hballen hbvalid hralign hrover hrootlen
+    hrvalid hcalign hcover hcodelen hcvalid hf0 hl0
+  exact cpsTripleWithin_mono_nSteps (by omega)
+    (cpsTripleWithin_seq_perm_same_cr (fun h hp => by xperm_hyp hp) hcopy hbb)
+
+#print axioms adField0Success
+
+set_option maxRecDepth 8000 in
+/-- Field-0 continue (`AB+92 → raSaved`): the nonce continue edge.  The `len ≤ 8`
+    length check gates the nonce copy (`adField0Success`) or the `field0Len`
+    failure. -/
+theorem adField0ContEpi
+    (sp0 spW raSaved listBase len nonceOut balanceOut rootOut codeOut oldNonce : Word)
+    (bytes oldBal oldRoot oldCode : List (BitVec 8)) (listLen : Nat)
+    (hspW : spW = sp0 + signExtend12 (-64 : BitVec 12))
+    (hret : raSaved &&& ~~~(1 : Word) = raSaved)
+    (hlenW : len = BitVec.ofNat 64 listLen)
+    (hsalign : listBase.toNat % 8 = 0)
+    (hslack : listLen + 9 ≤ bytes.length)
+    (hover : listBase.toNat + bytes.length < 2 ^ 64)
+    (hvalid : ∀ k, k < bytes.length →
+      isValidByteAccess (listBase + BitVec.ofNat 64 k) = true)
+    (hbalign : balanceOut.toNat % 8 = 0)
+    (hbover : balanceOut.toNat + 32 < 2 ^ 64)
+    (hballen : oldBal.length = 32)
+    (hbvalid : ∀ k, k < 32 → isValidByteAccess (balanceOut + BitVec.ofNat 64 k) = true)
+    (hralign : rootOut.toNat % 8 = 0)
+    (hrover : rootOut.toNat + 32 < 2 ^ 64)
+    (hrootlen : oldRoot.length = 32)
+    (hrvalid : ∀ k, k < 32 → isValidByteAccess (rootOut + BitVec.ofNat 64 k) = true)
+    (hcalign : codeOut.toNat % 8 = 0)
+    (hcover : codeOut.toNat + 32 < 2 ^ 64)
+    (hcodelen : oldCode.length = 32)
+    (hcvalid : ∀ k, k < 32 → isValidByteAccess (codeOut + BitVec.ofNat 64 k) = true) :
+    let saved0 : Saved :=
+      { ra := AB + 88, s0 := listBase, s1 := len, s2 := nonceOut, s3 := balanceOut,
+        s4 := rootOut, s5 := codeOut }
+    let savedCaller : Saved :=
+      { ra := raSaved, s0 := listBase, s1 := len, s2 := nonceOut, s3 := balanceOut,
+        s4 := rootOut, s5 := codeOut }
+    cpsTripleWithin (5 + 2200) (AB + 92) raSaved fullCode
+      (adK20ContPost spW listBase 0 saved0 bytes listLen **
+       (savedFrame spW savedCaller ** (nonceOut ↦ₘ oldNonce) **
+        bytesRegion balanceOut oldBal **
+        bytesRegion rootOut oldRoot ** bytesRegion codeOut oldCode **
+        ((.x15 : Reg) ↦ᵣ codeOut)))
+      (adWholePost sp0 spW savedCaller listBase listLen bytes oldRoot oldCode) := by
+  intro saved0 savedCaller
+  -- (1) expose the K20 continue existentials, keeping x5/x6/x7 owned.
+  refine cpsTripleWithin_weaken
+    (P := fun h => ∃ offset len' v11 v12,
+      (((⌜Success bytes listBase listLen 0 offset len'⌝ : Assertion) **
+        ((.x2 : Reg) ↦ᵣ spW) ** regsAt listNthFrame (savedVals saved0) ** stackFree spW 8 **
+        ((.x10 : Reg) ↦ᵣ (0 : Word)) ** ((.x11 : Reg) ↦ᵣ v11) ** ((.x12 : Reg) ↦ᵣ v12) **
+        regOwn .x13 ** regOwn .x14 ** regOwn .x28 ** regOwn .x29 ** regOwn .x30 **
+        regOwn .x31 ** ((.x0 : Reg) ↦ᵣ (0 : Word)) ** bytesRegion listBase bytes **
+        (adOffsetAddr ↦ₘ offset) ** (adLengthAddr ↦ₘ len') ** savedFrame spW savedCaller **
+        (nonceOut ↦ₘ oldNonce) ** bytesRegion balanceOut oldBal **
+        bytesRegion rootOut oldRoot ** bytesRegion codeOut oldCode **
+        ((.x15 : Reg) ↦ᵣ codeOut)) ** regOwn .x5 ** regOwn .x6 ** regOwn .x7) h)
+    (fun h hp => by
+      obtain ⟨h1, h2, hd, hu, hcont, hacc⟩ := hp
+      unfold adK20ContPost at hcont
+      obtain ⟨offset, len', v11, v12, hbody⟩ := hcont
+      refine ⟨offset, len', v11, v12, ?_⟩
+      have hcomb : (_ ** _) h := ⟨h1, h2, hd, hu, hbody, hacc⟩
+      xperm_hyp hcomb)
+    (fun _ hq => hq) ?_
+  refine cpsTripleWithin_exists_pre_gen (fun offset => ?_)
+  refine cpsTripleWithin_exists_pre_gen (fun len' => ?_)
+  refine cpsTripleWithin_exists_pre_gen (fun v11 => ?_)
+  refine cpsTripleWithin_exists_pre_gen (fun v12 => ?_)
+  refine cpsTripleWithin_of_forall_regIs_to_regOwn3 (fun v5 v6 v7 => ?_)
+  -- (2) continue reshape into length-check pre plus the ambient continue frame.
+  refine cpsTripleWithin_weaken
+    (P := (((.x5 : Reg) ↦ᵣ v5) ** ((.x6 : Reg) ↦ᵣ v6) ** ((.x7 : Reg) ↦ᵣ v7) **
+        (adLengthAddr ↦ₘ len')) **
+       (adContFrame spW listBase 0 saved0 bytes listLen offset len' v11 v12 **
+        savedFrame spW savedCaller ** (nonceOut ↦ₘ oldNonce) **
+        bytesRegion balanceOut oldBal **
+        bytesRegion rootOut oldRoot ** bytesRegion codeOut oldCode **
+        ((.x15 : Reg) ↦ᵣ codeOut)))
+    (fun h hp => by
+      have hin : (((⌜Success bytes listBase listLen 0 offset len'⌝ : Assertion) **
+          ((((.x2 : Reg) ↦ᵣ spW) ** regsAt listNthFrame (savedVals saved0) ** stackFree spW 8) **
+           (((.x10 : Reg) ↦ᵣ (0 : Word)) ** ((.x5 : Reg) ↦ᵣ v5) ** ((.x6 : Reg) ↦ᵣ v6) **
+            ((.x7 : Reg) ↦ᵣ v7) ** ((.x11 : Reg) ↦ᵣ v11) ** ((.x12 : Reg) ↦ᵣ v12) **
+            regOwn .x13 ** regOwn .x14 ** regOwn .x28 ** regOwn .x29 ** regOwn .x30 **
+            regOwn .x31 ** ((.x0 : Reg) ↦ᵣ (0 : Word)) ** bytesRegion listBase bytes **
+            (adOffsetAddr ↦ₘ offset) ** (adLengthAddr ↦ₘ len')))) **
+          (savedFrame spW savedCaller ** (nonceOut ↦ₘ oldNonce) **
+           bytesRegion balanceOut oldBal **
+           bytesRegion rootOut oldRoot ** bytesRegion codeOut oldCode **
+           ((.x15 : Reg) ↦ᵣ codeOut))) h := by xperm_hyp hp
+      have hout := sepConj_mono_left (adContReshape spW listBase 0 saved0 bytes listLen offset len'
+        v11 v12 v5 v6 v7) h hin
+      xperm_hyp hout)
+    (fun _ hq => hq) ?_
+  -- (3) length-check branch, framed by the continue frame plus the output cells.
+  have hbr := cpsBranchWithin_frameR
+    (adContFrame spW listBase 0 saved0 bytes listLen offset len' v11 v12 **
+     savedFrame spW savedCaller ** (nonceOut ↦ₘ oldNonce) **
+     bytesRegion balanceOut oldBal **
+     bytesRegion rootOut oldRoot ** bytesRegion codeOut oldCode **
+     ((.x15 : Reg) ↦ᵣ codeOut))
+    (by pcfa) (adNonceLenCheck v5 v6 v7 len')
+  refine cpsBranchWithin_merge_same_cr hbr ?fail ?cont
+  case fail =>
+    -- 8 < len: field0Len failure through the shared fail arm.
+    refine cpsTripleWithin_weaken (fun h hp => ?_) (fun _ hq => hq)
+      (cpsTripleWithin_mono_nSteps (show (1 + 9) ≤ 2200 from by omega)
+        (adFailArm sp0 spW savedCaller listBase bytes oldRoot oldCode listLen hspW
+          (show savedCaller.ra &&& ~~~(1 : Word) = savedCaller.ra from hret)))
+    unfold adContFrame at hp
+    rw [regsAt_listNthFrame] at hp
+    have hf0 : Success bytes listBase listLen 0 offset len' := by
+      obtain ⟨_, _, _, _, _, hr⟩ := hp
+      obtain ⟨_, _, _, _, hcf, _⟩ := hr
+      exact ((sepConj_pure_left _).1 hcf).1
+    have hgt : 8 < len'.toNat := by
+      have hult : BitVec.ult (8 : Word) len' = true := by
+        obtain ⟨_, _, _, _, hfp, _⟩ := hp
+        obtain ⟨_, _, _, _, hAgrp, _⟩ := hfp
+        obtain ⟨_, _, _, _, _, hA2⟩ := hAgrp
+        exact ((sepConj_pure_right _).1 hA2).2
+      have h8 : ((8 : Word)).toNat = 8 := by decide
+      simp only [BitVec.ult, decide_eq_true_eq] at hult; omega
+    have hDF : DecodeFailure bytes listBase listLen := DecodeFailure.field0Len offset len' hf0 hgt
+    have hgP : ((⌜Success bytes listBase listLen 0 offset len'⌝ : Assertion) **
+        (⌜BitVec.ult (8 : Word) len' = true⌝ : Assertion) **
+        ((((.x2 : Reg) ↦ᵣ spW) **
+         (((.x1 : Reg) ↦ᵣ (AB + 88)) ** ((.x8 : Reg) ↦ᵣ listBase) ** ((.x9 : Reg) ↦ᵣ len) **
+          ((.x18 : Reg) ↦ᵣ nonceOut) ** ((.x19 : Reg) ↦ᵣ balanceOut) **
+          ((.x20 : Reg) ↦ᵣ saved0.s4) ** ((.x21 : Reg) ↦ᵣ codeOut)) **
+         savedFrame spW savedCaller) **
+        ((nonceOut ↦ₘ oldNonce) **
+         bytesRegion balanceOut oldBal **
+         bytesRegion rootOut oldRoot ** bytesRegion codeOut oldCode **
+         bytesRegion listBase bytes ** (adOffsetAddr ↦ₘ offset) ** (adLengthAddr ↦ₘ len') **
+         stackFree spW 8 **
+         (((.x5 : Reg) ↦ᵣ adLengthAddr) ** ((.x6 : Reg) ↦ᵣ len') ** ((.x7 : Reg) ↦ᵣ (8 : Word)) **
+          ((.x11 : Reg) ↦ᵣ v11) ** ((.x12 : Reg) ↦ᵣ v12) ** regOwn .x13 ** regOwn .x14 **
+          regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+          ((.x15 : Reg) ↦ᵣ codeOut)))) ** ((.x10 : Reg) ↦ᵣ (0 : Word))) h := by xperm_hyp hp
+    have hg := ((sepConj_pure_left h).1 (((sepConj_pure_left h).1 hgP).2)).2
+    exact sepConj_mono (sepConj_mono
+      (sepConj_mono_right (sepConj_mono_left (fun h' hr => listNthFrameRegs_implies_owned
+        listBase len nonceOut balanceOut saved0.s4 codeOut h'
+        (sepConj_mono_left (regIs_implies_regOwn .x1) h' hr))))
+      (fun h' hc => (sepConj_pure_left h').2
+        ⟨hDF, oldNonce, offset, len', oldBal, oldRoot, oldCode,
+          sepConj_mono_right (sepConj_mono_right (sepConj_mono_right (sepConj_mono_right
+            (sepConj_mono_right (sepConj_mono_right (sepConj_mono_right (sepConj_mono_right
+              (adScratch_of_regs_own codeOut adLengthAddr len' (8 : Word) v11 v12)))))))) h' hc⟩))
+      (regIs_implies_regOwn .x10) h hg
+  case cont =>
+    -- len ≤ 8: the nonce-copy success tie.  Introduce x13/x14/x28/x29.
+    refine cpsTripleWithin_weaken
+      (P := ((⌜Success bytes listBase listLen 0 offset len'⌝ : Assertion) **
+        (⌜¬ BitVec.ult (8 : Word) len'⌝ : Assertion) **
+        ((.x6 : Reg) ↦ᵣ len') ** ((.x7 : Reg) ↦ᵣ (8 : Word)) ** ((.x5 : Reg) ↦ᵣ adLengthAddr) **
+        (adLengthAddr ↦ₘ len') ** ((.x2 : Reg) ↦ᵣ spW) ** ((.x1 : Reg) ↦ᵣ (AB + 88)) **
+        ((.x8 : Reg) ↦ᵣ listBase) ** ((.x9 : Reg) ↦ᵣ len) ** ((.x18 : Reg) ↦ᵣ nonceOut) **
+        ((.x19 : Reg) ↦ᵣ balanceOut) ** ((.x20 : Reg) ↦ᵣ saved0.s4) ** ((.x21 : Reg) ↦ᵣ codeOut) **
+        stackFree spW 8 ** ((.x10 : Reg) ↦ᵣ (0 : Word)) ** ((.x11 : Reg) ↦ᵣ v11) **
+        ((.x12 : Reg) ↦ᵣ v12) ** regOwn .x30 ** regOwn .x31 **
+        ((.x0 : Reg) ↦ᵣ (0 : Word)) ** bytesRegion listBase bytes **
+        (adOffsetAddr ↦ₘ offset) ** ((.x15 : Reg) ↦ᵣ codeOut) ** savedFrame spW savedCaller **
+        (nonceOut ↦ₘ oldNonce) ** bytesRegion balanceOut oldBal **
+        bytesRegion rootOut oldRoot ** bytesRegion codeOut oldCode) **
+        regOwn .x13 ** regOwn .x14 ** regOwn .x28 ** regOwn .x29)
+      (fun h hp => by unfold adContFrame at hp; rw [regsAt_listNthFrame] at hp; xperm_hyp hp)
+      (fun _ hq => hq) ?_
+    refine cpsTripleWithin_of_forall_regIs_to_regOwn4 (fun v13 v14 x28v x29v => ?_)
+    refine cpsTripleWithin_weaken
+      (P := (⌜Success bytes listBase listLen 0 offset len'⌝ : Assertion) **
+        (⌜¬ BitVec.ult (8 : Word) len'⌝ : Assertion) **
+        (((.x6 : Reg) ↦ᵣ len') ** ((.x7 : Reg) ↦ᵣ (8 : Word)) ** ((.x5 : Reg) ↦ᵣ adLengthAddr) **
+         (adLengthAddr ↦ₘ len') ** ((.x2 : Reg) ↦ᵣ spW) ** ((.x1 : Reg) ↦ᵣ (AB + 88)) **
+         ((.x8 : Reg) ↦ᵣ listBase) ** ((.x9 : Reg) ↦ᵣ len) ** ((.x18 : Reg) ↦ᵣ nonceOut) **
+         ((.x19 : Reg) ↦ᵣ balanceOut) ** ((.x20 : Reg) ↦ᵣ saved0.s4) ** ((.x21 : Reg) ↦ᵣ codeOut) **
+         stackFree spW 8 ** ((.x10 : Reg) ↦ᵣ (0 : Word)) ** ((.x11 : Reg) ↦ᵣ v11) **
+         ((.x12 : Reg) ↦ᵣ v12) ** ((.x13 : Reg) ↦ᵣ v13) ** ((.x14 : Reg) ↦ᵣ v14) **
+         ((.x28 : Reg) ↦ᵣ x28v) ** ((.x29 : Reg) ↦ᵣ x29v) **
+         regOwn .x30 ** regOwn .x31 ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+         bytesRegion listBase bytes ** (adOffsetAddr ↦ₘ offset) ** ((.x15 : Reg) ↦ᵣ codeOut) **
+         savedFrame spW savedCaller ** (nonceOut ↦ₘ oldNonce) **
+         bytesRegion balanceOut oldBal **
+         bytesRegion rootOut oldRoot ** bytesRegion codeOut oldCode))
+      (fun h hp => by xperm_hyp hp) (fun _ hq => hq) ?_
+    refine cpsTripleWithin_pure_pre (fun hf0 => ?_)
+    refine cpsTripleWithin_pure_pre (fun hult => ?_)
+    have hl0 : len'.toNat ≤ 8 := by
+      have h8 : ((8 : Word)).toNat = 8 := by decide
+      by_contra hc; exact hult (by simp only [BitVec.ult, decide_eq_true_eq]; omega)
+    exact cpsTripleWithin_mono_nSteps (show 2144 + 7 * len'.toNat ≤ 2200 from by omega)
+      (adField0Success sp0 spW raSaved listBase len nonceOut balanceOut rootOut codeOut
+        offset oldNonce x28v x29v v11 v12 v13 v14 bytes oldBal oldRoot oldCode listLen hspW hret
+        hlenW hsalign hslack hover hvalid hbalign hbover hballen hbvalid hralign hrover hrootlen
+        hrvalid hcalign hcover hcodelen hcvalid hf0 hl0)
+
+#print axioms adField0ContEpi
+
+set_option maxRecDepth 8000 in
+/-- Field-0 (nonce) backbone (`AB+56 → raSaved`): merge the field-0 stage's
+    parse-fail edge (`field0List`) with the continue edge (`adField0ContEpi`).
+    All four output cells are untouched on entry. -/
+theorem adBBField0
+    (sp0 spW raEntry raSaved listBase len nonceOut balanceOut rootOut codeOut
+      oldOffset oldLen v10 v11 v12 v13 v14 oldNonce : Word)
+    (bytes oldBal oldRoot oldCode : List (BitVec 8)) (listLen : Nat)
+    (hspW : spW = sp0 + signExtend12 (-64 : BitVec 12))
+    (hret : raSaved &&& ~~~(1 : Word) = raSaved)
+    (hlenW : len = BitVec.ofNat 64 listLen)
+    (hsalign : listBase.toNat % 8 = 0)
+    (hslack : listLen + 9 ≤ bytes.length)
+    (hover : listBase.toNat + bytes.length < 2 ^ 64)
+    (hvalid : ∀ k, k < bytes.length →
+      isValidByteAccess (listBase + BitVec.ofNat 64 k) = true)
+    (hbalign : balanceOut.toNat % 8 = 0)
+    (hbover : balanceOut.toNat + 32 < 2 ^ 64)
+    (hballen : oldBal.length = 32)
+    (hbvalid : ∀ k, k < 32 → isValidByteAccess (balanceOut + BitVec.ofNat 64 k) = true)
+    (hralign : rootOut.toNat % 8 = 0)
+    (hrover : rootOut.toNat + 32 < 2 ^ 64)
+    (hrootlen : oldRoot.length = 32)
+    (hrvalid : ∀ k, k < 32 → isValidByteAccess (rootOut + BitVec.ofNat 64 k) = true)
+    (hcalign : codeOut.toNat % 8 = 0)
+    (hcover : codeOut.toNat + 32 < 2 ^ 64)
+    (hcodelen : oldCode.length = 32)
+    (hcvalid : ∀ k, k < 32 → isValidByteAccess (codeOut + BitVec.ofNat 64 k) = true) :
+    let savedCaller : Saved :=
+      { ra := raSaved, s0 := listBase, s1 := len, s2 := nonceOut, s3 := balanceOut,
+        s4 := rootOut, s5 := codeOut }
+    cpsTripleWithin (((7 + (1 + ((12 + ((85 + 93 * (0 + 2)) + 6)) + 9))) + 1) + 2205)
+      (AB + 56) raSaved fullCode
+      (adCallPre raEntry spW listBase len nonceOut balanceOut rootOut codeOut oldOffset oldLen
+        v10 v11 v12 v13 v14 bytes **
+       (savedFrame spW savedCaller ** (nonceOut ↦ₘ oldNonce) **
+        bytesRegion balanceOut oldBal **
+        bytesRegion rootOut oldRoot ** bytesRegion codeOut oldCode **
+        ((.x15 : Reg) ↦ᵣ codeOut)))
+      (adWholePost sp0 spW savedCaller listBase listLen bytes oldRoot oldCode) := by
+  intro savedCaller
+  have hstage := adField0Stage spW raEntry listBase len nonceOut balanceOut rootOut codeOut
+    oldOffset oldLen v10 v11 v12 v13 v14 bytes listLen hlenW hsalign hslack hover hvalid
+  have hbr := cpsBranchWithin_frameR
+    (savedFrame spW savedCaller ** (nonceOut ↦ₘ oldNonce) **
+     bytesRegion balanceOut oldBal **
+     bytesRegion rootOut oldRoot ** bytesRegion codeOut oldCode **
+     ((.x15 : Reg) ↦ᵣ codeOut))
+    (by pcfa) hstage
+  refine cpsBranchWithin_merge_same_cr hbr ?fail ?cont
+  case cont =>
+    exact cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp) (fun _ hq => hq)
+      (adField0ContEpi sp0 spW raSaved listBase len nonceOut balanceOut rootOut codeOut oldNonce
+        bytes oldBal oldRoot oldCode listLen hspW hret hlenW hsalign hslack hover hvalid hbalign
+        hbover hballen hbvalid hralign hrover hrootlen hrvalid hcalign hcover hcodelen hcvalid)
+  case fail =>
+    refine cpsTripleWithin_weaken (fun h hp => ?_) (fun _ hq => hq)
+      (cpsTripleWithin_mono_nSteps (show (1 + 9) ≤ 2205 from by omega)
+        (adFailArm sp0 spW savedCaller listBase bytes oldRoot oldCode listLen hspW
+          (show savedCaller.ra &&& ~~~(1 : Word) = savedCaller.ra from hret)))
+    obtain ⟨h1, h2, hd, hu, hfail, hacc⟩ := hp
+    unfold adK20FailPost at hfail
+    obtain ⟨status, offset', len', v11', v12', hbody⟩ := hfail
+    have hResPair : Result bytes listBase listLen 0 oldOffset oldLen status offset' len' ∧
+        status ≠ (0 : Word) := ((sepConj_pure_left h1).1 hbody).1
+    have hFail : Failure bytes listBase listLen 0 := by
+      cases hResPair.1 with
+      | ok o l hs => exact absurd rfl hResPair.2
+      | fail hf => exact hf
+    have hDF : DecodeFailure bytes listBase listLen := DecodeFailure.field0List hFail
+    have hbig := ((sepConj_pure_left h1).1 hbody).2
+    rw [regsAt_listNthFrame] at hbig
+    have hgP : (((((.x2 : Reg) ↦ᵣ spW) **
+        (((.x1 : Reg) ↦ᵣ (AB + 88)) ** ((.x8 : Reg) ↦ᵣ listBase) ** ((.x9 : Reg) ↦ᵣ len) **
+         ((.x18 : Reg) ↦ᵣ nonceOut) ** ((.x19 : Reg) ↦ᵣ balanceOut) **
+         ((.x20 : Reg) ↦ᵣ rootOut) ** ((.x21 : Reg) ↦ᵣ codeOut)) **
+        savedFrame spW savedCaller) **
+       ((nonceOut ↦ₘ oldNonce) **
+        bytesRegion balanceOut oldBal **
+        bytesRegion rootOut oldRoot ** bytesRegion codeOut oldCode **
+        bytesRegion listBase bytes ** (adOffsetAddr ↦ₘ offset') ** (adLengthAddr ↦ₘ len') **
+        stackFree spW 8 **
+        (regOwn .x5 ** regOwn .x6 ** regOwn .x7 ** ((.x11 : Reg) ↦ᵣ v11') **
+         ((.x12 : Reg) ↦ᵣ v12') ** regOwn .x13 ** regOwn .x14 **
+         regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+         ((.x15 : Reg) ↦ᵣ codeOut)))) ** ((.x10 : Reg) ↦ᵣ status)) h := by
+      have hcomb : (_ ** _) h := ⟨h1, h2, hd, hu, hbig, hacc⟩
+      xperm_hyp hcomb
+    exact sepConj_mono (sepConj_mono
+      (sepConj_mono_right (sepConj_mono_left (fun h' hr => listNthFrameRegs_implies_owned
+        listBase len nonceOut balanceOut rootOut codeOut h'
+        (sepConj_mono_left (regIs_implies_regOwn .x1) h' hr))))
+      (fun h' hc => (sepConj_pure_left h').2
+        ⟨hDF, oldNonce, offset', len', oldBal, oldRoot, oldCode,
+          sepConj_mono_right (sepConj_mono_right (sepConj_mono_right (sepConj_mono_right
+            (sepConj_mono_right (sepConj_mono_right (sepConj_mono_right (sepConj_mono_right
+              (adScratch_of_regs_own2 codeOut v11' v12')))))))) h' hc⟩))
+      (regIs_implies_regOwn .x10) h hgP
+
+#print axioms adBBField0
+
 end EvmAsm.Codegen.AccountDecodeSpec

--- a/EvmAsm/Codegen/Programs/AccountDecodeDispatch.lean
+++ b/EvmAsm/Codegen/Programs/AccountDecodeDispatch.lean
@@ -1,0 +1,337 @@
+/-
+  The per-field length-check dispatches of `accountDecode_prog`
+  (`Programs/State.lean`, PR-K27).  After each field's K20 call succeeds, the
+  selected content length (`ad_length` cell) is loaded and compared:
+
+    * field 0 (nonce)   [23]-[27] (`AB+92 → 504/112`):  `bltu 8, len`  → fail if `8 < len`.
+    * field 1 (balance) [50]-[54] (`AB+200 → 504/220`): `bltu 32, len` → fail if `32 < len`.
+    * field 2 (root)    [81]-[85] (`AB+324 → 504/344`): `bne  len, 32` → fail if `len ≠ 32`.
+    * field 3 (code)    [107]-[111] (`AB+428 → 504/448`): `bne len, 32` → fail if `len ≠ 32`.
+
+  Each dispatch is `la x5, ad_length ;; ld x6 ;; li x7,imm ;; branch`, a
+  five-step `cpsBranchWithin` with the shared failure edge `AB+504` (the
+  `li a0,1` fail tail) and a per-field continue edge.  Mirrors
+  `WithdrawalDecodeSpec.wdLenCheck`.
+
+  No `sorry`/`admit`/`native_decide`/`bv_decide`; classical-3 axioms only.
+-/
+
+import EvmAsm.Codegen.Programs.AccountDecodeCall
+import EvmAsm.Rv64.LaResolve
+
+namespace EvmAsm.Codegen.AccountDecodeSpec
+
+open EvmAsm.Rv64 EvmAsm.Rv64.SAsm
+
+/-! ## `la x5, ad_length` materialisers for the four length-check sites -/
+
+/-- `la x5, ad_length` at field 0 [23]-[24] (`AB+92 → AB+100`). -/
+private theorem adLaLenX5_92 (v : Word) :
+    cpsTripleWithin 2 (AB + 92) (AB + 100) fullCode
+      (.x5 ↦ᵣ v) (.x5 ↦ᵣ adLengthAddr) := by
+  have hau : ∀ a i, CodeReq.singleton (AB + 92)
+      (.AUIPC .x5 (Codegen.laHi GuestAddrs.ad_length (GuestAddrs.account_decode + 92)))
+        a = some i → fullCode a = some i := fun a i hi => ad_mono a i
+    (CodeReq.ofProg_mem_at AB (AB + 92) accountDecode_prog 23
+      (.AUIPC .x5 (Codegen.laHi GuestAddrs.ad_length (GuestAddrs.account_decode + 92)))
+      (by bv_omega) (by rw [ad_length]; decide) rfl (by rw [ad_length]; decide) a i hi)
+  have had : ∀ a i, CodeReq.singleton (AB + 96)
+      (.ADDI .x5 .x5 (Codegen.laLo GuestAddrs.ad_length (GuestAddrs.account_decode + 92)))
+        a = some i → fullCode a = some i := fun a i hi => ad_mono a i
+    (CodeReq.ofProg_mem_at AB (AB + 96) accountDecode_prog 24
+      (.ADDI .x5 .x5 (Codegen.laLo GuestAddrs.ad_length (GuestAddrs.account_decode + 92)))
+      (by bv_omega) (by rw [ad_length]; decide) rfl (by rw [ad_length]; decide) a i hi)
+  have h := la_materialize_within .x5 v (AB + 92) adLengthAddr (by decide) (by decide) hau had
+  rw [show (AB + 92 : Word) + 8 = AB + 100 from by bv_omega] at h
+  exact h
+
+/-- `la x5, ad_length` at field 1 [50]-[51] (`AB+200 → AB+208`). -/
+private theorem adLaLenX5_200 (v : Word) :
+    cpsTripleWithin 2 (AB + 200) (AB + 208) fullCode
+      (.x5 ↦ᵣ v) (.x5 ↦ᵣ adLengthAddr) := by
+  have hau : ∀ a i, CodeReq.singleton (AB + 200)
+      (.AUIPC .x5 (Codegen.laHi GuestAddrs.ad_length (GuestAddrs.account_decode + 200)))
+        a = some i → fullCode a = some i := fun a i hi => ad_mono a i
+    (CodeReq.ofProg_mem_at AB (AB + 200) accountDecode_prog 50
+      (.AUIPC .x5 (Codegen.laHi GuestAddrs.ad_length (GuestAddrs.account_decode + 200)))
+      (by bv_omega) (by rw [ad_length]; decide) rfl (by rw [ad_length]; decide) a i hi)
+  have had : ∀ a i, CodeReq.singleton (AB + 204)
+      (.ADDI .x5 .x5 (Codegen.laLo GuestAddrs.ad_length (GuestAddrs.account_decode + 200)))
+        a = some i → fullCode a = some i := fun a i hi => ad_mono a i
+    (CodeReq.ofProg_mem_at AB (AB + 204) accountDecode_prog 51
+      (.ADDI .x5 .x5 (Codegen.laLo GuestAddrs.ad_length (GuestAddrs.account_decode + 200)))
+      (by bv_omega) (by rw [ad_length]; decide) rfl (by rw [ad_length]; decide) a i hi)
+  have h := la_materialize_within .x5 v (AB + 200) adLengthAddr (by decide) (by decide) hau had
+  rw [show (AB + 200 : Word) + 8 = AB + 208 from by bv_omega] at h
+  exact h
+
+/-- `la x5, ad_length` at field 2 [81]-[82] (`AB+324 → AB+332`). -/
+private theorem adLaLenX5_324 (v : Word) :
+    cpsTripleWithin 2 (AB + 324) (AB + 332) fullCode
+      (.x5 ↦ᵣ v) (.x5 ↦ᵣ adLengthAddr) := by
+  have hau : ∀ a i, CodeReq.singleton (AB + 324)
+      (.AUIPC .x5 (Codegen.laHi GuestAddrs.ad_length (GuestAddrs.account_decode + 324)))
+        a = some i → fullCode a = some i := fun a i hi => ad_mono a i
+    (CodeReq.ofProg_mem_at AB (AB + 324) accountDecode_prog 81
+      (.AUIPC .x5 (Codegen.laHi GuestAddrs.ad_length (GuestAddrs.account_decode + 324)))
+      (by bv_omega) (by rw [ad_length]; decide) rfl (by rw [ad_length]; decide) a i hi)
+  have had : ∀ a i, CodeReq.singleton (AB + 328)
+      (.ADDI .x5 .x5 (Codegen.laLo GuestAddrs.ad_length (GuestAddrs.account_decode + 324)))
+        a = some i → fullCode a = some i := fun a i hi => ad_mono a i
+    (CodeReq.ofProg_mem_at AB (AB + 328) accountDecode_prog 82
+      (.ADDI .x5 .x5 (Codegen.laLo GuestAddrs.ad_length (GuestAddrs.account_decode + 324)))
+      (by bv_omega) (by rw [ad_length]; decide) rfl (by rw [ad_length]; decide) a i hi)
+  have h := la_materialize_within .x5 v (AB + 324) adLengthAddr (by decide) (by decide) hau had
+  rw [show (AB + 324 : Word) + 8 = AB + 332 from by bv_omega] at h
+  exact h
+
+/-- `la x5, ad_length` at field 3 [107]-[108] (`AB+428 → AB+436`). -/
+private theorem adLaLenX5_428 (v : Word) :
+    cpsTripleWithin 2 (AB + 428) (AB + 436) fullCode
+      (.x5 ↦ᵣ v) (.x5 ↦ᵣ adLengthAddr) := by
+  have hau : ∀ a i, CodeReq.singleton (AB + 428)
+      (.AUIPC .x5 (Codegen.laHi GuestAddrs.ad_length (GuestAddrs.account_decode + 428)))
+        a = some i → fullCode a = some i := fun a i hi => ad_mono a i
+    (CodeReq.ofProg_mem_at AB (AB + 428) accountDecode_prog 107
+      (.AUIPC .x5 (Codegen.laHi GuestAddrs.ad_length (GuestAddrs.account_decode + 428)))
+      (by bv_omega) (by rw [ad_length]; decide) rfl (by rw [ad_length]; decide) a i hi)
+  have had : ∀ a i, CodeReq.singleton (AB + 432)
+      (.ADDI .x5 .x5 (Codegen.laLo GuestAddrs.ad_length (GuestAddrs.account_decode + 428)))
+        a = some i → fullCode a = some i := fun a i hi => ad_mono a i
+    (CodeReq.ofProg_mem_at AB (AB + 432) accountDecode_prog 108
+      (.ADDI .x5 .x5 (Codegen.laLo GuestAddrs.ad_length (GuestAddrs.account_decode + 428)))
+      (by bv_omega) (by rw [ad_length]; decide) rfl (by rw [ad_length]; decide) a i hi)
+  have h := la_materialize_within .x5 v (AB + 428) adLengthAddr (by decide) (by decide) hau had
+  rw [show (AB + 428 : Word) + 8 = AB + 436 from by bv_omega] at h
+  exact h
+
+set_option maxRecDepth 8000 in
+/-- Field-0 (nonce) length check [23]-[27] (`AB+92 → 504/112`): `bltu 8, len`.
+    Fail edge (`AB+504`, `8 < len`) or continue (`AB+112`, `len ≤ 8`). -/
+theorem adNonceLenCheck (v5old v6old v7old len : Word) :
+    cpsBranchWithin 5 (AB + 92) fullCode
+      (((.x5 : Reg) ↦ᵣ v5old) ** ((.x6 : Reg) ↦ᵣ v6old) **
+       ((.x7 : Reg) ↦ᵣ v7old) ** (adLengthAddr ↦ₘ len))
+      (AB + 504)
+        ((((.x7 : Reg) ↦ᵣ (8 : Word)) ** ((.x6 : Reg) ↦ᵣ len) ** ⌜BitVec.ult (8 : Word) len⌝) **
+         ((.x5 : Reg) ↦ᵣ adLengthAddr) ** (adLengthAddr ↦ₘ len))
+      (AB + 112)
+        ((((.x7 : Reg) ↦ᵣ (8 : Word)) ** ((.x6 : Reg) ↦ᵣ len) ** ⌜¬BitVec.ult (8 : Word) len⌝) **
+         ((.x5 : Reg) ↦ᵣ adLengthAddr) ** (adLengthAddr ↦ₘ len)) := by
+  have hla := adLaLenX5_92 v5old
+  have hlaf := cpsTripleWithin_frameR
+    (((.x6 : Reg) ↦ᵣ v6old) ** ((.x7 : Reg) ↦ᵣ v7old) ** (adLengthAddr ↦ₘ len))
+    (by repeat' first | exact pcFree_regIs | exact pcFree_memIs | apply pcFree_sepConj) hla
+  have hld := ld_spec_gen_within .x6 .x5 adLengthAddr v6old len (0 : BitVec 12)
+    (AB + 100) (by decide)
+  rw [show adLengthAddr + signExtend12 (0 : BitVec 12) = adLengthAddr from by
+    rw [show signExtend12 (0 : BitVec 12) = (0 : Word) from by decide]; bv_omega,
+    show (AB + 100 : Word) + 4 = AB + 104 from by bv_omega] at hld
+  have hlde := cpsTripleWithin_extend_code ad_mono
+    (cpsTripleWithin_extend_code
+      (CodeReq.ofProg_mem_at AB (AB + 100) accountDecode_prog 25
+        (.LD .x6 .x5 (0 : BitVec 12)) (by bv_omega) (by rw [ad_length]; decide)
+        rfl (by rw [ad_length]; decide)) hld)
+  have hldf := cpsTripleWithin_frameR ((.x7 : Reg) ↦ᵣ v7old) pcFree_regIs hlde
+  have hli := li_spec_gen_within .x7 v7old (8 : Word) (AB + 104) (by decide)
+  rw [show (AB + 104 : Word) + 4 = AB + 108 from by bv_omega] at hli
+  have hlie := cpsTripleWithin_extend_code ad_mono
+    (cpsTripleWithin_extend_code
+      (CodeReq.ofProg_mem_at AB (AB + 104) accountDecode_prog 26
+        (.LI .x7 (8 : Word)) (by bv_omega) (by rw [ad_length]; decide)
+        rfl (by rw [ad_length]; decide)) hli)
+  have hlif := cpsTripleWithin_frameR
+    (((.x5 : Reg) ↦ᵣ adLengthAddr) ** ((.x6 : Reg) ↦ᵣ len) ** (adLengthAddr ↦ₘ len))
+    (by repeat' first | exact pcFree_regIs | exact pcFree_memIs | apply pcFree_sepConj) hlie
+  have s1 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) hlaf hldf
+  have sStraight := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) s1 hlif
+  have hbltu := bltu_spec_gen_within .x7 .x6 (396 : BitVec 13) (8 : Word) len (AB + 108)
+  rw [show (AB + 108 : Word) + signExtend13 (396 : BitVec 13) = AB + 504 from by
+    rw [show signExtend13 (396 : BitVec 13) = (396 : Word) from by decide]; bv_omega,
+    show (AB + 108 : Word) + 4 = AB + 112 from by bv_omega] at hbltu
+  have hbltue := cpsBranchWithin_extend_code ad_mono
+    (cpsBranchWithin_extend_code
+      (CodeReq.ofProg_mem_at AB (AB + 108) accountDecode_prog 27
+        (.BLTU .x7 .x6 (396 : BitVec 13)) (by bv_omega) (by rw [ad_length]; decide)
+        rfl (by rw [ad_length]; decide)) hbltu)
+  have hbltuf := cpsBranchWithin_frameR
+    (((.x5 : Reg) ↦ᵣ adLengthAddr) ** (adLengthAddr ↦ₘ len))
+    (by repeat' first | exact pcFree_regIs | exact pcFree_memIs | apply pcFree_sepConj) hbltue
+  have hcomposed := cpsTripleWithin_seq_cpsBranchWithin_perm_same_cr
+    (fun _ hp => by xperm_hyp hp) sStraight hbltuf
+  exact cpsBranchWithin_mono_nSteps (by omega) hcomposed
+
+#print axioms adNonceLenCheck
+
+set_option maxRecDepth 8000 in
+/-- Field-1 (balance) length check [50]-[54] (`AB+200 → 504/220`): `bltu 32, len`. -/
+theorem adBalLenCheck (v5old v6old v7old len : Word) :
+    cpsBranchWithin 5 (AB + 200) fullCode
+      (((.x5 : Reg) ↦ᵣ v5old) ** ((.x6 : Reg) ↦ᵣ v6old) **
+       ((.x7 : Reg) ↦ᵣ v7old) ** (adLengthAddr ↦ₘ len))
+      (AB + 504)
+        ((((.x7 : Reg) ↦ᵣ (32 : Word)) ** ((.x6 : Reg) ↦ᵣ len) ** ⌜BitVec.ult (32 : Word) len⌝) **
+         ((.x5 : Reg) ↦ᵣ adLengthAddr) ** (adLengthAddr ↦ₘ len))
+      (AB + 220)
+        ((((.x7 : Reg) ↦ᵣ (32 : Word)) ** ((.x6 : Reg) ↦ᵣ len) ** ⌜¬BitVec.ult (32 : Word) len⌝) **
+         ((.x5 : Reg) ↦ᵣ adLengthAddr) ** (adLengthAddr ↦ₘ len)) := by
+  have hla := adLaLenX5_200 v5old
+  have hlaf := cpsTripleWithin_frameR
+    (((.x6 : Reg) ↦ᵣ v6old) ** ((.x7 : Reg) ↦ᵣ v7old) ** (adLengthAddr ↦ₘ len))
+    (by repeat' first | exact pcFree_regIs | exact pcFree_memIs | apply pcFree_sepConj) hla
+  have hld := ld_spec_gen_within .x6 .x5 adLengthAddr v6old len (0 : BitVec 12)
+    (AB + 208) (by decide)
+  rw [show adLengthAddr + signExtend12 (0 : BitVec 12) = adLengthAddr from by
+    rw [show signExtend12 (0 : BitVec 12) = (0 : Word) from by decide]; bv_omega,
+    show (AB + 208 : Word) + 4 = AB + 212 from by bv_omega] at hld
+  have hlde := cpsTripleWithin_extend_code ad_mono
+    (cpsTripleWithin_extend_code
+      (CodeReq.ofProg_mem_at AB (AB + 208) accountDecode_prog 52
+        (.LD .x6 .x5 (0 : BitVec 12)) (by bv_omega) (by rw [ad_length]; decide)
+        rfl (by rw [ad_length]; decide)) hld)
+  have hldf := cpsTripleWithin_frameR ((.x7 : Reg) ↦ᵣ v7old) pcFree_regIs hlde
+  have hli := li_spec_gen_within .x7 v7old (32 : Word) (AB + 212) (by decide)
+  rw [show (AB + 212 : Word) + 4 = AB + 216 from by bv_omega] at hli
+  have hlie := cpsTripleWithin_extend_code ad_mono
+    (cpsTripleWithin_extend_code
+      (CodeReq.ofProg_mem_at AB (AB + 212) accountDecode_prog 53
+        (.LI .x7 (32 : Word)) (by bv_omega) (by rw [ad_length]; decide)
+        rfl (by rw [ad_length]; decide)) hli)
+  have hlif := cpsTripleWithin_frameR
+    (((.x5 : Reg) ↦ᵣ adLengthAddr) ** ((.x6 : Reg) ↦ᵣ len) ** (adLengthAddr ↦ₘ len))
+    (by repeat' first | exact pcFree_regIs | exact pcFree_memIs | apply pcFree_sepConj) hlie
+  have s1 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) hlaf hldf
+  have sStraight := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) s1 hlif
+  have hbltu := bltu_spec_gen_within .x7 .x6 (288 : BitVec 13) (32 : Word) len (AB + 216)
+  rw [show (AB + 216 : Word) + signExtend13 (288 : BitVec 13) = AB + 504 from by
+    rw [show signExtend13 (288 : BitVec 13) = (288 : Word) from by decide]; bv_omega,
+    show (AB + 216 : Word) + 4 = AB + 220 from by bv_omega] at hbltu
+  have hbltue := cpsBranchWithin_extend_code ad_mono
+    (cpsBranchWithin_extend_code
+      (CodeReq.ofProg_mem_at AB (AB + 216) accountDecode_prog 54
+        (.BLTU .x7 .x6 (288 : BitVec 13)) (by bv_omega) (by rw [ad_length]; decide)
+        rfl (by rw [ad_length]; decide)) hbltu)
+  have hbltuf := cpsBranchWithin_frameR
+    (((.x5 : Reg) ↦ᵣ adLengthAddr) ** (adLengthAddr ↦ₘ len))
+    (by repeat' first | exact pcFree_regIs | exact pcFree_memIs | apply pcFree_sepConj) hbltue
+  have hcomposed := cpsTripleWithin_seq_cpsBranchWithin_perm_same_cr
+    (fun _ hp => by xperm_hyp hp) sStraight hbltuf
+  exact cpsBranchWithin_mono_nSteps (by omega) hcomposed
+
+#print axioms adBalLenCheck
+
+set_option maxRecDepth 8000 in
+/-- Field-2 (storage_root) length check [81]-[85] (`AB+324 → 504/344`): `bne len, 32`. -/
+theorem adRootLenCheck (v5old v6old v7old len : Word) :
+    cpsBranchWithin 5 (AB + 324) fullCode
+      (((.x5 : Reg) ↦ᵣ v5old) ** ((.x6 : Reg) ↦ᵣ v6old) **
+       ((.x7 : Reg) ↦ᵣ v7old) ** (adLengthAddr ↦ₘ len))
+      (AB + 504)
+        ((((.x6 : Reg) ↦ᵣ len) ** ((.x7 : Reg) ↦ᵣ (32 : Word)) ** ⌜len ≠ (32 : Word)⌝) **
+         ((.x5 : Reg) ↦ᵣ adLengthAddr) ** (adLengthAddr ↦ₘ len))
+      (AB + 344)
+        ((((.x6 : Reg) ↦ᵣ len) ** ((.x7 : Reg) ↦ᵣ (32 : Word)) ** ⌜len = (32 : Word)⌝) **
+         ((.x5 : Reg) ↦ᵣ adLengthAddr) ** (adLengthAddr ↦ₘ len)) := by
+  have hla := adLaLenX5_324 v5old
+  have hlaf := cpsTripleWithin_frameR
+    (((.x6 : Reg) ↦ᵣ v6old) ** ((.x7 : Reg) ↦ᵣ v7old) ** (adLengthAddr ↦ₘ len))
+    (by repeat' first | exact pcFree_regIs | exact pcFree_memIs | apply pcFree_sepConj) hla
+  have hld := ld_spec_gen_within .x6 .x5 adLengthAddr v6old len (0 : BitVec 12)
+    (AB + 332) (by decide)
+  rw [show adLengthAddr + signExtend12 (0 : BitVec 12) = adLengthAddr from by
+    rw [show signExtend12 (0 : BitVec 12) = (0 : Word) from by decide]; bv_omega,
+    show (AB + 332 : Word) + 4 = AB + 336 from by bv_omega] at hld
+  have hlde := cpsTripleWithin_extend_code ad_mono
+    (cpsTripleWithin_extend_code
+      (CodeReq.ofProg_mem_at AB (AB + 332) accountDecode_prog 83
+        (.LD .x6 .x5 (0 : BitVec 12)) (by bv_omega) (by rw [ad_length]; decide)
+        rfl (by rw [ad_length]; decide)) hld)
+  have hldf := cpsTripleWithin_frameR ((.x7 : Reg) ↦ᵣ v7old) pcFree_regIs hlde
+  have hli := li_spec_gen_within .x7 v7old (32 : Word) (AB + 336) (by decide)
+  rw [show (AB + 336 : Word) + 4 = AB + 340 from by bv_omega] at hli
+  have hlie := cpsTripleWithin_extend_code ad_mono
+    (cpsTripleWithin_extend_code
+      (CodeReq.ofProg_mem_at AB (AB + 336) accountDecode_prog 84
+        (.LI .x7 (32 : Word)) (by bv_omega) (by rw [ad_length]; decide)
+        rfl (by rw [ad_length]; decide)) hli)
+  have hlif := cpsTripleWithin_frameR
+    (((.x5 : Reg) ↦ᵣ adLengthAddr) ** ((.x6 : Reg) ↦ᵣ len) ** (adLengthAddr ↦ₘ len))
+    (by repeat' first | exact pcFree_regIs | exact pcFree_memIs | apply pcFree_sepConj) hlie
+  have s1 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) hlaf hldf
+  have sStraight := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) s1 hlif
+  have hbne := bne_spec_gen_within .x6 .x7 (164 : BitVec 13) len (32 : Word) (AB + 340)
+  rw [show (AB + 340 : Word) + signExtend13 (164 : BitVec 13) = AB + 504 from by
+    rw [show signExtend13 (164 : BitVec 13) = (164 : Word) from by decide]; bv_omega,
+    show (AB + 340 : Word) + 4 = AB + 344 from by bv_omega] at hbne
+  have hbnee := cpsBranchWithin_extend_code ad_mono
+    (cpsBranchWithin_extend_code
+      (CodeReq.ofProg_mem_at AB (AB + 340) accountDecode_prog 85
+        (.BNE .x6 .x7 (164 : BitVec 13)) (by bv_omega) (by rw [ad_length]; decide)
+        rfl (by rw [ad_length]; decide)) hbne)
+  have hbnef := cpsBranchWithin_frameR
+    (((.x5 : Reg) ↦ᵣ adLengthAddr) ** (adLengthAddr ↦ₘ len))
+    (by repeat' first | exact pcFree_regIs | exact pcFree_memIs | apply pcFree_sepConj) hbnee
+  have hcomposed := cpsTripleWithin_seq_cpsBranchWithin_perm_same_cr
+    (fun _ hp => by xperm_hyp hp) sStraight hbnef
+  exact cpsBranchWithin_mono_nSteps (by omega) hcomposed
+
+#print axioms adRootLenCheck
+
+set_option maxRecDepth 8000 in
+/-- Field-3 (code_hash) length check [107]-[111] (`AB+428 → 504/448`): `bne len, 32`. -/
+theorem adCodeLenCheck (v5old v6old v7old len : Word) :
+    cpsBranchWithin 5 (AB + 428) fullCode
+      (((.x5 : Reg) ↦ᵣ v5old) ** ((.x6 : Reg) ↦ᵣ v6old) **
+       ((.x7 : Reg) ↦ᵣ v7old) ** (adLengthAddr ↦ₘ len))
+      (AB + 504)
+        ((((.x6 : Reg) ↦ᵣ len) ** ((.x7 : Reg) ↦ᵣ (32 : Word)) ** ⌜len ≠ (32 : Word)⌝) **
+         ((.x5 : Reg) ↦ᵣ adLengthAddr) ** (adLengthAddr ↦ₘ len))
+      (AB + 448)
+        ((((.x6 : Reg) ↦ᵣ len) ** ((.x7 : Reg) ↦ᵣ (32 : Word)) ** ⌜len = (32 : Word)⌝) **
+         ((.x5 : Reg) ↦ᵣ adLengthAddr) ** (adLengthAddr ↦ₘ len)) := by
+  have hla := adLaLenX5_428 v5old
+  have hlaf := cpsTripleWithin_frameR
+    (((.x6 : Reg) ↦ᵣ v6old) ** ((.x7 : Reg) ↦ᵣ v7old) ** (adLengthAddr ↦ₘ len))
+    (by repeat' first | exact pcFree_regIs | exact pcFree_memIs | apply pcFree_sepConj) hla
+  have hld := ld_spec_gen_within .x6 .x5 adLengthAddr v6old len (0 : BitVec 12)
+    (AB + 436) (by decide)
+  rw [show adLengthAddr + signExtend12 (0 : BitVec 12) = adLengthAddr from by
+    rw [show signExtend12 (0 : BitVec 12) = (0 : Word) from by decide]; bv_omega,
+    show (AB + 436 : Word) + 4 = AB + 440 from by bv_omega] at hld
+  have hlde := cpsTripleWithin_extend_code ad_mono
+    (cpsTripleWithin_extend_code
+      (CodeReq.ofProg_mem_at AB (AB + 436) accountDecode_prog 109
+        (.LD .x6 .x5 (0 : BitVec 12)) (by bv_omega) (by rw [ad_length]; decide)
+        rfl (by rw [ad_length]; decide)) hld)
+  have hldf := cpsTripleWithin_frameR ((.x7 : Reg) ↦ᵣ v7old) pcFree_regIs hlde
+  have hli := li_spec_gen_within .x7 v7old (32 : Word) (AB + 440) (by decide)
+  rw [show (AB + 440 : Word) + 4 = AB + 444 from by bv_omega] at hli
+  have hlie := cpsTripleWithin_extend_code ad_mono
+    (cpsTripleWithin_extend_code
+      (CodeReq.ofProg_mem_at AB (AB + 440) accountDecode_prog 110
+        (.LI .x7 (32 : Word)) (by bv_omega) (by rw [ad_length]; decide)
+        rfl (by rw [ad_length]; decide)) hli)
+  have hlif := cpsTripleWithin_frameR
+    (((.x5 : Reg) ↦ᵣ adLengthAddr) ** ((.x6 : Reg) ↦ᵣ len) ** (adLengthAddr ↦ₘ len))
+    (by repeat' first | exact pcFree_regIs | exact pcFree_memIs | apply pcFree_sepConj) hlie
+  have s1 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) hlaf hldf
+  have sStraight := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) s1 hlif
+  have hbne := bne_spec_gen_within .x6 .x7 (60 : BitVec 13) len (32 : Word) (AB + 444)
+  rw [show (AB + 444 : Word) + signExtend13 (60 : BitVec 13) = AB + 504 from by
+    rw [show signExtend13 (60 : BitVec 13) = (60 : Word) from by decide]; bv_omega,
+    show (AB + 444 : Word) + 4 = AB + 448 from by bv_omega] at hbne
+  have hbnee := cpsBranchWithin_extend_code ad_mono
+    (cpsBranchWithin_extend_code
+      (CodeReq.ofProg_mem_at AB (AB + 444) accountDecode_prog 111
+        (.BNE .x6 .x7 (60 : BitVec 13)) (by bv_omega) (by rw [ad_length]; decide)
+        rfl (by rw [ad_length]; decide)) hbne)
+  have hbnef := cpsBranchWithin_frameR
+    (((.x5 : Reg) ↦ᵣ adLengthAddr) ** (adLengthAddr ↦ₘ len))
+    (by repeat' first | exact pcFree_regIs | exact pcFree_memIs | apply pcFree_sepConj) hbnee
+  have hcomposed := cpsTripleWithin_seq_cpsBranchWithin_perm_same_cr
+    (fun _ hp => by xperm_hyp hp) sStraight hbnef
+  exact cpsBranchWithin_mono_nSteps (by omega) hcomposed
+
+#print axioms adCodeLenCheck
+
+end EvmAsm.Codegen.AccountDecodeSpec

--- a/EvmAsm/Codegen/Programs/AccountDecodeDispatch.lean
+++ b/EvmAsm/Codegen/Programs/AccountDecodeDispatch.lean
@@ -22,6 +22,125 @@ import EvmAsm.Rv64.LaResolve
 namespace EvmAsm.Codegen.AccountDecodeSpec
 
 open EvmAsm.Rv64 EvmAsm.Rv64.SAsm
+open EvmAsm.Codegen.RlpListNthItemSAsm (Saved savedVals listNthFrame flatReturnResult
+  Success Result)
+
+/-! ## K20 post-call status dispatch (all four fields)
+
+    After a field's K20 call returns `flatReturnResult`, `BNE x10, x0` routes a
+    nonzero status to the shared failure tail (`AB+504`, the `li a0,1`) and a
+    zero status (a genuine `Success`) to the next phase (`dispatchPC + 4`).
+    All four fields share this shape (only the guest PC / branch offset differ),
+    so one theorem — parameterised on the dispatch PC, branch offset, index, and
+    the concrete `BNE` fetch fact — covers every field.  Mirrors `k20Dispatch`. -/
+
+/-- Continue-exit post (status `0`, a genuine K20 `Success`) of a field's
+    post-call dispatch. -/
+def adK20ContPost (spW listBase : Word) (index : Nat)
+    (saved : Saved) (bytes : List (BitVec 8)) (listLen : Nat) : Assertion :=
+  fun h => ∃ offset len v11 v12,
+    ((⌜Success bytes listBase listLen index offset len⌝ : Assertion) **
+     ((((.x2 ↦ᵣ spW) ** regsAt listNthFrame (savedVals saved) ** stackFree spW 8) **
+       ((.x10 ↦ᵣ (0 : Word)) ** regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+        (.x11 ↦ᵣ v11) ** (.x12 ↦ᵣ v12) ** regOwn .x13 ** regOwn .x14 **
+        regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+        (.x0 ↦ᵣ (0 : Word)) ** bytesRegion listBase bytes **
+        (adOffsetAddr ↦ₘ offset) ** (adLengthAddr ↦ₘ len))))) h
+
+/-- Fail-exit post (nonzero status) of a field's post-call dispatch. -/
+def adK20FailPost (spW listBase oldOffset oldLen : Word) (index : Nat)
+    (saved : Saved) (bytes : List (BitVec 8)) (listLen : Nat) : Assertion :=
+  fun h => ∃ status offset len v11 v12,
+    ((⌜Result bytes listBase listLen index oldOffset oldLen status offset len ∧
+        status ≠ (0 : Word)⌝ : Assertion) **
+     ((((.x2 ↦ᵣ spW) ** regsAt listNthFrame (savedVals saved) ** stackFree spW 8) **
+       ((.x10 ↦ᵣ status) ** regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+        (.x11 ↦ᵣ v11) ** (.x12 ↦ᵣ v12) ** regOwn .x13 ** regOwn .x14 **
+        regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+        (.x0 ↦ᵣ (0 : Word)) ** bytesRegion listBase bytes **
+        (adOffsetAddr ↦ₘ offset) ** (adLengthAddr ↦ₘ len))))) h
+
+set_option maxRecDepth 8000 in
+/-- Generic K20 post-call status dispatch: `BNE x10, x0 bneOff` at `dispatchPC`
+    routes nonzero status → `AB+504` (fail) and status `0` → `dispatchPC+4`
+    (continue).  The concrete branch fetch and its taken target are supplied by
+    the caller (one per field). -/
+theorem adK20Dispatch (spW listBase oldOffset oldLen dispatchPC : Word)
+    (bneOff : BitVec 13) (index : Nat) (saved : Saved)
+    (bytes : List (BitVec 8)) (listLen : Nat)
+    (htaken : dispatchPC + signExtend13 bneOff = AB + 504)
+    (hmem : ∀ a i, CodeReq.singleton dispatchPC (.BNE .x10 .x0 bneOff) a = some i →
+      fullCode a = some i) :
+    cpsBranchWithin 1 dispatchPC fullCode
+      (flatReturnResult spW listBase (BitVec.ofNat 64 index) adOffsetAddr adLengthAddr
+        oldOffset oldLen saved bytes listLen index)
+      (AB + 504) (adK20FailPost spW listBase oldOffset oldLen index saved bytes listLen)
+      (dispatchPC + 4) (adK20ContPost spW listBase index saved bytes listLen) := by
+  refine cpsBranchWithin_weaken (P := fun h => ∃ status offset len v11 v12,
+      ((((.x2 ↦ᵣ spW) ** regsAt listNthFrame (savedVals saved) ** stackFree spW 8) **
+        ((.x10 ↦ᵣ status) ** regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+         (.x11 ↦ᵣ v11) ** (.x12 ↦ᵣ v12) ** regOwn .x13 ** regOwn .x14 **
+         regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+         (.x0 ↦ᵣ (0 : Word)) ** bytesRegion listBase bytes **
+         (adOffsetAddr ↦ₘ offset) ** (adLengthAddr ↦ₘ len))) **
+       ⌜Result bytes listBase listLen index oldOffset oldLen status offset len⌝) h)
+    (fun h hp => hp) (fun _ hq => hq) (fun _ hq => hq) ?_
+  refine cpsBranchWithin_exists_pre (fun status => ?_)
+  refine cpsBranchWithin_exists_pre (fun offset => ?_)
+  refine cpsBranchWithin_exists_pre (fun len => ?_)
+  refine cpsBranchWithin_exists_pre (fun v11 => ?_)
+  refine cpsBranchWithin_exists_pre (fun v12 => ?_)
+  let REST : Assertion :=
+    (((.x2 ↦ᵣ spW) ** regsAt listNthFrame (savedVals saved) ** stackFree spW 8) **
+     (regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+      (.x11 ↦ᵣ v11) ** (.x12 ↦ᵣ v12) ** regOwn .x13 ** regOwn .x14 **
+      regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+      bytesRegion listBase bytes **
+      (adOffsetAddr ↦ₘ offset) ** (adLengthAddr ↦ₘ len))) **
+    ⌜Result bytes listBase listLen index oldOffset oldLen status offset len⌝
+  have hbne := bne_spec_gen_within .x10 .x0 bneOff status (0 : Word) dispatchPC
+  rw [htaken, show (dispatchPC : Word) + 4 = dispatchPC + 4 from rfl] at hbne
+  have hbneL := cpsBranchWithin_extend_code hmem hbne
+  have hbneF := cpsBranchWithin_frameR REST (by unfold REST; pcf) hbneL
+  refine cpsBranchWithin_weaken (fun h hp => by
+      unfold REST
+      xperm_hyp hp)
+    (fun h hq => by
+      refine ⟨status, offset, len, v11, v12, ?_⟩
+      unfold REST at hq
+      obtain ⟨h1, h2, hd, hu, hA, hR⟩ := hq
+      obtain ⟨h3, h4, hd2, hu2, hx10, hrest⟩ := hA
+      have hne : status ≠ (0 : Word) := ((sepConj_pure_right h4).1 hrest).2
+      have hx0 : ((.x0 : Reg) ↦ᵣ (0 : Word)) h4 := ((sepConj_pure_right h4).1 hrest).1
+      have hbody := ((sepConj_pure_right h2).1 hR).1
+      have hres := ((sepConj_pure_right h2).1 hR).2
+      apply (sepConj_pure_left h).2
+      refine ⟨⟨hres, hne⟩, ?_⟩
+      have hq' : (((.x10 ↦ᵣ status) ** ((.x0 : Reg) ↦ᵣ (0 : Word))) ** _) h :=
+        ⟨h1, h2, hd, hu, ⟨h3, h4, hd2, hu2, hx10, hx0⟩, hbody⟩
+      xperm_hyp hq')
+    (fun h hq => by
+      unfold REST at hq
+      obtain ⟨h1, h2, hd, hu, hA, hR⟩ := hq
+      obtain ⟨h3, h4, hd2, hu2, hx10, hrest⟩ := hA
+      have hz : status = (0 : Word) := ((sepConj_pure_right h4).1 hrest).2
+      have hx0 : ((.x0 : Reg) ↦ᵣ (0 : Word)) h4 := ((sepConj_pure_right h4).1 hrest).1
+      have hres := ((sepConj_pure_right h2).1 hR).2
+      have hbody := ((sepConj_pure_right h2).1 hR).1
+      have hsucc : Success bytes listBase listLen index offset len := by
+        rw [hz] at hres
+        cases hres with
+        | ok o l hok => exact hok
+      refine ⟨offset, len, v11, v12, ?_⟩
+      subst hz
+      apply (sepConj_pure_left h).2
+      refine ⟨hsucc, ?_⟩
+      have hq' : (((.x10 ↦ᵣ (0 : Word)) ** ((.x0 : Reg) ↦ᵣ (0 : Word))) ** _) h :=
+        ⟨h1, h2, hd, hu, ⟨h3, h4, hd2, hu2, hx10, hx0⟩, hbody⟩
+      xperm_hyp hq')
+    hbneF
+
+#print axioms adK20Dispatch
 
 /-! ## `la x5, ad_length` materialisers for the four length-check sites -/
 

--- a/EvmAsm/Codegen/Programs/AccountDecodeFrame.lean
+++ b/EvmAsm/Codegen/Programs/AccountDecodeFrame.lean
@@ -26,6 +26,161 @@ open EvmAsm.Codegen.RlpListNthItemSAsm (Saved savedVals listNthFrame savedFrame
   regsAt_listNthFrame frameSlotsSaved_listNthFrame)
 
 set_option maxRecDepth 8000 in
+/-- The six `mv` shuffles [8]-[13] (`AB+32 → AB+56`): copy the caller arguments
+    `a0..a5` (in `x10..x15`) into the saved registers `s0..s5`
+    (`x8/x9/x18/x19/x20/x21`).  The source argument registers are unchanged. -/
+theorem adShuffle (a0 a1 a2 a3 a4 a5 os0 os1 os2 os3 os4 os5 : Word) :
+    cpsTripleWithin 6 (AB + 32) (AB + 56) fullCode
+      (((.x8 : Reg) ↦ᵣ os0) ** ((.x10 : Reg) ↦ᵣ a0) **
+       ((.x9 : Reg) ↦ᵣ os1) ** ((.x11 : Reg) ↦ᵣ a1) **
+       ((.x18 : Reg) ↦ᵣ os2) ** ((.x12 : Reg) ↦ᵣ a2) **
+       ((.x19 : Reg) ↦ᵣ os3) ** ((.x13 : Reg) ↦ᵣ a3) **
+       ((.x20 : Reg) ↦ᵣ os4) ** ((.x14 : Reg) ↦ᵣ a4) **
+       ((.x21 : Reg) ↦ᵣ os5) ** ((.x15 : Reg) ↦ᵣ a5))
+      (((.x8 : Reg) ↦ᵣ a0) ** ((.x10 : Reg) ↦ᵣ a0) **
+       ((.x9 : Reg) ↦ᵣ a1) ** ((.x11 : Reg) ↦ᵣ a1) **
+       ((.x18 : Reg) ↦ᵣ a2) ** ((.x12 : Reg) ↦ᵣ a2) **
+       ((.x19 : Reg) ↦ᵣ a3) ** ((.x13 : Reg) ↦ᵣ a3) **
+       ((.x20 : Reg) ↦ᵣ a4) ** ((.x14 : Reg) ↦ᵣ a4) **
+       ((.x21 : Reg) ↦ᵣ a5) ** ((.x15 : Reg) ↦ᵣ a5)) := by
+  have h8 := mv_spec_gen_within .x8 .x10 a0 os0 (AB + 32) (by decide)
+  have h9 := mv_spec_gen_within .x9 .x11 a1 os1 (AB + 36) (by decide)
+  have h10 := mv_spec_gen_within .x18 .x12 a2 os2 (AB + 40) (by decide)
+  have h11 := mv_spec_gen_within .x19 .x13 a3 os3 (AB + 44) (by decide)
+  have h12 := mv_spec_gen_within .x20 .x14 a4 os4 (AB + 48) (by decide)
+  have h13 := mv_spec_gen_within .x21 .x15 a5 os5 (AB + 52) (by decide)
+  have l8 := cpsTripleWithin_extend_code ad_mono
+    (cpsTripleWithin_extend_code
+      (CodeReq.ofProg_mem_at AB (AB + 32) accountDecode_prog 8 (.MV .x8 .x10)
+        (by bv_omega) (by rw [ad_length]; norm_num) rfl (by rw [ad_length]; norm_num)) h8)
+  have l9 := cpsTripleWithin_extend_code ad_mono
+    (cpsTripleWithin_extend_code
+      (CodeReq.ofProg_mem_at AB (AB + 36) accountDecode_prog 9 (.MV .x9 .x11)
+        (by bv_omega) (by rw [ad_length]; norm_num) rfl (by rw [ad_length]; norm_num)) h9)
+  have l10 := cpsTripleWithin_extend_code ad_mono
+    (cpsTripleWithin_extend_code
+      (CodeReq.ofProg_mem_at AB (AB + 40) accountDecode_prog 10 (.MV .x18 .x12)
+        (by bv_omega) (by rw [ad_length]; norm_num) rfl (by rw [ad_length]; norm_num)) h10)
+  have l11 := cpsTripleWithin_extend_code ad_mono
+    (cpsTripleWithin_extend_code
+      (CodeReq.ofProg_mem_at AB (AB + 44) accountDecode_prog 11 (.MV .x19 .x13)
+        (by bv_omega) (by rw [ad_length]; norm_num) rfl (by rw [ad_length]; norm_num)) h11)
+  have l12 := cpsTripleWithin_extend_code ad_mono
+    (cpsTripleWithin_extend_code
+      (CodeReq.ofProg_mem_at AB (AB + 48) accountDecode_prog 12 (.MV .x20 .x14)
+        (by bv_omega) (by rw [ad_length]; norm_num) rfl (by rw [ad_length]; norm_num)) h12)
+  have l13 := cpsTripleWithin_extend_code ad_mono
+    (cpsTripleWithin_extend_code
+      (CodeReq.ofProg_mem_at AB (AB + 52) accountDecode_prog 13 (.MV .x21 .x15)
+        (by bv_omega) (by rw [ad_length]; norm_num) rfl (by rw [ad_length]; norm_num)) h13)
+  have s8 := cpsTripleWithin_frameR
+    (((.x9 : Reg) ↦ᵣ os1) ** ((.x11 : Reg) ↦ᵣ a1) ** ((.x18 : Reg) ↦ᵣ os2) **
+     ((.x12 : Reg) ↦ᵣ a2) ** ((.x19 : Reg) ↦ᵣ os3) ** ((.x13 : Reg) ↦ᵣ a3) **
+     ((.x20 : Reg) ↦ᵣ os4) ** ((.x14 : Reg) ↦ᵣ a4) ** ((.x21 : Reg) ↦ᵣ os5) **
+     ((.x15 : Reg) ↦ᵣ a5)) (by pcf) l8
+  have s9 := cpsTripleWithin_frameR
+    (((.x8 : Reg) ↦ᵣ a0) ** ((.x10 : Reg) ↦ᵣ a0) ** ((.x18 : Reg) ↦ᵣ os2) **
+     ((.x12 : Reg) ↦ᵣ a2) ** ((.x19 : Reg) ↦ᵣ os3) ** ((.x13 : Reg) ↦ᵣ a3) **
+     ((.x20 : Reg) ↦ᵣ os4) ** ((.x14 : Reg) ↦ᵣ a4) ** ((.x21 : Reg) ↦ᵣ os5) **
+     ((.x15 : Reg) ↦ᵣ a5)) (by pcf) l9
+  have s10 := cpsTripleWithin_frameR
+    (((.x8 : Reg) ↦ᵣ a0) ** ((.x10 : Reg) ↦ᵣ a0) ** ((.x9 : Reg) ↦ᵣ a1) **
+     ((.x11 : Reg) ↦ᵣ a1) ** ((.x19 : Reg) ↦ᵣ os3) ** ((.x13 : Reg) ↦ᵣ a3) **
+     ((.x20 : Reg) ↦ᵣ os4) ** ((.x14 : Reg) ↦ᵣ a4) ** ((.x21 : Reg) ↦ᵣ os5) **
+     ((.x15 : Reg) ↦ᵣ a5)) (by pcf) l10
+  have s11 := cpsTripleWithin_frameR
+    (((.x8 : Reg) ↦ᵣ a0) ** ((.x10 : Reg) ↦ᵣ a0) ** ((.x9 : Reg) ↦ᵣ a1) **
+     ((.x11 : Reg) ↦ᵣ a1) ** ((.x18 : Reg) ↦ᵣ a2) ** ((.x12 : Reg) ↦ᵣ a2) **
+     ((.x20 : Reg) ↦ᵣ os4) ** ((.x14 : Reg) ↦ᵣ a4) ** ((.x21 : Reg) ↦ᵣ os5) **
+     ((.x15 : Reg) ↦ᵣ a5)) (by pcf) l11
+  have s12 := cpsTripleWithin_frameR
+    (((.x8 : Reg) ↦ᵣ a0) ** ((.x10 : Reg) ↦ᵣ a0) ** ((.x9 : Reg) ↦ᵣ a1) **
+     ((.x11 : Reg) ↦ᵣ a1) ** ((.x18 : Reg) ↦ᵣ a2) ** ((.x12 : Reg) ↦ᵣ a2) **
+     ((.x19 : Reg) ↦ᵣ a3) ** ((.x13 : Reg) ↦ᵣ a3) ** ((.x21 : Reg) ↦ᵣ os5) **
+     ((.x15 : Reg) ↦ᵣ a5)) (by pcf) l12
+  have s13 := cpsTripleWithin_frameR
+    (((.x8 : Reg) ↦ᵣ a0) ** ((.x10 : Reg) ↦ᵣ a0) ** ((.x9 : Reg) ↦ᵣ a1) **
+     ((.x11 : Reg) ↦ᵣ a1) ** ((.x18 : Reg) ↦ᵣ a2) ** ((.x12 : Reg) ↦ᵣ a2) **
+     ((.x19 : Reg) ↦ᵣ a3) ** ((.x13 : Reg) ↦ᵣ a3) ** ((.x20 : Reg) ↦ᵣ a4) **
+     ((.x14 : Reg) ↦ᵣ a4)) (by pcf) l13
+  have c1 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) s8 s9
+  have c2 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) c1 s10
+  have c3 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) c2 s11
+  have c4 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) c3 s12
+  have c5 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) c4 s13
+  exact cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
+    (fun _ hq => by xperm_hyp hq) c5
+
+#print axioms adShuffle
+
+set_option maxRecDepth 8000 in
+/-- The ABI prologue [0]-[13] (`AB → AB+56`): `addi sp,-64`, save the seven
+    callee-saved registers into their frame slots (`saved` holds their entry
+    values), then shuffle the arguments `a0..a5` into `s0..s5`.  `x1` (the
+    caller return) is untouched by the shuffle and left live for the epilogue's
+    `ret`; the arguments remain live in `x10..x15`. -/
+theorem adPrologue (sp0 newSp callerRa a0 a1 a2 a3 a4 a5 os0 os1 os2 os3 os4 os5 : Word)
+    (hnewSp : newSp = sp0 + signExtend12 (-64 : BitVec 12)) :
+    let saved : Saved :=
+      { ra := callerRa, s0 := os0, s1 := os1, s2 := os2, s3 := os3, s4 := os4,
+        s5 := os5 }
+    cpsTripleWithin 14 AB (AB + 56) fullCode
+      ((.x2 ↦ᵣ sp0) ** regsAt listNthFrame (savedVals saved) **
+        frameSlotsOwn listNthFrame newSp **
+        (((.x10 : Reg) ↦ᵣ a0) ** ((.x11 : Reg) ↦ᵣ a1) ** ((.x12 : Reg) ↦ᵣ a2) **
+         ((.x13 : Reg) ↦ᵣ a3) ** ((.x14 : Reg) ↦ᵣ a4) ** ((.x15 : Reg) ↦ᵣ a5)))
+      (((.x2 : Reg) ↦ᵣ newSp) ** ((.x1 : Reg) ↦ᵣ callerRa) **
+       ((.x8 : Reg) ↦ᵣ a0) ** ((.x9 : Reg) ↦ᵣ a1) ** ((.x18 : Reg) ↦ᵣ a2) **
+       ((.x19 : Reg) ↦ᵣ a3) ** ((.x20 : Reg) ↦ᵣ a4) ** ((.x21 : Reg) ↦ᵣ a5) **
+       ((.x10 : Reg) ↦ᵣ a0) ** ((.x11 : Reg) ↦ᵣ a1) ** ((.x12 : Reg) ↦ᵣ a2) **
+       ((.x13 : Reg) ↦ᵣ a3) ** ((.x14 : Reg) ↦ᵣ a4) ** ((.x15 : Reg) ↦ᵣ a5) **
+       savedFrame newSp saved) := by
+  intro saved
+  -- [0] addi sp, sp, -64
+  have ha0 := addi_spec_gen_same_within .x2 sp0 (-64 : BitVec 12) AB (by decide)
+  rw [← hnewSp] at ha0
+  have ha := cpsTripleWithin_extend_code ad_mono
+    (cpsTripleWithin_extend_code
+      (CodeReq.ofProg_mem_at AB AB accountDecode_prog 0 (.ADDI .x2 .x2 (-64 : BitVec 12))
+        rfl (by rw [ad_length]; norm_num) rfl (by rw [ad_length]; norm_num)) ha0)
+  have haF := cpsTripleWithin_frameR
+    (regsAt listNthFrame (savedVals saved) ** frameSlotsOwn listNthFrame newSp **
+      (((.x10 : Reg) ↦ᵣ a0) ** ((.x11 : Reg) ↦ᵣ a1) ** ((.x12 : Reg) ↦ᵣ a2) **
+       ((.x13 : Reg) ↦ᵣ a3) ** ((.x14 : Reg) ↦ᵣ a4) ** ((.x15 : Reg) ↦ᵣ a5)))
+    (by pcf) ha
+  -- [1]-[7] store the seven callee-saved registers
+  have hs0 := storeSeq_spec listNthFrame newSp (savedVals saved) (AB + 4) (by decide)
+  have hstoreMono : ∀ a i,
+      CodeReq.ofProg (AB + 4) (storeProg listNthFrame) a = some i → fullCode a = some i := by
+    intro a i hmem
+    exact ad_mono a i (CodeReq.ofProg_mono_sub AB (AB + 4) accountDecode_prog
+      (storeProg listNthFrame) 1 (by bv_omega) (by rfl)
+      (by rw [ad_length]; simp [listNthFrame])
+      (by rw [ad_length]; norm_num) a i hmem)
+  have hs := cpsTripleWithin_extend_code hstoreMono hs0
+  rw [show AB + 4 + BitVec.ofNat 64 (4 * listNthFrame.length) = AB + 32 from by
+    simp [listNthFrame]; bv_omega] at hs
+  rw [frameSlotsSaved_listNthFrame] at hs
+  have hsF := cpsTripleWithin_frameR
+    (((.x10 : Reg) ↦ᵣ a0) ** ((.x11 : Reg) ↦ᵣ a1) ** ((.x12 : Reg) ↦ᵣ a2) **
+     ((.x13 : Reg) ↦ᵣ a3) ** ((.x14 : Reg) ↦ᵣ a4) ** ((.x15 : Reg) ↦ᵣ a5))
+    (by pcf) hs
+  -- [8]-[13] shuffle a0..a5 into s0..s5
+  have hsh := adShuffle a0 a1 a2 a3 a4 a5 os0 os1 os2 os3 os4 os5
+  have hshF := cpsTripleWithin_frameR
+    (((.x1 : Reg) ↦ᵣ callerRa) ** ((.x2 : Reg) ↦ᵣ newSp) ** savedFrame newSp saved)
+    (by unfold savedFrame; pcf) hsh
+  -- Compose [0] ;; [1-7] ;; [8-13].
+  have c1 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) haF hsF
+  have c2 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by
+    rw [regsAt_listNthFrame] at hp
+    xperm_hyp hp) c1 hshF
+  exact cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
+    (fun _ hq => by xperm_hyp hq) c2
+
+#print axioms adPrologue
+
+set_option maxRecDepth 8000 in
 /-- The ABI epilogue [127]-[135] (`AB+508 → saved.ra`): reload the seven
     callee-saved registers from their (untouched) frame slots, restore
     `sp := sp0`, and `ret`.  Generic over an arbitrary framed result `F`

--- a/EvmAsm/Codegen/Programs/AccountDecodeFrame.lean
+++ b/EvmAsm/Codegen/Programs/AccountDecodeFrame.lean
@@ -1,0 +1,95 @@
+/-
+  The ABI frame blocks of `accountDecode_prog` (`Programs/State.lean`, PR-K27):
+
+    * `adPrologue`  — instructions [0]-[13] (`AB → AB+56`): `addi sp,-64`, the
+      seven callee-saved stores (`x1/x8/x9/x18/x19/x20/x21`), and the six `mv`
+      shuffles copying the caller arguments `a0..a5` into the saved registers
+      `s0..s5` (`x8/x9/x18/x19/x20/x21`).
+    * `adEpilogue` — instructions [127]-[135] (`AB+508 → ra`): the seven
+      register reloads, `addi sp,+64`, and the `ret`.
+
+  Both reuse K20's 7-slot `listNthFrame` (identical layout).  The prologue is
+  the `storeSeq`/`setupMoves` pattern of `RlpListNthItemSAsm.wrapperPrologue`;
+  the epilogue mirrors `RlpListNthItemSAsm.epilogueOwned`.
+
+  No `sorry`/`admit`/`native_decide`/`bv_decide`; classical-3 axioms only.
+-/
+
+import EvmAsm.Codegen.Programs.AccountDecodeSpec
+import EvmAsm.Codegen.Programs.RlpListNthItemCallSAsm
+import EvmAsm.Evm64.CallingConvention
+
+namespace EvmAsm.Codegen.AccountDecodeSpec
+
+open EvmAsm.Rv64 EvmAsm.Rv64.SAsm
+open EvmAsm.Codegen.RlpListNthItemSAsm (Saved savedVals listNthFrame savedFrame
+  regsAt_listNthFrame frameSlotsSaved_listNthFrame)
+
+set_option maxRecDepth 8000 in
+/-- The ABI epilogue [127]-[135] (`AB+508 → saved.ra`): reload the seven
+    callee-saved registers from their (untouched) frame slots, restore
+    `sp := sp0`, and `ret`.  Generic over an arbitrary framed result `F`
+    (which carries the already-set `a0` status).  Mirrors `epilogueOwned`. -/
+theorem adEpilogue (sp0 newSp : Word) (saved : Saved)
+    (F : Assertion) (hF : F.pcFree)
+    (hnewSp : newSp = sp0 + signExtend12 (-64 : BitVec 12))
+    (hret : saved.ra &&& ~~~(1 : Word) = saved.ra) :
+    cpsTripleWithin 9 (AB + 508) saved.ra fullCode
+      (((.x2 ↦ᵣ newSp) ** regsOwnAt listNthFrame **
+        savedFrame newSp saved) ** F)
+      (((.x2 ↦ᵣ sp0) ** regsAt listNthFrame (savedVals saved) **
+        savedFrame newSp saved) ** F) := by
+  have hl0 := loadSeq_spec_own listNthFrame newSp (savedVals saved)
+    (AB + 508) (by decide) (by decide)
+  have hlMono : ∀ a i,
+      CodeReq.ofProg (AB + 508) (loadProg listNthFrame) a = some i → fullCode a = some i := by
+    intro a i hmem
+    exact ad_mono a i (CodeReq.ofProg_mono_sub AB (AB + 508) accountDecode_prog
+      (loadProg listNthFrame) 127 (by bv_omega) (by rfl)
+      (by rw [ad_length]; simp [listNthFrame])
+      (by rw [ad_length]; norm_num) a i hmem)
+  have hl := cpsTripleWithin_extend_code hlMono hl0
+  rw [show AB + 508 + BitVec.ofNat 64 (4 * listNthFrame.length) = AB + 536 from by
+    simp [listNthFrame]; bv_omega] at hl
+  rw [frameSlotsSaved_listNthFrame] at hl
+  have hlF := cpsTripleWithin_frameR F hF hl
+  have hd0 := addi_spec_gen_same_within .x2 newSp (64 : BitVec 12) (AB + 536)
+    (by decide)
+  rw [show newSp + signExtend12 (64 : BitVec 12) = sp0 from by
+    rw [hnewSp]
+    exact sext_frameRestore sp0 (-64 : BitVec 12) (64 : BitVec 12) (by decide)] at hd0
+  have hd := cpsTripleWithin_extend_code ad_mono
+    (cpsTripleWithin_extend_code
+      (CodeReq.ofProg_mem_at AB (AB + 536) accountDecode_prog 134
+        (.ADDI .x2 .x2 (64 : BitVec 12)) (by bv_omega)
+        (by rw [ad_length]; norm_num) rfl (by rw [ad_length]; norm_num)) hd0)
+  have hdF := cpsTripleWithin_frameR
+    (regsAt listNthFrame (savedVals saved) ** savedFrame newSp saved ** F)
+    (by unfold savedFrame; pcf; assumption) hd
+  have hr0 := EvmAsm.Evm64.ret_spec_within' (AB + 540) saved.ra
+  rw [hret] at hr0
+  have hr := cpsTripleWithin_extend_code ad_mono
+    (cpsTripleWithin_extend_code
+      (CodeReq.ofProg_mem_at AB (AB + 540) accountDecode_prog 135
+        (.JALR .x0 .x1 (0 : BitVec 12)) (by bv_omega)
+        (by rw [ad_length]; norm_num) rfl (by rw [ad_length]; norm_num)) hr0)
+  have hrF := cpsTripleWithin_frameR
+    (((.x2 ↦ᵣ sp0) **
+      (.x8 ↦ᵣ saved.s0) ** (.x9 ↦ᵣ saved.s1) **
+      (.x18 ↦ᵣ saved.s2) ** (.x19 ↦ᵣ saved.s3) **
+      (.x20 ↦ᵣ saved.s4) ** (.x21 ↦ᵣ saved.s5) **
+      savedFrame newSp saved) ** F) (by
+        unfold savedFrame
+        pcf
+        assumption) hr
+  have h12 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) hlF hdF
+  have h123 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by
+    rw [regsAt_listNthFrame] at hp
+    xperm_hyp hp) h12 hrF
+  exact cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp) (fun h hp => by
+    rw [regsAt_listNthFrame]
+    xperm_hyp hp) h123
+
+#print axioms adEpilogue
+
+end EvmAsm.Codegen.AccountDecodeSpec

--- a/EvmAsm/Codegen/Programs/AccountDecodeLoop.lean
+++ b/EvmAsm/Codegen/Programs/AccountDecodeLoop.lean
@@ -1,0 +1,288 @@
+/-
+  The fixed 32-byte copy loops of `accountDecode_prog` (storage_root, field 2,
+  instrs [90]-[95]; and code_hash, field 3, instrs [116]-[121]).
+
+  Both are byte-safe `LBU`/`SB` bottom-tested do-while copies (the pkljc #10344
+  byte-fix).  With `x28` the source cursor, `rd` the output cursor (x20 for
+  storage_root, x21 for code_hash), `x6` the remaining count and `x29` the byte
+  scratch, each iteration
+
+    LBU  x29, 0(x28)   SB  rd,  0(x29)  [i.e. store x29's byte at [rd]]
+    ADDI x28, x28, 1   ADDI rd, rd, 1
+    ADDI x6,  x6, -1   BNE  x6, x0, -20
+
+  copies one byte and decrements the counter.  This module hosts a **generic**
+  per-byte step (`adCopyBody`) and loop closure (`adCopyLoop`), parameterised on
+  the destination register `rd` and the loop's guest byte-base `GB`, taking the
+  per-instruction fetch facts as hypotheses so both fixed-32 fields reuse it.
+  The content tie is the same `copyIntoRegion` accumulator used by
+  `WithdrawalDecodeSpec.wdCopyLoop`.
+
+  No `sorry`/`admit`/`native_decide`/`bv_decide`; classical-3 axioms only.
+-/
+
+import EvmAsm.Codegen.Programs.AccountDecodeSpec
+
+namespace EvmAsm.Codegen.AccountDecodeSpec
+
+open EvmAsm.Rv64 EvmAsm.Rv64.SAsm
+open EvmAsm.Evm64.Terminating (copyIntoRegion copyIntoRegion_length)
+
+private theorem ad_succ_dec (n : Nat) :
+    BitVec.ofNat 64 (n + 1) + signExtend12 (-1 : BitVec 12) = BitVec.ofNat 64 n := by
+  apply BitVec.eq_of_toNat_eq
+  have hs : (signExtend12 (-1 : BitVec 12) : Word).toNat = 18446744073709551615 := by decide
+  rw [BitVec.toNat_add, hs, BitVec.toNat_ofNat, BitVec.toNat_ofNat]
+  omega
+
+private theorem ad_advance (b : Word) (m : Nat) :
+    (b + BitVec.ofNat 64 m) + signExtend12 (1 : BitVec 12) = b + BitVec.ofNat 64 (m + 1) := by
+  rw [show signExtend12 (1 : BitVec 12) = (1 : Word) from by decide]; bv_omega
+
+private theorem ad_ofNat_ne_zero (n : Nat) (h : n + 1 < 2 ^ 64) :
+    BitVec.ofNat 64 (n + 1) ≠ (0 : Word) := by
+  intro heq
+  have h2 := congrArg BitVec.toNat heq
+  rw [BitVec.toNat_ofNat, Nat.mod_eq_of_lt h,
+      show (0 : Word).toNat = 0 from by decide] at h2
+  omega
+
+/-- The per-instruction fetch facts for one fixed-32 copy loop, bundled: the
+    five body instructions at `GB..GB+16` and the back-edge `BNE` at `GB+20`. -/
+structure CopyFetch (rd : Reg) (GB : Word) : Prop where
+  lbu : ∀ a i, CodeReq.singleton GB (.LBU .x29 .x28 (0 : BitVec 12)) a = some i → adCode a = some i
+  sb : ∀ a i, CodeReq.singleton (GB + 4) (.SB rd .x29 (0 : BitVec 12)) a = some i → adCode a = some i
+  a28 : ∀ a i, CodeReq.singleton (GB + 8) (.ADDI .x28 .x28 (1 : BitVec 12)) a = some i → adCode a = some i
+  ard : ∀ a i, CodeReq.singleton (GB + 12) (.ADDI rd rd (1 : BitVec 12)) a = some i → adCode a = some i
+  a6 : ∀ a i, CodeReq.singleton (GB + 16) (.ADDI .x6 .x6 (-1 : BitVec 12)) a = some i → adCode a = some i
+  bne : ∀ a i, CodeReq.singleton (GB + 20) (.BNE .x6 .x0 (-20 : BitVec 13)) a = some i → adCode a = some i
+
+set_option maxRecDepth 8000 in
+/-- One copy-loop body (`GB → GB+20`): copy one byte from `srcBase[srcOff+i]` to
+    `dstBase[dstOff+i]` (advancing both cursors) and decrement the counter from
+    `m+1` to `m`.  The destination content grows by one byte in the
+    `copyIntoRegion` accumulator.  Generic in the destination register `rd`. -/
+theorem adCopyBody (rd : Reg) (GB srcBase dstBase x29old : Word)
+    (srcBytes dstBytes : List (BitVec 8)) (srcOff dstOff i m : Nat)
+    (hrd0 : rd ≠ .x0)
+    (hfetch : CopyFetch rd GB)
+    (h_src_align : srcBase.toNat % 8 = 0)
+    (h_dst_align : dstBase.toNat % 8 = 0)
+    (h_src_lt : srcOff + i < srcBytes.length)
+    (h_dst_lt : dstOff + i < dstBytes.length)
+    (h_src_over : srcBase.toNat + srcBytes.length < 2 ^ 64)
+    (h_dst_over : dstBase.toNat + dstBytes.length < 2 ^ 64)
+    (h_src_valid : ∀ k, k < srcBytes.length →
+      isValidByteAccess (srcBase + BitVec.ofNat 64 k) = true)
+    (h_dst_valid : ∀ k, k < dstBytes.length →
+      isValidByteAccess (dstBase + BitVec.ofNat 64 k) = true) :
+    cpsTripleWithin 5 GB (GB + 20) fullCode
+      (((.x6 : Reg) ↦ᵣ BitVec.ofNat 64 (m + 1)) **
+       ((.x28 : Reg) ↦ᵣ (srcBase + BitVec.ofNat 64 (srcOff + i))) **
+       (rd ↦ᵣ (dstBase + BitVec.ofNat 64 (dstOff + i))) **
+       ((.x29 : Reg) ↦ᵣ x29old) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+       bytesRegion srcBase srcBytes **
+       bytesRegion dstBase (copyIntoRegion dstBytes srcBytes dstOff srcOff i))
+      (((.x6 : Reg) ↦ᵣ BitVec.ofNat 64 m) **
+       ((.x28 : Reg) ↦ᵣ (srcBase + BitVec.ofNat 64 (srcOff + (i + 1)))) **
+       (rd ↦ᵣ (dstBase + BitVec.ofNat 64 (dstOff + (i + 1)))) **
+       ((.x29 : Reg) ↦ᵣ ((srcBytes.getD (srcOff + i) 0).zeroExtend 64)) **
+       ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+       bytesRegion srcBase srcBytes **
+       bytesRegion dstBase (copyIntoRegion dstBytes srcBytes dstOff srcOff (i + 1))) := by
+  set bval := srcBytes[srcOff + i]'h_src_lt with hbval
+  have htrunc : (bval.zeroExtend 64).truncate 8 = bval := by
+    apply BitVec.eq_of_toNat_eq
+    rw [BitVec.toNat_setWidth, BitVec.toNat_setWidth]
+    have := bval.isLt
+    rw [Nat.mod_eq_of_lt (by omega), Nat.mod_eq_of_lt (by omega)]
+  have hgetd : srcBytes.getD (srcOff + i) 0 = bval := by
+    rw [hbval, List.getD_eq_getElem?_getD, List.getElem?_eq_getElem h_src_lt]; rfl
+  have hstep : copyIntoRegion dstBytes srcBytes dstOff srcOff (i + 1)
+      = (copyIntoRegion dstBytes srcBytes dstOff srcOff i).set (dstOff + i) bval := by
+    simp only [copyIntoRegion, hgetd]
+  -- LBU x29, 0(x28)
+  have hlbu := bytesRegion_lbu_within .x29 .x28 srcBase x29old GB
+    srcBytes (srcOff + i) (by decide) h_src_align h_src_lt (by omega)
+    (h_src_valid (srcOff + i) h_src_lt)
+  rw [← hbval] at hlbu
+  have hlbue := cpsTripleWithin_extend_code ad_mono
+    (cpsTripleWithin_extend_code hfetch.lbu hlbu)
+  have hlbuf := cpsTripleWithin_frameR
+    (((.x6 : Reg) ↦ᵣ BitVec.ofNat 64 (m + 1)) **
+     (rd ↦ᵣ (dstBase + BitVec.ofNat 64 (dstOff + i))) **
+     ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+     bytesRegion dstBase (copyIntoRegion dstBytes srcBytes dstOff srcOff i))
+    (by repeat' first | exact bytesRegion_pcFree _ _ | exact pcFree_regIs | apply pcFree_sepConj) hlbue
+  -- SB rd, x29 (store x29's byte at [rd])
+  have hsb := bytesRegion_sb_within rd .x29 dstBase (bval.zeroExtend 64) (GB + 4)
+    (copyIntoRegion dstBytes srcBytes dstOff srcOff i) (dstOff + i) h_dst_align
+    (by rw [copyIntoRegion_length]; omega) (by omega)
+    (h_dst_valid (dstOff + i) h_dst_lt)
+  rw [htrunc, ← hstep, show (GB + 4 : Word) + 4 = GB + 8 from by bv_omega] at hsb
+  have hsbe := cpsTripleWithin_extend_code ad_mono
+    (cpsTripleWithin_extend_code hfetch.sb hsb)
+  have hsbf := cpsTripleWithin_frameR
+    (((.x6 : Reg) ↦ᵣ BitVec.ofNat 64 (m + 1)) **
+     ((.x28 : Reg) ↦ᵣ (srcBase + BitVec.ofNat 64 (srcOff + i))) **
+     ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+     bytesRegion srcBase srcBytes)
+    (by repeat' first | exact bytesRegion_pcFree _ _ | exact pcFree_regIs | apply pcFree_sepConj) hsbe
+  -- ADDI x28, x28, 1
+  have h3 := addi_spec_gen_same_within .x28
+    (srcBase + BitVec.ofNat 64 (srcOff + i)) (1 : BitVec 12) (GB + 8) (by decide)
+  rw [ad_advance srcBase (srcOff + i),
+      show srcOff + i + 1 = srcOff + (i + 1) from by omega,
+      show (GB + 8 : Word) + 4 = GB + 12 from by bv_omega] at h3
+  have h3e := cpsTripleWithin_extend_code ad_mono
+    (cpsTripleWithin_extend_code hfetch.a28 h3)
+  have h3f := cpsTripleWithin_frameR
+    (((.x6 : Reg) ↦ᵣ BitVec.ofNat 64 (m + 1)) **
+     (rd ↦ᵣ (dstBase + BitVec.ofNat 64 (dstOff + i))) **
+     ((.x29 : Reg) ↦ᵣ (bval.zeroExtend 64)) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+     bytesRegion srcBase srcBytes **
+     bytesRegion dstBase (copyIntoRegion dstBytes srcBytes dstOff srcOff (i + 1)))
+    (by repeat' first | exact bytesRegion_pcFree _ _ | exact pcFree_regIs | apply pcFree_sepConj) h3e
+  -- ADDI rd, rd, 1
+  have h4 := addi_spec_gen_same_within rd
+    (dstBase + BitVec.ofNat 64 (dstOff + i)) (1 : BitVec 12) (GB + 12) hrd0
+  rw [ad_advance dstBase (dstOff + i),
+      show dstOff + i + 1 = dstOff + (i + 1) from by omega,
+      show (GB + 12 : Word) + 4 = GB + 16 from by bv_omega] at h4
+  have h4e := cpsTripleWithin_extend_code ad_mono
+    (cpsTripleWithin_extend_code hfetch.ard h4)
+  have h4f := cpsTripleWithin_frameR
+    (((.x6 : Reg) ↦ᵣ BitVec.ofNat 64 (m + 1)) **
+     ((.x28 : Reg) ↦ᵣ (srcBase + BitVec.ofNat 64 (srcOff + (i + 1)))) **
+     ((.x29 : Reg) ↦ᵣ (bval.zeroExtend 64)) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+     bytesRegion srcBase srcBytes **
+     bytesRegion dstBase (copyIntoRegion dstBytes srcBytes dstOff srcOff (i + 1)))
+    (by repeat' first | exact bytesRegion_pcFree _ _ | exact pcFree_regIs | apply pcFree_sepConj) h4e
+  -- ADDI x6, x6, -1
+  have h5 := addi_spec_gen_same_within .x6 (BitVec.ofNat 64 (m + 1)) (-1 : BitVec 12)
+    (GB + 16) (by decide)
+  rw [ad_succ_dec m, show (GB + 16 : Word) + 4 = GB + 20 from by bv_omega] at h5
+  have h5e := cpsTripleWithin_extend_code ad_mono
+    (cpsTripleWithin_extend_code hfetch.a6 h5)
+  have h5f := cpsTripleWithin_frameR
+    (((.x28 : Reg) ↦ᵣ (srcBase + BitVec.ofNat 64 (srcOff + (i + 1)))) **
+     (rd ↦ᵣ (dstBase + BitVec.ofNat 64 (dstOff + (i + 1)))) **
+     ((.x29 : Reg) ↦ᵣ (bval.zeroExtend 64)) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+     bytesRegion srcBase srcBytes **
+     bytesRegion dstBase (copyIntoRegion dstBytes srcBytes dstOff srcOff (i + 1)))
+    (by repeat' first | exact bytesRegion_pcFree _ _ | exact pcFree_regIs | apply pcFree_sepConj) h5e
+  have s12 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_chunked hp) hlbuf hsbf
+  have s123 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_chunked hp) s12 h3f
+  have s1234 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_chunked hp) s123 h4f
+  have s12345 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_chunked hp) s1234 h5f
+  exact cpsTripleWithin_weaken (fun _ hp => by xperm_chunked hp)
+    (fun _ hq => by rw [hgetd]; xperm_chunked hq) s12345
+
+#print axioms adCopyBody
+
+set_option maxRecDepth 8000 in
+/-- The bottom-tested fixed-32-style copy loop closure (`GB → GB+24`): each round
+    copies one byte via `adCopyBody` and then `BNE x6, x0` at `GB+20` loops back
+    to the header while the counter is nonzero, exiting when it reaches `0`.
+    Copies `n+1` bytes, growing the `copyIntoRegion` accumulator.  Generic in the
+    destination register `rd`. -/
+theorem adCopyLoop (rd : Reg) (GB srcBase dstBase x29old : Word)
+    (srcBytes dstBytes : List (BitVec 8)) (srcOff dstOff i n : Nat)
+    (hrd0 : rd ≠ .x0)
+    (hfetch : CopyFetch rd GB)
+    (h_src_align : srcBase.toNat % 8 = 0)
+    (h_dst_align : dstBase.toNat % 8 = 0)
+    (h_src_bound : srcOff + i + (n + 1) ≤ srcBytes.length)
+    (h_dst_bound : dstOff + i + (n + 1) ≤ dstBytes.length)
+    (h_src_over : srcBase.toNat + srcBytes.length < 2 ^ 64)
+    (h_dst_over : dstBase.toNat + dstBytes.length < 2 ^ 64)
+    (h_src_valid : ∀ k, k < srcBytes.length →
+      isValidByteAccess (srcBase + BitVec.ofNat 64 k) = true)
+    (h_dst_valid : ∀ k, k < dstBytes.length →
+      isValidByteAccess (dstBase + BitVec.ofNat 64 k) = true) :
+    cpsTripleWithin (6 * (n + 1)) GB (GB + 24) fullCode
+      (((.x6 : Reg) ↦ᵣ BitVec.ofNat 64 (n + 1)) **
+       ((.x28 : Reg) ↦ᵣ (srcBase + BitVec.ofNat 64 (srcOff + i))) **
+       (rd ↦ᵣ (dstBase + BitVec.ofNat 64 (dstOff + i))) **
+       ((.x29 : Reg) ↦ᵣ x29old) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+       bytesRegion srcBase srcBytes **
+       bytesRegion dstBase (copyIntoRegion dstBytes srcBytes dstOff srcOff i))
+      (((.x6 : Reg) ↦ᵣ (0 : Word)) **
+       ((.x28 : Reg) ↦ᵣ (srcBase + BitVec.ofNat 64 (srcOff + (i + (n + 1))))) **
+       (rd ↦ᵣ (dstBase + BitVec.ofNat 64 (dstOff + (i + (n + 1))))) **
+       regOwn .x29 ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+       bytesRegion srcBase srcBytes **
+       bytesRegion dstBase
+         (copyIntoRegion dstBytes srcBytes dstOff srcOff (i + (n + 1)))) := by
+  have htaken : (GB + 20 : Word) + signExtend13 (-20 : BitVec 13) = GB := by
+    rw [show signExtend13 (-20 : BitVec 13) = (-20 : Word) from by decide]; bv_omega
+  have hfall : (GB + 20 : Word) + 4 = GB + 24 := by bv_omega
+  induction n generalizing i x29old with
+  | zero =>
+    have hbody := adCopyBody rd GB srcBase dstBase x29old srcBytes dstBytes srcOff dstOff i 0
+      hrd0 hfetch h_src_align h_dst_align (by omega) (by omega) h_src_over h_dst_over
+      h_src_valid h_dst_valid
+    have hbne := bne_spec_gen_within .x6 .x0 (-20 : BitVec 13) (BitVec.ofNat 64 0)
+      (0 : Word) (GB + 20)
+    rw [htaken, hfall] at hbne
+    have hbnee := cpsBranchWithin_extend_code ad_mono
+      (cpsBranchWithin_extend_code hfetch.bne hbne)
+    have hnt := cpsBranchWithin_ntakenStripPure2 hbnee (fun hp hQt => by
+      obtain ⟨_, _, _, _, _, hQ⟩ := hQt
+      exact ((sepConj_pure_right _).1 hQ).2 (by decide))
+    have hntf := cpsTripleWithin_frameR
+      (((.x28 : Reg) ↦ᵣ (srcBase + BitVec.ofNat 64 (srcOff + (i + 1)))) **
+       (rd ↦ᵣ (dstBase + BitVec.ofNat 64 (dstOff + (i + 1)))) **
+       ((.x29 : Reg) ↦ᵣ ((srcBytes.getD (srcOff + i) 0).zeroExtend 64)) **
+       bytesRegion srcBase srcBytes **
+       bytesRegion dstBase (copyIntoRegion dstBytes srcBytes dstOff srcOff (i + 1)))
+      (by repeat' first | exact bytesRegion_pcFree _ _ | exact pcFree_regIs | apply pcFree_sepConj) hnt
+    have s1 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_chunked hp) hbody hntf
+    refine cpsTripleWithin_mono_nSteps (nSteps := 5 + 1) (by omega) ?_
+    exact cpsTripleWithin_weaken (fun _ hp => by xperm_chunked hp)
+      (fun _ hq => by
+        simp only [Nat.zero_add]
+        rw [show (BitVec.ofNat 64 0 : Word) = 0 from by decide] at hq
+        have hq2 := sepConj_mono_left (regIs_implies_regOwn .x29) _
+          (show (((.x29 : Reg) ↦ᵣ ((srcBytes.getD (srcOff + i) 0).zeroExtend 64)) **
+            ((.x6 : Reg) ↦ᵣ (0 : Word)) **
+            ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+            ((.x28 : Reg) ↦ᵣ (srcBase + BitVec.ofNat 64 (srcOff + (i + 1)))) **
+            (rd ↦ᵣ (dstBase + BitVec.ofNat 64 (dstOff + (i + 1)))) **
+            bytesRegion srcBase srcBytes **
+            bytesRegion dstBase
+              (copyIntoRegion dstBytes srcBytes dstOff srcOff (i + 1))) _ from by
+            xperm_chunked hq)
+        xperm_chunked hq2) s1
+  | succ k ih =>
+    have hbody := adCopyBody rd GB srcBase dstBase x29old srcBytes dstBytes srcOff dstOff i (k + 1)
+      hrd0 hfetch h_src_align h_dst_align (by omega) (by omega) h_src_over h_dst_over
+      h_src_valid h_dst_valid
+    have hbne := bne_spec_gen_within .x6 .x0 (-20 : BitVec 13) (BitVec.ofNat 64 (k + 1))
+      (0 : Word) (GB + 20)
+    rw [htaken, hfall] at hbne
+    have hbnee := cpsBranchWithin_extend_code ad_mono
+      (cpsBranchWithin_extend_code hfetch.bne hbne)
+    have htk := cpsBranchWithin_takenStripPure2 hbnee (fun hp hQf => by
+      obtain ⟨_, _, _, _, _, hQ⟩ := hQf
+      exact ad_ofNat_ne_zero k (by omega) ((sepConj_pure_right _).1 hQ).2)
+    have htkf := cpsTripleWithin_frameR
+      (((.x28 : Reg) ↦ᵣ (srcBase + BitVec.ofNat 64 (srcOff + (i + 1)))) **
+       (rd ↦ᵣ (dstBase + BitVec.ofNat 64 (dstOff + (i + 1)))) **
+       ((.x29 : Reg) ↦ᵣ ((srcBytes.getD (srcOff + i) 0).zeroExtend 64)) **
+       bytesRegion srcBase srcBytes **
+       bytesRegion dstBase (copyIntoRegion dstBytes srcBytes dstOff srcOff (i + 1)))
+      (by repeat' first | exact bytesRegion_pcFree _ _ | exact pcFree_regIs | apply pcFree_sepConj) htk
+    have hih := ih ((srcBytes.getD (srcOff + i) 0).zeroExtend 64) (i + 1)
+      (by omega) (by omega)
+    have s1 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_chunked hp) hbody htkf
+    have s2 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_chunked hp) s1 hih
+    refine cpsTripleWithin_mono_nSteps (nSteps := (5 + 1) + 6 * (k + 1)) (by omega) ?_
+    exact cpsTripleWithin_weaken (fun _ hp => by xperm_chunked hp)
+      (fun _ hq => by
+        simp only [show i + 1 + (k + 1) = i + (k + 1 + 1) from by omega] at hq
+        xperm_chunked hq) s2
+
+#print axioms adCopyLoop
+
+end EvmAsm.Codegen.AccountDecodeSpec

--- a/EvmAsm/Codegen/Programs/AccountDecodeNonceLoop.lean
+++ b/EvmAsm/Codegen/Programs/AccountDecodeNonceLoop.lean
@@ -1,0 +1,278 @@
+/-
+  The nonce big-endian accumulate loop of `accountDecode_prog`
+  (`Programs/State.lean`, field 0, instrs [33]-[39], `AB+132 → AB+160`).
+
+  The top-tested `BEQ x6, x0, +28` header exits (to `AB+160`, the nonce `SD`)
+  when the byte countdown reaches zero; each taken iteration shifts the
+  big-endian accumulator `x7` left one byte and ORs in the next content byte:
+
+    [33] BEQ  x6, x0, +28   -- exit to AB+160 when x6 = 0
+    [34] SLLI x7, x7, 8
+    [35] LBU  x29, 0(x28)
+    [36] OR   x7, x7, x29
+    [37] ADDI x28, x28, 1
+    [38] ADDI x6,  x6, -1
+    [39] JAL  x0, -24       -- back to AB+132
+
+  This is exactly the merged `AccountIsEip161EmptyLoop.aieNonceLoop`
+  accumulate-scan (`beAccFrom`), re-derived here at the account-decode guest
+  offsets with the content tie the byte-identical `AccountDecodeSpec.beAccum`.
+
+  No `sorry`/`admit`/`native_decide`/`bv_decide`; classical-3 axioms only.
+-/
+
+import EvmAsm.Codegen.Programs.AccountDecodeSpec
+import EvmAsm.Rv64.Tactics.XPerm
+import EvmAsm.Rv64.Tactics.XPermChunked
+
+namespace EvmAsm.Codegen.AccountDecodeSpec
+
+open EvmAsm.Rv64
+open EvmAsm.Rv64.SAsm
+open EvmAsm.Rv64.Tactics
+
+set_option maxRecDepth 8000
+
+/-- Discharge a `.pcFree` side goal over frames of `bytesRegion`/`regIs`/`memIs`
+    cells. -/
+local macro "pcFreeR" : tactic =>
+  `(tactic| repeat' first
+    | exact bytesRegion_pcFree _ _
+    | exact pcFree_regIs
+    | exact pcFree_regOwn
+    | exact pcFree_memIs
+    | exact pcFree_memOwn
+    | apply pcFree_sepConj
+    | pcFree)
+
+/-- `k`-th instruction membership of `accountDecode_prog` into the full linked
+    closure `fullCode` (via `ad_mono` on the local `adCode`). -/
+local macro "adMemF" k:term ", " A:term ", " ins:term : term =>
+  `((fun a i h => ad_mono a i
+      (CodeReq.ofProg_mem_at AB $A accountDecode_prog $k $ins (by bv_omega)
+        (by rw [ad_length]; omega) rfl (by rw [ad_length]; norm_num) a i h)))
+
+/-! ## Nonce accumulate-scan loop ([33]-[39], `AB+132 → AB+160`) -/
+
+/-- The big-endian OR/shift step for `beAccum`, matching `x7 := (x7<<<8)|byte`. -/
+private theorem ad_x7_or_step (bytes : List (BitVec 8)) (o0 i : Nat)
+    (hi : o0 + i < bytes.length) :
+    ((beAccum bytes o0 i) <<< (8 : BitVec 6).toNat) |||
+      ((bytes[o0 + i]'hi).zeroExtend 64) = beAccum bytes o0 (i + 1) := by
+  rw [show (8 : BitVec 6).toNat = 8 from by decide]
+  have hgetd : bytes.getD (o0 + i) 0 = bytes[o0 + i]'hi := by
+    rw [List.getD_eq_getElem?_getD, List.getElem?_eq_getElem hi]; rfl
+  rw [← hgetd]; rfl
+
+/-- Word decrement of a successor counter (the `x6` countdown). -/
+private theorem adn_succ_dec (n : Nat) :
+    BitVec.ofNat 64 (n + 1) + signExtend12 (-1 : BitVec 12) = BitVec.ofNat 64 n := by
+  apply BitVec.eq_of_toNat_eq
+  have hs : (signExtend12 (-1 : BitVec 12) : Word).toNat = 18446744073709551615 := by decide
+  rw [BitVec.toNat_add, hs, BitVec.toNat_ofNat, BitVec.toNat_ofNat]
+  omega
+
+/-- A successor counter `< 2^64` is nonzero as a word. -/
+private theorem adn_succ_ne_zero (n : Nat) (h : n + 1 < 18446744073709551616) :
+    BitVec.ofNat 64 (n + 1) ≠ (0 : Word) := by
+  have ht : (BitVec.ofNat 64 (n + 1) : Word).toNat = n + 1 := by
+    rw [BitVec.toNat_ofNat]; omega
+  intro hc; rw [hc] at ht; simp at ht
+
+/-- Pointer advance by 1 byte. -/
+private theorem adn_advance (b : Word) (m : Nat) :
+    (b + BitVec.ofNat 64 m) + signExtend12 (1 : BitVec 12) = b + BitVec.ofNat 64 (m + 1) := by
+  rw [show signExtend12 (1 : BitVec 12) = (1 : Word) from by decide]; bv_omega
+
+/-- **One nonce-loop iteration** ([34]-[39], `AB+136 → AB+132`): shift the
+    accumulator, OR in `bytes[o0+i]`, advance the pointer and decrement the
+    countdown. -/
+private theorem adNonceBody (accBase : Word) (bytes : List (BitVec 8))
+    (o0 i k : Nat) (v29 : Word)
+    (halign : accBase.toNat % 8 = 0)
+    (hlt : o0 + i < bytes.length)
+    (hover : accBase.toNat + bytes.length < 2 ^ 64)
+    (hvalid : ∀ j, j < bytes.length →
+      isValidByteAccess (accBase + BitVec.ofNat 64 j) = true) :
+    cpsTripleWithin 6 (AB + 136) (AB + 132) fullCode
+      (((.x6 : Reg) ↦ᵣ BitVec.ofNat 64 (k + 1)) **
+       ((.x7 : Reg) ↦ᵣ beAccum bytes o0 i) **
+       ((.x28 : Reg) ↦ᵣ (accBase + BitVec.ofNat 64 (o0 + i))) **
+       ((.x29 : Reg) ↦ᵣ v29) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+       bytesRegion accBase bytes)
+      (((.x6 : Reg) ↦ᵣ BitVec.ofNat 64 k) **
+       ((.x7 : Reg) ↦ᵣ beAccum bytes o0 (i + 1)) **
+       ((.x28 : Reg) ↦ᵣ (accBase + BitVec.ofNat 64 (o0 + (i + 1)))) **
+       ((.x29 : Reg) ↦ᵣ ((bytes[o0 + i]'hlt).zeroExtend 64)) **
+       ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+       bytesRegion accBase bytes) := by
+  -- [34] SLLI x7, x7, 8
+  have h34 := slli_spec_gen_same_within .x7 (beAccum bytes o0 i) (8 : BitVec 6)
+    (AB + 136) (by decide)
+  rw [show (AB + 136 : Word) + 4 = AB + 140 from by bv_omega] at h34
+  have e34 := cpsTripleWithin_extend_code
+    (adMemF 34, (AB + 136), (.SLLI .x7 .x7 (8 : BitVec 6))) h34
+  have f34 := cpsTripleWithin_frameR
+    (((.x6 : Reg) ↦ᵣ BitVec.ofNat 64 (k + 1)) **
+     ((.x28 : Reg) ↦ᵣ (accBase + BitVec.ofNat 64 (o0 + i))) **
+     ((.x29 : Reg) ↦ᵣ v29) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+     bytesRegion accBase bytes)
+    (by pcFreeR) e34
+  -- [35] LBU x29 ← bytes[o0+i]
+  have h35 := bytesRegion_lbu_within .x29 .x28 accBase v29 (AB + 140) bytes (o0 + i)
+    (by decide) halign hlt (by omega) (hvalid (o0 + i) hlt)
+  rw [show (AB + 140 : Word) + 4 = AB + 144 from by bv_omega] at h35
+  have e35 := cpsTripleWithin_extend_code
+    (adMemF 35, (AB + 140), (.LBU .x29 .x28 (0 : BitVec 12))) h35
+  have f35 := cpsTripleWithin_frameR
+    (((.x7 : Reg) ↦ᵣ ((beAccum bytes o0 i) <<< (8 : BitVec 6).toNat)) **
+     ((.x6 : Reg) ↦ᵣ BitVec.ofNat 64 (k + 1)) ** ((.x0 : Reg) ↦ᵣ (0 : Word)))
+    (by pcFreeR) e35
+  -- [36] OR x7, x7, x29
+  have h36 := or_spec_gen_rd_eq_rs1_within .x7 .x29
+    ((beAccum bytes o0 i) <<< (8 : BitVec 6).toNat) ((bytes[o0 + i]'hlt).zeroExtend 64)
+    (AB + 144) (by decide)
+  rw [ad_x7_or_step bytes o0 i hlt,
+      show (AB + 144 : Word) + 4 = AB + 148 from by bv_omega] at h36
+  have e36 := cpsTripleWithin_extend_code
+    (adMemF 36, (AB + 144), (.OR .x7 .x7 .x29)) h36
+  have f36 := cpsTripleWithin_frameR
+    (((.x6 : Reg) ↦ᵣ BitVec.ofNat 64 (k + 1)) **
+     ((.x28 : Reg) ↦ᵣ (accBase + BitVec.ofNat 64 (o0 + i))) **
+     ((.x0 : Reg) ↦ᵣ (0 : Word)) ** bytesRegion accBase bytes)
+    (by pcFreeR) e36
+  -- [37] ADDI x28, x28, 1
+  have h37 := addi_spec_gen_same_within .x28 (accBase + BitVec.ofNat 64 (o0 + i))
+    (1 : BitVec 12) (AB + 148) (by decide)
+  rw [adn_advance accBase (o0 + i),
+      show o0 + i + 1 = o0 + (i + 1) from by omega,
+      show (AB + 148 : Word) + 4 = AB + 152 from by bv_omega] at h37
+  have e37 := cpsTripleWithin_extend_code
+    (adMemF 37, (AB + 148), (.ADDI .x28 .x28 (1 : BitVec 12))) h37
+  have f37 := cpsTripleWithin_frameR
+    (((.x7 : Reg) ↦ᵣ beAccum bytes o0 (i + 1)) **
+     ((.x6 : Reg) ↦ᵣ BitVec.ofNat 64 (k + 1)) **
+     ((.x29 : Reg) ↦ᵣ ((bytes[o0 + i]'hlt).zeroExtend 64)) **
+     ((.x0 : Reg) ↦ᵣ (0 : Word)) ** bytesRegion accBase bytes)
+    (by pcFreeR) e37
+  -- [38] ADDI x6, x6, -1
+  have h38 := addi_spec_gen_same_within .x6 (BitVec.ofNat 64 (k + 1)) (-1 : BitVec 12)
+    (AB + 152) (by decide)
+  rw [adn_succ_dec k, show (AB + 152 : Word) + 4 = AB + 156 from by bv_omega] at h38
+  have e38 := cpsTripleWithin_extend_code
+    (adMemF 38, (AB + 152), (.ADDI .x6 .x6 (-1 : BitVec 12))) h38
+  have f38 := cpsTripleWithin_frameR
+    (((.x7 : Reg) ↦ᵣ beAccum bytes o0 (i + 1)) **
+     ((.x28 : Reg) ↦ᵣ (accBase + BitVec.ofNat 64 (o0 + (i + 1)))) **
+     ((.x29 : Reg) ↦ᵣ ((bytes[o0 + i]'hlt).zeroExtend 64)) **
+     ((.x0 : Reg) ↦ᵣ (0 : Word)) ** bytesRegion accBase bytes)
+    (by pcFreeR) e38
+  -- [39] JAL x0, -24  → AB+132
+  have h39 := jal_x0_spec_gen_within (-24 : BitVec 21) (AB + 156)
+  rw [show AB + 156 + signExtend21 (-24 : BitVec 21) = AB + 132 from by
+      rw [show signExtend21 (-24 : BitVec 21) = (-24 : Word) from by decide]; bv_omega] at h39
+  have e39 := cpsTripleWithin_extend_code
+    (adMemF 39, (AB + 156), (.JAL .x0 (-24 : BitVec 21))) h39
+  have f39 := cpsTripleWithin_frameR
+    (((.x6 : Reg) ↦ᵣ BitVec.ofNat 64 k) **
+     ((.x7 : Reg) ↦ᵣ beAccum bytes o0 (i + 1)) **
+     ((.x28 : Reg) ↦ᵣ (accBase + BitVec.ofNat 64 (o0 + (i + 1)))) **
+     ((.x29 : Reg) ↦ᵣ ((bytes[o0 + i]'hlt).zeroExtend 64)) **
+     ((.x0 : Reg) ↦ᵣ (0 : Word)) ** bytesRegion accBase bytes)
+    (by pcFreeR) e39
+  rw [sepConj_emp_left'] at f39
+  -- compose the six body steps
+  have s1 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_chunked hp) f34 f35
+  have s2 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_chunked hp) s1 f36
+  have s3 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_chunked hp) s2 f37
+  have s4 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_chunked hp) s3 f38
+  have s5 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_chunked hp) s4 f39
+  refine cpsTripleWithin_mono_nSteps (by omega)
+    (cpsTripleWithin_weaken (fun _ hp => by xperm_chunked hp)
+      (fun _ hq => by xperm_chunked hq) s5)
+
+/-- **The nonce accumulate-scan loop closure** ([33]-[39], `AB+132 → AB+160`):
+    by induction on the byte countdown `n`, process the remaining `n` content
+    bytes into the big-endian accumulator and exit through the top `BEQ` with
+    `x6 = 0` and `x7 = beAccum bytes o0 (i+n)`.  Content tie identical to the
+    merged `aieNonceLoop`. -/
+theorem adNonceLoop (accBase : Word) (bytes : List (BitVec 8))
+    (o0 n i : Nat) (v29 : Word)
+    (halign : accBase.toNat % 8 = 0)
+    (hbound : o0 + i + n ≤ bytes.length)
+    (hover : accBase.toNat + bytes.length < 2 ^ 64)
+    (hvalid : ∀ j, j < bytes.length →
+      isValidByteAccess (accBase + BitVec.ofNat 64 j) = true) :
+    cpsTripleWithin (7 * n + 1) (AB + 132) (AB + 160) fullCode
+      (((.x6 : Reg) ↦ᵣ BitVec.ofNat 64 n) **
+       ((.x7 : Reg) ↦ᵣ beAccum bytes o0 i) **
+       ((.x28 : Reg) ↦ᵣ (accBase + BitVec.ofNat 64 (o0 + i))) **
+       ((.x29 : Reg) ↦ᵣ v29) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+       bytesRegion accBase bytes)
+      (((.x6 : Reg) ↦ᵣ (0 : Word)) **
+       ((.x7 : Reg) ↦ᵣ beAccum bytes o0 (i + n)) **
+       regOwn .x28 ** regOwn .x29 ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+       bytesRegion accBase bytes) := by
+  have hbeq : (AB + 132 : Word) + signExtend13 (28 : BitVec 13) = AB + 160 := by
+    rw [show signExtend13 (28 : BitVec 13) = (28 : Word) from by decide]; bv_omega
+  induction n generalizing i v29 with
+  | zero =>
+    -- x6 = 0 : BEQ taken → AB+160
+    have hb := beq_spec_gen_within .x6 .x0 (28 : BitVec 13) (BitVec.ofNat 64 0)
+      (0 : Word) (AB + 132)
+    rw [hbeq] at hb
+    have hbe := cpsBranchWithin_extend_code
+      (adMemF 33, (AB + 132), (.BEQ .x6 .x0 (28 : BitVec 13))) hb
+    have htaken := cpsBranchWithin_takenStripPure2 hbe (fun hp hQf => by
+      obtain ⟨_, _, _, _, _, hQ⟩ := hQf
+      exact ((sepConj_pure_right _).1 hQ).2 (by decide))
+    have htf := cpsTripleWithin_frameR
+      (((.x7 : Reg) ↦ᵣ beAccum bytes o0 i) **
+       ((.x28 : Reg) ↦ᵣ (accBase + BitVec.ofNat 64 (o0 + i))) **
+       ((.x29 : Reg) ↦ᵣ v29) ** bytesRegion accBase bytes)
+      (by pcFreeR) htaken
+    refine cpsTripleWithin_mono_nSteps (by omega)
+      (cpsTripleWithin_weaken (fun _ hp => by xperm_chunked hp)
+        (fun sState hq => by
+          simp only [show i + 0 = i from by omega]
+          rw [show (BitVec.ofNat 64 0 : Word) = 0 from by decide] at hq
+          have hq2 : (((.x6 : Reg) ↦ᵣ (0 : Word)) **
+              ((.x7 : Reg) ↦ᵣ beAccum bytes o0 i) **
+              ((.x28 : Reg) ↦ᵣ (accBase + BitVec.ofNat 64 (o0 + i))) **
+              ((.x29 : Reg) ↦ᵣ v29) ** ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+              bytesRegion accBase bytes) sState := by xperm_chunked hq
+          have hq3 := sepConj_mono_right (sepConj_mono_right
+            (sepConj_mono_left (regIs_implies_regOwn .x28))) _ hq2
+          have hq4 := sepConj_mono_right (sepConj_mono_right (sepConj_mono_right
+            (sepConj_mono_left (regIs_implies_regOwn .x29)))) _ hq3
+          xperm_chunked hq4) htf)
+  | succ k ih =>
+    -- x6 = k+1 ≠ 0 : BEQ not-taken → AB+136, then body, then IH
+    have hb := beq_spec_gen_within .x6 .x0 (28 : BitVec 13) (BitVec.ofNat 64 (k + 1))
+      (0 : Word) (AB + 132)
+    rw [hbeq] at hb
+    have hbe := cpsBranchWithin_extend_code
+      (adMemF 33, (AB + 132), (.BEQ .x6 .x0 (28 : BitVec 13))) hb
+    have hnt := cpsBranchWithin_ntakenStripPure2 hbe (fun hp hQt => by
+      obtain ⟨_, _, _, _, _, hQ⟩ := hQt
+      exact adn_succ_ne_zero k (by omega) ((sepConj_pure_right _).1 hQ).2)
+    have hntf := cpsTripleWithin_frameR
+      (((.x7 : Reg) ↦ᵣ beAccum bytes o0 i) **
+       ((.x28 : Reg) ↦ᵣ (accBase + BitVec.ofNat 64 (o0 + i))) **
+       ((.x29 : Reg) ↦ᵣ v29) ** bytesRegion accBase bytes)
+      (by pcFreeR) hnt
+    have hbody := adNonceBody accBase bytes o0 i k v29 halign (by omega) hover hvalid
+    have hih := ih (i + 1) ((bytes[o0 + i]'(by omega)).zeroExtend 64) (by omega)
+    have s1 := cpsTripleWithin_seq_perm_same_cr
+      (fun _ hp => by xperm_chunked hp) hntf hbody
+    have sfull := cpsTripleWithin_seq_perm_same_cr
+      (fun _ hp => by xperm_chunked hp) s1 hih
+    refine cpsTripleWithin_mono_nSteps (by omega)
+      (cpsTripleWithin_weaken (fun _ hp => by xperm_chunked hp)
+        (fun _ hq => by
+          simp only [show i + 1 + k = i + (k + 1) from by omega] at hq
+          xperm_chunked hq) sfull)
+
+#print axioms adNonceLoop
+
+end EvmAsm.Codegen.AccountDecodeSpec

--- a/EvmAsm/Codegen/Programs/AccountDecodeSpec.lean
+++ b/EvmAsm/Codegen/Programs/AccountDecodeSpec.lean
@@ -1,0 +1,200 @@
+/-
+  Whole-program caller-contract scaffolding for `accountDecode_prog`
+  (`Programs/State.lean`, PR-K27, 136 instructions, entry
+  `GuestAddrs.account_decode`).
+
+  An account is the RLP list `[nonce, balance, storage_root, code_hash]`.
+  The accessor decodes it into four caller-supplied output slots:
+
+    a2 : nonce         out ptr (8 bytes; written LE u64, big-endian decode)
+    a3 : balance       out ptr (32 bytes; BE, left-zero-padded, right-aligned)
+    a4 : storage_root  out ptr (32 bytes; exact 32-byte copy)
+    a5 : code_hash     out ptr (32 bytes; exact 32-byte copy)
+
+  Calling convention (matches the program's prologue saves):
+    a0 (input)  : account RLP bytes ptr        (saved into s0/x8)
+    a1 (input)  : account RLP byte length       (saved into s1/x9)
+    a2 (input)  : nonce out ptr                 (saved into s2/x18)
+    a3 (input)  : balance out ptr               (saved into s3/x19)
+    a4 (input)  : storage_root out ptr          (saved into s4/x20)
+    a5 (input)  : code_hash out ptr             (saved into s5/x21)
+    ra (input)  : return
+    a0 (output) : 0 success / 1 parse fail
+
+  ALL four fields are decoded via `rlp_list_nth_item` (`LI x12 = 0/1/2/3`),
+  each: nth_item call → `BNE x10,x0` (parse fail) → a per-field length check →
+  a byte-materialisation loop.  The four field materialisers differ:
+
+    * field 0 (nonce): variable-length, `len ≤ 8`; a top-tested big-endian
+      accumulation loop building a u64 register value, then `SD`.
+    * field 1 (balance): variable-length, `len ≤ 32`; the 32-byte output is
+      zeroed then the `len` content bytes are copied right-aligned (top-tested
+      `BEQ`/`JAL` copy loop into `out + (32-len)`).
+    * field 2 (storage_root): fixed `len = 32`; a bottom-tested 32-byte LBU/SB
+      copy loop (`BNE x6,x0 -20` back-edge), like withdrawal's address copy.
+    * field 3 (code_hash): fixed `len = 32`; same bottom-tested 32-byte copy.
+
+  The only linked callee is `rlp_list_nth_item`, so the full linked closure is
+  `adCode ∪ RlpListNthItemSAsm.code`.
+
+  This module hosts the code layout, disjointness/mono lemmas, the semantic
+  decode model (genuine per-field `Success`/`Failure` ties -- mirroring
+  `WithdrawalDecodeSpec`), and the caller-facing success/failure outcomes.
+
+  No `sorry`/`admit`/`native_decide`/`bv_decide`; classical-3 axioms only.
+-/
+
+import EvmAsm.Codegen.Programs.RlpListNthItemSAsm
+import EvmAsm.Codegen.Programs.State
+import EvmAsm.Evm64.Terminating.ReturnWindowLoopSpec
+
+namespace EvmAsm.Codegen.AccountDecodeSpec
+
+open EvmAsm.Rv64 EvmAsm.Rv64.RLP EvmAsm.Rv64.SAsm
+
+/-! ## Code layout -/
+
+/-- The accessor body's fixed guest base address. -/
+abbrev AB : Word := (GuestAddrs.account_decode : Word)
+
+set_option maxRecDepth 8000 in
+theorem ad_length : accountDecode_prog.length = 136 := by decide
+
+/-- The wrapper's own re-emitted instructions at `account_decode`. -/
+def adCode : CodeReq := CodeReq.ofProg AB accountDecode_prog
+
+/-- The full linked closure: this accessor plus the strict `rlp_list_nth_item`
+    subroutine (the only cross-`jal` callee). -/
+def fullCode : CodeReq := adCode.union EvmAsm.Codegen.RlpListNthItemSAsm.code
+
+theorem ad_disjoint :
+    adCode.Disjoint EvmAsm.Codegen.RlpListNthItemSAsm.code := by
+  unfold adCode EvmAsm.Codegen.RlpListNthItemSAsm.code
+    EvmAsm.Codegen.RlpListNthItemSAsm.B AB
+  apply CodeReq.Disjoint.ofProg_ranges
+  · rw [ad_length]; decide
+  · rw [EvmAsm.Codegen.RlpListNthItemSAsm.total_length]; decide
+  · rw [ad_length, EvmAsm.Codegen.RlpListNthItemSAsm.total_length]; decide
+
+#print axioms ad_disjoint
+
+theorem ad_mono : ∀ a i, adCode a = some i → fullCode a = some i := by
+  intro a i hi
+  unfold fullCode
+  exact CodeReq.union_mono_left a i hi
+
+/-- The strict `rlp_list_nth_item` subroutine (called for every field) is a
+    sub-union of the full closure. -/
+theorem k20_mono :
+    ∀ a i, EvmAsm.Codegen.RlpListNthItemSAsm.code a = some i → fullCode a = some i := by
+  intro a i hi
+  unfold fullCode
+  exact CodeReq.mono_union_right ad_disjoint (fun _ _ h => h) a i hi
+
+#print axioms ad_mono
+#print axioms k20_mono
+
+/-! ## Semantic decode model
+
+    Every field decodes via K20's `Success`/`Failure` relation on the same
+    strict RLP list.  The two variable-length fields (nonce/balance) carry an
+    upper length bound; the two fixed fields (storage_root/code_hash) require
+    exactly 32 content bytes.  No decode-determinism is assumed: each failure
+    arm names the *actual* failing stage (mirroring `WithdrawalDecodeSpec`). -/
+
+open EvmAsm.Evm64.Terminating (copyIntoRegion copyIntoRegion_length)
+
+/-- Big-endian accumulation of `len` content bytes starting at relative offset
+    `off`, matching the nonce loop `x7 := (x7 <<< 8) ||| byte`.  After `len`
+    iterations this is the big-endian numeric value the program stores (LE) into
+    the 8-byte nonce slot. -/
+def beAccum (bytes : List (BitVec 8)) (off : Nat) : Nat → Word
+  | 0 => 0
+  | (i + 1) => (beAccum bytes off i) <<< 8 |||
+      ((bytes.getD (off + i) 0).zeroExtend 64)
+
+/-- The 32-byte balance buffer after a successful decode: a fully-zeroed 32-byte
+    region into which the `len` content bytes are copied *right-aligned* (forward
+    copy into destination offset `32 - len`), matching the program's
+    `SD x0` zeroing + `ADD x29, x19, (32-len)` + forward LBU/SB copy. -/
+def balanceCopied (bytes : List (BitVec 8)) (o1 : Word) (l1 : Nat) : List (BitVec 8) :=
+  copyIntoRegion (List.replicate 32 (0 : BitVec 8)) bytes (32 - l1) o1.toNat l1
+
+theorem balanceCopied_length (bytes : List (BitVec 8)) (o1 : Word) (l1 : Nat) :
+    (balanceCopied bytes o1 l1).length = 32 := by
+  unfold balanceCopied; rw [copyIntoRegion_length]; simp
+
+/-- A fixed 32-byte content copy (storage_root / code_hash): the 32 content
+    bytes at relative offset `o` copied forward into the caller's old 32-byte
+    output slot. -/
+def fixed32Copied (bytes oldOut : List (BitVec 8)) (o : Word) : List (BitVec 8) :=
+  copyIntoRegion oldOut bytes 0 o.toNat 32
+
+theorem fixed32Copied_length (bytes oldOut : List (BitVec 8)) (o : Word)
+    (hlen : oldOut.length = 32) :
+    (fixed32Copied bytes oldOut o).length = 32 := by
+  unfold fixed32Copied; rw [copyIntoRegion_length]; exact hlen
+
+/-- The genuine success verdict: all four fields decode as K20 successes, with
+    the two variable fields within their length caps and the two fixed fields
+    exactly 32 bytes.  The output values are tied to the actual content:
+      * nonce   = `beAccum` of the `l0` content bytes at `o0`,
+      * balance = right-aligned 32-byte copy of the `l1` content bytes at `o1`,
+      * root    = 32-byte copy at `o2`,  code_hash = 32-byte copy at `o3`. -/
+def Decoded (bytes : List (BitVec 8)) (listBase : Word) (listLen : Nat)
+    (o0 l0 o1 l1 o2 l2 o3 l3 : Word) : Prop :=
+  EvmAsm.Codegen.RlpListNthItemSAsm.Success bytes listBase listLen 0 o0 l0 ∧
+  l0.toNat ≤ 8 ∧
+  EvmAsm.Codegen.RlpListNthItemSAsm.Success bytes listBase listLen 1 o1 l1 ∧
+  l1.toNat ≤ 32 ∧
+  EvmAsm.Codegen.RlpListNthItemSAsm.Success bytes listBase listLen 2 o2 l2 ∧
+  l2.toNat = 32 ∧
+  EvmAsm.Codegen.RlpListNthItemSAsm.Success bytes listBase listLen 3 o3 l3 ∧
+  l3.toNat = 32
+
+/-- The four output slots after a **successful** decode, each cell tied to the
+    actual decoded field value. -/
+def outputSuccess (nonceOut balanceOut rootOut codeOut o0 o1 o2 o3 : Word)
+    (l0 l1 : Nat) (bytes oldRoot oldCode : List (BitVec 8)) : Assertion :=
+  (nonceOut ↦ₘ beAccum bytes o0.toNat l0) **
+  bytesRegion balanceOut (balanceCopied bytes o1 l1) **
+  bytesRegion rootOut (fixed32Copied bytes oldRoot o2) **
+  bytesRegion codeOut (fixed32Copied bytes oldCode o3)
+
+/-- An account-decode **failure** outcome, matching the program's short-circuit
+    dispatch (field 0 list → field 0 len>8 → field 1 list → field 1 len>32 →
+    field 2 list → field 2 len≠32 → field 3 list → field 3 len≠32).  Each arm
+    names the *actual* failing stage via K20's semantics (no determinism
+    assumed).  Mirrors `WithdrawalDecodeSpec.DecodeFailure`. -/
+inductive DecodeFailure (bytes : List (BitVec 8)) (listBase : Word)
+    (listLen : Nat) : Prop
+  | field0List
+      (h : EvmAsm.Codegen.RlpListNthItemSAsm.Failure bytes listBase listLen 0) :
+      DecodeFailure bytes listBase listLen
+  | field0Len (o0 l0 : Word)
+      (h : EvmAsm.Codegen.RlpListNthItemSAsm.Success bytes listBase listLen 0 o0 l0)
+      (hlen : 8 < l0.toNat) :
+      DecodeFailure bytes listBase listLen
+  | field1List
+      (h : EvmAsm.Codegen.RlpListNthItemSAsm.Failure bytes listBase listLen 1) :
+      DecodeFailure bytes listBase listLen
+  | field1Len (o1 l1 : Word)
+      (h : EvmAsm.Codegen.RlpListNthItemSAsm.Success bytes listBase listLen 1 o1 l1)
+      (hlen : 32 < l1.toNat) :
+      DecodeFailure bytes listBase listLen
+  | field2List
+      (h : EvmAsm.Codegen.RlpListNthItemSAsm.Failure bytes listBase listLen 2) :
+      DecodeFailure bytes listBase listLen
+  | field2Len (o2 l2 : Word)
+      (h : EvmAsm.Codegen.RlpListNthItemSAsm.Success bytes listBase listLen 2 o2 l2)
+      (hlen : l2.toNat ≠ 32) :
+      DecodeFailure bytes listBase listLen
+  | field3List
+      (h : EvmAsm.Codegen.RlpListNthItemSAsm.Failure bytes listBase listLen 3) :
+      DecodeFailure bytes listBase listLen
+  | field3Len (o3 l3 : Word)
+      (h : EvmAsm.Codegen.RlpListNthItemSAsm.Success bytes listBase listLen 3 o3 l3)
+      (hlen : l3.toNat ≠ 32) :
+      DecodeFailure bytes listBase listLen
+
+end EvmAsm.Codegen.AccountDecodeSpec

--- a/EvmAsm/Codegen/Programs/Imports.lean
+++ b/EvmAsm/Codegen/Programs/Imports.lean
@@ -549,3 +549,5 @@ import EvmAsm.Codegen.Programs.AccountDecodeBalanceLoop
 import EvmAsm.Codegen.Programs.AccountDecodeCall
 
 import EvmAsm.Codegen.Programs.AccountDecodeFrame
+
+import EvmAsm.Codegen.Programs.AccountDecodeDispatch

--- a/EvmAsm/Codegen/Programs/Imports.lean
+++ b/EvmAsm/Codegen/Programs/Imports.lean
@@ -551,3 +551,5 @@ import EvmAsm.Codegen.Programs.AccountDecodeCall
 import EvmAsm.Codegen.Programs.AccountDecodeFrame
 
 import EvmAsm.Codegen.Programs.AccountDecodeDispatch
+
+import EvmAsm.Codegen.Programs.AccountDecodeBalanceSetup

--- a/EvmAsm/Codegen/Programs/Imports.lean
+++ b/EvmAsm/Codegen/Programs/Imports.lean
@@ -561,3 +561,5 @@ import EvmAsm.Codegen.Programs.AccountDecodeClose2
 import EvmAsm.Codegen.Programs.AccountDecodeClose3
 
 import EvmAsm.Codegen.Programs.AccountDecodeClose4
+
+import EvmAsm.Codegen.Programs.AccountDecodeClose5

--- a/EvmAsm/Codegen/Programs/Imports.lean
+++ b/EvmAsm/Codegen/Programs/Imports.lean
@@ -555,3 +555,5 @@ import EvmAsm.Codegen.Programs.AccountDecodeDispatch
 import EvmAsm.Codegen.Programs.AccountDecodeBalanceSetup
 
 import EvmAsm.Codegen.Programs.AccountDecodeClose
+
+import EvmAsm.Codegen.Programs.AccountDecodeClose2

--- a/EvmAsm/Codegen/Programs/Imports.lean
+++ b/EvmAsm/Codegen/Programs/Imports.lean
@@ -557,3 +557,5 @@ import EvmAsm.Codegen.Programs.AccountDecodeBalanceSetup
 import EvmAsm.Codegen.Programs.AccountDecodeClose
 
 import EvmAsm.Codegen.Programs.AccountDecodeClose2
+
+import EvmAsm.Codegen.Programs.AccountDecodeClose3

--- a/EvmAsm/Codegen/Programs/Imports.lean
+++ b/EvmAsm/Codegen/Programs/Imports.lean
@@ -543,3 +543,5 @@ import EvmAsm.Codegen.Programs.AccountDecodeSpec
 import EvmAsm.Codegen.Programs.AccountDecodeLoop
 
 import EvmAsm.Codegen.Programs.AccountDecodeNonceLoop
+
+import EvmAsm.Codegen.Programs.AccountDecodeBalanceLoop

--- a/EvmAsm/Codegen/Programs/Imports.lean
+++ b/EvmAsm/Codegen/Programs/Imports.lean
@@ -541,3 +541,5 @@ import EvmAsm.Codegen.Programs.ChainValidateConsecutiveNumbersLoopClose
 import EvmAsm.Codegen.Programs.AccountDecodeSpec
 
 import EvmAsm.Codegen.Programs.AccountDecodeLoop
+
+import EvmAsm.Codegen.Programs.AccountDecodeNonceLoop

--- a/EvmAsm/Codegen/Programs/Imports.lean
+++ b/EvmAsm/Codegen/Programs/Imports.lean
@@ -547,3 +547,5 @@ import EvmAsm.Codegen.Programs.AccountDecodeNonceLoop
 import EvmAsm.Codegen.Programs.AccountDecodeBalanceLoop
 
 import EvmAsm.Codegen.Programs.AccountDecodeCall
+
+import EvmAsm.Codegen.Programs.AccountDecodeFrame

--- a/EvmAsm/Codegen/Programs/Imports.lean
+++ b/EvmAsm/Codegen/Programs/Imports.lean
@@ -537,3 +537,5 @@ import EvmAsm.Codegen.Programs.ChainValidateIncreasingTimestampsLoopClose
 import EvmAsm.Codegen.Programs.ChainValidateConsecutiveNumbersSpec
 import EvmAsm.Codegen.Programs.ChainValidateConsecutiveNumbersLoop
 import EvmAsm.Codegen.Programs.ChainValidateConsecutiveNumbersLoopClose
+
+import EvmAsm.Codegen.Programs.AccountDecodeSpec

--- a/EvmAsm/Codegen/Programs/Imports.lean
+++ b/EvmAsm/Codegen/Programs/Imports.lean
@@ -553,3 +553,5 @@ import EvmAsm.Codegen.Programs.AccountDecodeFrame
 import EvmAsm.Codegen.Programs.AccountDecodeDispatch
 
 import EvmAsm.Codegen.Programs.AccountDecodeBalanceSetup
+
+import EvmAsm.Codegen.Programs.AccountDecodeClose

--- a/EvmAsm/Codegen/Programs/Imports.lean
+++ b/EvmAsm/Codegen/Programs/Imports.lean
@@ -559,3 +559,5 @@ import EvmAsm.Codegen.Programs.AccountDecodeClose
 import EvmAsm.Codegen.Programs.AccountDecodeClose2
 
 import EvmAsm.Codegen.Programs.AccountDecodeClose3
+
+import EvmAsm.Codegen.Programs.AccountDecodeClose4

--- a/EvmAsm/Codegen/Programs/Imports.lean
+++ b/EvmAsm/Codegen/Programs/Imports.lean
@@ -545,3 +545,5 @@ import EvmAsm.Codegen.Programs.AccountDecodeLoop
 import EvmAsm.Codegen.Programs.AccountDecodeNonceLoop
 
 import EvmAsm.Codegen.Programs.AccountDecodeBalanceLoop
+
+import EvmAsm.Codegen.Programs.AccountDecodeCall

--- a/EvmAsm/Codegen/Programs/Imports.lean
+++ b/EvmAsm/Codegen/Programs/Imports.lean
@@ -539,3 +539,5 @@ import EvmAsm.Codegen.Programs.ChainValidateConsecutiveNumbersLoop
 import EvmAsm.Codegen.Programs.ChainValidateConsecutiveNumbersLoopClose
 
 import EvmAsm.Codegen.Programs.AccountDecodeSpec
+
+import EvmAsm.Codegen.Programs.AccountDecodeLoop

--- a/EvmAsm/Codegen/Programs/Imports.lean
+++ b/EvmAsm/Codegen/Programs/Imports.lean
@@ -563,3 +563,5 @@ import EvmAsm.Codegen.Programs.AccountDecodeClose3
 import EvmAsm.Codegen.Programs.AccountDecodeClose4
 
 import EvmAsm.Codegen.Programs.AccountDecodeClose5
+
+import EvmAsm.Codegen.Programs.AccountDecodeClose6


### PR DESCRIPTION
## `accountDecode` caller `Fn.Spec` (pkljc-unblocked, multi-field decoder)

Proves `account_decode_spec_within` for the 136-instruction accessor decoding an account RLP
`[nonce, balance, storage_root, code_hash]` into four output cells.

**Proof-only. Opened for coord review.** Base main (pkljc accountDecode fix #10344 merged). The
second multi-field decoder; reuses the withdrawalDecode decoder-compose machinery (generic
fail/cont reshapes + per-field backbone-merge template), uniform-K20 (all 4 fields via
`rlp_list_nth_item`).

### Genuine content ties (total post `adWholePost`)
- **a0=0 (success)**: the four output cells = the genuinely-decoded fields — nonce (`beAccum`
  big-endian u64), balance (`balanceCopied`, right-aligned zero-padded 32B), storage_root &
  code_hash (`fixed32Copied`, 32-byte `copyIntoRegion`), each pinned to `rlp_list_nth_item`'s
  `Success` (with the field-N length bounds: nonce ≤8, balance ≤32, root/code =32), assembled
  into `Decoded`.
- **a0=1 (failure)**: the `DecodeFailure` 8-arm disjunction naming the actual failing stage
  (`field{0,1,2,3}List` = K20 `Failure` / `field{0,1,2,3}Len` = length violation), pinned to the
  real callee outcome. No decode-determinism.

### Structure
Uniform-K20: one generic `adFailArm` + one `adContReshape` cover all 4 boundaries. Per field:
`adFieldNCopy` (materialiser) → `adFieldNSuccess` → `adFieldNContEpi` → `adBBFieldN` (stage merge),
each split to stay under the elaboration/heartbeat ceiling. Top-level = `adPrologue ;; adBBField0`.

### Verification
- `lake build` green; `#print axioms account_decode_spec_within` → `[propext, Classical.choice,
  Quot.sound]`. `check-axioms`: 88 witnesses, classical-only.
- Full guard set green; files ≤1500 (Close5 1212 / Close6 1138). No `sorry`/`native_decide`/
  `bv_decide`/`maxHeartbeats`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

