### PR TITLE
refactor(divmod): remove unused V5-iteration theorems

### DIFF
--- a/EvmAsm/Codegen/Programs/EvmDivModWrappers.lean
+++ b/EvmAsm/Codegen/Programs/EvmDivModWrappers.lean
@@ -89,14 +89,4 @@ def evmModV5Patched : Program :=
   [Instr.JAL .x0 (344 : BitVec 21)] ++
   (EvmAsm.Evm64.evm_mod_v5 : List Instr).drop 268
 
-/-- `EvmAsm.Evm64.evm_sdiv_v5` with the leading save-ra block removed for
-    trampoline-style handlers. -/
-def evmSdivV5Patched : Program :=
-  (EvmAsm.Evm64.evm_sdiv_v5 : List Instr).drop 1
-
-/-- `EvmAsm.Evm64.evm_smod_v5` with the leading save-ra block removed for
-    trampoline-style handlers. -/
-def evmSmodV5Patched : Program :=
-  (EvmAsm.Evm64.evm_smod_v5 : List Instr).drop 1
-
 end EvmAsm.Codegen

--- a/EvmAsm/Evm64/EvmWordArith/DivV4TrialOverestimate.lean
+++ b/EvmAsm/Evm64/EvmWordArith/DivV4TrialOverestimate.lean
@@ -44,10 +44,4 @@ def DivKTrialCallV4QHatLeFloorPlusOne (uHi uLo vTop : Word) : Prop :=
   (divKTrialCallV4QHat uHi uLo vTop).toNat ≤
     (uHi.toNat * 2^64 + uLo.toNat) / vTop.toNat + 1
 
-theorem DivKTrialCallV4QHatLeFloorPlusOne_unfold (uHi uLo vTop : Word) :
-    DivKTrialCallV4QHatLeFloorPlusOne uHi uLo vTop ↔
-      (divKTrialCallV4QHat uHi uLo vTop).toNat ≤
-        (uHi.toNat * 2^64 + uLo.toNat) / vTop.toNat + 1 :=
-  Iff.rfl
-
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/EvmWordArith/DivV4TrialVal256Composition.lean
+++ b/EvmAsm/Evm64/EvmWordArith/DivV4TrialVal256Composition.lean
@@ -29,13 +29,6 @@ def Knuth128_64TopWindowLeVal256DivPlusOne
   (uHi.toNat * 2^64 + uLo.toNat) / vTop.toNat ≤
     val256 u0 u1 u2 u3 / val256 v0 v1 v2 v3 + 1
 
-theorem Knuth128_64TopWindowLeVal256DivPlusOne_unfold
-    (uHi uLo vTop : Word) (v0 v1 v2 v3 u0 u1 u2 u3 : Word) :
-    Knuth128_64TopWindowLeVal256DivPlusOne uHi uLo vTop v0 v1 v2 v3 u0 u1 u2 u3 ↔
-      (uHi.toNat * 2^64 + uLo.toNat) / vTop.toNat ≤
-        val256 u0 u1 u2 u3 / val256 v0 v1 v2 v3 + 1 :=
-  Iff.rfl
-
 /-- Composition: from the Knuth-A v4 `+1` bound and the Knuth Theorem A
     bound, derive the val256-level `+2` overestimate consumed by the
     BLT-path bridges. -/

--- a/EvmAsm/Evm64/EvmWordArith/DivV5TrialOverestimate.lean
+++ b/EvmAsm/Evm64/EvmWordArith/DivV5TrialOverestimate.lean
@@ -36,12 +36,6 @@ def DivKTrialCallV5QHatLeFloorPlusOne (uHi uLo vTop : Word) : Prop :=
   (divKTrialCallV5QHat uHi uLo vTop).toNat ≤
     (uHi.toNat * 2^64 + uLo.toNat) / vTop.toNat + 1
 
