### PR TITLE
chore: wire RlpItemSpanSpec into the Imports umbrella

### DIFF
--- a/EvmAsm/Codegen/Programs/Imports.lean
+++ b/EvmAsm/Codegen/Programs/Imports.lean
@@ -86,6 +86,7 @@ import EvmAsm.Codegen.Programs.AccountAccessorNonceSpec
 import EvmAsm.Codegen.Programs.AccountBalanceHelperSpec
 import EvmAsm.Codegen.Programs.RlpSpliceHelperSpec
 import EvmAsm.Codegen.Programs.MptSpliceSlotSpec
+import EvmAsm.Codegen.Programs.RlpItemSpanSpec
 import EvmAsm.Codegen.Programs.HeaderFieldsSpecCommon
 import EvmAsm.Codegen.Programs.HeaderFieldsSpecBlocks
 import EvmAsm.Codegen.Programs.HeaderFieldsSpecBlocksTail


### PR DESCRIPTION
RlpItemSpanSpec.lean (added in #10418) is not imported by any module, so scripts/check-unimported.sh flags it as an orphan — the same class as the earlier MptSpliceSlotSpec orphan fixed in #10406. This blocks #10422 and the merge queue.

Fix: add one import line to the Codegen/Programs Imports umbrella, next to MptSpliceSlotSpec (RlpItemSpanSpec already imports MptSpliceSlotSpec, so it slots in there naturally).

Verification: source-only change, no build needed. scripts/check-unimported.sh passes on a clean tree — 2755 modules, 2755 reachable, 0 orphans (exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)