### PR TITLE
fix(codegen): import RlpItemSpanSpec from the umbrella module

### DIFF
--- a/EvmAsm/Codegen/Programs/Imports.lean
+++ b/EvmAsm/Codegen/Programs/Imports.lean
@@ -85,6 +85,7 @@ import EvmAsm.Codegen.Programs.AccountAccessorTopSpec
 import EvmAsm.Codegen.Programs.AccountAccessorNonceSpec
 import EvmAsm.Codegen.Programs.AccountBalanceHelperSpec
 import EvmAsm.Codegen.Programs.RlpSpliceHelperSpec
+import EvmAsm.Codegen.Programs.RlpItemSpanSpec
 import EvmAsm.Codegen.Programs.MptSpliceSlotSpec
 import EvmAsm.Codegen.Programs.HeaderFieldsSpecCommon
 import EvmAsm.Codegen.Programs.HeaderFieldsSpecBlocks


### PR DESCRIPTION
#10418 added `EvmAsm/Codegen/Programs/RlpItemSpanSpec.lean` but never wired it into `Programs/Imports.lean`, leaving it an orphan file -- same class as the earlier `MptSpliceSlotSpec` orphan fixed in #10406. This trips `scripts/check-unimported.sh` on every downstream PR based on current main; coord flagged it as blocking #10422 + the merge queue.

Fix: added the missing import next to its sibling `RlpSpliceHelperSpec` (same shape per the new file's own header comment).

Verified: `lake build` green (4720 jobs), all 21 `scripts/check-*.sh` gates green, including a clean `check-unimported.sh` (2755/2755 reachable, 0 orphans). One import line only.