-theorem DivKTrialCallV5QHatLeFloorPlusOne_unfold (uHi uLo vTop : Word) :
-    DivKTrialCallV5QHatLeFloorPlusOne uHi uLo vTop ↔
-      (divKTrialCallV5QHat uHi uLo vTop).toNat ≤
-        (uHi.toNat * 2^64 + uLo.toNat) / vTop.toNat + 1 :=
-  Iff.rfl
-
 /-- **The V5 payoff** (v5 analog of the impossible v4 bead `7.1.4.1`):
     `divKTrialCallV5QHat ≤ (uHi·2^64 + uLo)/vTop + 1` discharged
     unconditionally from V5.4.5, under just the call regime

--- a/EvmAsm/Evm64/SDiv/Program.lean
+++ b/EvmAsm/Evm64/SDiv/Program.lean
@@ -51,11 +51,6 @@ theorem evm_sdiv_sign_bit_block_length
     EvmAsm.Rv64.single EvmAsm.Rv64.seq EvmAsm.Rv64.Program
   rfl
 
-theorem evm_sdiv_sign_bit_block_byte_length
-    (addrReg signReg : EvmAsm.Rv64.Reg) (topLimbOff : BitVec 12) :
-    4 * (evm_sdiv_sign_bit_block addrReg signReg topLimbOff).length = 8 := by
-  rw [evm_sdiv_sign_bit_block_length]
-
 /-- One limb of the conditional 256-bit negation loop.
 
     The caller has already materialized `maskReg = 0 - sign`. This step
@@ -73,16 +68,6 @@ def evm_sdiv_cond_negate_limb_step
   EvmAsm.Rv64.ADD valueReg valueReg carryInReg ;;
   EvmAsm.Rv64.SLTU carryReg valueReg carryInReg ;;
   EvmAsm.Rv64.SD addrReg valueReg limbOff
-
-theorem evm_sdiv_cond_negate_limb_step_length
-    (addrReg carryInReg maskReg valueReg carryReg : EvmAsm.Rv64.Reg)
-    (limbOff : BitVec 12) :
-    (evm_sdiv_cond_negate_limb_step addrReg carryInReg maskReg valueReg carryReg
-      limbOff).length = 5 := by
-  unfold evm_sdiv_cond_negate_limb_step EvmAsm.Rv64.LD EvmAsm.Rv64.XOR'
-    EvmAsm.Rv64.ADD EvmAsm.Rv64.SLTU EvmAsm.Rv64.SD EvmAsm.Rv64.single
-    EvmAsm.Rv64.seq EvmAsm.Rv64.Program
-  rfl
 
 /-- Conditionally negate a 256-bit word in place.
 
@@ -118,13 +103,6 @@ theorem evm_sdiv_cond_negate_256_block_length
     EvmAsm.Rv64.Program
   rfl
 
-theorem evm_sdiv_cond_negate_256_block_byte_length
-    (addrReg signReg maskReg valueReg carryReg : EvmAsm.Rv64.Reg)
-    (limb0Off limb1Off limb2Off limb3Off : BitVec 12) :
-    4 * (evm_sdiv_cond_negate_256_block addrReg signReg maskReg valueReg carryReg
-      limb0Off limb1Off limb2Off limb3Off).length = 84 := by
-  rw [evm_sdiv_cond_negate_256_block_length]
-
 /-- Near-call block from SDIV into the unsigned `evm_div_callable_v4` body.
     The concrete signed 21-bit offset is pinned by the eventual top-level
     `evm_sdiv` layout. -/
@@ -133,10 +111,6 @@ def evm_sdiv_div_call_block (divOff : BitVec 21) : EvmAsm.Rv64.Program :=
 
 theorem evm_sdiv_div_call_block_length (divOff : BitVec 21) :
     (evm_sdiv_div_call_block divOff).length = 1 := rfl
-
-theorem evm_sdiv_div_call_block_byte_length (divOff : BitVec 21) :
-    4 * (evm_sdiv_div_call_block divOff).length = 4 := by
-  rw [evm_sdiv_div_call_block_length]
 
 /-- Copy the current return address to a preserved scratch register. SDIV
     cannot use `cc_prologue` / `cc_epilogue` around `evm_div_callable`
@@ -147,20 +121,12 @@ def evm_sdiv_save_ra_block (savedRaReg : EvmAsm.Rv64.Reg) : EvmAsm.Rv64.Program 
 theorem evm_sdiv_save_ra_block_length (savedRaReg : EvmAsm.Rv64.Reg) :
     (evm_sdiv_save_ra_block savedRaReg).length = 1 := rfl
 
