### PR TITLE
refactor(codegen): split layout-independent RLP splice arithmetic out of RlpSpliceHelperSpec

### DIFF
--- a/EvmAsm/Codegen/Programs/RlpSpliceHelperArithmetic.lean
+++ b/EvmAsm/Codegen/Programs/RlpSpliceHelperArithmetic.lean
@@ -1,0 +1,56 @@
+/-
+  EvmAsm.Codegen.Programs.RlpSpliceHelperArithmetic
+
+  Layout-independent Word/byte arithmetic facts shared by the
+  `RlpSpliceHelperSpec` `rlp_item_size` triples.  Keep this module free of
+  `GuestAddrs`, `RegionMap`, and emitted-program imports so guest-layout
+  changes do not rebuild these facts.
+-/
+
+import EvmAsm.Rv64.Instructions
+
+namespace EvmAsm.Codegen.RlpSpliceHelperSpec
+
+open EvmAsm.Rv64
+
+/-- `zeroExtend 64` of a byte keeps its `toNat`. -/
+theorem toNat_zx (b : BitVec 8) : (b.zeroExtend 64).toNat = b.toNat := by
+  rw [BitVec.toNat_setWidth]
+  exact Nat.mod_eq_of_lt (by have := b.isLt; omega)
+
+/-- `ult` from a `toNat` bound (byte, zero-extended, against a literal). -/
+theorem ult_zx_of_lt (b : BitVec 8) (c : Word) (h : b.toNat < c.toNat) :
+    BitVec.ult (b.zeroExtend 64) c := by
+  have hN := toNat_zx b
+  simpa [BitVec.ult, decide_eq_true_eq, hN] using h
+
+/-- `¬ ult` from a `toNat` bound (byte, zero-extended, against a literal). -/
+theorem not_ult_zx_of_ge (b : BitVec 8) (c : Word) (h : c.toNat ≤ b.toNat) :
+    ¬ BitVec.ult (b.zeroExtend 64) c := by
+  have hN := toNat_zx b
+  simp only [BitVec.ult, decide_eq_true_eq, hN]
+  omega
+
+/-- The short-string span: `(zx b - 128) + 1 = b - 127` for `b ≥ 0x80`. -/
+theorem ris_result_128 (b : BitVec 8) (h : 128 ≤ b.toNat) :
+    ((b.zeroExtend 64) + signExtend12 (-128 : BitVec 12)) + signExtend12 (1 : BitVec 12)
+      = BitVec.ofNat 64 (b.toNat - 127) := by
+  have hb := b.isLt
+  have h1 : (signExtend12 (-128 : BitVec 12) : Word).toNat = 2 ^ 64 - 128 := by decide
+  have h2 : (signExtend12 (1 : BitVec 12) : Word).toNat = 1 := by decide
+  apply BitVec.eq_of_toNat_eq
+  rw [BitVec.toNat_add, BitVec.toNat_add, BitVec.toNat_setWidth, h1, h2, BitVec.toNat_ofNat]
+  omega
+
+/-- The short-list span: `(zx b - 192) + 1 = b - 191` for `b ≥ 0xc0`. -/
+theorem ris_result_192 (b : BitVec 8) (h : 192 ≤ b.toNat) :
+    ((b.zeroExtend 64) + signExtend12 (-192 : BitVec 12)) + signExtend12 (1 : BitVec 12)
+      = BitVec.ofNat 64 (b.toNat - 191) := by
+  have hb := b.isLt
+  have h1 : (signExtend12 (-192 : BitVec 12) : Word).toNat = 2 ^ 64 - 192 := by decide
+  have h2 : (signExtend12 (1 : BitVec 12) : Word).toNat = 1 := by decide
+  apply BitVec.eq_of_toNat_eq
+  rw [BitVec.toNat_add, BitVec.toNat_add, BitVec.toNat_setWidth, h1, h2, BitVec.toNat_ofNat]
+  omega
+
+end EvmAsm.Codegen.RlpSpliceHelperSpec

--- a/EvmAsm/Codegen/Programs/RlpSpliceHelperSpec.lean
+++ b/EvmAsm/Codegen/Programs/RlpSpliceHelperSpec.lean
@@ -53,6 +53,7 @@ import EvmAsm.Rv64.Tactics.XSimp
 import EvmAsm.Evm64.CallingConvention
 import EvmAsm.EL.RLP.Properties
 import EvmAsm.Codegen.Programs.RlpRead
+import EvmAsm.Codegen.Programs.RlpSpliceHelperArithmetic
 import EvmAsm.Codegen.GuestAddrs
 
 namespace EvmAsm.Codegen