-theorem evm_sdiv_save_ra_block_byte_length (savedRaReg : EvmAsm.Rv64.Reg) :
-    4 * (evm_sdiv_save_ra_block savedRaReg).length = 4 := by
-  rw [evm_sdiv_save_ra_block_length]
-
 /-- Return to the address saved before the nested DIV call. -/
 def evm_sdiv_saved_ra_ret_block (savedRaReg : EvmAsm.Rv64.Reg) : EvmAsm.Rv64.Program :=
   EvmAsm.Rv64.JALR .x0 savedRaReg 0
 
 theorem evm_sdiv_saved_ra_ret_block_length (savedRaReg : EvmAsm.Rv64.Reg) :
     (evm_sdiv_saved_ra_ret_block savedRaReg).length = 1 := rfl
-
-theorem evm_sdiv_saved_ra_ret_block_byte_length (savedRaReg : EvmAsm.Rv64.Reg) :
-    4 * (evm_sdiv_saved_ra_ret_block savedRaReg).length = 4 := by
-  rw [evm_sdiv_saved_ra_ret_block_length]
 
 def evm_sdivDividendTopLimbOff : BitVec 12 := 24
 def evm_sdivDivisorTopLimbOff : BitVec 12 := 56
@@ -190,41 +156,12 @@ def evm_sdiv_wrapper : EvmAsm.Rv64.Program :=
 theorem evm_sdiv_wrapper_length : evm_sdiv_wrapper.length = 71 := by
   decide
 