@@ -67,48 +68,6 @@ open EvmAsm.EL.RLP
 local macro "cmem" k:term:max : tactic =>
   `(tactic| exact CodeReq.singleton_mono
       (CodeReq.ofProg_lookup_addr _ _ $k _ (by decide) (by decide) (by bv_omega)))
-
-/-! ## Word arithmetic helpers -/
-
-/-- `zeroExtend 64` of a byte keeps its `toNat`. -/
-private theorem toNat_zx (b : BitVec 8) : (b.zeroExtend 64).toNat = b.toNat := by
-  rw [BitVec.toNat_setWidth]
-  exact Nat.mod_eq_of_lt (by have := b.isLt; omega)
-
-/-- `ult` from a `toNat` bound (byte, zero-extended, against a literal). -/
-private theorem ult_zx_of_lt (b : BitVec 8) (c : Word) (h : b.toNat < c.toNat) :
-    BitVec.ult (b.zeroExtend 64) c := by
-  have hN := toNat_zx b
-  simpa [BitVec.ult, decide_eq_true_eq, hN] using h
-
-/-- `¬ ult` from a `toNat` bound (byte, zero-extended, against a literal). -/
-private theorem not_ult_zx_of_ge (b : BitVec 8) (c : Word) (h : c.toNat ≤ b.toNat) :
-    ¬ BitVec.ult (b.zeroExtend 64) c := by
-  have hN := toNat_zx b
-  simp only [BitVec.ult, decide_eq_true_eq, hN]
-  omega
-
-/-- The short-string span: `(zx b - 128) + 1 = b - 127` for `b ≥ 0x80`. -/
-private theorem ris_result_128 (b : BitVec 8) (h : 128 ≤ b.toNat) :
-    ((b.zeroExtend 64) + signExtend12 (-128 : BitVec 12)) + signExtend12 (1 : BitVec 12)
-      = BitVec.ofNat 64 (b.toNat - 127) := by
-  have hb := b.isLt
-  have h1 : (signExtend12 (-128 : BitVec 12) : Word).toNat = 2 ^ 64 - 128 := by decide
-  have h2 : (signExtend12 (1 : BitVec 12) : Word).toNat = 1 := by decide
-  apply BitVec.eq_of_toNat_eq
-  rw [BitVec.toNat_add, BitVec.toNat_add, BitVec.toNat_setWidth, h1, h2, BitVec.toNat_ofNat]
-  omega
-
-/-- The short-list span: `(zx b - 192) + 1 = b - 191` for `b ≥ 0xc0`. -/
-private theorem ris_result_192 (b : BitVec 8) (h : 192 ≤ b.toNat) :
-    ((b.zeroExtend 64) + signExtend12 (-192 : BitVec 12)) + signExtend12 (1 : BitVec 12)
-      = BitVec.ofNat 64 (b.toNat - 191) := by
-  have hb := b.isLt
-  have h1 : (signExtend12 (-192 : BitVec 12) : Word).toNat = 2 ^ 64 - 192 := by decide
-  have h2 : (signExtend12 (1 : BitVec 12) : Word).toNat = 1 := by decide
-  apply BitVec.eq_of_toNat_eq
-  rw [BitVec.toNat_add, BitVec.toNat_add, BitVec.toNat_setWidth, h1, h2, BitVec.toNat_ofNat]
-  omega
 
 /-! ## `rlp_item_size` — per-form `∀ base` triples
 


### PR DESCRIPTION
## What & why

Per `docs/agents/layout-independent-codegen-splits.md` and the candidate queue from evm-asm3: move the five layout-independent Word/byte arithmetic helpers (`toNat_zx`, `ult_zx_of_lt`, `not_ult_zx_of_ge`, `ris_result_128`, `ris_result_192`) out of the layout-dependent `RlpSpliceHelperSpec.lean` into a new sibling `RlpSpliceHelperArithmetic.lean`, so these facts stop rebuilding on guest-layout churn.

## How

- New `RlpSpliceHelperArithmetic.lean` imports only `EvmAsm.Rv64.Instructions` — no `GuestAddrs` / `RegionMap` / emitted-program import.
- The sibling keeps the existing `EvmAsm.Codegen.RlpSpliceHelperSpec` namespace, so the helpers' fully-qualified names are unchanged and all call sites in the parent resolve with zero edits.
- `private` is dropped on the moved theorems (private is module-scoped, so the parent could not otherwise import them). Statements and proofs are preserved verbatim.
- The `∀ base` triples stay in the parent — they import the layout-dependent `RlpRead`, so per the rule doc they are not movable yet.

## Validation

- `lake build`: 4704 jobs, 0 errors.
- `scripts/check-unimported.sh`: 2739 modules, 2739 reachable, 0 orphans (new file reachable via the parent import).
- `scripts/check-no-warnings.sh`: 0 warnings under `EvmAsm/`.
- `git diff --check`: clean.

Behavior-neutral build-graph refactor; no statement/proof/byte change.

Sibling of #10414 (the StrictList payload split). Same mechanical recipe.

Opened for coord review; coord applies the label.