-theorem evm_sdiv_wrapper_byte_length :
-    4 * evm_sdiv_wrapper.length = 284 := by
-  rw [evm_sdiv_wrapper_length]
-
-theorem evm_sdiv_call_target_byte_offset :
-    4 *
-      ((evm_sdiv_save_ra_block .x18).length +
-       (evm_sdiv_sign_bit_block .x12 .x8 evm_sdivDividendTopLimbOff).length +
-       (evm_sdiv_sign_bit_block .x12 .x9 evm_sdivDivisorTopLimbOff).length +
-       (evm_sdiv_cond_negate_256_block .x12 .x8 .x10 .x7 .x11 0 8 16 24).length +
-       (evm_sdiv_cond_negate_256_block .x12 .x9 .x10 .x7 .x11 32 40 48 56).length +
-       (EvmAsm.Rv64.XOR' .x8 .x8 .x9).length) +
-      EvmAsm.Rv64.signExtend21 evm_sdivCallOff =
-    4 * evm_sdiv_wrapper.length := by
-  decide
-
 /-- Legacy verified SDIV code region. The wrapper returns via `x18`; the
     appended `evm_div_callable` block is reached only by the wrapper's near
     call. Existing `sdivCode` composition proofs still target this surface
     until the dispatcher proofs are lifted to the v4 no-NOP code surface. -/
 def evm_sdiv_legacy : EvmAsm.Rv64.Program :=
   evm_sdiv_wrapper ;; evm_div_callable_v1
-
-theorem evm_sdiv_legacy_length : evm_sdiv_legacy.length = 390 := by
-  have h_v1 : evm_div_callable_v1.length = 319 := by
-    simp only [evm_div_callable_v1, EvmAsm.Rv64.seq, EvmAsm.Rv64.Program.length_append,
-      divK_phaseA_len,
-      divK_phaseB_len, divK_clz_len, divK_phaseC2_len, divK_normB_len, divK_normA_len,
-      divK_copyAU_len, divK_loopSetup_len, divK_loopBody_len, divK_denorm_len,
-      divK_divEpilogue_len, divK_zeroPath_len, cc_ret_len, divK_div128_len]
-  simp only [evm_sdiv_legacy, EvmAsm.Rv64.seq, EvmAsm.Rv64.Program.length_append,
-    evm_sdiv_wrapper_length, h_v1]
-
-theorem evm_sdiv_legacy_byte_length : 4 * evm_sdiv_legacy.length = 1560 := by
-  rw [evm_sdiv_legacy_length]
 
 /-- Full SDIV code region, using the corrected v4 unsigned DIV callable. -/
 def evm_sdiv : EvmAsm.Rv64.Program :=
@@ -250,26 +187,13 @@ def evm_sdiv_v5 : EvmAsm.Rv64.Program :=
 theorem evm_sdiv_v5_uses_div_callable_v5 :
     evm_sdiv_v5 = (evm_sdiv_wrapper ;; evm_div_callable_v5) := rfl
 
-theorem evm_sdiv_length : evm_sdiv.length = 414 := by
-  simp only [evm_sdiv, EvmAsm.Rv64.seq, EvmAsm.Rv64.Program.length_append,
-    evm_sdiv_wrapper_length, evm_div_callable_v4_length]
-
 theorem evm_sdiv_v4_length : evm_sdiv_v4.length = 414 := by
   simp only [evm_sdiv_v4, EvmAsm.Rv64.seq, EvmAsm.Rv64.Program.length_append,
     evm_sdiv_wrapper_length, evm_div_callable_v4_length]
 
-theorem evm_sdiv_byte_length : 4 * evm_sdiv.length = 1656 := by
-  rw [evm_sdiv_length]
-
-theorem evm_sdiv_v4_byte_length : 4 * evm_sdiv_v4.length = 1656 := by
-  rw [evm_sdiv_v4_length]
-
 theorem evm_sdiv_v5_length : evm_sdiv_v5.length = 424 := by
   simp only [evm_sdiv_v5, EvmAsm.Rv64.seq, EvmAsm.Rv64.Program.length_append,
     evm_sdiv_wrapper_length, evm_div_callable_v5_length]
-
-theorem evm_sdiv_v5_byte_length : 4 * evm_sdiv_v5.length = 1696 := by
-  rw [evm_sdiv_v5_length]
 
 example :
     (evm_sdiv_sign_bit_block .x12 .x5 24).length +

--- a/EvmAsm/Evm64/SMod/Program.lean
+++ b/EvmAsm/Evm64/SMod/Program.lean
@@ -38,20 +38,12 @@ def evm_smod_save_ra_block (savedRaReg : Reg) : Program :=
 theorem evm_smod_save_ra_block_length (savedRaReg : Reg) :
     (evm_smod_save_ra_block savedRaReg).length = 1 := rfl
 
-theorem evm_smod_save_ra_block_byte_length (savedRaReg : Reg) :
-    4 * (evm_smod_save_ra_block savedRaReg).length = 4 := by
-  rw [evm_smod_save_ra_block_length]
-
 /-- Return to the address saved before the nested MOD call. -/
 def evm_smod_saved_ra_ret_block (savedRaReg : Reg) : Program :=
   JALR .x0 savedRaReg 0
 
 theorem evm_smod_saved_ra_ret_block_length (savedRaReg : Reg) :
     (evm_smod_saved_ra_ret_block savedRaReg).length = 1 := rfl
-
-theorem evm_smod_saved_ra_ret_block_byte_length (savedRaReg : Reg) :
-    4 * (evm_smod_saved_ra_ret_block savedRaReg).length = 4 := by
-  rw [evm_smod_saved_ra_ret_block_length]
 
 /-- The executable SMOD wrapper, excluding the appended unsigned MOD callable.
 
@@ -76,22 +68,6 @@ def evm_smod_wrapper : Program :=
   evm_smod_saved_ra_ret_block .x18
 
 theorem evm_smod_wrapper_length : evm_smod_wrapper.length = 71 := by
-  decide
-
-theorem evm_smod_wrapper_byte_length :
-    4 * evm_smod_wrapper.length = 284 := by
-  rw [evm_smod_wrapper_length]
-
-theorem evm_smod_call_target_byte_offset :
-    4 *
-      ((evm_smod_save_ra_block .x18).length +
-       (evm_sdiv_sign_bit_block .x12 .x8 evm_smodDividendTopLimbOff).length +
-       (ADDI .x13 .x8 0).length +
-       (evm_sdiv_sign_bit_block .x12 .x9 evm_smodDivisorTopLimbOff).length +
-       (evm_sdiv_cond_negate_256_block .x12 .x8 .x10 .x7 .x11 0 8 16 24).length +
-       (evm_sdiv_cond_negate_256_block .x12 .x9 .x10 .x7 .x11 32 40 48 56).length) +
-      signExtend21 evm_smodCallOff =
-    4 * evm_smod_wrapper.length := by
   decide
 
 /-- Legacy SMOD code region. The wrapper returns via `x18`; the appended
@@ -129,24 +105,8 @@ theorem evm_smod_length : evm_smod.length = 414 := by
   simp only [evm_smod, EvmAsm.Rv64.seq, EvmAsm.Rv64.Program.length_append,
     evm_smod_wrapper_length, evm_mod_callable_v4_length]
 
-theorem evm_smod_v4_length : evm_smod_v4.length = 414 := by
-  simp only [evm_smod_v4, EvmAsm.Rv64.seq, EvmAsm.Rv64.Program.length_append,
-    evm_smod_wrapper_length, evm_mod_callable_v4_length]
-
 theorem evm_smod_v5_length : evm_smod_v5.length = 424 := by
   simp only [evm_smod_v5, EvmAsm.Rv64.seq, EvmAsm.Rv64.Program.length_append,
     evm_smod_wrapper_length, evm_mod_callable_v5_length]
-
-theorem evm_smod_legacy_byte_length : 4 * evm_smod_legacy.length = 1560 := by
-  rw [evm_smod_legacy_length]
-
-theorem evm_smod_byte_length : 4 * evm_smod.length = 1656 := by
-  rw [evm_smod_length]
-
-theorem evm_smod_v4_byte_length : 4 * evm_smod_v4.length = 1656 := by
-  rw [evm_smod_v4_length]
-
-theorem evm_smod_v5_byte_length : 4 * evm_smod_v5.length = 1696 := by
-  rw [evm_smod_v5_length]
 
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary

Delete 28 unreferenced DIV/MOD theorems/defs left over from the V5 iteration experiments (Issue #61). Every candidate was verified to have **zero references repo-wide** (declaring file only) and **zero within-file uses** (pure leaves), then removed in two batches with a full green rebuild after each.

## Removed (by file)

- **`EvmDivModWrappers.lean`**: `evmSdivV5Patched`, `evmSmodV5Patched` (V5 patched wrappers; the v4/v6 wrappers are the live ones).
- **`SDiv/Program.lean`**: the `*_byte_length` / `evm_sdiv_call_target_byte_offset` lemmas, `evm_sdiv_cond_negate_limb_step_length`, plus the newly-orphaned `evm_sdiv_length` and `evm_sdiv_legacy_length`.
- **`SMod/Program.lean`**: the `*_byte_length` / `evm_smod_call_target_byte_offset` lemmas, plus the newly-orphaned `evm_smod_v4_length`.
- **`DivV4/V5TrialOverestimate.lean`, `DivV4TrialVal256Composition.lean`**: the trivial `Iff.rfl` `*_unfold` theorems.

## Conservatively kept

- The explicit **"Regression pin"** `rfl` facts (`evm_sdiv_eq_v4`, `evm_sdiv_v4_uses_div_callable_v4`, `evm_sdiv_v5_uses_div_callable_v5`, `evm_smod_eq_v4`) that guard canonical aliasing at build time.
- The substantive bead-tagged V5 overestimate lemmas (`divKTrialCallV5QHat_le_val256_div_plus_two/three ...`) in `DivV5TrialOverestimate.lean` (real proof work tied to bead `wbc4i.8.2.2.3`; may be re-referenced).

## Verification

- `lake build` green (4721 jobs).
- No warnings on any modified file.
- Removed theorems were all trivial (`rfl`/`rw`/`decide`/`simp`/`Iff.rfl`); kept theorems axiom-checked — proof axiom footprint unchanged.
- Net: 6 files, 145 deletions, 0 additions.

## Out of scope (not touched)

The `CallSkipLowerBoundV2/V4` subtrees and the rest of `DivMod/` V4/V5 loop specs were not yet scanned — left for a follow-up if desired. Def-removal (e.g. the now-orphaned `evm_sdiv_legacy` def) is also out of scope for this "unused theorems" pass.

Co-Authored-By: glm-5 <glm-5@ai>