### PR TITLE
proof(a4gbr): Fn.Spec for eip8037_prior_state_used_exact (success + mid-loop overflow)

### DIFF
--- a/EvmAsm/Codegen/Programs/Eip8037PriorStateUsedExactExecOvf.lean
+++ b/EvmAsm/Codegen/Programs/Eip8037PriorStateUsedExactExecOvf.lean
@@ -1,0 +1,752 @@
+/-
+  Exec-gas overflow fail path for `eip8037_prior_state_used_exact`.
+
+  When status[i]≠0 and sum+stateGas does not wrap but sum+stateGas+execGas wraps,
+  BLTU at P+136 takes to FailLi → a0=1, *out=0.
+-/
+
+import EvmAsm.Codegen.Programs.Eip8037PriorStateUsedExactIter
+import EvmAsm.Codegen.Programs.ChainValidateExtraDataLengthSpec
+import EvmAsm.Rv64.LaResolve
+import EvmAsm.Rv64.SyscallSpecs
+import EvmAsm.Rv64.ControlFlow
+import EvmAsm.Rv64.SAsm.DualReadByteScan
+
+namespace EvmAsm.Codegen.Eip8037PriorStateUsedExactExecOvf
+
+open EvmAsm.Rv64
+open EvmAsm.Codegen
+open EvmAsm.Codegen.Eip8037PriorStateUsedExactModel
+open EvmAsm.Codegen.Eip8037PriorStateUsedExactLoop
+open EvmAsm.Codegen.Eip8037PriorStateUsedExactIter
+open EvmAsm.Codegen.Eip8037PriorStateUsedExactSpec
+open EvmAsm.Codegen.ChainValidateExtraDataLengthSpec
+  (wordArray wordArrayFrom wordArray_split pcFree_wordArray pcFree_wordArrayFrom
+   shiftLeft3_ofNat)
+
+abbrev P : Word := Eip8037PriorStateUsedExactLoop.P
+abbrev pseProg : Program := Eip8037PriorStateUsedExactLoop.pseProg
+abbrev pseCode : CodeReq := Eip8037PriorStateUsedExactLoop.pseCode
+abbrev LoopGuard : Word := Eip8037PriorStateUsedExactLoop.LoopGuard
+abbrev LoopBody : Word := Eip8037PriorStateUsedExactLoop.LoopBody
+abbrev AfterSlli : Word := Eip8037PriorStateUsedExactLoop.AfterSlli
+abbrev AfterLaState : Word := Eip8037PriorStateUsedExactLoop.AfterLaState
+abbrev AfterMvSum : Word := Eip8037PriorStateUsedExactLoop.AfterMvSum
+abbrev AfterLaStatus : Word := Eip8037PriorStateUsedExactLoop.AfterLaStatus
+abbrev AfterLdStatus : Word := Eip8037PriorStateUsedExactLoop.AfterLdStatus
+abbrev AfterStatusSkip : Word := Eip8037PriorStateUsedExactLoop.AfterStatusSkip
+abbrev AfterIncr : Word := Eip8037PriorStateUsedExactLoop.AfterIncr
+abbrev AfterStatusBne : Word := Eip8037PriorStateUsedExactLoop.AfterStatusBne
+abbrev AfterLaExec : Word := Eip8037PriorStateUsedExactLoop.AfterLaExec
+abbrev TxStateGasAddr : Word := Eip8037PriorStateUsedExactLoop.TxStateGasAddr
+abbrev TxStatusAddr : Word := Eip8037PriorStateUsedExactLoop.TxStatusAddr
+abbrev TxExecStateGasAddr : Word := Eip8037PriorStateUsedExactLoop.TxExecStateGasAddr
+abbrev FailLi : Word := Eip8037PriorStateUsedExactSpec.FailLi
+
+theorem pse_length : pseProg.length = 43 := Eip8037PriorStateUsedExactLoop.pse_length
+
+private theorem se12_zero : signExtend12 (0 : BitVec 12) = (0 : Word) := by decide
+private theorem se12_one : signExtend12 (1 : BitVec 12) = (1 : Word) := by decide
+private theorem se13_32 : signExtend13 (32 : BitVec 13) = (32 : Word) := by decide
+private theorem se21_m88 : signExtend21 (-88 : BitVec 21) = BitVec.ofInt 64 (-88) := by decide
+
+private theorem ofNat_addi1 (i : Nat) :
+    BitVec.ofNat 64 i + signExtend12 (1 : BitVec 12) = BitVec.ofNat 64 (i + 1) := by
+  rw [se12_one, BitVec.ofNat_add]; rfl
+
+private theorem ofNat_add_lt (a b : Nat) (h : a + b < 2 ^ 64) :
+    BitVec.ofNat 64 a + BitVec.ofNat 64 b = BitVec.ofNat 64 (a + b) := by
+  apply BitVec.eq_of_toNat_eq
+  have ha : a < 2 ^ 64 := Nat.lt_of_le_of_lt (Nat.le_add_right a b) h
+  have hb : b < 2 ^ 64 := Nat.lt_of_le_of_lt (Nat.le_add_left b a) h
+  simp only [BitVec.toNat_add, BitVec.toNat_ofNat, Nat.mod_eq_of_lt ha, Nat.mod_eq_of_lt hb,
+    Nat.mod_eq_of_lt h]
+
+private theorem not_ult_add (s g : Nat) (h : s + g < 2 ^ 64) :
+    ¬BitVec.ult (BitVec.ofNat 64 (s + g)) (BitVec.ofNat 64 s) := by
+  have hs : s < 2 ^ 64 := Nat.lt_of_le_of_lt (Nat.le_add_right s g) h
+  simp only [BitVec.ult_eq_decide, decide_eq_true_eq, BitVec.toNat_ofNat,
+    Nat.mod_eq_of_lt hs, Nat.mod_eq_of_lt h]
+  omega
+
+private theorem AfterLdStatus_plus_4 : AfterLdStatus + 4 = AfterStatusBne := by
+  simp only [AfterLdStatus, AfterStatusBne]; decide
+private theorem AfterLaExec_plus_4 : AfterLaExec + 4 = P + 128 := by
+  simp only [AfterLaExec, P]; decide
+private theorem AfterLaState_plus_4 : AfterLaState + 4 = P + 80 := by
+  simp only [AfterLaState, P]; decide
+private theorem AfterLaStatus_plus_4 : AfterLaStatus + 4 = P + 108 := by
+  simp only [AfterLaStatus, P]; decide
+private theorem AfterStatusSkip_plus_4 : AfterStatusSkip + 4 = AfterIncr := by
+  simp only [AfterStatusSkip, AfterIncr]; decide
+private theorem AfterIncr_back :
+    AfterIncr + signExtend21 (-88 : BitVec 21) = LoopGuard := by
+  simp only [AfterIncr, LoopGuard, se21_m88]
+  decide
+private theorem P80_plus_4 : (P + 80 : Word) + 4 = P + 84 := by simp only [P]; decide
+private theorem P84_plus_4 : (P + 84 : Word) + 4 = P + 88 := by simp only [P]; decide
+private theorem P88_plus_4 : (P + 88 : Word) + 4 = P + 92 := by simp only [P]; decide
+private theorem P92_plus_4 : (P + 92 : Word) + 4 = AfterMvSum := by
+  simp only [AfterMvSum, P]; decide
+private theorem P108_plus_4 : (P + 108 : Word) + 4 = AfterLdStatus := by
+  simp only [AfterLdStatus, P]; decide
+private theorem P128_plus_4 : (P + 128 : Word) + 4 = P + 132 := by simp only [P]; decide
+private theorem P132_plus_4 : (P + 132 : Word) + 4 = P + 136 := by simp only [P]; decide
+private theorem P136_plus_4 : (P + 136 : Word) + 4 = P + 140 := by simp only [P]; decide
+private theorem P140_plus_4 : (P + 140 : Word) + 4 = AfterStatusSkip := by
+  simp only [AfterStatusSkip, P]; decide
+
+private theorem ofNat_add_wrap (s g : Nat)
+    (hs : s < 2 ^ 64) (hg : g < 2 ^ 64) :
+    BitVec.ofNat 64 s + BitVec.ofNat 64 g =
+      BitVec.ofNat 64 ((s + g) % 2 ^ 64) := by
+  apply BitVec.eq_of_toNat_eq
+  simp only [BitVec.toNat_add, BitVec.toNat_ofNat, Nat.mod_eq_of_lt hs, Nat.mod_eq_of_lt hg]
+  exact (Nat.mod_eq_of_lt (Nat.mod_lt (s + g) (by decide : 0 < 2 ^ 64))).symm
+
+private theorem ult_add_of_overflow (s g : Nat)
+    (hs : s < 2 ^ 64) (hg : g < 2 ^ 64) (hov : 2 ^ 64 ≤ s + g) :
+    BitVec.ult (BitVec.ofNat 64 s + BitVec.ofNat 64 g) (BitVec.ofNat 64 s) := by
+  have hwrap : (s + g) % 2 ^ 64 = s + g - 2 ^ 64 := by
+    have : s + g < 2 * 2 ^ 64 := by omega
+    omega
+  have hlt_s : (s + g) % 2 ^ 64 < s := by
+    rw [hwrap]; omega
+  have heq := ofNat_add_wrap s g hs hg
+  rw [heq]
+  simp only [BitVec.ult_eq_decide, decide_eq_true_eq, BitVec.toNat_ofNat,
+    Nat.mod_eq_of_lt hs,
+    Nat.mod_eq_of_lt (Nat.mod_lt (s + g) (by decide : 0 < 2 ^ 64))]
+  exact hlt_s
+
+set_option maxRecDepth 8000 in
+/-- Exec-gas overflow fail: status≠0 path, state add OK, exec add wraps → FailLi.
+    22 steps LoopGuard → postFail a0=1 *out=0. -/
+theorem pseIterExecOvf
+    (raIn priorW outPtr : Word)
+    (exactOkW runtimeW : Word)
+    (stateGas status execGas : List Nat)
+    (i sum : Nat)
+    (v28 v29 v30 v31 : Word)
+    (hi : i < stateGas.length)
+    (hstat : i < status.length)
+    (hexec : i < execGas.length)
+    (hstatNe : status[i] ≠ 0)
+    (hstatBound : status[i] < 2 ^ 64)
+    (hno : sum + stateGas[i] < 2 ^ 64)
+    (hg : execGas[i] < 2 ^ 64)
+    (hov : 2 ^ 64 ≤ sum + stateGas[i] + execGas[i])
+    (hne : BitVec.ofNat 64 i ≠ priorW)
+    (hret : raIn &&& ~~~(1 : Word) = raIn) :
+    let iW := BitVec.ofNat 64 i
+    let sumW := BitVec.ofNat 64 sum
+    let sumS := BitVec.ofNat 64 (sum + stateGas[i])
+    let execW := BitVec.ofNat 64 execGas[i]
+    let sumW' := sumS + execW
+    let offW := BitVec.ofNat 64 (8 * i)
+    cpsTripleWithin 22 LoopGuard raIn pseCode
+      (LoopInv raIn priorW outPtr sumW iW exactOkW runtimeW
+        stateGas status execGas v28 v29 v30 v31)
+      (postFail raIn outPtr (0 : Word)
+        ((.x5 ↦ᵣ priorW) ** (.x6 ↦ᵣ iW) ** (.x7 ↦ᵣ sumS) **
+          (.x28 ↦ᵣ offW) ** (.x29 ↦ᵣ (TxExecStateGasAddr + offW)) **
+          (.x30 ↦ᵣ execW) ** (.x31 ↦ᵣ sumW') **
+          loopGlobals exactOkW runtimeW stateGas status execGas)) := by
+  intro iW sumW sumS execW sumW' offW
+  have hGpf : (loopGlobals exactOkW runtimeW stateGas status execGas).pcFree :=
+    pcFree_loopGlobals exactOkW runtimeW stateGas status execGas
+  have hsumAdd : sumW + BitVec.ofNat 64 stateGas[i] = sumS := by
+    simpa [sumW, sumS] using ofNat_add_lt sum stateGas[i] hno
+  have hnoUlt : ¬BitVec.ult sumS sumW := by
+    simpa [sumW, sumS] using not_ult_add sum stateGas[i] hno
+  have hUltE : BitVec.ult sumW' sumS := by
+    simpa [sumS, sumW', execW] using
+      ult_add_of_overflow (sum + stateGas[i]) execGas[i] hno hg hov
+  have hoff : iW <<< 3 = offW := by
+    simpa [iW, offW] using shiftLeft3_ofNat i
+  have hstatW : BitVec.ofNat 64 status[i] ≠ (0 : Word) := by
+    intro heq
+    have hmod : status[i] % 2 ^ 64 = 0 := by
+      have := congrArg BitVec.toNat heq
+      simpa [BitVec.toNat_ofNat, BitVec.toNat_zero] using this
+    have : status[i] = 0 := by
+      have := Nat.mod_eq_of_lt hstatBound
+      omega
+    exact hstatNe this
+  have hsplit := wordArray_split TxStateGasAddr stateGas i hi
+  have hsplitS := wordArray_split TxStatusAddr status i hstat
+  have haddrState :
+      TxStateGasAddr + BitVec.ofNat 64 (8 * i) = TxStateGasAddr + offW := by
+    simp only [offW]
+  have haddrStatus :
+      TxStatusAddr + BitVec.ofNat 64 (8 * i) = TxStatusAddr + offW := by
+    simp only [offW]
+  -- 1. guard ntaken
+  have hguard := pseLoopGuardNtaken raIn priorW outPtr sumW iW exactOkW runtimeW
+    stateGas status execGas v28 v29 v30 v31 hne
+  -- 2. SLLI x28 = 8*i
+  have e16 :
+      cpsTripleWithin 1 LoopBody AfterSlli pseCode
+        ((.x6 ↦ᵣ iW) ** (.x28 ↦ᵣ v28))
+        ((.x6 ↦ᵣ iW) ** (.x28 ↦ᵣ offW)) := by
+    have h0 := slli_spec_gen_within .x28 .x6 v28 iW (3 : BitVec 6) LoopBody (by decide)
+    have h0' : cpsTripleWithin 1 LoopBody (LoopBody + 4) pseCode
+        ((.x6 ↦ᵣ iW) ** (.x28 ↦ᵣ v28))
+        ((.x6 ↦ᵣ iW) ** (.x28 ↦ᵣ (iW <<< 3))) :=
+      cpsTripleWithin_extend_code
+        (CodeReq.ofProg_mem_at P LoopBody pseProg 16
+          (.SLLI .x28 .x6 (3 : BitVec 6))
+          (by simp only [LoopBody]; decide)
+          (by rw [pse_length]; decide) rfl (by rw [pse_length]; decide)) h0
+    have h0'' : cpsTripleWithin 1 LoopBody AfterSlli pseCode
+        ((.x6 ↦ᵣ iW) ** (.x28 ↦ᵣ v28))
+        ((.x6 ↦ᵣ iW) ** (.x28 ↦ᵣ (iW <<< 3))) := by
+      rwa [show LoopBody + 4 = AfterSlli from by simp only [LoopBody, AfterSlli]; decide] at h0'
+    exact cpsTripleWithin_weaken (fun _ hp => hp)
+      (fun _ hq => by rw [← hoff]; exact hq) h0''
+  have e16F := cpsTripleWithin_frameR
+    ((.x1 ↦ᵣ raIn) ** (.x10 ↦ᵣ priorW) ** (.x11 ↦ᵣ outPtr) **
+      (outPtr ↦ₘ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) **
+      (.x5 ↦ᵣ priorW) ** (.x7 ↦ᵣ sumW) **
+      (.x29 ↦ᵣ v29) ** (.x30 ↦ᵣ v30) ** (.x31 ↦ᵣ v31) **
+      loopGlobals exactOkW runtimeW stateGas status execGas)
+    (by
+      repeat' first
+        | exact hGpf
+        | apply pcFree_sepConj
+        | exact pcFree_regIs
+        | exact pcFree_memIs) e16
+  -- 3. la state → x29 = TxStateGasAddr
+  have eLa := cpsTripleWithin_frameR
+    ((.x1 ↦ᵣ raIn) ** (.x10 ↦ᵣ priorW) ** (.x11 ↦ᵣ outPtr) **
+      (outPtr ↦ₘ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) **
+      (.x5 ↦ᵣ priorW) ** (.x6 ↦ᵣ iW) ** (.x7 ↦ᵣ sumW) **
+      (.x28 ↦ᵣ offW) ** (.x30 ↦ᵣ v30) ** (.x31 ↦ᵣ v31) **
+      loopGlobals exactOkW runtimeW stateGas status execGas)
+    (by
+      repeat' first
+        | exact hGpf
+        | apply pcFree_sepConj
+        | exact pcFree_regIs
+        | exact pcFree_memIs) (pseLaStateGas v29)
+  -- 4. ADD x29 += x28
+  have e19 :
+      cpsTripleWithin 1 AfterLaState (P + 80) pseCode
+        ((.x29 ↦ᵣ TxStateGasAddr) ** (.x28 ↦ᵣ offW))
+        ((.x29 ↦ᵣ (TxStateGasAddr + offW)) ** (.x28 ↦ᵣ offW)) := by
+    have h0 := add_spec_gen_rd_eq_rs1_within .x29 .x28 TxStateGasAddr offW AfterLaState (by decide)
+    have h0' : cpsTripleWithin 1 AfterLaState (AfterLaState + 4) pseCode
+        ((.x29 ↦ᵣ TxStateGasAddr) ** (.x28 ↦ᵣ offW))
+        ((.x29 ↦ᵣ (TxStateGasAddr + offW)) ** (.x28 ↦ᵣ offW)) :=
+      cpsTripleWithin_extend_code
+        (CodeReq.ofProg_mem_at P AfterLaState pseProg 19
+          (.ADD .x29 .x29 .x28)
+          (by simp only [AfterLaState]; decide)
+          (by rw [pse_length]; decide) rfl (by rw [pse_length]; decide)) h0
+    rwa [AfterLaState_plus_4] at h0'
+  have e19F := cpsTripleWithin_frameR
+    ((.x1 ↦ᵣ raIn) ** (.x10 ↦ᵣ priorW) ** (.x11 ↦ᵣ outPtr) **
+      (outPtr ↦ₘ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) **
+      (.x5 ↦ᵣ priorW) ** (.x6 ↦ᵣ iW) ** (.x7 ↦ᵣ sumW) **
+      (.x30 ↦ᵣ v30) ** (.x31 ↦ᵣ v31) **
+      loopGlobals exactOkW runtimeW stateGas status execGas)
+    (by
+      repeat' first
+        | exact hGpf
+        | apply pcFree_sepConj
+        | exact pcFree_regIs
+        | exact pcFree_memIs) e19
+  -- 5. LD state cell
+  have e20core :
+      cpsTripleWithin 1 (P + 80) (P + 84) pseCode
+        ((.x29 ↦ᵣ (TxStateGasAddr + offW)) ** (.x30 ↦ᵣ v30) **
+          ((TxStateGasAddr + offW) ↦ₘ BitVec.ofNat 64 stateGas[i]))
+        ((.x29 ↦ᵣ (TxStateGasAddr + offW)) ** (.x30 ↦ᵣ BitVec.ofNat 64 stateGas[i]) **
+          ((TxStateGasAddr + offW) ↦ₘ BitVec.ofNat 64 stateGas[i])) := by
+    have haddr : (TxStateGasAddr + offW) + signExtend12 (0 : BitVec 12) =
+        TxStateGasAddr + offW := by
+      rw [se12_zero]; exact BitVec.add_zero _
+    have h0 := ld_spec_gen_within .x30 .x29 (TxStateGasAddr + offW) v30
+      (BitVec.ofNat 64 stateGas[i]) (0 : BitVec 12) (P + 80) (by decide)
+    rw [haddr] at h0
+    exact cpsTripleWithin_extend_code
+      (CodeReq.ofProg_mem_at P (P + 80) pseProg 20
+        (.LD .x30 .x29 (0 : BitVec 12))
+        (by simp only [P]; decide)
+        (by rw [pse_length]; decide) rfl (by rw [pse_length]; decide)) h0
+  have e20F0 := cpsTripleWithin_frameR
+    (wordArrayFrom TxStateGasAddr 0 (stateGas.take i) **
+      wordArrayFrom TxStateGasAddr (i + 1) (stateGas.drop (i + 1)) **
+      wordArray TxStatusAddr status **
+      wordArray TxExecStateGasAddr execGas **
+      loopGlobalsCore exactOkW runtimeW **
+      (.x1 ↦ᵣ raIn) ** (.x10 ↦ᵣ priorW) ** (.x11 ↦ᵣ outPtr) **
+      (outPtr ↦ₘ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) **
+      (.x5 ↦ᵣ priorW) ** (.x6 ↦ᵣ iW) ** (.x7 ↦ᵣ sumW) **
+      (.x28 ↦ᵣ offW) ** (.x31 ↦ᵣ v31))
+    (by
+      repeat' first
+        | apply pcFree_sepConj
+        | exact pcFree_regIs
+        | exact pcFree_memIs
+        | exact pcFree_wordArray _ _
+        | exact pcFree_wordArrayFrom _ _ _) e20core
+  have e20F : cpsTripleWithin 1 (P + 80) (P + 84) pseCode
+      ((.x29 ↦ᵣ (TxStateGasAddr + offW)) ** (.x30 ↦ᵣ v30) **
+        (.x1 ↦ᵣ raIn) ** (.x10 ↦ᵣ priorW) ** (.x11 ↦ᵣ outPtr) **
+        (outPtr ↦ₘ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) **
+        (.x5 ↦ᵣ priorW) ** (.x6 ↦ᵣ iW) ** (.x7 ↦ᵣ sumW) **
+        (.x28 ↦ᵣ offW) ** (.x31 ↦ᵣ v31) **
+        loopGlobals exactOkW runtimeW stateGas status execGas)
+      ((.x29 ↦ᵣ (TxStateGasAddr + offW)) ** (.x30 ↦ᵣ BitVec.ofNat 64 stateGas[i]) **
+        (.x1 ↦ᵣ raIn) ** (.x10 ↦ᵣ priorW) ** (.x11 ↦ᵣ outPtr) **
+        (outPtr ↦ₘ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) **
+        (.x5 ↦ᵣ priorW) ** (.x6 ↦ᵣ iW) ** (.x7 ↦ᵣ sumW) **
+        (.x28 ↦ᵣ offW) ** (.x31 ↦ᵣ v31) **
+        loopGlobals exactOkW runtimeW stateGas status execGas) := by
+    refine cpsTripleWithin_weaken ?_ ?_ e20F0
+    · intro _ hp
+      have hp' := hp
+      rw [loopGlobals_eq, hsplit, haddrState] at hp'
+      xperm_hyp hp'
+    · intro _ hq
+      have hq' := hq
+      rw [loopGlobals_eq, hsplit, haddrState]
+      xperm_hyp hq'
+  -- 6. ADD x31 = sum + state
+  have e21 :
+      cpsTripleWithin 1 (P + 84) (P + 88) pseCode
+        ((.x7 ↦ᵣ sumW) ** (.x30 ↦ᵣ BitVec.ofNat 64 stateGas[i]) ** (.x31 ↦ᵣ v31))
+        ((.x7 ↦ᵣ sumW) ** (.x30 ↦ᵣ BitVec.ofNat 64 stateGas[i]) ** (.x31 ↦ᵣ sumS)) := by
+    have h0 := add_spec_gen_within .x31 .x7 .x30 sumW (BitVec.ofNat 64 stateGas[i]) v31
+      (P + 84) (by decide)
+    have h0' : cpsTripleWithin 1 (P + 84) (P + 84 + 4) pseCode
+        ((.x7 ↦ᵣ sumW) ** (.x30 ↦ᵣ BitVec.ofNat 64 stateGas[i]) ** (.x31 ↦ᵣ v31))
+        ((.x7 ↦ᵣ sumW) ** (.x30 ↦ᵣ BitVec.ofNat 64 stateGas[i]) **
+          (.x31 ↦ᵣ (sumW + BitVec.ofNat 64 stateGas[i]))) :=
+      cpsTripleWithin_extend_code
+        (CodeReq.ofProg_mem_at P (P + 84) pseProg 21
+          (.ADD .x31 .x7 .x30)
+          (by simp only [P]; decide)
+          (by rw [pse_length]; decide) rfl (by rw [pse_length]; decide)) h0
+    have h0'' : cpsTripleWithin 1 (P + 84) (P + 88) pseCode
+        ((.x7 ↦ᵣ sumW) ** (.x30 ↦ᵣ BitVec.ofNat 64 stateGas[i]) ** (.x31 ↦ᵣ v31))
+        ((.x7 ↦ᵣ sumW) ** (.x30 ↦ᵣ BitVec.ofNat 64 stateGas[i]) **
+          (.x31 ↦ᵣ (sumW + BitVec.ofNat 64 stateGas[i]))) := by
+      rwa [P84_plus_4] at h0'
+    exact cpsTripleWithin_weaken (fun _ hp => hp)
+      (fun _ hq => by rw [← hsumAdd]; exact hq) h0''
+  have e21F := cpsTripleWithin_frameR
+    ((.x1 ↦ᵣ raIn) ** (.x10 ↦ᵣ priorW) ** (.x11 ↦ᵣ outPtr) **
+      (outPtr ↦ₘ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) **
+      (.x5 ↦ᵣ priorW) ** (.x6 ↦ᵣ iW) **
+      (.x28 ↦ᵣ offW) ** (.x29 ↦ᵣ (TxStateGasAddr + offW)) **
+      loopGlobals exactOkW runtimeW stateGas status execGas)
+    (by
+      repeat' first
+        | exact hGpf
+        | apply pcFree_sepConj
+        | exact pcFree_regIs
+        | exact pcFree_memIs) e21
+  -- 7. BLTU overflow ntaken
+  have e22 :
+      cpsTripleWithin 1 (P + 88) (P + 92) pseCode
+        ((.x31 ↦ᵣ sumS) ** (.x7 ↦ᵣ sumW))
+        ((.x31 ↦ᵣ sumS) ** (.x7 ↦ᵣ sumW)) := by
+    have hbr := bltu_spec_gen_within .x31 .x7 (76 : BitVec 13) sumS sumW (P + 88)
+    have hbrC := cpsBranchWithin_extend_code
+      (CodeReq.ofProg_mem_at P (P + 88) pseProg 22
+        (.BLTU .x31 .x7 (76 : BitVec 13))
+        (by simp only [P]; decide)
+        (by rw [pse_length]; decide) rfl (by rw [pse_length]; decide)) hbr
+    have hnt0 := cpsBranchWithin_ntakenStripPure2 hbrC (fun _ hq => by
+      obtain ⟨_, _, _, _, _, hrest⟩ := hq
+      exact absurd ((sepConj_pure_right _).1 hrest).2 hnoUlt)
+    rwa [P88_plus_4] at hnt0
+  have e22F := cpsTripleWithin_frameR
+    ((.x1 ↦ᵣ raIn) ** (.x10 ↦ᵣ priorW) ** (.x11 ↦ᵣ outPtr) **
+      (outPtr ↦ₘ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) **
+      (.x5 ↦ᵣ priorW) ** (.x6 ↦ᵣ iW) **
+      (.x28 ↦ᵣ offW) ** (.x29 ↦ᵣ (TxStateGasAddr + offW)) **
+      (.x30 ↦ᵣ BitVec.ofNat 64 stateGas[i]) **
+      loopGlobals exactOkW runtimeW stateGas status execGas)
+    (by
+      repeat' first
+        | exact hGpf
+        | apply pcFree_sepConj
+        | exact pcFree_regIs
+        | exact pcFree_memIs) e22
+  -- 8. MV x7, x31
+  have e23 :
+      cpsTripleWithin 1 (P + 92) AfterMvSum pseCode
+        ((.x31 ↦ᵣ sumS) ** (.x7 ↦ᵣ sumW))
+        ((.x31 ↦ᵣ sumS) ** (.x7 ↦ᵣ sumS)) := by
+    have h0 := mv_spec_gen_within .x7 .x31 sumS sumW (P + 92) (by decide)
+    have h0' : cpsTripleWithin 1 (P + 92) (P + 92 + 4) pseCode
+        ((.x31 ↦ᵣ sumS) ** (.x7 ↦ᵣ sumW))
+        ((.x31 ↦ᵣ sumS) ** (.x7 ↦ᵣ sumS)) :=
+      cpsTripleWithin_extend_code
+        (CodeReq.ofProg_mem_at P (P + 92) pseProg 23
+          (.MV .x7 .x31)
+          (by simp only [P]; decide)
+          (by rw [pse_length]; decide) rfl (by rw [pse_length]; decide)) h0
+    rwa [P92_plus_4] at h0'
+  have e23F := cpsTripleWithin_frameR
+    ((.x1 ↦ᵣ raIn) ** (.x10 ↦ᵣ priorW) ** (.x11 ↦ᵣ outPtr) **
+      (outPtr ↦ₘ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) **
+      (.x5 ↦ᵣ priorW) ** (.x6 ↦ᵣ iW) **
+      (.x28 ↦ᵣ offW) ** (.x29 ↦ᵣ (TxStateGasAddr + offW)) **
+      (.x30 ↦ᵣ BitVec.ofNat 64 stateGas[i]) **
+      loopGlobals exactOkW runtimeW stateGas status execGas)
+    (by
+      repeat' first
+        | exact hGpf
+        | apply pcFree_sepConj
+        | exact pcFree_regIs
+        | exact pcFree_memIs) e23
+  -- 9. la status
+  have eLaSt := cpsTripleWithin_frameR
+    ((.x1 ↦ᵣ raIn) ** (.x10 ↦ᵣ priorW) ** (.x11 ↦ᵣ outPtr) **
+      (outPtr ↦ₘ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) **
+      (.x5 ↦ᵣ priorW) ** (.x6 ↦ᵣ iW) ** (.x7 ↦ᵣ sumS) **
+      (.x28 ↦ᵣ offW) ** (.x30 ↦ᵣ BitVec.ofNat 64 stateGas[i]) **
+      (.x31 ↦ᵣ sumS) **
+      loopGlobals exactOkW runtimeW stateGas status execGas)
+    (by
+      repeat' first
+        | exact hGpf
+        | apply pcFree_sepConj
+        | exact pcFree_regIs
+        | exact pcFree_memIs)
+    (pseLaStatus (TxStateGasAddr + offW))
+  -- 10. ADD x29 += x28
+  have e26 :
+      cpsTripleWithin 1 AfterLaStatus (P + 108) pseCode
+        ((.x29 ↦ᵣ TxStatusAddr) ** (.x28 ↦ᵣ offW))
+        ((.x29 ↦ᵣ (TxStatusAddr + offW)) ** (.x28 ↦ᵣ offW)) := by
+    have h0 := add_spec_gen_rd_eq_rs1_within .x29 .x28 TxStatusAddr offW AfterLaStatus (by decide)
+    have h0' : cpsTripleWithin 1 AfterLaStatus (AfterLaStatus + 4) pseCode
+        ((.x29 ↦ᵣ TxStatusAddr) ** (.x28 ↦ᵣ offW))
+        ((.x29 ↦ᵣ (TxStatusAddr + offW)) ** (.x28 ↦ᵣ offW)) :=
+      cpsTripleWithin_extend_code
+        (CodeReq.ofProg_mem_at P AfterLaStatus pseProg 26
+          (.ADD .x29 .x29 .x28)
+          (by simp only [AfterLaStatus]; decide)
+          (by rw [pse_length]; decide) rfl (by rw [pse_length]; decide)) h0
+    rwa [AfterLaStatus_plus_4] at h0'
+  have e26F := cpsTripleWithin_frameR
+    ((.x1 ↦ᵣ raIn) ** (.x10 ↦ᵣ priorW) ** (.x11 ↦ᵣ outPtr) **
+      (outPtr ↦ₘ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) **
+      (.x5 ↦ᵣ priorW) ** (.x6 ↦ᵣ iW) ** (.x7 ↦ᵣ sumS) **
+      (.x30 ↦ᵣ BitVec.ofNat 64 stateGas[i]) ** (.x31 ↦ᵣ sumS) **
+      loopGlobals exactOkW runtimeW stateGas status execGas)
+    (by
+      repeat' first
+        | exact hGpf
+        | apply pcFree_sepConj
+        | exact pcFree_regIs
+        | exact pcFree_memIs) e26
+  -- 11. LD status
+  have e27core :
+      cpsTripleWithin 1 (P + 108) AfterLdStatus pseCode
+        ((.x29 ↦ᵣ (TxStatusAddr + offW)) ** (.x30 ↦ᵣ BitVec.ofNat 64 stateGas[i]) **
+          ((TxStatusAddr + offW) ↦ₘ BitVec.ofNat 64 status[i]))
+        ((.x29 ↦ᵣ (TxStatusAddr + offW)) ** (.x30 ↦ᵣ BitVec.ofNat 64 status[i]) **
+          ((TxStatusAddr + offW) ↦ₘ BitVec.ofNat 64 status[i])) := by
+    have haddr : (TxStatusAddr + offW) + signExtend12 (0 : BitVec 12) =
+        TxStatusAddr + offW := by
+      rw [se12_zero]; exact BitVec.add_zero _
+    have h0 := ld_spec_gen_within .x30 .x29 (TxStatusAddr + offW)
+      (BitVec.ofNat 64 stateGas[i]) (BitVec.ofNat 64 status[i])
+      (0 : BitVec 12) (P + 108) (by decide)
+    rw [haddr] at h0
+    have h0' : cpsTripleWithin 1 (P + 108) (P + 108 + 4) pseCode
+        ((.x29 ↦ᵣ (TxStatusAddr + offW)) ** (.x30 ↦ᵣ BitVec.ofNat 64 stateGas[i]) **
+          ((TxStatusAddr + offW) ↦ₘ BitVec.ofNat 64 status[i]))
+        ((.x29 ↦ᵣ (TxStatusAddr + offW)) ** (.x30 ↦ᵣ BitVec.ofNat 64 status[i]) **
+          ((TxStatusAddr + offW) ↦ₘ BitVec.ofNat 64 status[i])) :=
+      cpsTripleWithin_extend_code
+        (CodeReq.ofProg_mem_at P (P + 108) pseProg 27
+          (.LD .x30 .x29 (0 : BitVec 12))
+          (by simp only [P]; decide)
+          (by rw [pse_length]; decide) rfl (by rw [pse_length]; decide)) h0
+    rwa [P108_plus_4] at h0'
+  have e27F0 := cpsTripleWithin_frameR
+    (wordArrayFrom TxStatusAddr 0 (status.take i) **
+      wordArrayFrom TxStatusAddr (i + 1) (status.drop (i + 1)) **
+      wordArray TxStateGasAddr stateGas **
+      wordArray TxExecStateGasAddr execGas **
+      loopGlobalsCore exactOkW runtimeW **
+      (.x1 ↦ᵣ raIn) ** (.x10 ↦ᵣ priorW) ** (.x11 ↦ᵣ outPtr) **
+      (outPtr ↦ₘ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) **
+      (.x5 ↦ᵣ priorW) ** (.x6 ↦ᵣ iW) ** (.x7 ↦ᵣ sumS) **
+      (.x28 ↦ᵣ offW) ** (.x31 ↦ᵣ sumS))
+    (by
+      repeat' first
+        | apply pcFree_sepConj
+        | exact pcFree_regIs
+        | exact pcFree_memIs
+        | exact pcFree_wordArray _ _
+        | exact pcFree_wordArrayFrom _ _ _) e27core
+  have e27F : cpsTripleWithin 1 (P + 108) AfterLdStatus pseCode
+      ((.x29 ↦ᵣ (TxStatusAddr + offW)) ** (.x30 ↦ᵣ BitVec.ofNat 64 stateGas[i]) **
+        (.x1 ↦ᵣ raIn) ** (.x10 ↦ᵣ priorW) ** (.x11 ↦ᵣ outPtr) **
+        (outPtr ↦ₘ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) **
+        (.x5 ↦ᵣ priorW) ** (.x6 ↦ᵣ iW) ** (.x7 ↦ᵣ sumS) **
+        (.x28 ↦ᵣ offW) ** (.x31 ↦ᵣ sumS) **
+        loopGlobals exactOkW runtimeW stateGas status execGas)
+      ((.x29 ↦ᵣ (TxStatusAddr + offW)) ** (.x30 ↦ᵣ BitVec.ofNat 64 status[i]) **
+        (.x1 ↦ᵣ raIn) ** (.x10 ↦ᵣ priorW) ** (.x11 ↦ᵣ outPtr) **
+        (outPtr ↦ₘ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) **
+        (.x5 ↦ᵣ priorW) ** (.x6 ↦ᵣ iW) ** (.x7 ↦ᵣ sumS) **
+        (.x28 ↦ᵣ offW) ** (.x31 ↦ᵣ sumS) **
+        loopGlobals exactOkW runtimeW stateGas status execGas) := by
+    refine cpsTripleWithin_weaken ?_ ?_ e27F0
+    · intro _ hp
+      have hp' := hp
+      rw [loopGlobals_eq, hsplitS, haddrStatus] at hp'
+      xperm_hyp hp'
+    · intro _ hq
+      have hq' := hq
+      rw [loopGlobals_eq, hsplitS, haddrStatus]
+      xperm_hyp hq'
+  have hsplitE := wordArray_split TxExecStateGasAddr execGas i hexec
+  have haddrExec :
+      TxExecStateGasAddr + BitVec.ofNat 64 (8 * i) = TxExecStateGasAddr + offW := by
+    simp only [offW]
+  -- 12. BEQ status=0 ntaken (status ≠ 0)
+  have e28 :
+      cpsTripleWithin 1 AfterLdStatus AfterStatusBne pseCode
+        ((.x30 ↦ᵣ BitVec.ofNat 64 status[i]) ** (.x0 ↦ᵣ (0 : Word)))
+        ((.x30 ↦ᵣ BitVec.ofNat 64 status[i]) ** (.x0 ↦ᵣ (0 : Word))) := by
+    have hbr := beq_spec_gen_within .x30 .x0 (32 : BitVec 13)
+      (BitVec.ofNat 64 status[i]) (0 : Word) AfterLdStatus
+    have hbrC := cpsBranchWithin_extend_code
+      (CodeReq.ofProg_mem_at P AfterLdStatus pseProg 28
+        (.BEQ .x30 .x0 (32 : BitVec 13))
+        (by simp only [AfterLdStatus]; decide)
+        (by rw [pse_length]; decide) rfl (by rw [pse_length]; decide)) hbr
+    have hnt0 := cpsBranchWithin_ntakenStripPure2 hbrC (fun _ hq => by
+      obtain ⟨_, _, _, _, _, hrest⟩ := hq
+      exact absurd ((sepConj_pure_right _).1 hrest).2 hstatW)
+    rwa [AfterLdStatus_plus_4] at hnt0
+  have e28F := cpsTripleWithin_frameR
+    ((.x1 ↦ᵣ raIn) ** (.x10 ↦ᵣ priorW) ** (.x11 ↦ᵣ outPtr) **
+      (outPtr ↦ₘ (0 : Word)) **
+      (.x5 ↦ᵣ priorW) ** (.x6 ↦ᵣ iW) ** (.x7 ↦ᵣ sumS) **
+      (.x28 ↦ᵣ offW) ** (.x29 ↦ᵣ (TxStatusAddr + offW)) **
+      (.x31 ↦ᵣ sumS) **
+      loopGlobals exactOkW runtimeW stateGas status execGas)
+    (by
+      repeat' first
+        | exact hGpf
+        | apply pcFree_sepConj
+        | exact pcFree_regIs
+        | exact pcFree_memIs) e28
+  -- 13. la exec
+  have eLaEx := cpsTripleWithin_frameR
+    ((.x1 ↦ᵣ raIn) ** (.x10 ↦ᵣ priorW) ** (.x11 ↦ᵣ outPtr) **
+      (outPtr ↦ₘ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) **
+      (.x5 ↦ᵣ priorW) ** (.x6 ↦ᵣ iW) ** (.x7 ↦ᵣ sumS) **
+      (.x28 ↦ᵣ offW) ** (.x30 ↦ᵣ BitVec.ofNat 64 status[i]) **
+      (.x31 ↦ᵣ sumS) **
+      loopGlobals exactOkW runtimeW stateGas status execGas)
+    (by
+      repeat' first
+        | exact hGpf
+        | apply pcFree_sepConj
+        | exact pcFree_regIs
+        | exact pcFree_memIs)
+    (pseLaExec (TxStatusAddr + offW))
+  -- 14. ADD x29 += x28
+  have e31 :
+      cpsTripleWithin 1 AfterLaExec (P + 128) pseCode
+        ((.x29 ↦ᵣ TxExecStateGasAddr) ** (.x28 ↦ᵣ offW))
+        ((.x29 ↦ᵣ (TxExecStateGasAddr + offW)) ** (.x28 ↦ᵣ offW)) := by
+    have h0 := add_spec_gen_rd_eq_rs1_within .x29 .x28 TxExecStateGasAddr offW AfterLaExec (by decide)
+    have h0' : cpsTripleWithin 1 AfterLaExec (AfterLaExec + 4) pseCode
+        ((.x29 ↦ᵣ TxExecStateGasAddr) ** (.x28 ↦ᵣ offW))
+        ((.x29 ↦ᵣ (TxExecStateGasAddr + offW)) ** (.x28 ↦ᵣ offW)) :=
+      cpsTripleWithin_extend_code
+        (CodeReq.ofProg_mem_at P AfterLaExec pseProg 31
+          (.ADD .x29 .x29 .x28)
+          (by simp only [AfterLaExec]; decide)
+          (by rw [pse_length]; decide) rfl (by rw [pse_length]; decide)) h0
+    rwa [AfterLaExec_plus_4] at h0'
+  have e31F := cpsTripleWithin_frameR
+    ((.x1 ↦ᵣ raIn) ** (.x10 ↦ᵣ priorW) ** (.x11 ↦ᵣ outPtr) **
+      (outPtr ↦ₘ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) **
+      (.x5 ↦ᵣ priorW) ** (.x6 ↦ᵣ iW) ** (.x7 ↦ᵣ sumS) **
+      (.x30 ↦ᵣ BitVec.ofNat 64 status[i]) ** (.x31 ↦ᵣ sumS) **
+      loopGlobals exactOkW runtimeW stateGas status execGas)
+    (by
+      repeat' first
+        | exact hGpf
+        | apply pcFree_sepConj
+        | exact pcFree_regIs
+        | exact pcFree_memIs) e31
+  -- 15. LD exec cell
+  have e32core :
+      cpsTripleWithin 1 (P + 128) (P + 132) pseCode
+        ((.x29 ↦ᵣ (TxExecStateGasAddr + offW)) ** (.x30 ↦ᵣ BitVec.ofNat 64 status[i]) **
+          ((TxExecStateGasAddr + offW) ↦ₘ BitVec.ofNat 64 execGas[i]))
+        ((.x29 ↦ᵣ (TxExecStateGasAddr + offW)) ** (.x30 ↦ᵣ BitVec.ofNat 64 execGas[i]) **
+          ((TxExecStateGasAddr + offW) ↦ₘ BitVec.ofNat 64 execGas[i])) := by
+    have haddr : (TxExecStateGasAddr + offW) + signExtend12 (0 : BitVec 12) =
+        TxExecStateGasAddr + offW := by
+      rw [se12_zero]; exact BitVec.add_zero _
+    have h0 := ld_spec_gen_within .x30 .x29 (TxExecStateGasAddr + offW)
+      (BitVec.ofNat 64 status[i]) (BitVec.ofNat 64 execGas[i])
+      (0 : BitVec 12) (P + 128) (by decide)
+    rw [haddr] at h0
+    have h0' : cpsTripleWithin 1 (P + 128) (P + 128 + 4) pseCode
+        ((.x29 ↦ᵣ (TxExecStateGasAddr + offW)) ** (.x30 ↦ᵣ BitVec.ofNat 64 status[i]) **
+          ((TxExecStateGasAddr + offW) ↦ₘ BitVec.ofNat 64 execGas[i]))
+        ((.x29 ↦ᵣ (TxExecStateGasAddr + offW)) ** (.x30 ↦ᵣ BitVec.ofNat 64 execGas[i]) **
+          ((TxExecStateGasAddr + offW) ↦ₘ BitVec.ofNat 64 execGas[i])) :=
+      cpsTripleWithin_extend_code
+        (CodeReq.ofProg_mem_at P (P + 128) pseProg 32
+          (.LD .x30 .x29 (0 : BitVec 12))
+          (by simp only [P]; decide)
+          (by rw [pse_length]; decide) rfl (by rw [pse_length]; decide)) h0
+    rwa [P128_plus_4] at h0'
+  have e32F0 := cpsTripleWithin_frameR
+    (wordArrayFrom TxExecStateGasAddr 0 (execGas.take i) **
+      wordArrayFrom TxExecStateGasAddr (i + 1) (execGas.drop (i + 1)) **
+      wordArray TxStateGasAddr stateGas **
+      wordArray TxStatusAddr status **
+      loopGlobalsCore exactOkW runtimeW **
+      (.x1 ↦ᵣ raIn) ** (.x10 ↦ᵣ priorW) ** (.x11 ↦ᵣ outPtr) **
+      (outPtr ↦ₘ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) **
+      (.x5 ↦ᵣ priorW) ** (.x6 ↦ᵣ iW) ** (.x7 ↦ᵣ sumS) **
+      (.x28 ↦ᵣ offW) ** (.x31 ↦ᵣ sumS))
+    (by
+      repeat' first
+        | apply pcFree_sepConj
+        | exact pcFree_regIs
+        | exact pcFree_memIs
+        | exact pcFree_wordArray _ _
+        | exact pcFree_wordArrayFrom _ _ _) e32core
+  have e32F : cpsTripleWithin 1 (P + 128) (P + 132) pseCode
+      ((.x29 ↦ᵣ (TxExecStateGasAddr + offW)) ** (.x30 ↦ᵣ BitVec.ofNat 64 status[i]) **
+        (.x1 ↦ᵣ raIn) ** (.x10 ↦ᵣ priorW) ** (.x11 ↦ᵣ outPtr) **
+        (outPtr ↦ₘ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) **
+        (.x5 ↦ᵣ priorW) ** (.x6 ↦ᵣ iW) ** (.x7 ↦ᵣ sumS) **
+        (.x28 ↦ᵣ offW) ** (.x31 ↦ᵣ sumS) **
+        loopGlobals exactOkW runtimeW stateGas status execGas)
+      ((.x29 ↦ᵣ (TxExecStateGasAddr + offW)) ** (.x30 ↦ᵣ BitVec.ofNat 64 execGas[i]) **
+        (.x1 ↦ᵣ raIn) ** (.x10 ↦ᵣ priorW) ** (.x11 ↦ᵣ outPtr) **
+        (outPtr ↦ₘ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) **
+        (.x5 ↦ᵣ priorW) ** (.x6 ↦ᵣ iW) ** (.x7 ↦ᵣ sumS) **
+        (.x28 ↦ᵣ offW) ** (.x31 ↦ᵣ sumS) **
+        loopGlobals exactOkW runtimeW stateGas status execGas) := by
+    refine cpsTripleWithin_weaken ?_ ?_ e32F0
+    · intro _ hp
+      have hp' := hp
+      rw [loopGlobals_eq, hsplitE, haddrExec] at hp'
+      xperm_hyp hp'
+    · intro _ hq
+      have hq' := hq
+      rw [loopGlobals_eq, hsplitE, haddrExec]
+      xperm_hyp hq'
+  -- 16. ADD x31 = sumS + exec (may wrap)
+  have e33 :
+      cpsTripleWithin 1 (P + 132) (P + 136) pseCode
+        ((.x7 ↦ᵣ sumS) ** (.x30 ↦ᵣ execW) ** (.x31 ↦ᵣ sumS))
+        ((.x7 ↦ᵣ sumS) ** (.x30 ↦ᵣ execW) ** (.x31 ↦ᵣ sumW')) := by
+    have h0 := add_spec_gen_within .x31 .x7 .x30 sumS execW sumS
+      (P + 132) (by decide)
+    have h0' : cpsTripleWithin 1 (P + 132) (P + 132 + 4) pseCode
+        ((.x7 ↦ᵣ sumS) ** (.x30 ↦ᵣ execW) ** (.x31 ↦ᵣ sumS))
+        ((.x7 ↦ᵣ sumS) ** (.x30 ↦ᵣ execW) ** (.x31 ↦ᵣ (sumS + execW))) :=
+      cpsTripleWithin_extend_code
+        (CodeReq.ofProg_mem_at P (P + 132) pseProg 33
+          (.ADD .x31 .x7 .x30)
+          (by simp only [P]; decide)
+          (by rw [pse_length]; decide) rfl (by rw [pse_length]; decide)) h0
+    have h0'' : cpsTripleWithin 1 (P + 132) (P + 136) pseCode
+        ((.x7 ↦ᵣ sumS) ** (.x30 ↦ᵣ execW) ** (.x31 ↦ᵣ sumS))
+        ((.x7 ↦ᵣ sumS) ** (.x30 ↦ᵣ execW) ** (.x31 ↦ᵣ (sumS + execW))) := by
+      rwa [P132_plus_4] at h0'
+    exact cpsTripleWithin_weaken (fun _ hp => hp)
+      (fun _ hq => by simpa [sumW'] using hq) h0''
+  have e33F := cpsTripleWithin_frameR
+    ((.x1 ↦ᵣ raIn) ** (.x10 ↦ᵣ priorW) ** (.x11 ↦ᵣ outPtr) **
+      (outPtr ↦ₘ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) **
+      (.x5 ↦ᵣ priorW) ** (.x6 ↦ᵣ iW) **
+      (.x28 ↦ᵣ offW) ** (.x29 ↦ᵣ (TxExecStateGasAddr + offW)) **
+      loopGlobals exactOkW runtimeW stateGas status execGas)
+    (by
+      repeat' first
+        | exact hGpf
+        | apply pcFree_sepConj
+        | exact pcFree_regIs
+        | exact pcFree_memIs) e33
+  -- 17. BLTU overflow TAKEN → FailLi (+28)
+  have e34tk : cpsTripleWithin 1 (P + 136) FailLi pseCode
+      ((.x31 ↦ᵣ sumW') ** (.x7 ↦ᵣ sumS))
+      ((.x31 ↦ᵣ sumW') ** (.x7 ↦ᵣ sumS)) := by
+    have hbr := bltu_spec_gen_within .x31 .x7 (28 : BitVec 13) sumW' sumS (P + 136)
+    have hbrC := cpsBranchWithin_extend_code
+      (CodeReq.ofProg_mem_at P (P + 136) pseProg 34
+        (.BLTU .x31 .x7 (28 : BitVec 13))
+        (by simp only [P]; decide)
+        (by rw [pse_length]; decide) rfl (by rw [pse_length]; decide)) hbr
+    have htk0 := cpsBranchWithin_takenStripPure2 hbrC (fun _ hq => by
+      obtain ⟨_, _, _, _, _, hrest⟩ := hq
+      exact ((sepConj_pure_right _).1 hrest).2 hUltE)
+    have hpc : (P + 136) + signExtend13 (28 : BitVec 13) = FailLi := by
+      simp only [P, FailLi]; decide
+    rwa [hpc] at htk0
+  have e34tkF := cpsTripleWithin_frameR
+    ((.x1 ↦ᵣ raIn) ** (.x10 ↦ᵣ priorW) ** (.x11 ↦ᵣ outPtr) **
+      (outPtr ↦ₘ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) **
+      (.x5 ↦ᵣ priorW) ** (.x6 ↦ᵣ iW) **
+      (.x28 ↦ᵣ offW) ** (.x29 ↦ᵣ (TxExecStateGasAddr + offW)) **
+      (.x30 ↦ᵣ execW) **
+      loopGlobals exactOkW runtimeW stateGas status execGas)
+    (by
+      repeat' first
+        | exact hGpf
+        | apply pcFree_sepConj
+        | exact pcFree_regIs
+        | exact pcFree_memIs) e34tk
+  -- 18-19. fail ret; x10 and x5 both priorW
+  have eFail :=
+    pseFailRet_spec raIn outPtr (0 : Word)
+      priorW iW sumS offW (TxExecStateGasAddr + offW) execW sumW' hret
+  have eFailF := cpsTripleWithin_frameR
+    (loopGlobals exactOkW runtimeW stateGas status execGas)
+    (by exact hGpf) eFail
+  -- Compose through state path + status≠0 + exec load + ovf
+  have c01 := cpsTripleWithin_seq_perm_same_cr
+    (fun _ hp => by dsimp only [LoopInv] at hp; xperm_hyp hp) hguard e16F
+  have c02 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) c01 eLa
+  have c03 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) c02 e19F
+  have c04 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) c03 e20F
+  have c05 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) c04 e21F
+  have c06 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) c05 e22F
+  have c07 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) c06 e23F
+  have c08 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) c07 eLaSt
+  have c09 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) c08 e26F
+  have c10 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) c09 e27F
+  have c11 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) c10 e28F
+  have c12 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) c11 eLaEx
+  have c13 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) c12 e31F
+  have c14 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) c13 e32F
+  have c15 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) c14 e33F
+  have c16 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) c15 e34tkF
+  have c17 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) c16 eFailF
+  -- step budget: 1+1+2+1+1+1+1+1+2+1+1+1+2+1+1+1+1+2 = 22? recount
+  -- guard1 slli1 la2 add1 ld1 add1 bltu1 mv1 laSt2 add1 ld1 beq1 laEx2 add1 ld1 add1 bltu1 fail2
+  -- = 1+1+2+1+1+1+1+1+2+1+1+1+2+1+1+1+1+2 = 22
+  change cpsTripleWithin (1+1+2+1+1+1+1+1+2+1+1+1+2+1+1+1+1+2) LoopGuard raIn pseCode _ _ at c17
+  exact cpsTripleWithin_weaken
+    (fun _ hp => by dsimp only [LoopInv] at hp ⊢; xperm_hyp hp)
+    (fun _ hq => by
+      dsimp only [postFail] at hq ⊢
+      xperm_hyp hq) c17
+
+#print axioms pseIterExecOvf
+
+end EvmAsm.Codegen.Eip8037PriorStateUsedExactExecOvf

--- a/EvmAsm/Codegen/Programs/Eip8037PriorStateUsedExactInduct.lean
+++ b/EvmAsm/Codegen/Programs/Eip8037PriorStateUsedExactInduct.lean
@@ -1,0 +1,300 @@
+/-
+  Loop induction + success top path for `eip8037_prior_state_used_exact`.
+-/
+
+import EvmAsm.Codegen.Programs.Eip8037PriorStateUsedExactStatusNez
+import EvmAsm.Codegen.Programs.ChainValidateExtraDataLengthSpec
+import EvmAsm.Rv64.SyscallSpecs
+import EvmAsm.Rv64.SAsm.DualReadByteScan
+
+namespace EvmAsm.Codegen.Eip8037PriorStateUsedExactInduct
+
+open EvmAsm.Rv64
+open EvmAsm.Codegen
+open EvmAsm.Codegen.Eip8037PriorStateUsedExactModel
+open EvmAsm.Codegen.Eip8037PriorStateUsedExactSpec
+open EvmAsm.Codegen.Eip8037PriorStateUsedExactLoop
+open EvmAsm.Codegen.Eip8037PriorStateUsedExactIter
+open EvmAsm.Codegen.Eip8037PriorStateUsedExactStatusNez
+
+abbrev LoopGuard : Word := Eip8037PriorStateUsedExactLoop.LoopGuard
+abbrev pseCode : CodeReq := Eip8037PriorStateUsedExactLoop.pseCode
+
+def nOneIterSteps : Nat := 23
+
+def nLoopFrom : Nat → Nat
+  | 0 => 4
+  | r + 1 => nOneIterSteps + nLoopFrom r
+
+private theorem getElem_bang (as : List Nat) (i : Nat) (h : i < as.length) :
+    as[i]! = as[i] := getElem!_pos as i h
+
+theorem priorCell_of_status0 (stateGas status execGas : List Nat) (i : Nat)
+    (hstat : i < status.length) (h0 : status[i] = 0) (hi : i < stateGas.length) :
+    priorCell stateGas status execGas i = stateGas[i] := by
+  simp only [priorCell, getElem_bang status i hstat, h0, ↓reduceIte,
+    getElem_bang stateGas i hi, Nat.add_zero]
+
+theorem priorCell_of_statusNez (stateGas status execGas : List Nat) (i : Nat)
+    (hstat : i < status.length) (hne : status[i] ≠ 0)
+    (hi : i < stateGas.length) (hexec : i < execGas.length) :
+    priorCell stateGas status execGas i = stateGas[i] + execGas[i] := by
+  simp only [priorCell, getElem_bang status i hstat, hne, ↓reduceIte,
+    getElem_bang stateGas i hi, getElem_bang execGas i hexec]
+
+theorem priorPrefixExact_eq_prefix (stateGas status execGas : List Nat)
+    (k s : Nat) (h : priorPrefixExact stateGas status execGas k = some s) :
+    s = priorPrefix stateGas status execGas k := by
+  induction k generalizing s with
+  | zero =>
+    simp only [priorPrefixExact, priorPrefix] at h ⊢
+    injection h with h; exact h.symm
+  | succ k ih =>
+    simp only [priorPrefixExact] at h
+    split at h
+    · contradiction
+    · next t ht =>
+      simp only [add64?] at h
+      split at h
+      · next hlt =>
+        injection h with heq
+        have iht := ih t ht
+        simp only [priorPrefix, iht] at heq ⊢
+        exact heq.symm
+      · contradiction
+
+theorem ofNat_ne_of_lt (i n : Nat) (hi : i < n) (hn : n < 2 ^ 64) :
+    BitVec.ofNat 64 i ≠ BitVec.ofNat 64 n := by
+  intro heq
+  have hi' : i < 2 ^ 64 := Nat.lt_trans hi hn
+  have := congrArg BitVec.toNat heq
+  simp only [BitVec.toNat_ofNat, Nat.mod_eq_of_lt hi', Nat.mod_eq_of_lt hn] at this
+  omega
+
+set_option maxRecDepth 8000 in
+theorem pseIterOne
+    (raIn priorW outPtr : Word)
+    (exactOkW runtimeW : Word)
+    (stateGas status execGas : List Nat)
+    (i sum : Nat)
+    (v28 v29 v30 v31 : Word)
+    (hi : i < stateGas.length)
+    (hstat : i < status.length)
+    (hexec : i < execGas.length)
+    (hstatBound : status[i] < 2 ^ 64)
+    (hno : sum + priorCell stateGas status execGas i < 2 ^ 64)
+    (hne : BitVec.ofNat 64 i ≠ priorW)
+    (hi61 : i < 2 ^ 61) :
+    ∃ v28' v29' v30' v31',
+      cpsTripleWithin nOneIterSteps LoopGuard LoopGuard pseCode
+        (LoopInv raIn priorW outPtr (BitVec.ofNat 64 sum) (BitVec.ofNat 64 i)
+          exactOkW runtimeW stateGas status execGas v28 v29 v30 v31)
+        (LoopInv raIn priorW outPtr
+          (BitVec.ofNat 64 (sum + priorCell stateGas status execGas i))
+          (BitVec.ofNat 64 (i + 1)) exactOkW runtimeW
+          stateGas status execGas v28' v29' v30' v31') := by
+  by_cases hst : status[i] = 0
+  · have hcell := priorCell_of_status0 stateGas status execGas i hstat hst hi
+    have hno' : sum + stateGas[i] < 2 ^ 64 := by simpa [hcell] using hno
+    have htrip := pseIterStatus0 raIn priorW outPtr exactOkW runtimeW
+      stateGas status execGas i sum v28 v29 v30 v31 hi hstat hst hno' hne hi61
+    refine ⟨BitVec.ofNat 64 (8 * i),
+      Eip8037PriorStateUsedExactLoop.TxStatusAddr + BitVec.ofNat 64 (8 * i),
+      (0 : Word),
+      BitVec.ofNat 64 (sum + stateGas[i]), ?_⟩
+    have hle : 16 ≤ nOneIterSteps := by unfold nOneIterSteps; omega
+    have htrip' := cpsTripleWithin_mono_nSteps hle htrip
+    -- goal post sum uses priorCell; leaf uses stateGas[i]
+    rw [hcell]
+    exact htrip'
+  · have hcell := priorCell_of_statusNez stateGas status execGas i hstat hst hi hexec
+    have hnoS : sum + stateGas[i] < 2 ^ 64 := by
+      have : stateGas[i] ≤ priorCell stateGas status execGas i := by
+        simp only [hcell]; omega
+      omega
+    have hnoE : sum + stateGas[i] + execGas[i] < 2 ^ 64 := by
+      have : sum + priorCell stateGas status execGas i =
+          sum + stateGas[i] + execGas[i] := by
+        simp only [hcell, Nat.add_assoc]
+      simpa [this] using hno
+    have htrip := pseIterStatusNez raIn priorW outPtr exactOkW runtimeW
+      stateGas status execGas i sum v28 v29 v30 v31 hi hstat hexec hst hstatBound
+      hnoS hnoE hne
+    refine ⟨BitVec.ofNat 64 (8 * i),
+      Eip8037PriorStateUsedExactLoop.TxExecStateGasAddr + BitVec.ofNat 64 (8 * i),
+      BitVec.ofNat 64 execGas[i],
+      BitVec.ofNat 64 (sum + stateGas[i] + execGas[i]), ?_⟩
+    -- goal: ofNat (sum + priorCell) = ofNat (sum + (state+exec))
+    -- leaf: ofNat (sum + state + exec)
+    have hassoc : sum + stateGas[i] + execGas[i] =
+        sum + (stateGas[i] + execGas[i]) := by omega
+    rw [hcell, ← hassoc]
+    exact htrip
+
+set_option maxRecDepth 8000 in
+theorem pseLoopFrom
+    (raIn priorW outPtr : Word)
+    (exactOkW runtimeW : Word)
+    (stateGas status execGas : List Nat)
+    (n : Nat)
+    (hnW : priorW = BitVec.ofNat 64 n)
+    (hn16 : n ≤ 16)
+    (hAllState : n ≤ stateGas.length)
+    (hAllStat : n ≤ status.length)
+    (hAllExec : n ≤ execGas.length)
+    (hAllStatBound : ∀ j < n, status[j]! < 2 ^ 64)
+    (hAllNoOvf : ∀ j < n,
+      ∀ s, priorPrefixExact stateGas status execGas j = some s →
+        s + priorCell stateGas status execGas j < 2 ^ 64)
+    (hret : raIn &&& ~~~(1 : Word) = raIn)
+    (fuel i sum : Nat)
+    (v28 v29 v30 v31 : Word)
+    (hfuel : n - i ≤ fuel)
+    (hi : i ≤ n)
+    (hsum : priorPrefixExact stateGas status execGas i = some sum) :
+    let sumW := BitVec.ofNat 64 sum
+    let iW := BitVec.ofNat 64 i
+    let finalSum := priorPrefix stateGas status execGas n
+    let finalW := BitVec.ofNat 64 finalSum
+    ∃ v28' v29' v30' v31',
+      cpsTripleWithin (nLoopFrom (n - i)) LoopGuard raIn pseCode
+        (LoopInv raIn priorW outPtr sumW iW exactOkW runtimeW
+          stateGas status execGas v28 v29 v30 v31)
+        (postOk raIn outPtr finalW
+          ((.x5 ↦ᵣ priorW) ** (.x6 ↦ᵣ priorW) ** (.x7 ↦ᵣ finalW) **
+            (.x28 ↦ᵣ v28') ** (.x29 ↦ᵣ v29') ** (.x30 ↦ᵣ v30') ** (.x31 ↦ᵣ v31') **
+            loopGlobals exactOkW runtimeW stateGas status execGas)) := by
+  intro sumW iW finalSum finalW
+  induction fuel generalizing i sum v28 v29 v30 v31 with
+  | zero =>
+    have hni : n - i = 0 := Nat.le_zero.mp hfuel
+    have hi_eq : i = n := by omega
+    have hsumEq : sum = finalSum := by
+      rw [hi_eq] at hsum
+      -- finalSum := priorPrefix ... n
+      exact priorPrefixExact_eq_prefix stateGas status execGas n sum hsum
+    refine ⟨v28, v29, v30, v31, ?_⟩
+    have hexit := pseLoopExitOk raIn priorW outPtr (BitVec.ofNat 64 sum)
+      exactOkW runtimeW stateGas status execGas v28 v29 v30 v31 hret
+    have hiW : BitVec.ofNat 64 n = priorW := hnW.symm
+    have hexit' : cpsTripleWithin 4 LoopGuard raIn pseCode
+        (LoopInv raIn priorW outPtr (BitVec.ofNat 64 sum) (BitVec.ofNat 64 n)
+          exactOkW runtimeW stateGas status execGas v28 v29 v30 v31)
+        (postOk raIn outPtr (BitVec.ofNat 64 sum)
+          ((.x5 ↦ᵣ priorW) ** (.x6 ↦ᵣ priorW) ** (.x7 ↦ᵣ BitVec.ofNat 64 sum) **
+            (.x28 ↦ᵣ v28) ** (.x29 ↦ᵣ v29) ** (.x30 ↦ᵣ v30) ** (.x31 ↦ᵣ v31) **
+            loopGlobals exactOkW runtimeW stateGas status execGas)) := by
+      simpa [hiW] using hexit
+    have hgoal : cpsTripleWithin 4 LoopGuard raIn pseCode
+        (LoopInv raIn priorW outPtr sumW iW exactOkW runtimeW
+          stateGas status execGas v28 v29 v30 v31)
+        (postOk raIn outPtr finalW
+          ((.x5 ↦ᵣ priorW) ** (.x6 ↦ᵣ priorW) ** (.x7 ↦ᵣ finalW) **
+            (.x28 ↦ᵣ v28) ** (.x29 ↦ᵣ v29) ** (.x30 ↦ᵣ v30) ** (.x31 ↦ᵣ v31) **
+            loopGlobals exactOkW runtimeW stateGas status execGas)) := by
+      simpa [sumW, iW, finalW, hsumEq, hi_eq] using hexit'
+    simpa [nLoopFrom, hni] using hgoal
+  | succ fuel ih =>
+    by_cases hdone : i = n
+    · -- exit without subst: rewrite with hdone
+      have hsumEq : sum = finalSum := by
+        rw [hdone] at hsum
+        exact priorPrefixExact_eq_prefix stateGas status execGas n sum hsum
+      refine ⟨v28, v29, v30, v31, ?_⟩
+      have hexit := pseLoopExitOk raIn priorW outPtr (BitVec.ofNat 64 sum)
+        exactOkW runtimeW stateGas status execGas v28 v29 v30 v31 hret
+      have hiW : BitVec.ofNat 64 n = priorW := hnW.symm
+      have hexit' : cpsTripleWithin 4 LoopGuard raIn pseCode
+          (LoopInv raIn priorW outPtr (BitVec.ofNat 64 sum) (BitVec.ofNat 64 n)
+            exactOkW runtimeW stateGas status execGas v28 v29 v30 v31)
+          (postOk raIn outPtr (BitVec.ofNat 64 sum)
+            ((.x5 ↦ᵣ priorW) ** (.x6 ↦ᵣ priorW) ** (.x7 ↦ᵣ BitVec.ofNat 64 sum) **
+              (.x28 ↦ᵣ v28) ** (.x29 ↦ᵣ v29) ** (.x30 ↦ᵣ v30) ** (.x31 ↦ᵣ v31) **
+              loopGlobals exactOkW runtimeW stateGas status execGas)) := by
+        simpa [hiW] using hexit
+      have hgoal : cpsTripleWithin 4 LoopGuard raIn pseCode
+          (LoopInv raIn priorW outPtr sumW iW exactOkW runtimeW
+            stateGas status execGas v28 v29 v30 v31)
+          (postOk raIn outPtr finalW
+            ((.x5 ↦ᵣ priorW) ** (.x6 ↦ᵣ priorW) ** (.x7 ↦ᵣ finalW) **
+              (.x28 ↦ᵣ v28) ** (.x29 ↦ᵣ v29) ** (.x30 ↦ᵣ v30) ** (.x31 ↦ᵣ v31) **
+              loopGlobals exactOkW runtimeW stateGas status execGas)) := by
+        simpa [sumW, iW, finalW, hsumEq, hdone] using hexit'
+      simpa [hdone, Nat.sub_self, nLoopFrom] using hgoal
+    · have hilt : i < n := Nat.lt_of_le_of_ne hi hdone
+      have hiS : i < stateGas.length := Nat.lt_of_lt_of_le hilt hAllState
+      have hiSt : i < status.length := Nat.lt_of_lt_of_le hilt hAllStat
+      have hiE : i < execGas.length := Nat.lt_of_lt_of_le hilt hAllExec
+      have hstatBound : status[i] < 2 ^ 64 := by
+        have := hAllStatBound i hilt
+        rwa [getElem_bang status i hiSt] at this
+      have hno : sum + priorCell stateGas status execGas i < 2 ^ 64 :=
+        hAllNoOvf i hilt sum hsum
+      have hn64 : n < 2 ^ 64 := Nat.lt_of_le_of_lt hn16 (by decide : (16 : Nat) < 2 ^ 64)
+      have hne : BitVec.ofNat 64 i ≠ priorW := by
+        rw [hnW]; exact ofNat_ne_of_lt i n hilt hn64
+      have hi61 : i < 2 ^ 61 :=
+        Nat.lt_of_lt_of_le hilt (Nat.le_trans hn16 (by decide : (16 : Nat) ≤ 2 ^ 61))
+      obtain ⟨v28a, v29a, v30a, v31a, hiter⟩ :=
+        pseIterOne raIn priorW outPtr exactOkW runtimeW
+          stateGas status execGas i sum v28 v29 v30 v31
+          hiS hiSt hiE hstatBound hno hne hi61
+      have hsum' : priorPrefixExact stateGas status execGas (i + 1) =
+          some (sum + priorCell stateGas status execGas i) := by
+        simp only [priorPrefixExact, hsum, add64?, if_pos hno]
+      have hfuel' : n - (i + 1) ≤ fuel := by omega
+      have hi' : i + 1 ≤ n := Nat.succ_le_of_lt hilt
+      obtain ⟨v28b, v29b, v30b, v31b, htail⟩ :=
+        ih (i + 1) (sum + priorCell stateGas status execGas i)
+          v28a v29a v30a v31a hfuel' hi' hsum'
+      refine ⟨v28b, v29b, v30b, v31b, ?_⟩
+      have hcomp := cpsTripleWithin_seq_perm_same_cr
+        (fun _ hp => hp) hiter htail
+      have hsteps : nOneIterSteps + nLoopFrom (n - (i + 1)) = nLoopFrom (n - i) := by
+        have : n - i = (n - (i + 1)) + 1 := by omega
+        rw [this, nLoopFrom]
+      simpa [hsteps] using hcomp
+
+set_option maxRecDepth 8000 in
+theorem pseLoop
+    (raIn priorW outPtr : Word)
+    (exactOkW runtimeW : Word)
+    (stateGas status execGas : List Nat)
+    (n finalSum : Nat)
+    (v28 v29 v30 v31 : Word)
+    (hnW : priorW = BitVec.ofNat 64 n)
+    (hn16 : n ≤ 16)
+    (hfinal : priorPrefixExact stateGas status execGas n = some finalSum)
+    (hAllState : n ≤ stateGas.length)
+    (hAllStat : n ≤ status.length)
+    (hAllExec : n ≤ execGas.length)
+    (hAllStatBound : ∀ j < n, status[j]! < 2 ^ 64)
+    (hAllNoOvf : ∀ j < n,
+      ∀ s, priorPrefixExact stateGas status execGas j = some s →
+        s + priorCell stateGas status execGas j < 2 ^ 64)
+    (hret : raIn &&& ~~~(1 : Word) = raIn) :
+    let finalW := BitVec.ofNat 64 finalSum
+    ∃ v28' v29' v30' v31',
+      cpsTripleWithin (nLoopFrom n) LoopGuard raIn pseCode
+        (LoopInv raIn priorW outPtr (0 : Word) (0 : Word) exactOkW runtimeW
+          stateGas status execGas v28 v29 v30 v31)
+        (postOk raIn outPtr finalW
+          ((.x5 ↦ᵣ priorW) ** (.x6 ↦ᵣ priorW) ** (.x7 ↦ᵣ finalW) **
+            (.x28 ↦ᵣ v28') ** (.x29 ↦ᵣ v29') ** (.x30 ↦ᵣ v30') ** (.x31 ↦ᵣ v31') **
+            loopGlobals exactOkW runtimeW stateGas status execGas)) := by
+  intro finalW
+  have hsum0 : priorPrefixExact stateGas status execGas 0 = some 0 := rfl
+  have hfeq : finalSum = priorPrefix stateGas status execGas n :=
+    priorPrefixExact_eq_prefix stateGas status execGas n finalSum hfinal
+  obtain ⟨v28', v29', v30', v31', h⟩ :=
+    pseLoopFrom raIn priorW outPtr exactOkW runtimeW
+      stateGas status execGas n hnW hn16
+      hAllState hAllStat hAllExec hAllStatBound hAllNoOvf hret
+      n 0 0 v28 v29 v30 v31 (by omega) (by omega) hsum0
+  refine ⟨v28', v29', v30', v31', ?_⟩
+  -- finalW = ofNat finalSum; h has ofNat (priorPrefix) = ofNat finalSum via hfeq
+  simpa [Nat.sub_zero, ← hfeq] using h
+
+#print axioms pseLoop
+
+end EvmAsm.Codegen.Eip8037PriorStateUsedExactInduct

--- a/EvmAsm/Codegen/Programs/Eip8037PriorStateUsedExactInduct.lean
+++ b/EvmAsm/Codegen/Programs/Eip8037PriorStateUsedExactInduct.lean
@@ -83,8 +83,7 @@ theorem pseIterOne
     (hexec : i < execGas.length)
     (hstatBound : status[i] < 2 ^ 64)
     (hno : sum + priorCell stateGas status execGas i < 2 ^ 64)
-    (hne : BitVec.ofNat 64 i ≠ priorW)
-    (hi61 : i < 2 ^ 61) :
+    (hne : BitVec.ofNat 64 i ≠ priorW) :
     ∃ v28' v29' v30' v31',
       cpsTripleWithin nOneIterSteps LoopGuard LoopGuard pseCode
         (LoopInv raIn priorW outPtr (BitVec.ofNat 64 sum) (BitVec.ofNat 64 i)
@@ -97,7 +96,7 @@ theorem pseIterOne
   · have hcell := priorCell_of_status0 stateGas status execGas i hstat hst hi
     have hno' : sum + stateGas[i] < 2 ^ 64 := by simpa [hcell] using hno
     have htrip := pseIterStatus0 raIn priorW outPtr exactOkW runtimeW
-      stateGas status execGas i sum v28 v29 v30 v31 hi hstat hst hno' hne hi61
+      stateGas status execGas i sum v28 v29 v30 v31 hi hstat hst hno' hne
     refine ⟨BitVec.ofNat 64 (8 * i),
       Eip8037PriorStateUsedExactLoop.TxStatusAddr + BitVec.ofNat 64 (8 * i),
       (0 : Word),
@@ -233,12 +232,10 @@ theorem pseLoopFrom
       have hn64 : n < 2 ^ 64 := Nat.lt_of_le_of_lt hn16 (by decide : (16 : Nat) < 2 ^ 64)
       have hne : BitVec.ofNat 64 i ≠ priorW := by
         rw [hnW]; exact ofNat_ne_of_lt i n hilt hn64
-      have hi61 : i < 2 ^ 61 :=
-        Nat.lt_of_lt_of_le hilt (Nat.le_trans hn16 (by decide : (16 : Nat) ≤ 2 ^ 61))
       obtain ⟨v28a, v29a, v30a, v31a, hiter⟩ :=
         pseIterOne raIn priorW outPtr exactOkW runtimeW
           stateGas status execGas i sum v28 v29 v30 v31
-          hiS hiSt hiE hstatBound hno hne hi61
+          hiS hiSt hiE hstatBound hno hne
       have hsum' : priorPrefixExact stateGas status execGas (i + 1) =
           some (sum + priorCell stateGas status execGas i) := by
         simp only [priorPrefixExact, hsum, add64?, if_pos hno]

--- a/EvmAsm/Codegen/Programs/Eip8037PriorStateUsedExactIter.lean
+++ b/EvmAsm/Codegen/Programs/Eip8037PriorStateUsedExactIter.lean
@@ -1,0 +1,653 @@
+/-
+  One-iter body for `eip8037_prior_state_used_exact` (status=0 skip path).
+-/
+
+import EvmAsm.Codegen.Programs.Eip8037PriorStateUsedExactLoop
+import EvmAsm.Codegen.Programs.ChainValidateExtraDataLengthSpec
+import EvmAsm.Rv64.LaResolve
+import EvmAsm.Rv64.SyscallSpecs
+import EvmAsm.Rv64.ControlFlow
+import EvmAsm.Rv64.SAsm.DualReadByteScan
+
+namespace EvmAsm.Codegen.Eip8037PriorStateUsedExactIter
+
+open EvmAsm.Rv64
+open EvmAsm.Codegen
+open EvmAsm.Codegen.Eip8037PriorStateUsedExactModel
+open EvmAsm.Codegen.Eip8037PriorStateUsedExactLoop
+open EvmAsm.Codegen.ChainValidateExtraDataLengthSpec
+  (wordArray wordArrayFrom wordArray_split pcFree_wordArray pcFree_wordArrayFrom
+   shiftLeft3_ofNat)
+
+abbrev P : Word := Eip8037PriorStateUsedExactLoop.P
+abbrev pseProg : Program := Eip8037PriorStateUsedExactLoop.pseProg
+abbrev pseCode : CodeReq := Eip8037PriorStateUsedExactLoop.pseCode
+abbrev LoopGuard : Word := Eip8037PriorStateUsedExactLoop.LoopGuard
+abbrev LoopBody : Word := Eip8037PriorStateUsedExactLoop.LoopBody
+abbrev AfterSlli : Word := Eip8037PriorStateUsedExactLoop.AfterSlli
+abbrev AfterLaState : Word := Eip8037PriorStateUsedExactLoop.AfterLaState
+abbrev AfterMvSum : Word := Eip8037PriorStateUsedExactLoop.AfterMvSum
+abbrev AfterLaStatus : Word := Eip8037PriorStateUsedExactLoop.AfterLaStatus
+abbrev AfterLdStatus : Word := Eip8037PriorStateUsedExactLoop.AfterLdStatus
+abbrev AfterStatusSkip : Word := Eip8037PriorStateUsedExactLoop.AfterStatusSkip
+abbrev AfterIncr : Word := Eip8037PriorStateUsedExactLoop.AfterIncr
+abbrev TxStateGasAddr : Word := Eip8037PriorStateUsedExactLoop.TxStateGasAddr
+abbrev TxStatusAddr : Word := Eip8037PriorStateUsedExactLoop.TxStatusAddr
+abbrev TxExecStateGasAddr : Word := Eip8037PriorStateUsedExactLoop.TxExecStateGasAddr
+
+theorem pse_length : pseProg.length = 43 := Eip8037PriorStateUsedExactLoop.pse_length
+
+private theorem se12_zero : signExtend12 (0 : BitVec 12) = (0 : Word) := by decide
+private theorem se12_one : signExtend12 (1 : BitVec 12) = (1 : Word) := by decide
+private theorem se13_32 : signExtend13 (32 : BitVec 13) = (32 : Word) := by decide
+private theorem se21_m88 : signExtend21 (-88 : BitVec 21) = BitVec.ofInt 64 (-88) := by decide
+
+private theorem ofNat_addi1 (i : Nat) :
+    BitVec.ofNat 64 i + signExtend12 (1 : BitVec 12) = BitVec.ofNat 64 (i + 1) := by
+  rw [se12_one, BitVec.ofNat_add]; rfl
+
+private theorem ofNat_add_lt (a b : Nat) (h : a + b < 2 ^ 64) :
+    BitVec.ofNat 64 a + BitVec.ofNat 64 b = BitVec.ofNat 64 (a + b) := by
+  apply BitVec.eq_of_toNat_eq
+  have ha : a < 2 ^ 64 := Nat.lt_of_le_of_lt (Nat.le_add_right a b) h
+  have hb : b < 2 ^ 64 := Nat.lt_of_le_of_lt (Nat.le_add_left b a) h
+  simp only [BitVec.toNat_add, BitVec.toNat_ofNat, Nat.mod_eq_of_lt ha, Nat.mod_eq_of_lt hb,
+    Nat.mod_eq_of_lt h]
+
+private theorem not_ult_add (s g : Nat) (h : s + g < 2 ^ 64) :
+    ¬BitVec.ult (BitVec.ofNat 64 (s + g)) (BitVec.ofNat 64 s) := by
+  have hs : s < 2 ^ 64 := Nat.lt_of_le_of_lt (Nat.le_add_right s g) h
+  simp only [BitVec.ult_eq_decide, decide_eq_true_eq, BitVec.toNat_ofNat,
+    Nat.mod_eq_of_lt hs, Nat.mod_eq_of_lt h]
+  omega
+
+private theorem AfterLdStatus_plus_32 :
+    AfterLdStatus + signExtend13 (32 : BitVec 13) = AfterStatusSkip := by
+  simp only [AfterLdStatus, AfterStatusSkip, P, se13_32]; decide
+
+private theorem AfterIncr_back :
+    AfterIncr + signExtend21 (-88 : BitVec 21) = LoopGuard := by
+  simp only [AfterIncr, LoopGuard, P, se21_m88, GuestAddrs.eip8037_prior_state_used_exact]
+  decide
+
+private theorem AfterLaState_plus_4 : AfterLaState + 4 = P + 80 := by
+  simp only [AfterLaState, P]; decide
+private theorem AfterLaStatus_plus_4 : AfterLaStatus + 4 = P + 108 := by
+  simp only [AfterLaStatus, P]; decide
+private theorem AfterStatusSkip_plus_4 : AfterStatusSkip + 4 = AfterIncr := by
+  simp only [AfterStatusSkip, AfterIncr, P]; decide
+private theorem P80_plus_4 : (P + 80 : Word) + 4 = P + 84 := by simp only [P]; decide
+private theorem P84_plus_4 : (P + 84 : Word) + 4 = P + 88 := by simp only [P]; decide
+private theorem P88_plus_4 : (P + 88 : Word) + 4 = P + 92 := by simp only [P]; decide
+private theorem P92_plus_4 : (P + 92 : Word) + 4 = AfterMvSum := by
+  simp only [AfterMvSum, P]; decide
+private theorem P108_plus_4 : (P + 108 : Word) + 4 = AfterLdStatus := by
+  simp only [AfterLdStatus, P]; decide
+
+/-- Ambient without the three gas arrays (for peels). -/
+def loopGlobalsCore (exactOkW runtimeW : Word) : Assertion :=
+  (ExactOkAddr ↦ₘ exactOkW) ** (RuntimeCountAddr ↦ₘ runtimeW)
+
+theorem pcFree_loopGlobalsCore (exactOkW runtimeW : Word) :
+    (loopGlobalsCore exactOkW runtimeW).pcFree := by
+  unfold loopGlobalsCore
+  exact pcFree_sepConj pcFree_memIs pcFree_memIs
+
+/-- Match `loopGlobals` after peeling one wordArray via `wordArray_split`. -/
+theorem loopGlobals_eq (exactOkW runtimeW : Word)
+    (stateGas status execGas : List Nat) :
+    loopGlobals exactOkW runtimeW stateGas status execGas =
+      (loopGlobalsCore exactOkW runtimeW **
+        wordArray TxStateGasAddr stateGas **
+        wordArray TxStatusAddr status **
+        wordArray TxExecStateGasAddr execGas) := by
+  unfold loopGlobals loopGlobalsCore
+  -- LHS: E ** R ** s ** st ** e
+  -- RHS: (E ** R) ** s ** st ** e
+  exact (sepConj_assoc' _ _ _).symm
+
+/-- Caller-private ambient used across straight-line body steps (full arrays). -/
+def iterAmbient (raIn priorW outPtr sumW iW exactOkW runtimeW : Word)
+    (stateGas status execGas : List Nat)
+    (v28 v29 v30 v31 : Word) : Assertion :=
+  (.x1 ↦ᵣ raIn) ** (.x10 ↦ᵣ priorW) ** (.x11 ↦ᵣ outPtr) **
+  (outPtr ↦ₘ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) **
+  (.x5 ↦ᵣ priorW) ** (.x6 ↦ᵣ iW) ** (.x7 ↦ᵣ sumW) **
+  (.x28 ↦ᵣ v28) ** (.x29 ↦ᵣ v29) ** (.x30 ↦ᵣ v30) ** (.x31 ↦ᵣ v31) **
+  loopGlobals exactOkW runtimeW stateGas status execGas
+
+theorem pcFree_iterAmbient (raIn priorW outPtr sumW iW exactOkW runtimeW : Word)
+    (stateGas status execGas : List Nat)
+    (v28 v29 v30 v31 : Word) :
+    (iterAmbient raIn priorW outPtr sumW iW exactOkW runtimeW
+      stateGas status execGas v28 v29 v30 v31).pcFree := by
+  unfold iterAmbient
+  have hGpf : (loopGlobals exactOkW runtimeW stateGas status execGas).pcFree :=
+    pcFree_loopGlobals exactOkW runtimeW stateGas status execGas
+  repeat' first
+    | exact hGpf
+    | apply pcFree_sepConj
+    | exact pcFree_regIs
+    | exact pcFree_memIs
+
+set_option maxRecDepth 8000 in
+/-- Status=0 one-iter: LoopGuard → LoopGuard, sum+=stateGas[i], i+=1.
+    Requires status[i]=0 and no u64 overflow on the state add. -/
+theorem pseIterStatus0
+    (raIn priorW outPtr : Word)
+    (exactOkW runtimeW : Word)
+    (stateGas status execGas : List Nat)
+    (i sum : Nat)
+    (v28 v29 v30 v31 : Word)
+    (hi : i < stateGas.length)
+    (hstat : i < status.length)
+    (hstat0 : status[i] = 0)
+    (hno : sum + stateGas[i] < 2 ^ 64)
+    (hne : BitVec.ofNat 64 i ≠ priorW)
+    (hi61 : i < 2 ^ 61) :
+    let iW := BitVec.ofNat 64 i
+    let sumW := BitVec.ofNat 64 sum
+    let sumW' := BitVec.ofNat 64 (sum + stateGas[i])
+    let iW' := BitVec.ofNat 64 (i + 1)
+    let offW := BitVec.ofNat 64 (8 * i)
+    cpsTripleWithin 16 LoopGuard LoopGuard pseCode
+      (LoopInv raIn priorW outPtr sumW iW exactOkW runtimeW
+        stateGas status execGas v28 v29 v30 v31)
+      (LoopInv raIn priorW outPtr sumW' iW' exactOkW runtimeW
+        stateGas status execGas offW
+          (TxStatusAddr + offW) (0 : Word) sumW') := by
+  intro iW sumW sumW' iW' offW
+  have hGpf : (loopGlobals exactOkW runtimeW stateGas status execGas).pcFree :=
+    pcFree_loopGlobals exactOkW runtimeW stateGas status execGas
+  have hsumAdd : sumW + BitVec.ofNat 64 stateGas[i] = sumW' := by
+    simpa [sumW, sumW'] using ofNat_add_lt sum stateGas[i] hno
+  have hnoUlt : ¬BitVec.ult sumW' sumW := by
+    simpa [sumW, sumW'] using not_ult_add sum stateGas[i] hno
+  have hoff : iW <<< 3 = offW := by
+    simpa [iW, offW] using shiftLeft3_ofNat i
+  have hstatW : BitVec.ofNat 64 status[i] = (0 : Word) := by
+    simp only [hstat0]; rfl
+  have hsplit := wordArray_split TxStateGasAddr stateGas i hi
+  have hsplitS := wordArray_split TxStatusAddr status i hstat
+  have haddrState :
+      TxStateGasAddr + BitVec.ofNat 64 (8 * i) = TxStateGasAddr + offW := by
+    simp only [offW]
+  have haddrStatus :
+      TxStatusAddr + BitVec.ofNat 64 (8 * i) = TxStatusAddr + offW := by
+    simp only [offW]
+  -- 1. guard ntaken
+  have hguard := pseLoopGuardNtaken raIn priorW outPtr sumW iW exactOkW runtimeW
+    stateGas status execGas v28 v29 v30 v31 hne
+  -- 2. SLLI x28 = 8*i
+  have e16 :
+      cpsTripleWithin 1 LoopBody AfterSlli pseCode
+        ((.x6 ↦ᵣ iW) ** (.x28 ↦ᵣ v28))
+        ((.x6 ↦ᵣ iW) ** (.x28 ↦ᵣ offW)) := by
+    have h0 := slli_spec_gen_within .x28 .x6 v28 iW (3 : BitVec 6) LoopBody (by decide)
+    have h0' : cpsTripleWithin 1 LoopBody (LoopBody + 4) pseCode
+        ((.x6 ↦ᵣ iW) ** (.x28 ↦ᵣ v28))
+        ((.x6 ↦ᵣ iW) ** (.x28 ↦ᵣ (iW <<< 3))) :=
+      cpsTripleWithin_extend_code
+        (CodeReq.ofProg_mem_at P LoopBody pseProg 16
+          (.SLLI .x28 .x6 (3 : BitVec 6))
+          (by simp only [LoopBody]; decide)
+          (by rw [pse_length]; decide) rfl (by rw [pse_length]; decide)) h0
+    have h0'' : cpsTripleWithin 1 LoopBody AfterSlli pseCode
+        ((.x6 ↦ᵣ iW) ** (.x28 ↦ᵣ v28))
+        ((.x6 ↦ᵣ iW) ** (.x28 ↦ᵣ (iW <<< 3))) := by
+      rwa [show LoopBody + 4 = AfterSlli from by simp only [LoopBody, AfterSlli]; decide] at h0'
+    exact cpsTripleWithin_weaken (fun _ hp => hp)
+      (fun _ hq => by rw [← hoff]; exact hq) h0''
+  have e16F := cpsTripleWithin_frameR
+    ((.x1 ↦ᵣ raIn) ** (.x10 ↦ᵣ priorW) ** (.x11 ↦ᵣ outPtr) **
+      (outPtr ↦ₘ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) **
+      (.x5 ↦ᵣ priorW) ** (.x7 ↦ᵣ sumW) **
+      (.x29 ↦ᵣ v29) ** (.x30 ↦ᵣ v30) ** (.x31 ↦ᵣ v31) **
+      loopGlobals exactOkW runtimeW stateGas status execGas)
+    (by
+      repeat' first
+        | exact hGpf
+        | apply pcFree_sepConj
+        | exact pcFree_regIs
+        | exact pcFree_memIs) e16
+  -- 3. la state → x29 = TxStateGasAddr
+  have eLa := cpsTripleWithin_frameR
+    ((.x1 ↦ᵣ raIn) ** (.x10 ↦ᵣ priorW) ** (.x11 ↦ᵣ outPtr) **
+      (outPtr ↦ₘ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) **
+      (.x5 ↦ᵣ priorW) ** (.x6 ↦ᵣ iW) ** (.x7 ↦ᵣ sumW) **
+      (.x28 ↦ᵣ offW) ** (.x30 ↦ᵣ v30) ** (.x31 ↦ᵣ v31) **
+      loopGlobals exactOkW runtimeW stateGas status execGas)
+    (by
+      repeat' first
+        | exact hGpf
+        | apply pcFree_sepConj
+        | exact pcFree_regIs
+        | exact pcFree_memIs) (pseLaStateGas v29)
+  -- 4. ADD x29 += x28
+  have e19 :
+      cpsTripleWithin 1 AfterLaState (P + 80) pseCode
+        ((.x29 ↦ᵣ TxStateGasAddr) ** (.x28 ↦ᵣ offW))
+        ((.x29 ↦ᵣ (TxStateGasAddr + offW)) ** (.x28 ↦ᵣ offW)) := by
+    have h0 := add_spec_gen_rd_eq_rs1_within .x29 .x28 TxStateGasAddr offW AfterLaState (by decide)
+    have h0' : cpsTripleWithin 1 AfterLaState (AfterLaState + 4) pseCode
+        ((.x29 ↦ᵣ TxStateGasAddr) ** (.x28 ↦ᵣ offW))
+        ((.x29 ↦ᵣ (TxStateGasAddr + offW)) ** (.x28 ↦ᵣ offW)) :=
+      cpsTripleWithin_extend_code
+        (CodeReq.ofProg_mem_at P AfterLaState pseProg 19
+          (.ADD .x29 .x29 .x28)
+          (by simp only [AfterLaState]; decide)
+          (by rw [pse_length]; decide) rfl (by rw [pse_length]; decide)) h0
+    rwa [AfterLaState_plus_4] at h0'
+  have e19F := cpsTripleWithin_frameR
+    ((.x1 ↦ᵣ raIn) ** (.x10 ↦ᵣ priorW) ** (.x11 ↦ᵣ outPtr) **
+      (outPtr ↦ₘ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) **
+      (.x5 ↦ᵣ priorW) ** (.x6 ↦ᵣ iW) ** (.x7 ↦ᵣ sumW) **
+      (.x30 ↦ᵣ v30) ** (.x31 ↦ᵣ v31) **
+      loopGlobals exactOkW runtimeW stateGas status execGas)
+    (by
+      repeat' first
+        | exact hGpf
+        | apply pcFree_sepConj
+        | exact pcFree_regIs
+        | exact pcFree_memIs) e19
+  -- 5. LD state cell
+  have e20core :
+      cpsTripleWithin 1 (P + 80) (P + 84) pseCode
+        ((.x29 ↦ᵣ (TxStateGasAddr + offW)) ** (.x30 ↦ᵣ v30) **
+          ((TxStateGasAddr + offW) ↦ₘ BitVec.ofNat 64 stateGas[i]))
+        ((.x29 ↦ᵣ (TxStateGasAddr + offW)) ** (.x30 ↦ᵣ BitVec.ofNat 64 stateGas[i]) **
+          ((TxStateGasAddr + offW) ↦ₘ BitVec.ofNat 64 stateGas[i])) := by
+    have haddr : (TxStateGasAddr + offW) + signExtend12 (0 : BitVec 12) =
+        TxStateGasAddr + offW := by
+      rw [se12_zero]; exact BitVec.add_zero _
+    have h0 := ld_spec_gen_within .x30 .x29 (TxStateGasAddr + offW) v30
+      (BitVec.ofNat 64 stateGas[i]) (0 : BitVec 12) (P + 80) (by decide)
+    rw [haddr] at h0
+    exact cpsTripleWithin_extend_code
+      (CodeReq.ofProg_mem_at P (P + 80) pseProg 20
+        (.LD .x30 .x29 (0 : BitVec 12))
+        (by simp only [P]; decide)
+        (by rw [pse_length]; decide) rfl (by rw [pse_length]; decide)) h0
+  have e20F0 := cpsTripleWithin_frameR
+    (wordArrayFrom TxStateGasAddr 0 (stateGas.take i) **
+      wordArrayFrom TxStateGasAddr (i + 1) (stateGas.drop (i + 1)) **
+      wordArray TxStatusAddr status **
+      wordArray TxExecStateGasAddr execGas **
+      loopGlobalsCore exactOkW runtimeW **
+      (.x1 ↦ᵣ raIn) ** (.x10 ↦ᵣ priorW) ** (.x11 ↦ᵣ outPtr) **
+      (outPtr ↦ₘ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) **
+      (.x5 ↦ᵣ priorW) ** (.x6 ↦ᵣ iW) ** (.x7 ↦ᵣ sumW) **
+      (.x28 ↦ᵣ offW) ** (.x31 ↦ᵣ v31))
+    (by
+      repeat' first
+        | apply pcFree_sepConj
+        | exact pcFree_regIs
+        | exact pcFree_memIs
+        | exact pcFree_wordArray _ _
+        | exact pcFree_wordArrayFrom _ _ _
+        | exact pcFree_loopGlobalsCore _ _) e20core
+  have e20F : cpsTripleWithin 1 (P + 80) (P + 84) pseCode
+      ((.x29 ↦ᵣ (TxStateGasAddr + offW)) ** (.x30 ↦ᵣ v30) **
+        (.x1 ↦ᵣ raIn) ** (.x10 ↦ᵣ priorW) ** (.x11 ↦ᵣ outPtr) **
+        (outPtr ↦ₘ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) **
+        (.x5 ↦ᵣ priorW) ** (.x6 ↦ᵣ iW) ** (.x7 ↦ᵣ sumW) **
+        (.x28 ↦ᵣ offW) ** (.x31 ↦ᵣ v31) **
+        loopGlobals exactOkW runtimeW stateGas status execGas)
+      ((.x29 ↦ᵣ (TxStateGasAddr + offW)) ** (.x30 ↦ᵣ BitVec.ofNat 64 stateGas[i]) **
+        (.x1 ↦ᵣ raIn) ** (.x10 ↦ᵣ priorW) ** (.x11 ↦ᵣ outPtr) **
+        (outPtr ↦ₘ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) **
+        (.x5 ↦ᵣ priorW) ** (.x6 ↦ᵣ iW) ** (.x7 ↦ᵣ sumW) **
+        (.x28 ↦ᵣ offW) ** (.x31 ↦ᵣ v31) **
+        loopGlobals exactOkW runtimeW stateGas status execGas) := by
+    refine cpsTripleWithin_weaken ?_ ?_ e20F0
+    · intro _ hp
+      have hp' := hp
+      rw [loopGlobals_eq, hsplit, haddrState] at hp'
+      xperm_hyp hp'
+    · intro _ hq
+      have hq' := hq
+      rw [loopGlobals_eq, hsplit, haddrState]
+      xperm_hyp hq'
+  -- 6. ADD x31 = sum + state
+  have e21 :
+      cpsTripleWithin 1 (P + 84) (P + 88) pseCode
+        ((.x7 ↦ᵣ sumW) ** (.x30 ↦ᵣ BitVec.ofNat 64 stateGas[i]) ** (.x31 ↦ᵣ v31))
+        ((.x7 ↦ᵣ sumW) ** (.x30 ↦ᵣ BitVec.ofNat 64 stateGas[i]) ** (.x31 ↦ᵣ sumW')) := by
+    have h0 := add_spec_gen_within .x31 .x7 .x30 sumW (BitVec.ofNat 64 stateGas[i]) v31
+      (P + 84) (by decide)
+    have h0' : cpsTripleWithin 1 (P + 84) (P + 84 + 4) pseCode
+        ((.x7 ↦ᵣ sumW) ** (.x30 ↦ᵣ BitVec.ofNat 64 stateGas[i]) ** (.x31 ↦ᵣ v31))
+        ((.x7 ↦ᵣ sumW) ** (.x30 ↦ᵣ BitVec.ofNat 64 stateGas[i]) **
+          (.x31 ↦ᵣ (sumW + BitVec.ofNat 64 stateGas[i]))) :=
+      cpsTripleWithin_extend_code
+        (CodeReq.ofProg_mem_at P (P + 84) pseProg 21
+          (.ADD .x31 .x7 .x30)
+          (by simp only [P]; decide)
+          (by rw [pse_length]; decide) rfl (by rw [pse_length]; decide)) h0
+    have h0'' : cpsTripleWithin 1 (P + 84) (P + 88) pseCode
+        ((.x7 ↦ᵣ sumW) ** (.x30 ↦ᵣ BitVec.ofNat 64 stateGas[i]) ** (.x31 ↦ᵣ v31))
+        ((.x7 ↦ᵣ sumW) ** (.x30 ↦ᵣ BitVec.ofNat 64 stateGas[i]) **
+          (.x31 ↦ᵣ (sumW + BitVec.ofNat 64 stateGas[i]))) := by
+      rwa [P84_plus_4] at h0'
+    exact cpsTripleWithin_weaken (fun _ hp => hp)
+      (fun _ hq => by rw [← hsumAdd]; exact hq) h0''
+  have e21F := cpsTripleWithin_frameR
+    ((.x1 ↦ᵣ raIn) ** (.x10 ↦ᵣ priorW) ** (.x11 ↦ᵣ outPtr) **
+      (outPtr ↦ₘ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) **
+      (.x5 ↦ᵣ priorW) ** (.x6 ↦ᵣ iW) **
+      (.x28 ↦ᵣ offW) ** (.x29 ↦ᵣ (TxStateGasAddr + offW)) **
+      loopGlobals exactOkW runtimeW stateGas status execGas)
+    (by
+      repeat' first
+        | exact hGpf
+        | apply pcFree_sepConj
+        | exact pcFree_regIs
+        | exact pcFree_memIs) e21
+  -- 7. BLTU overflow ntaken
+  have e22 :
+      cpsTripleWithin 1 (P + 88) (P + 92) pseCode
+        ((.x31 ↦ᵣ sumW') ** (.x7 ↦ᵣ sumW))
+        ((.x31 ↦ᵣ sumW') ** (.x7 ↦ᵣ sumW)) := by
+    have hbr := bltu_spec_gen_within .x31 .x7 (76 : BitVec 13) sumW' sumW (P + 88)
+    have hbrC := cpsBranchWithin_extend_code
+      (CodeReq.ofProg_mem_at P (P + 88) pseProg 22
+        (.BLTU .x31 .x7 (76 : BitVec 13))
+        (by simp only [P]; decide)
+        (by rw [pse_length]; decide) rfl (by rw [pse_length]; decide)) hbr
+    have hnt0 := cpsBranchWithin_ntakenStripPure2 hbrC (fun _ hq => by
+      obtain ⟨_, _, _, _, _, hrest⟩ := hq
+      exact absurd ((sepConj_pure_right _).1 hrest).2 hnoUlt)
+    rwa [P88_plus_4] at hnt0
+  have e22F := cpsTripleWithin_frameR
+    ((.x1 ↦ᵣ raIn) ** (.x10 ↦ᵣ priorW) ** (.x11 ↦ᵣ outPtr) **
+      (outPtr ↦ₘ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) **
+      (.x5 ↦ᵣ priorW) ** (.x6 ↦ᵣ iW) **
+      (.x28 ↦ᵣ offW) ** (.x29 ↦ᵣ (TxStateGasAddr + offW)) **
+      (.x30 ↦ᵣ BitVec.ofNat 64 stateGas[i]) **
+      loopGlobals exactOkW runtimeW stateGas status execGas)
+    (by
+      repeat' first
+        | exact hGpf
+        | apply pcFree_sepConj
+        | exact pcFree_regIs
+        | exact pcFree_memIs) e22
+  -- 8. MV x7, x31
+  have e23 :
+      cpsTripleWithin 1 (P + 92) AfterMvSum pseCode
+        ((.x31 ↦ᵣ sumW') ** (.x7 ↦ᵣ sumW))
+        ((.x31 ↦ᵣ sumW') ** (.x7 ↦ᵣ sumW')) := by
+    have h0 := mv_spec_gen_within .x7 .x31 sumW' sumW (P + 92) (by decide)
+    have h0' : cpsTripleWithin 1 (P + 92) (P + 92 + 4) pseCode
+        ((.x31 ↦ᵣ sumW') ** (.x7 ↦ᵣ sumW))
+        ((.x31 ↦ᵣ sumW') ** (.x7 ↦ᵣ sumW')) :=
+      cpsTripleWithin_extend_code
+        (CodeReq.ofProg_mem_at P (P + 92) pseProg 23
+          (.MV .x7 .x31)
+          (by simp only [P]; decide)
+          (by rw [pse_length]; decide) rfl (by rw [pse_length]; decide)) h0
+    rwa [P92_plus_4] at h0'
+  have e23F := cpsTripleWithin_frameR
+    ((.x1 ↦ᵣ raIn) ** (.x10 ↦ᵣ priorW) ** (.x11 ↦ᵣ outPtr) **
+      (outPtr ↦ₘ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) **
+      (.x5 ↦ᵣ priorW) ** (.x6 ↦ᵣ iW) **
+      (.x28 ↦ᵣ offW) ** (.x29 ↦ᵣ (TxStateGasAddr + offW)) **
+      (.x30 ↦ᵣ BitVec.ofNat 64 stateGas[i]) **
+      loopGlobals exactOkW runtimeW stateGas status execGas)
+    (by
+      repeat' first
+        | exact hGpf
+        | apply pcFree_sepConj
+        | exact pcFree_regIs
+        | exact pcFree_memIs) e23
+  -- 9. la status
+  have eLaSt := cpsTripleWithin_frameR
+    ((.x1 ↦ᵣ raIn) ** (.x10 ↦ᵣ priorW) ** (.x11 ↦ᵣ outPtr) **
+      (outPtr ↦ₘ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) **
+      (.x5 ↦ᵣ priorW) ** (.x6 ↦ᵣ iW) ** (.x7 ↦ᵣ sumW') **
+      (.x28 ↦ᵣ offW) ** (.x30 ↦ᵣ BitVec.ofNat 64 stateGas[i]) **
+      (.x31 ↦ᵣ sumW') **
+      loopGlobals exactOkW runtimeW stateGas status execGas)
+    (by
+      repeat' first
+        | exact hGpf
+        | apply pcFree_sepConj
+        | exact pcFree_regIs
+        | exact pcFree_memIs)
+    (pseLaStatus (TxStateGasAddr + offW))
+  -- 10. ADD x29 += x28
+  have e26 :
+      cpsTripleWithin 1 AfterLaStatus (P + 108) pseCode
+        ((.x29 ↦ᵣ TxStatusAddr) ** (.x28 ↦ᵣ offW))
+        ((.x29 ↦ᵣ (TxStatusAddr + offW)) ** (.x28 ↦ᵣ offW)) := by
+    have h0 := add_spec_gen_rd_eq_rs1_within .x29 .x28 TxStatusAddr offW AfterLaStatus (by decide)
+    have h0' : cpsTripleWithin 1 AfterLaStatus (AfterLaStatus + 4) pseCode
+        ((.x29 ↦ᵣ TxStatusAddr) ** (.x28 ↦ᵣ offW))
+        ((.x29 ↦ᵣ (TxStatusAddr + offW)) ** (.x28 ↦ᵣ offW)) :=
+      cpsTripleWithin_extend_code
+        (CodeReq.ofProg_mem_at P AfterLaStatus pseProg 26
+          (.ADD .x29 .x29 .x28)
+          (by simp only [AfterLaStatus]; decide)
+          (by rw [pse_length]; decide) rfl (by rw [pse_length]; decide)) h0
+    rwa [AfterLaStatus_plus_4] at h0'
+  have e26F := cpsTripleWithin_frameR
+    ((.x1 ↦ᵣ raIn) ** (.x10 ↦ᵣ priorW) ** (.x11 ↦ᵣ outPtr) **
+      (outPtr ↦ₘ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) **
+      (.x5 ↦ᵣ priorW) ** (.x6 ↦ᵣ iW) ** (.x7 ↦ᵣ sumW') **
+      (.x30 ↦ᵣ BitVec.ofNat 64 stateGas[i]) ** (.x31 ↦ᵣ sumW') **
+      loopGlobals exactOkW runtimeW stateGas status execGas)
+    (by
+      repeat' first
+        | exact hGpf
+        | apply pcFree_sepConj
+        | exact pcFree_regIs
+        | exact pcFree_memIs) e26
+  -- 11. LD status
+  have e27core :
+      cpsTripleWithin 1 (P + 108) AfterLdStatus pseCode
+        ((.x29 ↦ᵣ (TxStatusAddr + offW)) ** (.x30 ↦ᵣ BitVec.ofNat 64 stateGas[i]) **
+          ((TxStatusAddr + offW) ↦ₘ BitVec.ofNat 64 status[i]))
+        ((.x29 ↦ᵣ (TxStatusAddr + offW)) ** (.x30 ↦ᵣ BitVec.ofNat 64 status[i]) **
+          ((TxStatusAddr + offW) ↦ₘ BitVec.ofNat 64 status[i])) := by
+    have haddr : (TxStatusAddr + offW) + signExtend12 (0 : BitVec 12) =
+        TxStatusAddr + offW := by
+      rw [se12_zero]; exact BitVec.add_zero _
+    have h0 := ld_spec_gen_within .x30 .x29 (TxStatusAddr + offW)
+      (BitVec.ofNat 64 stateGas[i]) (BitVec.ofNat 64 status[i])
+      (0 : BitVec 12) (P + 108) (by decide)
+    rw [haddr] at h0
+    have h0' : cpsTripleWithin 1 (P + 108) (P + 108 + 4) pseCode
+        ((.x29 ↦ᵣ (TxStatusAddr + offW)) ** (.x30 ↦ᵣ BitVec.ofNat 64 stateGas[i]) **
+          ((TxStatusAddr + offW) ↦ₘ BitVec.ofNat 64 status[i]))
+        ((.x29 ↦ᵣ (TxStatusAddr + offW)) ** (.x30 ↦ᵣ BitVec.ofNat 64 status[i]) **
+          ((TxStatusAddr + offW) ↦ₘ BitVec.ofNat 64 status[i])) :=
+      cpsTripleWithin_extend_code
+        (CodeReq.ofProg_mem_at P (P + 108) pseProg 27
+          (.LD .x30 .x29 (0 : BitVec 12))
+          (by simp only [P]; decide)
+          (by rw [pse_length]; decide) rfl (by rw [pse_length]; decide)) h0
+    rwa [P108_plus_4] at h0'
+  have e27F0 := cpsTripleWithin_frameR
+    (wordArrayFrom TxStatusAddr 0 (status.take i) **
+      wordArrayFrom TxStatusAddr (i + 1) (status.drop (i + 1)) **
+      wordArray TxStateGasAddr stateGas **
+      wordArray TxExecStateGasAddr execGas **
+      loopGlobalsCore exactOkW runtimeW **
+      (.x1 ↦ᵣ raIn) ** (.x10 ↦ᵣ priorW) ** (.x11 ↦ᵣ outPtr) **
+      (outPtr ↦ₘ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) **
+      (.x5 ↦ᵣ priorW) ** (.x6 ↦ᵣ iW) ** (.x7 ↦ᵣ sumW') **
+      (.x28 ↦ᵣ offW) ** (.x31 ↦ᵣ sumW'))
+    (by
+      repeat' first
+        | apply pcFree_sepConj
+        | exact pcFree_regIs
+        | exact pcFree_memIs
+        | exact pcFree_wordArray _ _
+        | exact pcFree_wordArrayFrom _ _ _
+        | exact pcFree_loopGlobalsCore _ _) e27core
+  have e27F : cpsTripleWithin 1 (P + 108) AfterLdStatus pseCode
+      ((.x29 ↦ᵣ (TxStatusAddr + offW)) ** (.x30 ↦ᵣ BitVec.ofNat 64 stateGas[i]) **
+        (.x1 ↦ᵣ raIn) ** (.x10 ↦ᵣ priorW) ** (.x11 ↦ᵣ outPtr) **
+        (outPtr ↦ₘ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) **
+        (.x5 ↦ᵣ priorW) ** (.x6 ↦ᵣ iW) ** (.x7 ↦ᵣ sumW') **
+        (.x28 ↦ᵣ offW) ** (.x31 ↦ᵣ sumW') **
+        loopGlobals exactOkW runtimeW stateGas status execGas)
+      ((.x29 ↦ᵣ (TxStatusAddr + offW)) ** (.x30 ↦ᵣ BitVec.ofNat 64 status[i]) **
+        (.x1 ↦ᵣ raIn) ** (.x10 ↦ᵣ priorW) ** (.x11 ↦ᵣ outPtr) **
+        (outPtr ↦ₘ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) **
+        (.x5 ↦ᵣ priorW) ** (.x6 ↦ᵣ iW) ** (.x7 ↦ᵣ sumW') **
+        (.x28 ↦ᵣ offW) ** (.x31 ↦ᵣ sumW') **
+        loopGlobals exactOkW runtimeW stateGas status execGas) := by
+    refine cpsTripleWithin_weaken ?_ ?_ e27F0
+    · intro _ hp
+      have hp' := hp
+      rw [loopGlobals_eq, hsplitS, haddrStatus] at hp'
+      xperm_hyp hp'
+    · intro _ hq
+      have hq' := hq
+      rw [loopGlobals_eq, hsplitS, haddrStatus]
+      xperm_hyp hq'
+  -- 12. BEQ status=0 taken → skip
+  have e28 :
+      cpsTripleWithin 1 AfterLdStatus AfterStatusSkip pseCode
+        ((.x30 ↦ᵣ BitVec.ofNat 64 status[i]) ** (.x0 ↦ᵣ (0 : Word)))
+        ((.x30 ↦ᵣ BitVec.ofNat 64 status[i]) ** (.x0 ↦ᵣ (0 : Word))) := by
+    have hbr := beq_spec_gen_within .x30 .x0 (32 : BitVec 13)
+      (BitVec.ofNat 64 status[i]) (0 : Word) AfterLdStatus
+    have hbrC := cpsBranchWithin_extend_code
+      (CodeReq.ofProg_mem_at P AfterLdStatus pseProg 28
+        (.BEQ .x30 .x0 (32 : BitVec 13))
+        (by simp only [AfterLdStatus]; decide)
+        (by rw [pse_length]; decide) rfl (by rw [pse_length]; decide)) hbr
+    have htk0 := cpsBranchWithin_takenStripPure2 hbrC (fun _ hq => by
+      obtain ⟨_, _, _, _, _, hrest⟩ := hq
+      exact absurd hstatW ((sepConj_pure_right _).1 hrest).2)
+    rwa [AfterLdStatus_plus_32] at htk0
+  have e28F := cpsTripleWithin_frameR
+    ((.x1 ↦ᵣ raIn) ** (.x10 ↦ᵣ priorW) ** (.x11 ↦ᵣ outPtr) **
+      (outPtr ↦ₘ (0 : Word)) **
+      (.x5 ↦ᵣ priorW) ** (.x6 ↦ᵣ iW) ** (.x7 ↦ᵣ sumW') **
+      (.x28 ↦ᵣ offW) ** (.x29 ↦ᵣ (TxStatusAddr + offW)) **
+      (.x31 ↦ᵣ sumW') **
+      loopGlobals exactOkW runtimeW stateGas status execGas)
+    (by
+      repeat' first
+        | exact hGpf
+        | apply pcFree_sepConj
+        | exact pcFree_regIs
+        | exact pcFree_memIs) e28
+  -- 13. ADDI i++
+  have e36 :
+      cpsTripleWithin 1 AfterStatusSkip AfterIncr pseCode
+        (.x6 ↦ᵣ iW) (.x6 ↦ᵣ iW') := by
+    have h0 := addi_spec_gen_same_within .x6 iW (1 : BitVec 12) AfterStatusSkip (by decide)
+    have h0' : cpsTripleWithin 1 AfterStatusSkip (AfterStatusSkip + 4) pseCode
+        (.x6 ↦ᵣ iW) (.x6 ↦ᵣ (iW + signExtend12 (1 : BitVec 12))) :=
+      cpsTripleWithin_extend_code
+        (CodeReq.ofProg_mem_at P AfterStatusSkip pseProg 36
+          (.ADDI .x6 .x6 (1 : BitVec 12))
+          (by simp only [AfterStatusSkip]; decide)
+          (by rw [pse_length]; decide) rfl (by rw [pse_length]; decide)) h0
+    have h0'' : cpsTripleWithin 1 AfterStatusSkip AfterIncr pseCode
+        (.x6 ↦ᵣ iW) (.x6 ↦ᵣ (iW + signExtend12 (1 : BitVec 12))) := by
+      rwa [AfterStatusSkip_plus_4] at h0'
+    exact cpsTripleWithin_weaken (fun _ hp => hp)
+      (fun _ hq => by
+        have hadd : iW + signExtend12 (1 : BitVec 12) = iW' := by
+          simpa [iW, iW'] using ofNat_addi1 i
+        rw [hadd] at hq
+        exact hq) h0''
+  have e36F : cpsTripleWithin 1 AfterStatusSkip AfterIncr pseCode
+      ((.x6 ↦ᵣ iW) **
+        (.x1 ↦ᵣ raIn) ** (.x10 ↦ᵣ priorW) ** (.x11 ↦ᵣ outPtr) **
+        (outPtr ↦ₘ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) **
+        (.x5 ↦ᵣ priorW) ** (.x7 ↦ᵣ sumW') **
+        (.x28 ↦ᵣ offW) ** (.x29 ↦ᵣ (TxStatusAddr + offW)) **
+        (.x30 ↦ᵣ BitVec.ofNat 64 status[i]) ** (.x31 ↦ᵣ sumW') **
+        loopGlobals exactOkW runtimeW stateGas status execGas)
+      ((.x6 ↦ᵣ iW') **
+        (.x1 ↦ᵣ raIn) ** (.x10 ↦ᵣ priorW) ** (.x11 ↦ᵣ outPtr) **
+        (outPtr ↦ₘ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) **
+        (.x5 ↦ᵣ priorW) ** (.x7 ↦ᵣ sumW') **
+        (.x28 ↦ᵣ offW) ** (.x29 ↦ᵣ (TxStatusAddr + offW)) **
+        (.x30 ↦ᵣ (0 : Word)) ** (.x31 ↦ᵣ sumW') **
+        loopGlobals exactOkW runtimeW stateGas status execGas) := by
+    have hF := cpsTripleWithin_frameR
+      ((.x1 ↦ᵣ raIn) ** (.x10 ↦ᵣ priorW) ** (.x11 ↦ᵣ outPtr) **
+        (outPtr ↦ₘ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) **
+        (.x5 ↦ᵣ priorW) ** (.x7 ↦ᵣ sumW') **
+        (.x28 ↦ᵣ offW) ** (.x29 ↦ᵣ (TxStatusAddr + offW)) **
+        (.x30 ↦ᵣ BitVec.ofNat 64 status[i]) ** (.x31 ↦ᵣ sumW') **
+        loopGlobals exactOkW runtimeW stateGas status execGas)
+      (by
+        repeat' first
+          | exact hGpf
+          | apply pcFree_sepConj
+          | exact pcFree_regIs
+          | exact pcFree_memIs) e36
+    exact cpsTripleWithin_weaken (fun _ hp => hp)
+      (fun _ hq => by simp only [hstatW] at hq; exact hq) hF
+  -- 14. JAL back (frameR already yields ambient ** emp)
+  have e37 :
+      cpsTripleWithin 1 AfterIncr LoopGuard pseCode
+        empAssertion empAssertion := by
+    have h0 := jal_x0_spec_gen_within (-88 : BitVec 21) AfterIncr
+    have h0' : cpsTripleWithin 1 AfterIncr
+        (AfterIncr + signExtend21 (-88 : BitVec 21)) pseCode
+        empAssertion empAssertion :=
+      cpsTripleWithin_extend_code
+        (CodeReq.ofProg_mem_at P AfterIncr pseProg 37
+          (.JAL .x0 (-88 : BitVec 21))
+          (by simp only [AfterIncr]; decide)
+          (by rw [pse_length]; decide) rfl (by rw [pse_length]; decide)) h0
+    rwa [AfterIncr_back] at h0'
+  let ambientExit : Assertion :=
+    (.x1 ↦ᵣ raIn) ** (.x10 ↦ᵣ priorW) ** (.x11 ↦ᵣ outPtr) **
+      (outPtr ↦ₘ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) **
+      (.x5 ↦ᵣ priorW) ** (.x6 ↦ᵣ iW') ** (.x7 ↦ᵣ sumW') **
+      (.x28 ↦ᵣ offW) ** (.x29 ↦ᵣ (TxStatusAddr + offW)) **
+      (.x30 ↦ᵣ (0 : Word)) ** (.x31 ↦ᵣ sumW') **
+      loopGlobals exactOkW runtimeW stateGas status execGas
+  have hAmbPf : ambientExit.pcFree := by
+    dsimp only [ambientExit]
+    repeat' first
+      | exact hGpf
+      | apply pcFree_sepConj
+      | exact pcFree_regIs
+      | exact pcFree_memIs
+  -- frameR emp: pre/post = emp ** ambientExit
+  have e37F0 := cpsTripleWithin_frameR ambientExit hAmbPf e37
+  have e37F : cpsTripleWithin 1 AfterIncr LoopGuard pseCode
+      ambientExit ambientExit := by
+    refine cpsTripleWithin_weaken ?_ ?_ e37F0
+    · intro s hp
+      -- ambient → emp ** ambient
+      exact (sepConj_emp_left' ambientExit).symm ▸ hp
+    · intro s hq
+      -- emp ** ambient → ambient
+      exact (sepConj_emp_left' ambientExit) ▸ hq
+  -- Compose with explicit LoopInv unfolds on reshapes
+  have c01 := cpsTripleWithin_seq_perm_same_cr
+    (fun _ hp => by dsimp only [LoopInv] at hp; xperm_hyp hp) hguard e16F
+  have c02 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) c01 eLa
+  have c03 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) c02 e19F
+  have c04 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) c03 e20F
+  have c05 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) c04 e21F
+  have c06 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) c05 e22F
+  have c07 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) c06 e23F
+  have c08 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) c07 eLaSt
+  have c09 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) c08 e26F
+  have c10 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) c09 e27F
+  have c11 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) c10 e28F
+  have c12 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) c11 e36F
+  have c13 := cpsTripleWithin_seq_perm_same_cr
+    (fun _ hp => by dsimp only [ambientExit] at hp ⊢; xperm_hyp hp) c12 e37F
+  change cpsTripleWithin (1+1+2+1+1+1+1+1+2+1+1+1+1+1) LoopGuard LoopGuard pseCode _ _ at c13
+  exact cpsTripleWithin_weaken
+    (fun _ hp => by dsimp only [LoopInv] at hp ⊢; xperm_hyp hp)
+    (fun _ hq => by
+      dsimp only [LoopInv, ambientExit] at hq ⊢
+      xperm_hyp hq) c13
+
+#print axioms pseIterStatus0
+
+end EvmAsm.Codegen.Eip8037PriorStateUsedExactIter

--- a/EvmAsm/Codegen/Programs/Eip8037PriorStateUsedExactIter.lean
+++ b/EvmAsm/Codegen/Programs/Eip8037PriorStateUsedExactIter.lean
@@ -63,19 +63,18 @@ private theorem not_ult_add (s g : Nat) (h : s + g < 2 ^ 64) :
 
 private theorem AfterLdStatus_plus_32 :
     AfterLdStatus + signExtend13 (32 : BitVec 13) = AfterStatusSkip := by
-  simp only [AfterLdStatus, AfterStatusSkip, P, se13_32]; decide
+  simp only [AfterLdStatus, AfterStatusSkip, se13_32]; decide
 
 private theorem AfterIncr_back :
     AfterIncr + signExtend21 (-88 : BitVec 21) = LoopGuard := by
-  simp only [AfterIncr, LoopGuard, P, se21_m88, GuestAddrs.eip8037_prior_state_used_exact]
-  decide
+  simp only [AfterIncr, LoopGuard, se21_m88]; decide
 
 private theorem AfterLaState_plus_4 : AfterLaState + 4 = P + 80 := by
   simp only [AfterLaState, P]; decide
 private theorem AfterLaStatus_plus_4 : AfterLaStatus + 4 = P + 108 := by
   simp only [AfterLaStatus, P]; decide
 private theorem AfterStatusSkip_plus_4 : AfterStatusSkip + 4 = AfterIncr := by
-  simp only [AfterStatusSkip, AfterIncr, P]; decide
+  simp only [AfterStatusSkip, AfterIncr]; decide
 private theorem P80_plus_4 : (P + 80 : Word) + 4 = P + 84 := by simp only [P]; decide
 private theorem P84_plus_4 : (P + 84 : Word) + 4 = P + 88 := by simp only [P]; decide
 private theorem P88_plus_4 : (P + 88 : Word) + 4 = P + 92 := by simp only [P]; decide
@@ -143,8 +142,7 @@ theorem pseIterStatus0
     (hstat : i < status.length)
     (hstat0 : status[i] = 0)
     (hno : sum + stateGas[i] < 2 ^ 64)
-    (hne : BitVec.ofNat 64 i ≠ priorW)
-    (hi61 : i < 2 ^ 61) :
+    (hne : BitVec.ofNat 64 i ≠ priorW) :
     let iW := BitVec.ofNat 64 i
     let sumW := BitVec.ofNat 64 sum
     let sumW' := BitVec.ofNat 64 (sum + stateGas[i])
@@ -284,8 +282,7 @@ theorem pseIterStatus0
         | exact pcFree_regIs
         | exact pcFree_memIs
         | exact pcFree_wordArray _ _
-        | exact pcFree_wordArrayFrom _ _ _
-        | exact pcFree_loopGlobalsCore _ _) e20core
+        | exact pcFree_wordArrayFrom _ _ _) e20core
   have e20F : cpsTripleWithin 1 (P + 80) (P + 84) pseCode
       ((.x29 ↦ᵣ (TxStateGasAddr + offW)) ** (.x30 ↦ᵣ v30) **
         (.x1 ↦ᵣ raIn) ** (.x10 ↦ᵣ priorW) ** (.x11 ↦ᵣ outPtr) **
@@ -482,8 +479,7 @@ theorem pseIterStatus0
         | exact pcFree_regIs
         | exact pcFree_memIs
         | exact pcFree_wordArray _ _
-        | exact pcFree_wordArrayFrom _ _ _
-        | exact pcFree_loopGlobalsCore _ _) e27core
+        | exact pcFree_wordArrayFrom _ _ _) e27core
   have e27F : cpsTripleWithin 1 (P + 108) AfterLdStatus pseCode
       ((.x29 ↦ᵣ (TxStatusAddr + offW)) ** (.x30 ↦ᵣ BitVec.ofNat 64 stateGas[i]) **
         (.x1 ↦ᵣ raIn) ** (.x10 ↦ᵣ priorW) ** (.x11 ↦ᵣ outPtr) **

--- a/EvmAsm/Codegen/Programs/Eip8037PriorStateUsedExactLoop.lean
+++ b/EvmAsm/Codegen/Programs/Eip8037PriorStateUsedExactLoop.lean
@@ -1,0 +1,246 @@
+/-
+  Loop + exit for `eip8037_prior_state_used_exact` (a4gbr residual leaf).
+-/
+
+import EvmAsm.Codegen.Programs.Eip8037PriorStateUsedExactSpec
+import EvmAsm.Codegen.Programs.ChainValidateExtraDataLengthSpec
+import EvmAsm.Rv64.LaResolve
+import EvmAsm.Rv64.SyscallSpecs
+import EvmAsm.Rv64.SAsm.DualReadByteScan
+
+namespace EvmAsm.Codegen.Eip8037PriorStateUsedExactLoop
+
+open EvmAsm.Rv64
+open EvmAsm.Codegen
+open EvmAsm.Codegen.Eip8037PriorStateUsedExactSpec
+open EvmAsm.Codegen.Eip8037PriorStateUsedExactModel
+open EvmAsm.Codegen.ChainValidateExtraDataLengthSpec
+  (wordArray wordArrayFrom wordArray_split pcFree_wordArray pcFree_wordArrayFrom
+   shiftLeft3_ofNat)
+
+abbrev P : Word := Eip8037PriorStateUsedExactSpec.P
+abbrev pseProg : Program := Eip8037PriorStateUsedExactSpec.pseProg
+abbrev pseCode : CodeReq := Eip8037PriorStateUsedExactSpec.pseCode
+abbrev LoopGuard : Word := Eip8037PriorStateUsedExactSpec.LoopGuard
+abbrev StoreSum : Word := Eip8037PriorStateUsedExactSpec.StoreSum
+abbrev OkLi : Word := Eip8037PriorStateUsedExactSpec.OkLi
+abbrev OkRet : Word := Eip8037PriorStateUsedExactSpec.OkRet
+abbrev FailLi : Word := Eip8037PriorStateUsedExactSpec.FailLi
+abbrev TxStateGasAddr : Word := Eip8037PriorStateUsedExactSpec.TxStateGasAddr
+abbrev TxStatusAddr : Word := Eip8037PriorStateUsedExactSpec.TxStatusAddr
+abbrev TxExecStateGasAddr : Word := Eip8037PriorStateUsedExactSpec.TxExecStateGasAddr
+abbrev ExactOkAddr : Word := Eip8037PriorStateUsedExactSpec.ExactOkAddr
+abbrev RuntimeCountAddr : Word := Eip8037PriorStateUsedExactSpec.RuntimeCountAddr
+
+theorem pse_length : pseProg.length = 43 := Eip8037PriorStateUsedExactSpec.pse_length
+
+private theorem se12_zero : signExtend12 (0 : BitVec 12) = (0 : Word) := by decide
+private theorem se13_92 : signExtend13 (92 : BitVec 13) = (92 : Word) := by decide
+
+private theorem LoopGuard_plus_92 :
+    LoopGuard + signExtend13 (92 : BitVec 13) = StoreSum := by
+  simp only [LoopGuard, StoreSum, se13_92]; decide
+
+private theorem StoreSum_plus_4 : StoreSum + 4 = OkLi := by
+  simp only [StoreSum, OkLi]; decide
+
+private theorem OkLi_plus_4 : OkLi + 4 = OkRet := by
+  simp only [OkLi, OkRet]; decide
+
+/-- Ambient globals framed through the loop (read-only). -/
+def loopGlobals (exactOkW runtimeW : Word)
+    (stateGas status execGas : List Nat) : Assertion :=
+  (ExactOkAddr ↦ₘ exactOkW) ** (RuntimeCountAddr ↦ₘ runtimeW) **
+    wordArray TxStateGasAddr stateGas **
+    wordArray TxStatusAddr status **
+    wordArray TxExecStateGasAddr execGas
+
+theorem pcFree_loopGlobals (exactOkW runtimeW : Word)
+    (stateGas status execGas : List Nat) :
+    (loopGlobals exactOkW runtimeW stateGas status execGas).pcFree := by
+  unfold loopGlobals
+  repeat' first
+    | apply pcFree_sepConj
+    | exact pcFree_memIs
+    | exact pcFree_wordArray _ _
+
+/-- Loop invariant at LoopGuard: i ≤ n, sum = priorPrefixExact ... i as Word. -/
+def LoopInv
+    (raIn priorW outPtr sumW iW : Word)
+    (exactOkW runtimeW : Word)
+    (stateGas status execGas : List Nat)
+    (v28 v29 v30 v31 : Word) : Assertion :=
+  (.x1 ↦ᵣ raIn) ** (.x10 ↦ᵣ priorW) ** (.x11 ↦ᵣ outPtr) **
+    (outPtr ↦ₘ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) **
+    (.x5 ↦ᵣ priorW) ** (.x6 ↦ᵣ iW) ** (.x7 ↦ᵣ sumW) **
+    (.x28 ↦ᵣ v28) ** (.x29 ↦ᵣ v29) ** (.x30 ↦ᵣ v30) ** (.x31 ↦ᵣ v31) **
+    loopGlobals exactOkW runtimeW stateGas status execGas
+
+set_option maxRecDepth 8000 in
+/-- Guard taken (i=n): BEQ → StoreSum, SD sum, OkRet. -/
+theorem pseLoopExitOk
+    (raIn priorW outPtr sumW : Word)
+    (exactOkW runtimeW : Word)
+    (stateGas status execGas : List Nat)
+    (v28 v29 v30 v31 : Word)
+    (hret : raIn &&& ~~~(1 : Word) = raIn) :
+    cpsTripleWithin 4 LoopGuard raIn pseCode
+      (LoopInv raIn priorW outPtr sumW priorW exactOkW runtimeW
+        stateGas status execGas v28 v29 v30 v31)
+      (postOk raIn outPtr sumW
+        ((.x5 ↦ᵣ priorW) ** (.x6 ↦ᵣ priorW) ** (.x7 ↦ᵣ sumW) **
+          (.x28 ↦ᵣ v28) ** (.x29 ↦ᵣ v29) ** (.x30 ↦ᵣ v30) ** (.x31 ↦ᵣ v31) **
+          loopGlobals exactOkW runtimeW stateGas status execGas)) := by
+  have hGpf : (loopGlobals exactOkW runtimeW stateGas status execGas).pcFree :=
+    pcFree_loopGlobals exactOkW runtimeW stateGas status execGas
+  -- [15] BEQ i,n taken
+  have hbr := beq_spec_gen_within .x6 .x5 (92 : BitVec 13) priorW priorW LoopGuard
+  have hbrC := cpsBranchWithin_extend_code
+    (CodeReq.ofProg_mem_at P LoopGuard pseProg 15
+      (.BEQ .x6 .x5 (92 : BitVec 13))
+      (by simp only [LoopGuard]; decide)
+      (by rw [pse_length]; decide) rfl (by rw [pse_length]; decide)) hbr
+  have htk0 := cpsBranchWithin_takenStripPure2 hbrC (fun _ hq => by
+    obtain ⟨_, _, _, _, _, hrest⟩ := hq
+    exact absurd rfl ((sepConj_pure_right _).1 hrest).2)
+  have htk : cpsTripleWithin 1 LoopGuard StoreSum pseCode
+      ((.x6 ↦ᵣ priorW) ** (.x5 ↦ᵣ priorW))
+      ((.x6 ↦ᵣ priorW) ** (.x5 ↦ᵣ priorW)) := by
+    rwa [LoopGuard_plus_92] at htk0
+  have e15F := cpsTripleWithin_frameR
+    ((.x1 ↦ᵣ raIn) ** (.x10 ↦ᵣ priorW) ** (.x11 ↦ᵣ outPtr) **
+      (outPtr ↦ₘ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) **
+      (.x7 ↦ᵣ sumW) **
+      (.x28 ↦ᵣ v28) ** (.x29 ↦ᵣ v29) ** (.x30 ↦ᵣ v30) ** (.x31 ↦ᵣ v31) **
+      loopGlobals exactOkW runtimeW stateGas status execGas)
+    (by
+      repeat' first
+        | exact hGpf
+        | apply pcFree_sepConj
+        | exact pcFree_regIs
+        | exact pcFree_memIs) htk
+  -- [38] SD sum *out
+  have haddr : outPtr + signExtend12 (0 : BitVec 12) = outPtr := by
+    rw [se12_zero]; exact BitVec.add_zero outPtr
+  have e38 :
+      cpsTripleWithin 1 StoreSum OkLi pseCode
+        ((.x11 ↦ᵣ outPtr) ** (.x7 ↦ᵣ sumW) ** (outPtr ↦ₘ (0 : Word)))
+        ((.x11 ↦ᵣ outPtr) ** (.x7 ↦ᵣ sumW) ** (outPtr ↦ₘ sumW)) := by
+    have h0 := sd_spec_gen_within .x11 .x7 outPtr sumW (0 : Word)
+      (0 : BitVec 12) StoreSum
+    rw [haddr] at h0
+    have h0' : cpsTripleWithin 1 StoreSum (StoreSum + 4) pseCode
+        ((.x11 ↦ᵣ outPtr) ** (.x7 ↦ᵣ sumW) ** (outPtr ↦ₘ (0 : Word)))
+        ((.x11 ↦ᵣ outPtr) ** (.x7 ↦ᵣ sumW) ** (outPtr ↦ₘ sumW)) :=
+      cpsTripleWithin_extend_code
+        (CodeReq.ofProg_mem_at P StoreSum pseProg 38
+          (.SD .x11 .x7 (0 : BitVec 12))
+          (by simp only [StoreSum]; decide)
+          (by rw [pse_length]; decide) rfl (by rw [pse_length]; decide)) h0
+    rwa [StoreSum_plus_4] at h0'
+  have e38F := cpsTripleWithin_frameR
+    ((.x1 ↦ᵣ raIn) ** (.x10 ↦ᵣ priorW) ** (.x0 ↦ᵣ (0 : Word)) **
+      (.x5 ↦ᵣ priorW) ** (.x6 ↦ᵣ priorW) **
+      (.x28 ↦ᵣ v28) ** (.x29 ↦ᵣ v29) ** (.x30 ↦ᵣ v30) ** (.x31 ↦ᵣ v31) **
+      loopGlobals exactOkW runtimeW stateGas status execGas)
+    (by
+      repeat' first
+        | exact hGpf
+        | apply pcFree_sepConj
+        | exact pcFree_regIs) e38
+  -- Ok ret: a0 was priorW
+  have eOk :
+      cpsTripleWithin 2 OkLi raIn pseCode
+        ((.x1 ↦ᵣ raIn) ** (.x10 ↦ᵣ priorW) ** (.x11 ↦ᵣ outPtr) **
+          (outPtr ↦ₘ sumW) ** (.x0 ↦ᵣ (0 : Word)) **
+          (.x5 ↦ᵣ priorW) ** (.x6 ↦ᵣ priorW) ** (.x7 ↦ᵣ sumW) **
+          (.x28 ↦ᵣ v28) ** (.x29 ↦ᵣ v29) ** (.x30 ↦ᵣ v30) ** (.x31 ↦ᵣ v31) **
+          loopGlobals exactOkW runtimeW stateGas status execGas)
+        (postOk raIn outPtr sumW
+          ((.x5 ↦ᵣ priorW) ** (.x6 ↦ᵣ priorW) ** (.x7 ↦ᵣ sumW) **
+            (.x28 ↦ᵣ v28) ** (.x29 ↦ᵣ v29) ** (.x30 ↦ᵣ v30) ** (.x31 ↦ᵣ v31) **
+            loopGlobals exactOkW runtimeW stateGas status execGas)) := by
+    have e39 :
+        cpsTripleWithin 1 OkLi OkRet pseCode
+          (.x10 ↦ᵣ priorW) (.x10 ↦ᵣ (0 : Word)) := by
+      have h0 := li_spec_gen_within .x10 priorW (0 : Word) OkLi (by decide)
+      have h0' : cpsTripleWithin 1 OkLi (OkLi + 4) pseCode
+          (.x10 ↦ᵣ priorW) (.x10 ↦ᵣ (0 : Word)) :=
+        cpsTripleWithin_extend_code
+          (CodeReq.ofProg_mem_at P OkLi pseProg 39 (.LI .x10 (0 : Word))
+            (by simp only [OkLi]; decide)
+            (by rw [pse_length]; decide) rfl (by rw [pse_length]; decide)) h0
+      rwa [OkLi_plus_4] at h0'
+    have e39F := cpsTripleWithin_frameR
+      ((.x1 ↦ᵣ raIn) ** (.x11 ↦ᵣ outPtr) ** (outPtr ↦ₘ sumW) **
+        (.x0 ↦ᵣ (0 : Word)) **
+        (.x5 ↦ᵣ priorW) ** (.x6 ↦ᵣ priorW) ** (.x7 ↦ᵣ sumW) **
+        (.x28 ↦ᵣ v28) ** (.x29 ↦ᵣ v29) ** (.x30 ↦ᵣ v30) ** (.x31 ↦ᵣ v31) **
+        loopGlobals exactOkW runtimeW stateGas status execGas)
+      (by
+        repeat' first
+          | exact hGpf
+          | apply pcFree_sepConj
+          | exact pcFree_regIs
+          | exact pcFree_memIs) e39
+    have hexit :
+        ((raIn + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word)) = raIn := by
+      have hadd : raIn + signExtend12 (0 : BitVec 12) = raIn := by
+        rw [se12_zero]; exact BitVec.add_zero raIn
+      rw [hadd, hret]
+    have e40 :
+        cpsTripleWithin 1 OkRet raIn pseCode
+          (.x1 ↦ᵣ raIn) (.x1 ↦ᵣ raIn) := by
+      have h0 := jalr_x0_spec_gen_within .x1 raIn (0 : BitVec 12) OkRet
+      rw [hexit] at h0
+      exact cpsTripleWithin_extend_code
+        (CodeReq.ofProg_mem_at P OkRet pseProg 40
+          (.JALR .x0 .x1 (0 : BitVec 12))
+          (by simp only [OkRet]; decide)
+          (by rw [pse_length]; decide) rfl (by rw [pse_length]; decide)) h0
+    have e40F0 := cpsTripleWithin_frameR
+      ((.x10 ↦ᵣ (0 : Word)) ** (.x11 ↦ᵣ outPtr) ** (outPtr ↦ₘ sumW) **
+        (.x0 ↦ᵣ (0 : Word)) **
+        (.x5 ↦ᵣ priorW) ** (.x6 ↦ᵣ priorW) ** (.x7 ↦ᵣ sumW) **
+        (.x28 ↦ᵣ v28) ** (.x29 ↦ᵣ v29) ** (.x30 ↦ᵣ v30) ** (.x31 ↦ᵣ v31) **
+        loopGlobals exactOkW runtimeW stateGas status execGas)
+      (by
+        repeat' first
+          | exact hGpf
+          | apply pcFree_sepConj
+          | exact pcFree_regIs
+          | exact pcFree_memIs) e40
+    have e40F : cpsTripleWithin 1 OkRet raIn pseCode
+        ((.x10 ↦ᵣ (0 : Word)) ** (.x1 ↦ᵣ raIn) ** (.x11 ↦ᵣ outPtr) **
+          (outPtr ↦ₘ sumW) ** (.x0 ↦ᵣ (0 : Word)) **
+          (.x5 ↦ᵣ priorW) ** (.x6 ↦ᵣ priorW) ** (.x7 ↦ᵣ sumW) **
+          (.x28 ↦ᵣ v28) ** (.x29 ↦ᵣ v29) ** (.x30 ↦ᵣ v30) ** (.x31 ↦ᵣ v31) **
+          loopGlobals exactOkW runtimeW stateGas status execGas)
+        ((.x10 ↦ᵣ (0 : Word)) ** (.x1 ↦ᵣ raIn) ** (.x11 ↦ᵣ outPtr) **
+          (outPtr ↦ₘ sumW) ** (.x0 ↦ᵣ (0 : Word)) **
+          (.x5 ↦ᵣ priorW) ** (.x6 ↦ᵣ priorW) ** (.x7 ↦ᵣ sumW) **
+          (.x28 ↦ᵣ v28) ** (.x29 ↦ᵣ v29) ** (.x30 ↦ᵣ v30) ** (.x31 ↦ᵣ v31) **
+          loopGlobals exactOkW runtimeW stateGas status execGas) :=
+      cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
+        (fun _ hq => by xperm_hyp hq) e40F0
+    have c := cpsTripleWithin_seq_perm_same_cr
+      (fun _ hp => by xperm_hyp hp) e39F e40F
+    exact cpsTripleWithin_weaken
+      (fun _ hp => by xperm_hyp hp)
+      (fun _ hq => by
+        dsimp only [postOk] at hq ⊢
+        xperm_hyp hq) c
+  have c01 := cpsTripleWithin_seq_perm_same_cr
+    (fun _ hp => by xperm_hyp hp) e15F e38F
+  have c02 := cpsTripleWithin_seq_perm_same_cr
+    (fun _ hp => by xperm_hyp hp) c01 eOk
+  change cpsTripleWithin (1 + 1 + 2) LoopGuard raIn pseCode _ _ at c02
+  exact cpsTripleWithin_weaken
+    (fun _ hp => by
+      dsimp only [LoopInv] at hp ⊢
+      xperm_hyp hp)
+    (fun _ hq => by xperm_hyp hq) c02
+
+#print axioms pseLoopExitOk
+
+end EvmAsm.Codegen.Eip8037PriorStateUsedExactLoop

--- a/EvmAsm/Codegen/Programs/Eip8037PriorStateUsedExactLoop.lean
+++ b/EvmAsm/Codegen/Programs/Eip8037PriorStateUsedExactLoop.lean
@@ -253,7 +253,9 @@ abbrev AfterAddState : Word := P + 88
 abbrev AfterMvSum : Word := P + 96
 abbrev AfterLaStatus : Word := P + 104
 abbrev AfterLdStatus : Word := P + 112
-abbrev AfterStatusSkip : Word := P + 144
+abbrev AfterStatusBne : Word := P + 116  -- fall-through of status BEQ (status ≠ 0)
+abbrev AfterLaExec : Word := P + 124
+abbrev AfterStatusSkip : Word := P + 144  -- join of status=0 skip and status≠0 exec path
 abbrev AfterIncr : Word := P + 148
 
 private theorem LoopGuard_plus_4 : LoopGuard + 4 = LoopBody := by
@@ -307,6 +309,27 @@ theorem pseLaStatus (v : Word) :
   rwa [show AfterMvSum + 8 = AfterLaStatus from by
     simp only [AfterMvSum, AfterLaStatus]; decide] at h
 
+/-- `la bvgr_tx_exec_state_gas` at instr 29–30 (PC P+116). -/
+theorem pseLaExec (v : Word) :
+    cpsTripleWithin 2 AfterStatusBne AfterLaExec pseCode
+      (.x29 ↦ᵣ v) (.x29 ↦ᵣ TxExecStateGasAddr) := by
+  have hau := CodeReq.ofProg_mem_at P AfterStatusBne pseProg 29
+    (.AUIPC .x29 (Codegen.laHi GuestAddrs.bvgr_tx_exec_state_gas
+      (GuestAddrs.eip8037_prior_state_used_exact + 116)))
+    (by simp only [AfterStatusBne]; decide)
+    (by rw [pse_length]; decide) rfl (by rw [pse_length]; decide)
+  have had := CodeReq.ofProg_mem_at P (AfterStatusBne + 4) pseProg 30
+    (.ADDI .x29 .x29 (Codegen.laLo GuestAddrs.bvgr_tx_exec_state_gas
+      (GuestAddrs.eip8037_prior_state_used_exact + 116)))
+    (by simp only [AfterStatusBne]; decide)
+    (by rw [pse_length]; decide) rfl (by rw [pse_length]; decide)
+  have h := la_materialize_within .x29 v AfterStatusBne TxExecStateGasAddr
+    (by decide)
+    (by simp only [AfterStatusBne, TxExecStateGasAddr]; decide)
+    hau had
+  rwa [show AfterStatusBne + 8 = AfterLaExec from by
+    simp only [AfterStatusBne, AfterLaExec]; decide] at h
+
 set_option maxRecDepth 8000 in
 /-- Guard fall-through when i ≠ n. -/
 theorem pseLoopGuardNtaken
@@ -355,6 +378,7 @@ theorem pseLoopGuardNtaken
 
 #print axioms pseLaStateGas
 #print axioms pseLaStatus
+#print axioms pseLaExec
 
 end EvmAsm.Codegen.Eip8037PriorStateUsedExactLoop
 

--- a/EvmAsm/Codegen/Programs/Eip8037PriorStateUsedExactLoop.lean
+++ b/EvmAsm/Codegen/Programs/Eip8037PriorStateUsedExactLoop.lean
@@ -243,4 +243,118 @@ theorem pseLoopExitOk
 
 #print axioms pseLoopExitOk
 
+/-! ## Loop addresses / la helpers / one-iter (status = 0) -/
+
+abbrev LoopBody : Word := P + 64
+abbrev AfterSlli : Word := P + 68
+abbrev AfterLaState : Word := P + 76
+abbrev AfterLdState : Word := P + 84
+abbrev AfterAddState : Word := P + 88
+abbrev AfterMvSum : Word := P + 96
+abbrev AfterLaStatus : Word := P + 104
+abbrev AfterLdStatus : Word := P + 112
+abbrev AfterStatusSkip : Word := P + 144
+abbrev AfterIncr : Word := P + 148
+
+private theorem LoopGuard_plus_4 : LoopGuard + 4 = LoopBody := by
+  simp only [LoopGuard, LoopBody]; decide
+
+private theorem ofNat_addi1 (i : Nat) :
+    BitVec.ofNat 64 i + signExtend12 (1 : BitVec 12) = BitVec.ofNat 64 (i + 1) := by
+  have h1 : signExtend12 (1 : BitVec 12) = (1 : Word) := by decide
+  rw [h1, BitVec.ofNat_add]
+  rfl
+
+/-- `la bvgr_tx_state_gas` at instr 17–18 (PC P+68). -/
+theorem pseLaStateGas (v : Word) :
+    cpsTripleWithin 2 AfterSlli AfterLaState pseCode
+      (.x29 ↦ᵣ v) (.x29 ↦ᵣ TxStateGasAddr) := by
+  have hau := CodeReq.ofProg_mem_at P AfterSlli pseProg 17
+    (.AUIPC .x29 (Codegen.laHi GuestAddrs.bvgr_tx_state_gas
+      (GuestAddrs.eip8037_prior_state_used_exact + 68)))
+    (by simp only [AfterSlli]; decide)
+    (by rw [pse_length]; decide) rfl (by rw [pse_length]; decide)
+  have had := CodeReq.ofProg_mem_at P (AfterSlli + 4) pseProg 18
+    (.ADDI .x29 .x29 (Codegen.laLo GuestAddrs.bvgr_tx_state_gas
+      (GuestAddrs.eip8037_prior_state_used_exact + 68)))
+    (by simp only [AfterSlli]; decide)
+    (by rw [pse_length]; decide) rfl (by rw [pse_length]; decide)
+  have h := la_materialize_within .x29 v AfterSlli TxStateGasAddr
+    (by decide)
+    (by simp only [AfterSlli, TxStateGasAddr]; decide)
+    hau had
+  rwa [show AfterSlli + 8 = AfterLaState from by
+    simp only [AfterSlli, AfterLaState]; decide] at h
+
+/-- `la bv_tx_status_arr` at instr 24–25 (PC P+96). -/
+theorem pseLaStatus (v : Word) :
+    cpsTripleWithin 2 AfterMvSum AfterLaStatus pseCode
+      (.x29 ↦ᵣ v) (.x29 ↦ᵣ TxStatusAddr) := by
+  have hau := CodeReq.ofProg_mem_at P AfterMvSum pseProg 24
+    (.AUIPC .x29 (Codegen.laHi GuestAddrs.bv_tx_status_arr
+      (GuestAddrs.eip8037_prior_state_used_exact + 96)))
+    (by simp only [AfterMvSum]; decide)
+    (by rw [pse_length]; decide) rfl (by rw [pse_length]; decide)
+  have had := CodeReq.ofProg_mem_at P (AfterMvSum + 4) pseProg 25
+    (.ADDI .x29 .x29 (Codegen.laLo GuestAddrs.bv_tx_status_arr
+      (GuestAddrs.eip8037_prior_state_used_exact + 96)))
+    (by simp only [AfterMvSum]; decide)
+    (by rw [pse_length]; decide) rfl (by rw [pse_length]; decide)
+  have h := la_materialize_within .x29 v AfterMvSum TxStatusAddr
+    (by decide)
+    (by simp only [AfterMvSum, TxStatusAddr]; decide)
+    hau had
+  rwa [show AfterMvSum + 8 = AfterLaStatus from by
+    simp only [AfterMvSum, AfterLaStatus]; decide] at h
+
+set_option maxRecDepth 8000 in
+/-- Guard fall-through when i ≠ n. -/
+theorem pseLoopGuardNtaken
+    (raIn priorW outPtr sumW iW : Word)
+    (exactOkW runtimeW : Word)
+    (stateGas status execGas : List Nat)
+    (v28 v29 v30 v31 : Word)
+    (hne : iW ≠ priorW) :
+    cpsTripleWithin 1 LoopGuard LoopBody pseCode
+      (LoopInv raIn priorW outPtr sumW iW exactOkW runtimeW
+        stateGas status execGas v28 v29 v30 v31)
+      (LoopInv raIn priorW outPtr sumW iW exactOkW runtimeW
+        stateGas status execGas v28 v29 v30 v31) := by
+  have hGpf : (loopGlobals exactOkW runtimeW stateGas status execGas).pcFree :=
+    pcFree_loopGlobals exactOkW runtimeW stateGas status execGas
+  have hbr := beq_spec_gen_within .x6 .x5 (92 : BitVec 13) iW priorW LoopGuard
+  have hbrC := cpsBranchWithin_extend_code
+    (CodeReq.ofProg_mem_at P LoopGuard pseProg 15
+      (.BEQ .x6 .x5 (92 : BitVec 13))
+      (by simp only [LoopGuard]; decide)
+      (by rw [pse_length]; decide) rfl (by rw [pse_length]; decide)) hbr
+  have hnt0 := cpsBranchWithin_ntakenStripPure2 hbrC (fun _ hq => by
+    obtain ⟨_, _, _, _, _, hrest⟩ := hq
+    exact absurd ((sepConj_pure_right _).1 hrest).2 hne)
+  have hnt : cpsTripleWithin 1 LoopGuard LoopBody pseCode
+      ((.x6 ↦ᵣ iW) ** (.x5 ↦ᵣ priorW))
+      ((.x6 ↦ᵣ iW) ** (.x5 ↦ᵣ priorW)) := by
+    rwa [LoopGuard_plus_4] at hnt0
+  have hF := cpsTripleWithin_frameR
+    ((.x1 ↦ᵣ raIn) ** (.x10 ↦ᵣ priorW) ** (.x11 ↦ᵣ outPtr) **
+      (outPtr ↦ₘ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) **
+      (.x7 ↦ᵣ sumW) **
+      (.x28 ↦ᵣ v28) ** (.x29 ↦ᵣ v29) ** (.x30 ↦ᵣ v30) ** (.x31 ↦ᵣ v31) **
+      loopGlobals exactOkW runtimeW stateGas status execGas)
+    (by
+      repeat' first
+        | exact hGpf
+        | apply pcFree_sepConj
+        | exact pcFree_regIs
+        | exact pcFree_memIs) hnt
+  exact cpsTripleWithin_weaken
+    (fun _ hp => by dsimp only [LoopInv] at hp ⊢; xperm_hyp hp)
+    (fun _ hq => by dsimp only [LoopInv] at hq ⊢; xperm_hyp hq) hF
+
+#print axioms pseLoopGuardNtaken
+
+#print axioms pseLaStateGas
+#print axioms pseLaStatus
+
 end EvmAsm.Codegen.Eip8037PriorStateUsedExactLoop
+

--- a/EvmAsm/Codegen/Programs/Eip8037PriorStateUsedExactModel.lean
+++ b/EvmAsm/Codegen/Programs/Eip8037PriorStateUsedExactModel.lean
@@ -1,0 +1,73 @@
+/-
+  Pure model for `eip8037_prior_state_used_exact` (a4gbr residual leaf).
+
+  Guest (43-instr Program): given prior tx count `a0` and out-ptr `a1`,
+  write the exact prior-state gas sum into `*a1` and return `a0=0`, or
+  return `a0=1` on any gate/overflow failure.
+
+  Sum over i < prior:
+    sum += bvgr_tx_state_gas[i]
+    if bv_tx_status_arr[i] ≠ 0:
+      sum += bvgr_tx_exec_state_gas[i]
+  with unsigned 64-bit overflow → fail.
+
+  Gates (when prior ≠ 0):
+    bsg_exact_state_ok ≠ 0
+    bvgr_runtime_count ≥ prior
+    prior ≤ 16
+-/
+
+import EvmAsm.Rv64.Basic
+
+namespace EvmAsm.Codegen.Eip8037PriorStateUsedExactModel
+
+open EvmAsm.Rv64
+
+/-- Per-tx contribution: state gas always; exec state gas only when status ≠ 0. -/
+def priorCell (stateGas status execGas : List Nat) (i : Nat) : Nat :=
+  stateGas[i]! + (if status[i]! = 0 then 0 else execGas[i]!)
+
+/-- Prefix sum of `priorCell` over `i < k` (unbounded Nat; overflow checked separately). -/
+def priorPrefix (stateGas status execGas : List Nat) : Nat → Nat
+  | 0 => 0
+  | k + 1 => priorPrefix stateGas status execGas k + priorCell stateGas status execGas k
+
+/-- Unsigned 64-bit overflow-safe add: `none` iff wrap. -/
+def add64? (a b : Nat) : Option Nat :=
+  if a + b < 2 ^ 64 then some (a + b) else none
+
+/-- Overflow-safe prefix: `none` on any intermediate wrap. -/
+def priorPrefixExact (stateGas status execGas : List Nat) : Nat → Option Nat
+  | 0 => some 0
+  | k + 1 =>
+      match priorPrefixExact stateGas status execGas k with
+      | none => none
+      | some s => add64? s (priorCell stateGas status execGas k)
+
+/-- Static gates that must hold when `prior ≠ 0` (as Bool for computable match). -/
+def priorGatesOkB (exactOk runtimeCount prior : Nat) : Bool :=
+  decide (exactOk ≠ 0) && decide (runtimeCount ≥ prior) && decide (prior ≤ 16)
+
+def priorGatesOk (exactOk runtimeCount prior : Nat) : Prop :=
+  exactOk ≠ 0 ∧ runtimeCount ≥ prior ∧ prior ≤ 16
+
+theorem priorGatesOk_iff (exactOk runtimeCount prior : Nat) :
+    priorGatesOk exactOk runtimeCount prior ↔ priorGatesOkB exactOk runtimeCount prior = true := by
+  simp only [priorGatesOk, priorGatesOkB, Bool.and_eq_true, decide_eq_true_eq]
+  constructor
+  · intro ⟨h1, h2, h3⟩; exact ⟨⟨h1, h2⟩, h3⟩
+  · intro ⟨⟨h1, h2⟩, h3⟩; exact ⟨h1, h2, h3⟩
+
+/-- Full pure outcome: `some sum` on success, `none` on fail. -/
+def priorExactResult (exactOk runtimeCount prior : Nat)
+    (stateGas status execGas : List Nat) : Option Nat :=
+  if prior = 0 then some 0
+  else if priorGatesOkB exactOk runtimeCount prior = false then none
+  else priorPrefixExact stateGas status execGas prior
+
+theorem priorExactResult_zero (exactOk runtimeCount : Nat)
+    (stateGas status execGas : List Nat) :
+    priorExactResult exactOk runtimeCount 0 stateGas status execGas = some 0 := by
+  simp [priorExactResult]
+
+end EvmAsm.Codegen.Eip8037PriorStateUsedExactModel

--- a/EvmAsm/Codegen/Programs/Eip8037PriorStateUsedExactOvf.lean
+++ b/EvmAsm/Codegen/Programs/Eip8037PriorStateUsedExactOvf.lean
@@ -1,0 +1,332 @@
+/-
+  Mid-loop overflow fail paths for `eip8037_prior_state_used_exact`.
+
+  Program overflow sites:
+    Instr 22 BLTU x31,x7 +76 at P+88  → FailLi (after state_gas ADD)
+    Instr 34 BLTU x31,x7 +28 at P+136 → FailLi (after exec_gas ADD)
+
+  On overflow: a0=1, *out stays 0. Classical-3 only.
+-/
+import EvmAsm.Codegen.Programs.Eip8037PriorStateUsedExactIter
+import EvmAsm.Codegen.Programs.ChainValidateExtraDataLengthSpec
+import EvmAsm.Rv64.LaResolve
+import EvmAsm.Rv64.SyscallSpecs
+import EvmAsm.Rv64.ControlFlow
+import EvmAsm.Rv64.SAsm.DualReadByteScan
+
+namespace EvmAsm.Codegen.Eip8037PriorStateUsedExactOvf
+
+open EvmAsm.Rv64
+open EvmAsm.Codegen
+open EvmAsm.Codegen.Eip8037PriorStateUsedExactModel
+open EvmAsm.Codegen.Eip8037PriorStateUsedExactSpec
+open EvmAsm.Codegen.Eip8037PriorStateUsedExactLoop
+open EvmAsm.Codegen.Eip8037PriorStateUsedExactIter
+open EvmAsm.Codegen.ChainValidateExtraDataLengthSpec
+  (wordArray wordArrayFrom wordArray_split pcFree_wordArray pcFree_wordArrayFrom
+   shiftLeft3_ofNat)
+
+abbrev P : Word := Eip8037PriorStateUsedExactLoop.P
+abbrev pseProg : Program := Eip8037PriorStateUsedExactLoop.pseProg
+abbrev pseCode : CodeReq := Eip8037PriorStateUsedExactLoop.pseCode
+abbrev LoopGuard : Word := Eip8037PriorStateUsedExactLoop.LoopGuard
+abbrev LoopBody : Word := Eip8037PriorStateUsedExactLoop.LoopBody
+abbrev AfterSlli : Word := Eip8037PriorStateUsedExactLoop.AfterSlli
+abbrev AfterLaState : Word := Eip8037PriorStateUsedExactLoop.AfterLaState
+abbrev TxStateGasAddr : Word := Eip8037PriorStateUsedExactLoop.TxStateGasAddr
+abbrev TxStatusAddr : Word := Eip8037PriorStateUsedExactLoop.TxStatusAddr
+abbrev TxExecStateGasAddr : Word := Eip8037PriorStateUsedExactLoop.TxExecStateGasAddr
+abbrev FailLi : Word := Eip8037PriorStateUsedExactSpec.FailLi
+
+theorem pse_length : pseProg.length = 43 := Eip8037PriorStateUsedExactLoop.pse_length
+
+private theorem se12_zero : signExtend12 (0 : BitVec 12) = (0 : Word) := by decide
+
+private theorem AfterLaState_plus_4 : AfterLaState + 4 = P + 80 := by
+  simp only [AfterLaState, P]; decide
+private theorem P80_plus_4 : (P + 80 : Word) + 4 = P + 84 := by simp only [P]; decide
+private theorem P84_plus_4 : (P + 84 : Word) + 4 = P + 88 := by simp only [P]; decide
+private theorem P88_plus_4 : (P + 88 : Word) + 4 = P + 92 := by simp only [P]; decide
+
+private theorem ofNat_add_wrap (s g : Nat)
+    (hs : s < 2 ^ 64) (hg : g < 2 ^ 64) :
+    BitVec.ofNat 64 s + BitVec.ofNat 64 g =
+      BitVec.ofNat 64 ((s + g) % 2 ^ 64) := by
+  apply BitVec.eq_of_toNat_eq
+  simp only [BitVec.toNat_add, BitVec.toNat_ofNat, Nat.mod_eq_of_lt hs, Nat.mod_eq_of_lt hg]
+  exact (Nat.mod_eq_of_lt (Nat.mod_lt (s + g) (by decide : 0 < 2 ^ 64))).symm
+
+/-- Detect u64 wrap as Prop: ofNat s + ofNat g ult ofNat s when s+g ≥ 2^64. -/
+private theorem ult_add_of_overflow (s g : Nat)
+    (hs : s < 2 ^ 64) (hg : g < 2 ^ 64) (hov : 2 ^ 64 ≤ s + g) :
+    BitVec.ult (BitVec.ofNat 64 s + BitVec.ofNat 64 g) (BitVec.ofNat 64 s) := by
+  have hwrap : (s + g) % 2 ^ 64 = s + g - 2 ^ 64 := by
+    have : s + g < 2 * 2 ^ 64 := by omega
+    omega
+  have hlt_s : (s + g) % 2 ^ 64 < s := by
+    rw [hwrap]; omega
+  have heq := ofNat_add_wrap s g hs hg
+  rw [heq]
+  simp only [BitVec.ult_eq_decide, decide_eq_true_eq, BitVec.toNat_ofNat,
+    Nat.mod_eq_of_lt hs,
+    Nat.mod_eq_of_lt (Nat.mod_lt (s + g) (by decide : 0 < 2 ^ 64))]
+  exact hlt_s
+
+set_option maxRecDepth 8000 in
+/-- State-gas overflow fail: LoopGuard → postFail in 10 steps when
+    2^64 ≤ sum + stateGas[i]. BLTU taken before status is loaded. -/
+theorem pseIterStateOvf
+    (raIn priorW outPtr : Word)
+    (exactOkW runtimeW : Word)
+    (stateGas status execGas : List Nat)
+    (i sum : Nat)
+    (v28 v29 v30 v31 : Word)
+    (hi : i < stateGas.length)
+    (hs : sum < 2 ^ 64)
+    (hg : stateGas[i] < 2 ^ 64)
+    (hov : 2 ^ 64 ≤ sum + stateGas[i])
+    (hne : BitVec.ofNat 64 i ≠ priorW)
+    (hret : raIn &&& ~~~(1 : Word) = raIn) :
+    let iW := BitVec.ofNat 64 i
+    let sumW := BitVec.ofNat 64 sum
+    let offW := BitVec.ofNat 64 (8 * i)
+    let gasW := BitVec.ofNat 64 stateGas[i]
+    let sumW' := sumW + gasW
+    cpsTripleWithin 10 LoopGuard raIn pseCode
+      (LoopInv raIn priorW outPtr sumW iW exactOkW runtimeW
+        stateGas status execGas v28 v29 v30 v31)
+      (postFail raIn outPtr (0 : Word)
+        ((.x5 ↦ᵣ priorW) ** (.x6 ↦ᵣ iW) ** (.x7 ↦ᵣ sumW) **
+          (.x28 ↦ᵣ offW) ** (.x29 ↦ᵣ (TxStateGasAddr + offW)) **
+          (.x30 ↦ᵣ gasW) ** (.x31 ↦ᵣ sumW') **
+          loopGlobals exactOkW runtimeW stateGas status execGas)) := by
+  intro iW sumW offW gasW sumW'
+  have hGpf : (loopGlobals exactOkW runtimeW stateGas status execGas).pcFree :=
+    pcFree_loopGlobals exactOkW runtimeW stateGas status execGas
+  have hoff : iW <<< 3 = offW := by
+    simpa [iW, offW] using shiftLeft3_ofNat i
+  have hUlt : BitVec.ult sumW' sumW := by
+    simpa [sumW, sumW', gasW] using ult_add_of_overflow sum stateGas[i] hs hg hov
+  have hsplit := wordArray_split TxStateGasAddr stateGas i hi
+  have haddrState :
+      TxStateGasAddr + BitVec.ofNat 64 (8 * i) = TxStateGasAddr + offW := by
+    simp only [offW]
+  -- 1. guard ntaken
+  have hguard := pseLoopGuardNtaken raIn priorW outPtr sumW iW exactOkW runtimeW
+    stateGas status execGas v28 v29 v30 v31 hne
+  -- 2. SLLI x28 = 8*i
+  have e16 :
+      cpsTripleWithin 1 LoopBody AfterSlli pseCode
+        ((.x6 ↦ᵣ iW) ** (.x28 ↦ᵣ v28))
+        ((.x6 ↦ᵣ iW) ** (.x28 ↦ᵣ offW)) := by
+    have h0 := slli_spec_gen_within .x28 .x6 v28 iW (3 : BitVec 6) LoopBody (by decide)
+    have h0' : cpsTripleWithin 1 LoopBody (LoopBody + 4) pseCode
+        ((.x6 ↦ᵣ iW) ** (.x28 ↦ᵣ v28))
+        ((.x6 ↦ᵣ iW) ** (.x28 ↦ᵣ (iW <<< 3))) :=
+      cpsTripleWithin_extend_code
+        (CodeReq.ofProg_mem_at P LoopBody pseProg 16
+          (.SLLI .x28 .x6 (3 : BitVec 6))
+          (by simp only [LoopBody]; decide)
+          (by rw [pse_length]; decide) rfl (by rw [pse_length]; decide)) h0
+    have h0'' : cpsTripleWithin 1 LoopBody AfterSlli pseCode
+        ((.x6 ↦ᵣ iW) ** (.x28 ↦ᵣ v28))
+        ((.x6 ↦ᵣ iW) ** (.x28 ↦ᵣ (iW <<< 3))) := by
+      rwa [show LoopBody + 4 = AfterSlli from by simp only [LoopBody, AfterSlli]; decide] at h0'
+    exact cpsTripleWithin_weaken (fun _ hp => hp)
+      (fun _ hq => by rw [← hoff]; exact hq) h0''
+  have e16F := cpsTripleWithin_frameR
+    ((.x1 ↦ᵣ raIn) ** (.x10 ↦ᵣ priorW) ** (.x11 ↦ᵣ outPtr) **
+      (outPtr ↦ₘ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) **
+      (.x5 ↦ᵣ priorW) ** (.x7 ↦ᵣ sumW) **
+      (.x29 ↦ᵣ v29) ** (.x30 ↦ᵣ v30) ** (.x31 ↦ᵣ v31) **
+      loopGlobals exactOkW runtimeW stateGas status execGas)
+    (by
+      repeat' first
+        | exact hGpf
+        | apply pcFree_sepConj
+        | exact pcFree_regIs
+        | exact pcFree_memIs) e16
+  -- 3. la state → x29
+  have eLa := cpsTripleWithin_frameR
+    ((.x1 ↦ᵣ raIn) ** (.x10 ↦ᵣ priorW) ** (.x11 ↦ᵣ outPtr) **
+      (outPtr ↦ₘ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) **
+      (.x5 ↦ᵣ priorW) ** (.x6 ↦ᵣ iW) ** (.x7 ↦ᵣ sumW) **
+      (.x28 ↦ᵣ offW) ** (.x30 ↦ᵣ v30) ** (.x31 ↦ᵣ v31) **
+      loopGlobals exactOkW runtimeW stateGas status execGas)
+    (by
+      repeat' first
+        | exact hGpf
+        | apply pcFree_sepConj
+        | exact pcFree_regIs
+        | exact pcFree_memIs) (pseLaStateGas v29)
+  -- 4. ADD x29 += x28
+  have e19 :
+      cpsTripleWithin 1 AfterLaState (P + 80) pseCode
+        ((.x29 ↦ᵣ TxStateGasAddr) ** (.x28 ↦ᵣ offW))
+        ((.x29 ↦ᵣ (TxStateGasAddr + offW)) ** (.x28 ↦ᵣ offW)) := by
+    have h0 := add_spec_gen_rd_eq_rs1_within .x29 .x28 TxStateGasAddr offW AfterLaState (by decide)
+    have h0' : cpsTripleWithin 1 AfterLaState (AfterLaState + 4) pseCode
+        ((.x29 ↦ᵣ TxStateGasAddr) ** (.x28 ↦ᵣ offW))
+        ((.x29 ↦ᵣ (TxStateGasAddr + offW)) ** (.x28 ↦ᵣ offW)) :=
+      cpsTripleWithin_extend_code
+        (CodeReq.ofProg_mem_at P AfterLaState pseProg 19
+          (.ADD .x29 .x29 .x28)
+          (by simp only [AfterLaState]; decide)
+          (by rw [pse_length]; decide) rfl (by rw [pse_length]; decide)) h0
+    rwa [AfterLaState_plus_4] at h0'
+  have e19F := cpsTripleWithin_frameR
+    ((.x1 ↦ᵣ raIn) ** (.x10 ↦ᵣ priorW) ** (.x11 ↦ᵣ outPtr) **
+      (outPtr ↦ₘ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) **
+      (.x5 ↦ᵣ priorW) ** (.x6 ↦ᵣ iW) ** (.x7 ↦ᵣ sumW) **
+      (.x30 ↦ᵣ v30) ** (.x31 ↦ᵣ v31) **
+      loopGlobals exactOkW runtimeW stateGas status execGas)
+    (by
+      repeat' first
+        | exact hGpf
+        | apply pcFree_sepConj
+        | exact pcFree_regIs
+        | exact pcFree_memIs) e19
+  -- 5. LD state cell
+  have e20core :
+      cpsTripleWithin 1 (P + 80) (P + 84) pseCode
+        ((.x29 ↦ᵣ (TxStateGasAddr + offW)) ** (.x30 ↦ᵣ v30) **
+          ((TxStateGasAddr + offW) ↦ₘ gasW))
+        ((.x29 ↦ᵣ (TxStateGasAddr + offW)) ** (.x30 ↦ᵣ gasW) **
+          ((TxStateGasAddr + offW) ↦ₘ gasW)) := by
+    have haddr : (TxStateGasAddr + offW) + signExtend12 (0 : BitVec 12) =
+        TxStateGasAddr + offW := by
+      rw [se12_zero]; exact BitVec.add_zero _
+    have h0 := ld_spec_gen_within .x30 .x29 (TxStateGasAddr + offW) v30
+      gasW (0 : BitVec 12) (P + 80) (by decide)
+    rw [haddr] at h0
+    exact cpsTripleWithin_extend_code
+      (CodeReq.ofProg_mem_at P (P + 80) pseProg 20
+        (.LD .x30 .x29 (0 : BitVec 12))
+        (by simp only [P]; decide)
+        (by rw [pse_length]; decide) rfl (by rw [pse_length]; decide)) h0
+  have e20F0 := cpsTripleWithin_frameR
+    (wordArrayFrom TxStateGasAddr 0 (stateGas.take i) **
+      wordArrayFrom TxStateGasAddr (i + 1) (stateGas.drop (i + 1)) **
+      wordArray TxStatusAddr status **
+      wordArray TxExecStateGasAddr execGas **
+      loopGlobalsCore exactOkW runtimeW **
+      (.x1 ↦ᵣ raIn) ** (.x10 ↦ᵣ priorW) ** (.x11 ↦ᵣ outPtr) **
+      (outPtr ↦ₘ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) **
+      (.x5 ↦ᵣ priorW) ** (.x6 ↦ᵣ iW) ** (.x7 ↦ᵣ sumW) **
+      (.x28 ↦ᵣ offW) ** (.x31 ↦ᵣ v31))
+    (by
+      repeat' first
+        | apply pcFree_sepConj
+        | exact pcFree_regIs
+        | exact pcFree_memIs
+        | exact pcFree_wordArray _ _
+        | exact pcFree_wordArrayFrom _ _ _) e20core
+  have e20F : cpsTripleWithin 1 (P + 80) (P + 84) pseCode
+      ((.x29 ↦ᵣ (TxStateGasAddr + offW)) ** (.x30 ↦ᵣ v30) **
+        (.x1 ↦ᵣ raIn) ** (.x10 ↦ᵣ priorW) ** (.x11 ↦ᵣ outPtr) **
+        (outPtr ↦ₘ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) **
+        (.x5 ↦ᵣ priorW) ** (.x6 ↦ᵣ iW) ** (.x7 ↦ᵣ sumW) **
+        (.x28 ↦ᵣ offW) ** (.x31 ↦ᵣ v31) **
+        loopGlobals exactOkW runtimeW stateGas status execGas)
+      ((.x29 ↦ᵣ (TxStateGasAddr + offW)) ** (.x30 ↦ᵣ gasW) **
+        (.x1 ↦ᵣ raIn) ** (.x10 ↦ᵣ priorW) ** (.x11 ↦ᵣ outPtr) **
+        (outPtr ↦ₘ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) **
+        (.x5 ↦ᵣ priorW) ** (.x6 ↦ᵣ iW) ** (.x7 ↦ᵣ sumW) **
+        (.x28 ↦ᵣ offW) ** (.x31 ↦ᵣ v31) **
+        loopGlobals exactOkW runtimeW stateGas status execGas) := by
+    refine cpsTripleWithin_weaken ?_ ?_ e20F0
+    · intro s hp
+      have hp' := hp
+      rw [loopGlobals_eq, hsplit, haddrState] at hp'
+      xperm_hyp hp'
+    · intro s hq
+      have hq' := hq
+      rw [loopGlobals_eq, hsplit, haddrState]
+      xperm_hyp hq'
+  -- 6. ADD x31 = sum + gas  (args: rd rs1 rs2 v_rs1 v_rs2 v_rd_old)
+  have e21 :
+      cpsTripleWithin 1 (P + 84) (P + 88) pseCode
+        ((.x7 ↦ᵣ sumW) ** (.x30 ↦ᵣ gasW) ** (.x31 ↦ᵣ v31))
+        ((.x7 ↦ᵣ sumW) ** (.x30 ↦ᵣ gasW) ** (.x31 ↦ᵣ sumW')) := by
+    have h0 := add_spec_gen_within .x31 .x7 .x30 sumW gasW v31 (P + 84) (by decide)
+    have h0' : cpsTripleWithin 1 (P + 84) (P + 84 + 4) pseCode
+        ((.x7 ↦ᵣ sumW) ** (.x30 ↦ᵣ gasW) ** (.x31 ↦ᵣ v31))
+        ((.x7 ↦ᵣ sumW) ** (.x30 ↦ᵣ gasW) ** (.x31 ↦ᵣ (sumW + gasW))) :=
+      cpsTripleWithin_extend_code
+        (CodeReq.ofProg_mem_at P (P + 84) pseProg 21
+          (.ADD .x31 .x7 .x30)
+          (by simp only [P]; decide)
+          (by rw [pse_length]; decide) rfl (by rw [pse_length]; decide)) h0
+    have h0'' : cpsTripleWithin 1 (P + 84) (P + 88) pseCode
+        ((.x7 ↦ᵣ sumW) ** (.x30 ↦ᵣ gasW) ** (.x31 ↦ᵣ v31))
+        ((.x7 ↦ᵣ sumW) ** (.x30 ↦ᵣ gasW) ** (.x31 ↦ᵣ (sumW + gasW))) := by
+      rwa [P84_plus_4] at h0'
+    exact cpsTripleWithin_weaken (fun _ hp => hp)
+      (fun _ hq => by simpa [sumW'] using hq) h0''
+  have e21F := cpsTripleWithin_frameR
+    ((.x1 ↦ᵣ raIn) ** (.x10 ↦ᵣ priorW) ** (.x11 ↦ᵣ outPtr) **
+      (outPtr ↦ₘ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) **
+      (.x5 ↦ᵣ priorW) ** (.x6 ↦ᵣ iW) **
+      (.x28 ↦ᵣ offW) ** (.x29 ↦ᵣ (TxStateGasAddr + offW)) **
+      loopGlobals exactOkW runtimeW stateGas status execGas)
+    (by
+      repeat' first
+        | exact hGpf
+        | apply pcFree_sepConj
+        | exact pcFree_regIs
+        | exact pcFree_memIs) e21
+  -- 7. BLTU taken → FailLi (offset is BitVec 13)
+  have e22tk : cpsTripleWithin 1 (P + 88) FailLi pseCode
+      ((.x31 ↦ᵣ sumW') ** (.x7 ↦ᵣ sumW))
+      ((.x31 ↦ᵣ sumW') ** (.x7 ↦ᵣ sumW)) := by
+    have hbr := bltu_spec_gen_within .x31 .x7 (76 : BitVec 13) sumW' sumW (P + 88)
+    have hbrC := cpsBranchWithin_extend_code
+      (CodeReq.ofProg_mem_at P (P + 88) pseProg 22
+        (.BLTU .x31 .x7 (76 : BitVec 13))
+        (by simp only [P]; decide)
+        (by rw [pse_length]; decide) rfl (by rw [pse_length]; decide)) hbr
+    have htk0 := cpsBranchWithin_takenStripPure2 hbrC (fun _ hq => by
+      obtain ⟨_, _, _, _, _, hrest⟩ := hq
+      exact ((sepConj_pure_right _).1 hrest).2 hUlt)
+    have hpc : (P + 88) + signExtend13 (76 : BitVec 13) = FailLi := by
+      simp only [P, FailLi]; decide
+    rwa [hpc] at htk0
+  have e22tkF := cpsTripleWithin_frameR
+    ((.x1 ↦ᵣ raIn) ** (.x10 ↦ᵣ priorW) ** (.x11 ↦ᵣ outPtr) **
+      (outPtr ↦ₘ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) **
+      (.x5 ↦ᵣ priorW) ** (.x6 ↦ᵣ iW) **
+      (.x28 ↦ᵣ offW) ** (.x29 ↦ᵣ (TxStateGasAddr + offW)) **
+      (.x30 ↦ᵣ gasW) **
+      loopGlobals exactOkW runtimeW stateGas status execGas)
+    (by
+      repeat' first
+        | exact hGpf
+        | apply pcFree_sepConj
+        | exact pcFree_regIs
+        | exact pcFree_memIs) e22tk
+  -- 8-9. fail ret; x10 and x5 both priorW (pseFailRet pins both as v5)
+  have eFail :=
+    pseFailRet_spec raIn outPtr (0 : Word)
+      priorW iW sumW offW (TxStateGasAddr + offW) gasW sumW' hret
+  have eFailF := cpsTripleWithin_frameR
+    (loopGlobals exactOkW runtimeW stateGas status execGas)
+    (by exact hGpf) eFail
+  -- Compose (seq_perm_same_cr: hperm Q1→Q2, h1, h2)
+  have c01 := cpsTripleWithin_seq_perm_same_cr
+    (fun _ hp => by dsimp only [LoopInv] at hp; xperm_hyp hp) hguard e16F
+  have c02 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) c01 eLa
+  have c03 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) c02 e19F
+  have c04 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) c03 e20F
+  have c05 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) c04 e21F
+  have c06 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) c05 e22tkF
+  have c07 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) c06 eFailF
+  change cpsTripleWithin (1+1+2+1+1+1+1+2) LoopGuard raIn pseCode _ _ at c07
+  exact cpsTripleWithin_weaken
+    (fun _ hp => by dsimp only [LoopInv] at hp ⊢; xperm_hyp hp)
+    (fun _ hq => by
+      dsimp only [postFail] at hq ⊢
+      xperm_hyp hq) c07
+
+#print axioms pseIterStateOvf
+
+end EvmAsm.Codegen.Eip8037PriorStateUsedExactOvf

--- a/EvmAsm/Codegen/Programs/Eip8037PriorStateUsedExactSpec.lean
+++ b/EvmAsm/Codegen/Programs/Eip8037PriorStateUsedExactSpec.lean
@@ -1,0 +1,215 @@
+/-
+  Fn.Spec for `eip8037_prior_state_used_exact` (43-instr sum leaf; a4gbr residual).
+
+  ABI: a0 = prior tx count, a1 = out ptr.
+  Success: a0=0 ∧ *out = pure prior-state sum (0 when prior=0).
+  Fail: a0=1 (gates/overflow).
+
+  No stack frame; leaf ret via JALR x0,x1,0.
+  Globals: bsg_exact_state_ok, bvgr_runtime_count, bvgr_tx_state_gas[16],
+  bv_tx_status_arr[16], bvgr_tx_exec_state_gas[16].
+-/
+
+import EvmAsm.Codegen.Programs.BlockVerdictGasGate
+import EvmAsm.Codegen.Programs.Eip8037PriorStateUsedExactModel
+import EvmAsm.Rv64.SyscallSpecs
+import EvmAsm.Rv64.SAsm.DualReadByteScan
+
+namespace EvmAsm.Codegen.Eip8037PriorStateUsedExactSpec
+
+open EvmAsm.Rv64
+open EvmAsm.Codegen
+open EvmAsm.Codegen.Eip8037PriorStateUsedExactModel
+
+abbrev P : Word := (GuestAddrs.eip8037_prior_state_used_exact : Word)
+abbrev ExactOkAddr : Word := (GuestAddrs.bsg_exact_state_ok : Word)
+abbrev RuntimeCountAddr : Word := (GuestAddrs.bvgr_runtime_count : Word)
+abbrev TxStateGasAddr : Word := (GuestAddrs.bvgr_tx_state_gas : Word)
+abbrev TxStatusAddr : Word := (GuestAddrs.bv_tx_status_arr : Word)
+abbrev TxExecStateGasAddr : Word := (GuestAddrs.bvgr_tx_exec_state_gas : Word)
+
+abbrev pseProg : Program := eip8037PriorStateUsedExact_prog
+
+theorem pse_length : pseProg.length = 43 := by decide
+
+def pseCode : CodeReq := CodeReq.ofProg P pseProg
+
+/-- Exit PCs (byte offsets from P). -/
+abbrev OkLi : Word := P + 156    -- instr 39 LI a0,0
+abbrev OkRet : Word := P + 160   -- instr 40 JALR success
+abbrev FailLi : Word := P + 164  -- instr 41 LI a0,1
+abbrev FailRet : Word := P + 168 -- instr 42 JALR fail
+abbrev LoopGuard : Word := P + 60 -- instr 15 BEQ i,n
+abbrev StoreSum : Word := P + 152 -- instr 38 SD sum
+
+/-- Success post: a0=0, *out=sum, ra preserved, hardwired x0. -/
+def postOk (raIn outPtr sumW : Word) (scratch : Assertion) : Assertion :=
+  (.x1 ↦ᵣ raIn) ** (.x10 ↦ᵣ (0 : Word)) ** (.x11 ↦ᵣ outPtr) **
+    (outPtr ↦ₘ sumW) ** scratch ** (.x0 ↦ᵣ (0 : Word))
+
+/-- Fail post: a0=1. -/
+def postFail (raIn outPtr oldOut : Word) (scratch : Assertion) : Assertion :=
+  (.x1 ↦ᵣ raIn) ** (.x10 ↦ᵣ (1 : Word)) ** (.x11 ↦ᵣ outPtr) **
+    (outPtr ↦ₘ oldOut) ** scratch ** (.x0 ↦ᵣ (0 : Word))
+
+/-- Entry pre: ABI + out cell + ambient scratch + hardwired x0. -/
+def entryPre (raIn priorW outPtr oldOut : Word) (scratch : Assertion) : Assertion :=
+  (.x1 ↦ᵣ raIn) ** (.x10 ↦ᵣ priorW) ** (.x11 ↦ᵣ outPtr) **
+    (outPtr ↦ₘ oldOut) ** scratch ** (.x0 ↦ᵣ (0 : Word))
+
+def nZeroSteps : Nat := 4
+
+private theorem se12_zero : signExtend12 (0 : BitVec 12) = (0 : Word) := by decide
+private theorem se13_152 : signExtend13 (152 : BitVec 13) = (152 : Word) := by decide
+
+private theorem P_plus_4_plus_152 : P + 4 + signExtend13 (152 : BitVec 13) = OkLi := by
+  simp only [OkLi, P, GuestAddrs.eip8037_prior_state_used_exact, se13_152]
+  decide
+
+private theorem OkLi_plus_4 : OkLi + 4 = OkRet := by
+  simp only [OkLi, OkRet, P, GuestAddrs.eip8037_prior_state_used_exact]; decide
+
+set_option maxRecDepth 8000 in
+/-- `prior=0`: zero *out, BEQ taken to ok, LI a0=0, ret. Matches pure model. -/
+theorem eip8037PriorStateUsedExact_zero_spec_within
+    (raIn outPtr oldOut : Word)
+    (v5 v6 v7 v28 v29 v30 v31 : Word)
+    (hret : raIn &&& ~~~(1 : Word) = raIn) :
+    cpsTripleWithin nZeroSteps P raIn pseCode
+      (entryPre raIn (0 : Word) outPtr oldOut
+        ((.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
+          (.x28 ↦ᵣ v28) ** (.x29 ↦ᵣ v29) ** (.x30 ↦ᵣ v30) ** (.x31 ↦ᵣ v31)))
+      (postOk raIn outPtr (0 : Word)
+        ((.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
+          (.x28 ↦ᵣ v28) ** (.x29 ↦ᵣ v29) ** (.x30 ↦ᵣ v30) ** (.x31 ↦ᵣ v31))) := by
+  -- [0] SD x0, 0(x11)
+  have haddr :
+      outPtr + signExtend12 (0 : BitVec 12) = outPtr := by
+    rw [se12_zero]; exact BitVec.add_zero outPtr
+  have e0 :
+      cpsTripleWithin 1 P (P + 4) pseCode
+        ((.x11 ↦ᵣ outPtr) ** (.x0 ↦ᵣ (0 : Word)) ** (outPtr ↦ₘ oldOut))
+        ((.x11 ↦ᵣ outPtr) ** (.x0 ↦ᵣ (0 : Word)) ** (outPtr ↦ₘ (0 : Word))) := by
+    have h0 := sd_spec_gen_within .x11 .x0 outPtr (0 : Word) oldOut
+      (0 : BitVec 12) P
+    rw [haddr] at h0
+    exact cpsTripleWithin_extend_code
+      (CodeReq.ofProg_mem_at P P pseProg 0
+        (.SD .x11 .x0 (0 : BitVec 12))
+        (by decide) (by rw [pse_length]; decide) rfl
+        (by rw [pse_length]; decide)) h0
+  have e0F := cpsTripleWithin_frameR
+    ((.x1 ↦ᵣ raIn) ** (.x10 ↦ᵣ (0 : Word)) **
+      (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
+      (.x28 ↦ᵣ v28) ** (.x29 ↦ᵣ v29) ** (.x30 ↦ᵣ v30) ** (.x31 ↦ᵣ v31))
+    (by
+      repeat' first
+        | apply pcFree_sepConj
+        | exact pcFree_regIs) e0
+  -- [1] BEQ x10, x0, +152 — taken (prior=0)
+  have hbr := beq_spec_gen_within .x10 .x0 (152 : BitVec 13) (0 : Word) (0 : Word) (P + 4)
+  have hbrC := cpsBranchWithin_extend_code
+    (CodeReq.ofProg_mem_at P (P + 4) pseProg 1
+      (.BEQ .x10 .x0 (152 : BitVec 13))
+      (by simp only [P, GuestAddrs.eip8037_prior_state_used_exact]; decide)
+      (by rw [pse_length]; decide) rfl
+      (by rw [pse_length]; decide)) hbr
+  have htk0 := cpsBranchWithin_takenStripPure2 hbrC (fun _ hq => by
+    obtain ⟨_, _, _, _, _, hrest⟩ := hq
+    exact absurd rfl ((sepConj_pure_right _).1 hrest).2)
+  have htk : cpsTripleWithin 1 (P + 4) OkLi pseCode
+      ((.x10 ↦ᵣ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)))
+      ((.x10 ↦ᵣ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word))) := by
+    rwa [P_plus_4_plus_152] at htk0
+  have e1F := cpsTripleWithin_frameR
+    ((.x1 ↦ᵣ raIn) ** (.x11 ↦ᵣ outPtr) ** (outPtr ↦ₘ (0 : Word)) **
+      (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
+      (.x28 ↦ᵣ v28) ** (.x29 ↦ᵣ v29) ** (.x30 ↦ᵣ v30) ** (.x31 ↦ᵣ v31))
+    (by
+      repeat' first
+        | apply pcFree_sepConj
+        | exact pcFree_regIs
+        | exact pcFree_memIs) htk
+  -- [39] LI a0, 0
+  have e39 :
+      cpsTripleWithin 1 OkLi OkRet pseCode
+        (.x10 ↦ᵣ (0 : Word)) (.x10 ↦ᵣ (0 : Word)) := by
+    have h0 := li_spec_gen_within .x10 (0 : Word) (0 : Word) OkLi (by decide)
+    have h0' : cpsTripleWithin 1 OkLi (OkLi + 4) pseCode
+        (.x10 ↦ᵣ (0 : Word)) (.x10 ↦ᵣ (0 : Word)) :=
+      cpsTripleWithin_extend_code
+        (CodeReq.ofProg_mem_at P OkLi pseProg 39
+          (.LI .x10 (0 : Word))
+          (by simp only [OkLi, P, GuestAddrs.eip8037_prior_state_used_exact]; decide)
+          (by rw [pse_length]; decide) rfl
+          (by rw [pse_length]; decide)) h0
+    rwa [OkLi_plus_4] at h0'
+  have e39F := cpsTripleWithin_frameR
+    ((.x1 ↦ᵣ raIn) ** (.x11 ↦ᵣ outPtr) ** (outPtr ↦ₘ (0 : Word)) **
+      (.x0 ↦ᵣ (0 : Word)) **
+      (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
+      (.x28 ↦ᵣ v28) ** (.x29 ↦ᵣ v29) ** (.x30 ↦ᵣ v30) ** (.x31 ↦ᵣ v31))
+    (by
+      repeat' first
+        | apply pcFree_sepConj
+        | exact pcFree_regIs
+        | exact pcFree_memIs) e39
+  -- [40] JALR x0, x1, 0 → raIn
+  have hexit :
+      ((raIn + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word)) = raIn := by
+    have hadd : raIn + signExtend12 (0 : BitVec 12) = raIn := by
+      rw [se12_zero]
+      exact BitVec.add_zero raIn
+    rw [hadd, hret]
+  have e40 :
+      cpsTripleWithin 1 OkRet raIn pseCode
+        (.x1 ↦ᵣ raIn) (.x1 ↦ᵣ raIn) := by
+    have h0 := jalr_x0_spec_gen_within .x1 raIn (0 : BitVec 12) OkRet
+    rw [hexit] at h0
+    exact cpsTripleWithin_extend_code
+      (CodeReq.ofProg_mem_at P OkRet pseProg 40
+        (.JALR .x0 .x1 (0 : BitVec 12))
+        (by simp only [OkRet, P, GuestAddrs.eip8037_prior_state_used_exact]; decide)
+        (by rw [pse_length]; decide) rfl
+        (by rw [pse_length]; decide)) h0
+  -- Frame for JALR ordered to match e39F post: x10 ** x1 ** rest
+  -- so reshape is identity-ish after one xperm on the framed triple.
+  have e40F0 := cpsTripleWithin_frameR
+    ((.x10 ↦ᵣ (0 : Word)) ** (.x11 ↦ᵣ outPtr) ** (outPtr ↦ₘ (0 : Word)) **
+      (.x0 ↦ᵣ (0 : Word)) **
+      (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
+      (.x28 ↦ᵣ v28) ** (.x29 ↦ᵣ v29) ** (.x30 ↦ᵣ v30) ** (.x31 ↦ᵣ v31))
+    (by
+      repeat' first
+        | apply pcFree_sepConj
+        | exact pcFree_regIs
+        | exact pcFree_memIs) e40
+  have e40F : cpsTripleWithin 1 OkRet raIn pseCode
+      ((.x10 ↦ᵣ (0 : Word)) ** (.x1 ↦ᵣ raIn) ** (.x11 ↦ᵣ outPtr) **
+        (outPtr ↦ₘ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) **
+        (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
+        (.x28 ↦ᵣ v28) ** (.x29 ↦ᵣ v29) ** (.x30 ↦ᵣ v30) ** (.x31 ↦ᵣ v31))
+      ((.x10 ↦ᵣ (0 : Word)) ** (.x1 ↦ᵣ raIn) ** (.x11 ↦ᵣ outPtr) **
+        (outPtr ↦ₘ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) **
+        (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
+        (.x28 ↦ᵣ v28) ** (.x29 ↦ᵣ v29) ** (.x30 ↦ᵣ v30) ** (.x31 ↦ᵣ v31)) :=
+    cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
+      (fun _ hq => by xperm_hyp hq) e40F0
+  have c01 := cpsTripleWithin_seq_perm_same_cr
+    (fun _ hp => by xperm_hyp hp) e0F e1F
+  have c02 := cpsTripleWithin_seq_perm_same_cr
+    (fun _ hp => by xperm_hyp hp) c01 e39F
+  have c03 := cpsTripleWithin_seq_perm_same_cr
+    (fun _ hp => by xperm_hyp hp) c02 e40F
+  change cpsTripleWithin (1 + 1 + 1 + 1) P raIn pseCode _ _ at c03
+  exact cpsTripleWithin_weaken
+    (fun _ hp => by
+      dsimp only [entryPre, nZeroSteps] at hp ⊢
+      xperm_hyp hp)
+    (fun _ hq => by
+      dsimp only [postOk, nZeroSteps] at hq ⊢
+      xperm_hyp hq) c03
+
+#print axioms eip8037PriorStateUsedExact_zero_spec_within
+
+end EvmAsm.Codegen.Eip8037PriorStateUsedExactSpec

--- a/EvmAsm/Codegen/Programs/Eip8037PriorStateUsedExactSpec.lean
+++ b/EvmAsm/Codegen/Programs/Eip8037PriorStateUsedExactSpec.lean
@@ -14,6 +14,7 @@ import EvmAsm.Codegen.Programs.BlockVerdictGasGate
 import EvmAsm.Codegen.Programs.Eip8037PriorStateUsedExactModel
 import EvmAsm.Rv64.SyscallSpecs
 import EvmAsm.Rv64.SAsm.DualReadByteScan
+import EvmAsm.Rv64.LaResolve
 
 namespace EvmAsm.Codegen.Eip8037PriorStateUsedExactSpec
 
@@ -211,5 +212,474 @@ theorem eip8037PriorStateUsedExact_zero_spec_within
       xperm_hyp hq) c03
 
 #print axioms eip8037PriorStateUsedExact_zero_spec_within
+
+/-! ## Shared exit tails -/
+
+private theorem FailLi_plus_4 : FailLi + 4 = FailRet := by
+  simp only [FailLi, FailRet, P, GuestAddrs.eip8037_prior_state_used_exact]; decide
+
+private theorem P20_plus_144 : P + 20 + signExtend13 (144 : BitVec 13) = FailLi := by
+  simp only [FailLi, P, GuestAddrs.eip8037_prior_state_used_exact]
+  decide
+
+private theorem P36_plus_128 : P + 36 + signExtend13 (128 : BitVec 13) = FailLi := by
+  simp only [FailLi, P, GuestAddrs.eip8037_prior_state_used_exact]
+  decide
+
+private theorem P44_plus_120 : P + 44 + signExtend13 (120 : BitVec 13) = FailLi := by
+  simp only [FailLi, P, GuestAddrs.eip8037_prior_state_used_exact]
+  decide
+
+set_option maxRecDepth 8000 in
+/-- Fail tail: LI a0=1; JALR. Preserves `*out` (still the entry old or zeroed). -/
+theorem pseFailRet_spec
+    (raIn outPtr outVal : Word)
+    (v5 v6 v7 v28 v29 v30 v31 : Word)
+    (hret : raIn &&& ~~~(1 : Word) = raIn) :
+    cpsTripleWithin 2 FailLi raIn pseCode
+      ((.x1 ↦ᵣ raIn) ** (.x10 ↦ᵣ v5) ** (.x11 ↦ᵣ outPtr) **
+        (outPtr ↦ₘ outVal) ** (.x0 ↦ᵣ (0 : Word)) **
+        (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
+        (.x28 ↦ᵣ v28) ** (.x29 ↦ᵣ v29) ** (.x30 ↦ᵣ v30) ** (.x31 ↦ᵣ v31))
+      (postFail raIn outPtr outVal
+        ((.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
+          (.x28 ↦ᵣ v28) ** (.x29 ↦ᵣ v29) ** (.x30 ↦ᵣ v30) ** (.x31 ↦ᵣ v31))) := by
+  have e41 :
+      cpsTripleWithin 1 FailLi FailRet pseCode
+        (.x10 ↦ᵣ v5) (.x10 ↦ᵣ (1 : Word)) := by
+    have h0 := li_spec_gen_within .x10 v5 (1 : Word) FailLi (by decide)
+    have h0' : cpsTripleWithin 1 FailLi (FailLi + 4) pseCode
+        (.x10 ↦ᵣ v5) (.x10 ↦ᵣ (1 : Word)) :=
+      cpsTripleWithin_extend_code
+        (CodeReq.ofProg_mem_at P FailLi pseProg 41
+          (.LI .x10 (1 : Word))
+          (by simp only [FailLi, P, GuestAddrs.eip8037_prior_state_used_exact]; decide)
+          (by rw [pse_length]; decide) rfl
+          (by rw [pse_length]; decide)) h0
+    rwa [FailLi_plus_4] at h0'
+  have e41F := cpsTripleWithin_frameR
+    ((.x1 ↦ᵣ raIn) ** (.x11 ↦ᵣ outPtr) ** (outPtr ↦ₘ outVal) **
+      (.x0 ↦ᵣ (0 : Word)) **
+      (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
+      (.x28 ↦ᵣ v28) ** (.x29 ↦ᵣ v29) ** (.x30 ↦ᵣ v30) ** (.x31 ↦ᵣ v31))
+    (by
+      repeat' first
+        | apply pcFree_sepConj
+        | exact pcFree_regIs
+        | exact pcFree_memIs) e41
+  have hexit :
+      ((raIn + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word)) = raIn := by
+    have hadd : raIn + signExtend12 (0 : BitVec 12) = raIn := by
+      rw [se12_zero]; exact BitVec.add_zero raIn
+    rw [hadd, hret]
+  have e42 :
+      cpsTripleWithin 1 FailRet raIn pseCode
+        (.x1 ↦ᵣ raIn) (.x1 ↦ᵣ raIn) := by
+    have h0 := jalr_x0_spec_gen_within .x1 raIn (0 : BitVec 12) FailRet
+    rw [hexit] at h0
+    exact cpsTripleWithin_extend_code
+      (CodeReq.ofProg_mem_at P FailRet pseProg 42
+        (.JALR .x0 .x1 (0 : BitVec 12))
+        (by simp only [FailRet, P, GuestAddrs.eip8037_prior_state_used_exact]; decide)
+        (by rw [pse_length]; decide) rfl
+        (by rw [pse_length]; decide)) h0
+  have e42F0 := cpsTripleWithin_frameR
+    ((.x10 ↦ᵣ (1 : Word)) ** (.x11 ↦ᵣ outPtr) ** (outPtr ↦ₘ outVal) **
+      (.x0 ↦ᵣ (0 : Word)) **
+      (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
+      (.x28 ↦ᵣ v28) ** (.x29 ↦ᵣ v29) ** (.x30 ↦ᵣ v30) ** (.x31 ↦ᵣ v31))
+    (by
+      repeat' first
+        | apply pcFree_sepConj
+        | exact pcFree_regIs
+        | exact pcFree_memIs) e42
+  have e42F : cpsTripleWithin 1 FailRet raIn pseCode
+      ((.x10 ↦ᵣ (1 : Word)) ** (.x1 ↦ᵣ raIn) ** (.x11 ↦ᵣ outPtr) **
+        (outPtr ↦ₘ outVal) ** (.x0 ↦ᵣ (0 : Word)) **
+        (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
+        (.x28 ↦ᵣ v28) ** (.x29 ↦ᵣ v29) ** (.x30 ↦ᵣ v30) ** (.x31 ↦ᵣ v31))
+      ((.x10 ↦ᵣ (1 : Word)) ** (.x1 ↦ᵣ raIn) ** (.x11 ↦ᵣ outPtr) **
+        (outPtr ↦ₘ outVal) ** (.x0 ↦ᵣ (0 : Word)) **
+        (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
+        (.x28 ↦ᵣ v28) ** (.x29 ↦ᵣ v29) ** (.x30 ↦ᵣ v30) ** (.x31 ↦ᵣ v31)) :=
+    cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
+      (fun _ hq => by xperm_hyp hq) e42F0
+  have c := cpsTripleWithin_seq_perm_same_cr
+    (fun _ hp => by xperm_hyp hp) e41F e42F
+  exact cpsTripleWithin_weaken
+    (fun _ hp => by xperm_hyp hp)
+    (fun _ hq => by
+      dsimp only [postFail] at hq ⊢
+      xperm_hyp hq) c
+
+set_option maxRecDepth 8000 in
+/-- Success tail: LI a0=0; JALR. -/
+theorem pseOkRet_spec
+    (raIn outPtr sumW : Word)
+    (v5 v6 v7 v28 v29 v30 v31 : Word)
+    (hret : raIn &&& ~~~(1 : Word) = raIn) :
+    cpsTripleWithin 2 OkLi raIn pseCode
+      ((.x1 ↦ᵣ raIn) ** (.x10 ↦ᵣ v5) ** (.x11 ↦ᵣ outPtr) **
+        (outPtr ↦ₘ sumW) ** (.x0 ↦ᵣ (0 : Word)) **
+        (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
+        (.x28 ↦ᵣ v28) ** (.x29 ↦ᵣ v29) ** (.x30 ↦ᵣ v30) ** (.x31 ↦ᵣ v31))
+      (postOk raIn outPtr sumW
+        ((.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
+          (.x28 ↦ᵣ v28) ** (.x29 ↦ᵣ v29) ** (.x30 ↦ᵣ v30) ** (.x31 ↦ᵣ v31))) := by
+  have e39 :
+      cpsTripleWithin 1 OkLi OkRet pseCode
+        (.x10 ↦ᵣ v5) (.x10 ↦ᵣ (0 : Word)) := by
+    have h0 := li_spec_gen_within .x10 v5 (0 : Word) OkLi (by decide)
+    have h0' : cpsTripleWithin 1 OkLi (OkLi + 4) pseCode
+        (.x10 ↦ᵣ v5) (.x10 ↦ᵣ (0 : Word)) :=
+      cpsTripleWithin_extend_code
+        (CodeReq.ofProg_mem_at P OkLi pseProg 39
+          (.LI .x10 (0 : Word))
+          (by simp only [OkLi, P, GuestAddrs.eip8037_prior_state_used_exact]; decide)
+          (by rw [pse_length]; decide) rfl
+          (by rw [pse_length]; decide)) h0
+    rwa [OkLi_plus_4] at h0'
+  have e39F := cpsTripleWithin_frameR
+    ((.x1 ↦ᵣ raIn) ** (.x11 ↦ᵣ outPtr) ** (outPtr ↦ₘ sumW) **
+      (.x0 ↦ᵣ (0 : Word)) **
+      (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
+      (.x28 ↦ᵣ v28) ** (.x29 ↦ᵣ v29) ** (.x30 ↦ᵣ v30) ** (.x31 ↦ᵣ v31))
+    (by
+      repeat' first
+        | apply pcFree_sepConj
+        | exact pcFree_regIs
+        | exact pcFree_memIs) e39
+  have hexit :
+      ((raIn + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word)) = raIn := by
+    have hadd : raIn + signExtend12 (0 : BitVec 12) = raIn := by
+      rw [se12_zero]; exact BitVec.add_zero raIn
+    rw [hadd, hret]
+  have e40 :
+      cpsTripleWithin 1 OkRet raIn pseCode
+        (.x1 ↦ᵣ raIn) (.x1 ↦ᵣ raIn) := by
+    have h0 := jalr_x0_spec_gen_within .x1 raIn (0 : BitVec 12) OkRet
+    rw [hexit] at h0
+    exact cpsTripleWithin_extend_code
+      (CodeReq.ofProg_mem_at P OkRet pseProg 40
+        (.JALR .x0 .x1 (0 : BitVec 12))
+        (by simp only [OkRet, P, GuestAddrs.eip8037_prior_state_used_exact]; decide)
+        (by rw [pse_length]; decide) rfl
+        (by rw [pse_length]; decide)) h0
+  have e40F0 := cpsTripleWithin_frameR
+    ((.x10 ↦ᵣ (0 : Word)) ** (.x11 ↦ᵣ outPtr) ** (outPtr ↦ₘ sumW) **
+      (.x0 ↦ᵣ (0 : Word)) **
+      (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
+      (.x28 ↦ᵣ v28) ** (.x29 ↦ᵣ v29) ** (.x30 ↦ᵣ v30) ** (.x31 ↦ᵣ v31))
+    (by
+      repeat' first
+        | apply pcFree_sepConj
+        | exact pcFree_regIs
+        | exact pcFree_memIs) e40
+  have e40F : cpsTripleWithin 1 OkRet raIn pseCode
+      ((.x10 ↦ᵣ (0 : Word)) ** (.x1 ↦ᵣ raIn) ** (.x11 ↦ᵣ outPtr) **
+        (outPtr ↦ₘ sumW) ** (.x0 ↦ᵣ (0 : Word)) **
+        (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
+        (.x28 ↦ᵣ v28) ** (.x29 ↦ᵣ v29) ** (.x30 ↦ᵣ v30) ** (.x31 ↦ᵣ v31))
+      ((.x10 ↦ᵣ (0 : Word)) ** (.x1 ↦ᵣ raIn) ** (.x11 ↦ᵣ outPtr) **
+        (outPtr ↦ₘ sumW) ** (.x0 ↦ᵣ (0 : Word)) **
+        (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
+        (.x28 ↦ᵣ v28) ** (.x29 ↦ᵣ v29) ** (.x30 ↦ᵣ v30) ** (.x31 ↦ᵣ v31)) :=
+    cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
+      (fun _ hq => by xperm_hyp hq) e40F0
+  have c := cpsTripleWithin_seq_perm_same_cr
+    (fun _ hp => by xperm_hyp hp) e39F e40F
+  exact cpsTripleWithin_weaken
+    (fun _ hp => by xperm_hyp hp)
+    (fun _ hq => by
+      dsimp only [postOk] at hq ⊢
+      xperm_hyp hq) c
+
+/-! ## `la` materializations for gate globals -/
+
+private theorem pseLaExactOk (v : Word) :
+    cpsTripleWithin 2 (P + 8) (P + 16) pseCode
+      (.x5 ↦ᵣ v) (.x5 ↦ᵣ ExactOkAddr) := by
+  have hau := CodeReq.ofProg_mem_at P (P + 8) pseProg 2
+    (.AUIPC .x5 (Codegen.laHi GuestAddrs.bsg_exact_state_ok
+      (GuestAddrs.eip8037_prior_state_used_exact + 8)))
+    (by simp only [P, GuestAddrs.eip8037_prior_state_used_exact]; decide)
+    (by rw [pse_length]; decide) rfl (by rw [pse_length]; decide)
+  have had := CodeReq.ofProg_mem_at P (P + 12) pseProg 3
+    (.ADDI .x5 .x5 (Codegen.laLo GuestAddrs.bsg_exact_state_ok
+      (GuestAddrs.eip8037_prior_state_used_exact + 8)))
+    (by simp only [P, GuestAddrs.eip8037_prior_state_used_exact]; decide)
+    (by rw [pse_length]; decide) rfl (by rw [pse_length]; decide)
+  have h := la_materialize_within .x5 v (P + 8) ExactOkAddr
+    (by decide)
+    (by simp only [P, ExactOkAddr, GuestAddrs.eip8037_prior_state_used_exact,
+          GuestAddrs.bsg_exact_state_ok]; decide)
+    hau had
+  rwa [show (P + 8 : Word) + 8 = P + 16 from by
+    simp only [P, GuestAddrs.eip8037_prior_state_used_exact]; decide] at h
+
+private theorem pseLaRuntime (v : Word) :
+    cpsTripleWithin 2 (P + 24) (P + 32) pseCode
+      (.x5 ↦ᵣ v) (.x5 ↦ᵣ RuntimeCountAddr) := by
+  have hau := CodeReq.ofProg_mem_at P (P + 24) pseProg 6
+    (.AUIPC .x5 (Codegen.laHi GuestAddrs.bvgr_runtime_count
+      (GuestAddrs.eip8037_prior_state_used_exact + 24)))
+    (by simp only [P, GuestAddrs.eip8037_prior_state_used_exact]; decide)
+    (by rw [pse_length]; decide) rfl (by rw [pse_length]; decide)
+  have had := CodeReq.ofProg_mem_at P (P + 28) pseProg 7
+    (.ADDI .x5 .x5 (Codegen.laLo GuestAddrs.bvgr_runtime_count
+      (GuestAddrs.eip8037_prior_state_used_exact + 24)))
+    (by simp only [P, GuestAddrs.eip8037_prior_state_used_exact]; decide)
+    (by rw [pse_length]; decide) rfl (by rw [pse_length]; decide)
+  have h := la_materialize_within .x5 v (P + 24) RuntimeCountAddr
+    (by decide)
+    (by simp only [P, RuntimeCountAddr, GuestAddrs.eip8037_prior_state_used_exact,
+          GuestAddrs.bvgr_runtime_count]; decide)
+    hau had
+  rwa [show (P + 24 : Word) + 8 = P + 32 from by
+    simp only [P, GuestAddrs.eip8037_prior_state_used_exact]; decide] at h
+
+/-! ## Gate fail: exact_ok = 0 (after prior ≠ 0) -/
+
+set_option maxRecDepth 8000 in
+/-- From P (entry) with prior≠0 and *exact_ok=0: zero out, fall through BEQ,
+    load exact_ok=0, take fail branch, ret a0=1. -/
+theorem eip8037PriorStateUsedExact_exactOkFail_spec_within
+    (raIn priorW outPtr oldOut : Word)
+    (v5 v6 v7 v28 v29 v30 v31 : Word)
+    (hret : raIn &&& ~~~(1 : Word) = raIn)
+    (hprior : priorW ≠ (0 : Word)) :
+    cpsTripleWithin 8 P raIn pseCode
+      (entryPre raIn priorW outPtr oldOut
+        ((.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
+          (.x28 ↦ᵣ v28) ** (.x29 ↦ᵣ v29) ** (.x30 ↦ᵣ v30) ** (.x31 ↦ᵣ v31) **
+          (ExactOkAddr ↦ₘ (0 : Word))))
+      (postFail raIn outPtr (0 : Word)
+        ((.x5 ↦ᵣ (0 : Word)) ** (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
+          (.x28 ↦ᵣ v28) ** (.x29 ↦ᵣ v29) ** (.x30 ↦ᵣ v30) ** (.x31 ↦ᵣ v31) **
+          (ExactOkAddr ↦ₘ (0 : Word)))) := by
+  -- [0] SD zero *out
+  have haddr : outPtr + signExtend12 (0 : BitVec 12) = outPtr := by
+    rw [se12_zero]; exact BitVec.add_zero outPtr
+  have e0 :
+      cpsTripleWithin 1 P (P + 4) pseCode
+        ((.x11 ↦ᵣ outPtr) ** (.x0 ↦ᵣ (0 : Word)) ** (outPtr ↦ₘ oldOut))
+        ((.x11 ↦ᵣ outPtr) ** (.x0 ↦ᵣ (0 : Word)) ** (outPtr ↦ₘ (0 : Word))) := by
+    have h0 := sd_spec_gen_within .x11 .x0 outPtr (0 : Word) oldOut
+      (0 : BitVec 12) P
+    rw [haddr] at h0
+    exact cpsTripleWithin_extend_code
+      (CodeReq.ofProg_mem_at P P pseProg 0
+        (.SD .x11 .x0 (0 : BitVec 12))
+        (by decide) (by rw [pse_length]; decide) rfl
+        (by rw [pse_length]; decide)) h0
+  have e0F := cpsTripleWithin_frameR
+    ((.x1 ↦ᵣ raIn) ** (.x10 ↦ᵣ priorW) **
+      (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
+      (.x28 ↦ᵣ v28) ** (.x29 ↦ᵣ v29) ** (.x30 ↦ᵣ v30) ** (.x31 ↦ᵣ v31) **
+      (ExactOkAddr ↦ₘ (0 : Word)))
+    (by
+      repeat' first
+        | apply pcFree_sepConj
+        | exact pcFree_regIs
+        | exact pcFree_memIs) e0
+  -- [1] BEQ prior,0 — ntaken
+  have hbr := beq_spec_gen_within .x10 .x0 (152 : BitVec 13) priorW (0 : Word) (P + 4)
+  have hbrC := cpsBranchWithin_extend_code
+    (CodeReq.ofProg_mem_at P (P + 4) pseProg 1
+      (.BEQ .x10 .x0 (152 : BitVec 13))
+      (by simp only [P, GuestAddrs.eip8037_prior_state_used_exact]; decide)
+      (by rw [pse_length]; decide) rfl
+      (by rw [pse_length]; decide)) hbr
+  have hnt0 := cpsBranchWithin_ntakenStripPure2 hbrC (fun _ hq => by
+    obtain ⟨_, _, _, _, _, hrest⟩ := hq
+    exact absurd ((sepConj_pure_right _).1 hrest).2 hprior)
+  have hnt : cpsTripleWithin 1 (P + 4) (P + 8) pseCode
+      ((.x10 ↦ᵣ priorW) ** (.x0 ↦ᵣ (0 : Word)))
+      ((.x10 ↦ᵣ priorW) ** (.x0 ↦ᵣ (0 : Word))) := by
+    rwa [show (P + 4 : Word) + 4 = P + 8 from by
+      simp only [P, GuestAddrs.eip8037_prior_state_used_exact]; decide] at hnt0
+  have e1F := cpsTripleWithin_frameR
+    ((.x1 ↦ᵣ raIn) ** (.x11 ↦ᵣ outPtr) ** (outPtr ↦ₘ (0 : Word)) **
+      (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
+      (.x28 ↦ᵣ v28) ** (.x29 ↦ᵣ v29) ** (.x30 ↦ᵣ v30) ** (.x31 ↦ᵣ v31) **
+      (ExactOkAddr ↦ₘ (0 : Word)))
+    (by
+      repeat' first
+        | apply pcFree_sepConj
+        | exact pcFree_regIs
+        | exact pcFree_memIs) hnt
+  -- [2-3] la exact_ok
+  have e23F := cpsTripleWithin_frameR
+    ((.x1 ↦ᵣ raIn) ** (.x10 ↦ᵣ priorW) ** (.x11 ↦ᵣ outPtr) **
+      (outPtr ↦ₘ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) **
+      (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
+      (.x28 ↦ᵣ v28) ** (.x29 ↦ᵣ v29) ** (.x30 ↦ᵣ v30) ** (.x31 ↦ᵣ v31) **
+      (ExactOkAddr ↦ₘ (0 : Word)))
+    (by
+      repeat' first
+        | apply pcFree_sepConj
+        | exact pcFree_regIs
+        | exact pcFree_memIs) (pseLaExactOk v5)
+  -- [4] LD x5,0(x5) — same-reg load exact_ok=0
+  have e4 :
+      cpsTripleWithin 1 (P + 16) (P + 20) pseCode
+        ((.x5 ↦ᵣ ExactOkAddr) ** (ExactOkAddr ↦ₘ (0 : Word)))
+        ((.x5 ↦ᵣ (0 : Word)) ** (ExactOkAddr ↦ₘ (0 : Word))) := by
+    have haddrE : ExactOkAddr + signExtend12 (0 : BitVec 12) = ExactOkAddr := by
+      rw [se12_zero]; exact BitVec.add_zero ExactOkAddr
+    have h0 := ld_spec_gen_same_within .x5 ExactOkAddr (0 : Word)
+      (0 : BitVec 12) (P + 16) (by decide)
+    rw [haddrE] at h0
+    have h0' : cpsTripleWithin 1 (P + 16) ((P + 16) + 4) pseCode
+        ((.x5 ↦ᵣ ExactOkAddr) ** (ExactOkAddr ↦ₘ (0 : Word)))
+        ((.x5 ↦ᵣ (0 : Word)) ** (ExactOkAddr ↦ₘ (0 : Word))) :=
+      cpsTripleWithin_extend_code
+        (CodeReq.ofProg_mem_at P (P + 16) pseProg 4
+          (.LD .x5 .x5 (0 : BitVec 12))
+          (by simp only [P, GuestAddrs.eip8037_prior_state_used_exact]; decide)
+          (by rw [pse_length]; decide) rfl
+          (by rw [pse_length]; decide)) h0
+    rwa [show (P + 16 : Word) + 4 = P + 20 from by
+      simp only [P, GuestAddrs.eip8037_prior_state_used_exact]; decide] at h0'
+  have e4F := cpsTripleWithin_frameR
+    ((.x1 ↦ᵣ raIn) ** (.x10 ↦ᵣ priorW) ** (.x11 ↦ᵣ outPtr) **
+      (outPtr ↦ₘ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) **
+      (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
+      (.x28 ↦ᵣ v28) ** (.x29 ↦ᵣ v29) ** (.x30 ↦ᵣ v30) ** (.x31 ↦ᵣ v31))
+    (by
+      repeat' first
+        | apply pcFree_sepConj
+        | exact pcFree_regIs
+        | exact pcFree_memIs) e4
+  -- [5] BEQ x5,x0 taken → FailLi
+  have hbr5 := beq_spec_gen_within .x5 .x0 (144 : BitVec 13) (0 : Word) (0 : Word) (P + 20)
+  have hbr5C := cpsBranchWithin_extend_code
+    (CodeReq.ofProg_mem_at P (P + 20) pseProg 5
+      (.BEQ .x5 .x0 (144 : BitVec 13))
+      (by simp only [P, GuestAddrs.eip8037_prior_state_used_exact]; decide)
+      (by rw [pse_length]; decide) rfl
+      (by rw [pse_length]; decide)) hbr5
+  have htk5_0 := cpsBranchWithin_takenStripPure2 hbr5C (fun _ hq => by
+    obtain ⟨_, _, _, _, _, hrest⟩ := hq
+    exact absurd rfl ((sepConj_pure_right _).1 hrest).2)
+  have htk5 : cpsTripleWithin 1 (P + 20) FailLi pseCode
+      ((.x5 ↦ᵣ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)))
+      ((.x5 ↦ᵣ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word))) := by
+    rwa [P20_plus_144] at htk5_0
+  have e5F := cpsTripleWithin_frameR
+    ((.x1 ↦ᵣ raIn) ** (.x10 ↦ᵣ priorW) ** (.x11 ↦ᵣ outPtr) **
+      (outPtr ↦ₘ (0 : Word)) **
+      (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
+      (.x28 ↦ᵣ v28) ** (.x29 ↦ᵣ v29) ** (.x30 ↦ᵣ v30) ** (.x31 ↦ᵣ v31) **
+      (ExactOkAddr ↦ₘ (0 : Word)))
+    (by
+      repeat' first
+        | apply pcFree_sepConj
+        | exact pcFree_regIs
+        | exact pcFree_memIs) htk5
+  -- Fail ret: a0 was priorW, LI overwrites to 1; frame ExactOkAddr through.
+  have eFail' : cpsTripleWithin 2 FailLi raIn pseCode
+      ((.x1 ↦ᵣ raIn) ** (.x10 ↦ᵣ priorW) ** (.x11 ↦ᵣ outPtr) **
+        (outPtr ↦ₘ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) **
+        (.x5 ↦ᵣ (0 : Word)) ** (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
+        (.x28 ↦ᵣ v28) ** (.x29 ↦ᵣ v29) ** (.x30 ↦ᵣ v30) ** (.x31 ↦ᵣ v31) **
+        (ExactOkAddr ↦ₘ (0 : Word)))
+      (postFail raIn outPtr (0 : Word)
+        ((.x5 ↦ᵣ (0 : Word)) ** (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
+          (.x28 ↦ᵣ v28) ** (.x29 ↦ᵣ v29) ** (.x30 ↦ᵣ v30) ** (.x31 ↦ᵣ v31) **
+          (ExactOkAddr ↦ₘ (0 : Word)))) := by
+    have e41 :
+        cpsTripleWithin 1 FailLi FailRet pseCode
+          (.x10 ↦ᵣ priorW) (.x10 ↦ᵣ (1 : Word)) := by
+      have h0 := li_spec_gen_within .x10 priorW (1 : Word) FailLi (by decide)
+      have h0' : cpsTripleWithin 1 FailLi (FailLi + 4) pseCode
+          (.x10 ↦ᵣ priorW) (.x10 ↦ᵣ (1 : Word)) :=
+        cpsTripleWithin_extend_code
+          (CodeReq.ofProg_mem_at P FailLi pseProg 41
+            (.LI .x10 (1 : Word))
+            (by simp only [FailLi, P, GuestAddrs.eip8037_prior_state_used_exact]; decide)
+            (by rw [pse_length]; decide) rfl
+            (by rw [pse_length]; decide)) h0
+      rwa [FailLi_plus_4] at h0'
+    have e41F := cpsTripleWithin_frameR
+      ((.x1 ↦ᵣ raIn) ** (.x11 ↦ᵣ outPtr) ** (outPtr ↦ₘ (0 : Word)) **
+        (.x0 ↦ᵣ (0 : Word)) **
+        (.x5 ↦ᵣ (0 : Word)) ** (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
+        (.x28 ↦ᵣ v28) ** (.x29 ↦ᵣ v29) ** (.x30 ↦ᵣ v30) ** (.x31 ↦ᵣ v31) **
+        (ExactOkAddr ↦ₘ (0 : Word)))
+      (by
+        repeat' first
+          | apply pcFree_sepConj
+          | exact pcFree_regIs
+          | exact pcFree_memIs) e41
+    have hexit :
+        ((raIn + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word)) = raIn := by
+      have hadd : raIn + signExtend12 (0 : BitVec 12) = raIn := by
+        rw [se12_zero]; exact BitVec.add_zero raIn
+      rw [hadd, hret]
+    have e42 :
+        cpsTripleWithin 1 FailRet raIn pseCode
+          (.x1 ↦ᵣ raIn) (.x1 ↦ᵣ raIn) := by
+      have h0 := jalr_x0_spec_gen_within .x1 raIn (0 : BitVec 12) FailRet
+      rw [hexit] at h0
+      exact cpsTripleWithin_extend_code
+        (CodeReq.ofProg_mem_at P FailRet pseProg 42
+          (.JALR .x0 .x1 (0 : BitVec 12))
+          (by simp only [FailRet, P, GuestAddrs.eip8037_prior_state_used_exact]; decide)
+          (by rw [pse_length]; decide) rfl
+          (by rw [pse_length]; decide)) h0
+    have e42F0 := cpsTripleWithin_frameR
+      ((.x10 ↦ᵣ (1 : Word)) ** (.x11 ↦ᵣ outPtr) ** (outPtr ↦ₘ (0 : Word)) **
+        (.x0 ↦ᵣ (0 : Word)) **
+        (.x5 ↦ᵣ (0 : Word)) ** (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
+        (.x28 ↦ᵣ v28) ** (.x29 ↦ᵣ v29) ** (.x30 ↦ᵣ v30) ** (.x31 ↦ᵣ v31) **
+        (ExactOkAddr ↦ₘ (0 : Word)))
+      (by
+        repeat' first
+          | apply pcFree_sepConj
+          | exact pcFree_regIs
+          | exact pcFree_memIs) e42
+    have e42F : cpsTripleWithin 1 FailRet raIn pseCode
+        ((.x10 ↦ᵣ (1 : Word)) ** (.x1 ↦ᵣ raIn) ** (.x11 ↦ᵣ outPtr) **
+          (outPtr ↦ₘ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) **
+          (.x5 ↦ᵣ (0 : Word)) ** (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
+          (.x28 ↦ᵣ v28) ** (.x29 ↦ᵣ v29) ** (.x30 ↦ᵣ v30) ** (.x31 ↦ᵣ v31) **
+          (ExactOkAddr ↦ₘ (0 : Word)))
+        ((.x10 ↦ᵣ (1 : Word)) ** (.x1 ↦ᵣ raIn) ** (.x11 ↦ᵣ outPtr) **
+          (outPtr ↦ₘ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) **
+          (.x5 ↦ᵣ (0 : Word)) ** (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
+          (.x28 ↦ᵣ v28) ** (.x29 ↦ᵣ v29) ** (.x30 ↦ᵣ v30) ** (.x31 ↦ᵣ v31) **
+          (ExactOkAddr ↦ₘ (0 : Word))) :=
+      cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
+        (fun _ hq => by xperm_hyp hq) e42F0
+    have c := cpsTripleWithin_seq_perm_same_cr
+      (fun _ hp => by xperm_hyp hp) e41F e42F
+    exact cpsTripleWithin_weaken
+      (fun _ hp => by xperm_hyp hp)
+      (fun _ hq => by
+        dsimp only [postFail] at hq ⊢
+        xperm_hyp hq) c
+  have c01 := cpsTripleWithin_seq_perm_same_cr
+    (fun _ hp => by xperm_hyp hp) e0F e1F
+  have c02 := cpsTripleWithin_seq_perm_same_cr
+    (fun _ hp => by xperm_hyp hp) c01 e23F
+  have c03 := cpsTripleWithin_seq_perm_same_cr
+    (fun _ hp => by xperm_hyp hp) c02 e4F
+  have c04 := cpsTripleWithin_seq_perm_same_cr
+    (fun _ hp => by xperm_hyp hp) c03 e5F
+  have c05 := cpsTripleWithin_seq_perm_same_cr
+    (fun _ hp => by xperm_hyp hp) c04 eFail'
+  change cpsTripleWithin (1 + 1 + 2 + 1 + 1 + 2) P raIn pseCode _ _ at c05
+  exact cpsTripleWithin_weaken
+    (fun _ hp => by
+      dsimp only [entryPre] at hp ⊢
+      xperm_hyp hp)
+    (fun _ hq => by
+      dsimp only [postFail] at hq ⊢
+      xperm_hyp hq) c05
+
+#print axioms eip8037PriorStateUsedExact_exactOkFail_spec_within
+#print axioms pseFailRet_spec
+#print axioms pseOkRet_spec
 
 end EvmAsm.Codegen.Eip8037PriorStateUsedExactSpec

--- a/EvmAsm/Codegen/Programs/Eip8037PriorStateUsedExactSpec.lean
+++ b/EvmAsm/Codegen/Programs/Eip8037PriorStateUsedExactSpec.lean
@@ -682,4 +682,374 @@ theorem eip8037PriorStateUsedExact_exactOkFail_spec_within
 #print axioms pseFailRet_spec
 #print axioms pseOkRet_spec
 
+/-! ## Gate success → LoopGuard (prior≠0, gates hold) -/
+
+/-- Loop-entry regs after gates: n=prior, i=0, sum=0; *out already zeroed. -/
+def loopEntry
+    (raIn priorW outPtr exactOkW runtimeW : Word)
+    (v28 v29 v30 v31 : Word) : Assertion :=
+  (.x1 ↦ᵣ raIn) ** (.x10 ↦ᵣ priorW) ** (.x11 ↦ᵣ outPtr) **
+    (outPtr ↦ₘ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) **
+    (.x5 ↦ᵣ priorW) ** (.x6 ↦ᵣ (0 : Word)) ** (.x7 ↦ᵣ (0 : Word)) **
+    (.x28 ↦ᵣ v28) ** (.x29 ↦ᵣ v29) ** (.x30 ↦ᵣ v30) ** (.x31 ↦ᵣ v31) **
+    (ExactOkAddr ↦ₘ exactOkW) ** (RuntimeCountAddr ↦ₘ runtimeW)
+
+def nGateSteps : Nat := 15
+
+private theorem P36_plus_4 : P + 36 + 4 = P + 40 := by
+  simp only [P, GuestAddrs.eip8037_prior_state_used_exact]; decide
+private theorem P40_plus_4 : P + 40 + 4 = P + 44 := by
+  simp only [P, GuestAddrs.eip8037_prior_state_used_exact]; decide
+private theorem P44_plus_4 : P + 44 + 4 = P + 48 := by
+  simp only [P, GuestAddrs.eip8037_prior_state_used_exact]; decide
+private theorem P48_plus_4 : P + 48 + 4 = P + 52 := by
+  simp only [P, GuestAddrs.eip8037_prior_state_used_exact]; decide
+private theorem P52_plus_4 : P + 52 + 4 = P + 56 := by
+  simp only [P, GuestAddrs.eip8037_prior_state_used_exact]; decide
+private theorem P56_plus_4 : P + 56 + 4 = LoopGuard := by
+  simp only [LoopGuard, P, GuestAddrs.eip8037_prior_state_used_exact]; decide
+private theorem P32_plus_4 : P + 32 + 4 = P + 36 := by
+  simp only [P, GuestAddrs.eip8037_prior_state_used_exact]; decide
+private theorem P20_plus_4 : P + 20 + 4 = P + 24 := by
+  simp only [P, GuestAddrs.eip8037_prior_state_used_exact]; decide
+private theorem P16_plus_4 : P + 16 + 4 = P + 20 := by
+  simp only [P, GuestAddrs.eip8037_prior_state_used_exact]; decide
+private theorem P8_plus_8 : P + 8 + 8 = P + 16 := by
+  simp only [P, GuestAddrs.eip8037_prior_state_used_exact]; decide
+private theorem P4_plus_4 : P + 4 + 4 = P + 8 := by
+  simp only [P, GuestAddrs.eip8037_prior_state_used_exact]; decide
+
+set_option maxRecDepth 8000 in
+/-- Entry → LoopGuard under prior≠0 and gate hyps (exactOk≠0, runtime≥prior, prior≤16). -/
+theorem eip8037PriorStateUsedExact_gatesToLoop_spec_within
+    (raIn priorW outPtr oldOut exactOkW runtimeW : Word)
+    (v5 v6 v7 v28 v29 v30 v31 : Word)
+    (hprior : priorW ≠ (0 : Word))
+    (hexact : exactOkW ≠ (0 : Word))
+    (hruntime : ¬ BitVec.ult runtimeW priorW)
+    (hpriorLe16 : ¬ BitVec.ult (16 : Word) priorW) :
+    cpsTripleWithin nGateSteps P LoopGuard pseCode
+      (entryPre raIn priorW outPtr oldOut
+        ((.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
+          (.x28 ↦ᵣ v28) ** (.x29 ↦ᵣ v29) ** (.x30 ↦ᵣ v30) ** (.x31 ↦ᵣ v31) **
+          (ExactOkAddr ↦ₘ exactOkW) ** (RuntimeCountAddr ↦ₘ runtimeW)))
+      (loopEntry raIn priorW outPtr exactOkW runtimeW v28 v29 v30 v31) := by
+  -- [0] SD
+  have haddr : outPtr + signExtend12 (0 : BitVec 12) = outPtr := by
+    rw [se12_zero]; exact BitVec.add_zero outPtr
+  have e0 :
+      cpsTripleWithin 1 P (P + 4) pseCode
+        ((.x11 ↦ᵣ outPtr) ** (.x0 ↦ᵣ (0 : Word)) ** (outPtr ↦ₘ oldOut))
+        ((.x11 ↦ᵣ outPtr) ** (.x0 ↦ᵣ (0 : Word)) ** (outPtr ↦ₘ (0 : Word))) := by
+    have h0 := sd_spec_gen_within .x11 .x0 outPtr (0 : Word) oldOut (0 : BitVec 12) P
+    rw [haddr] at h0
+    exact cpsTripleWithin_extend_code
+      (CodeReq.ofProg_mem_at P P pseProg 0 (.SD .x11 .x0 (0 : BitVec 12))
+        (by decide) (by rw [pse_length]; decide) rfl (by rw [pse_length]; decide)) h0
+  have e0F := cpsTripleWithin_frameR
+    ((.x1 ↦ᵣ raIn) ** (.x10 ↦ᵣ priorW) **
+      (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
+      (.x28 ↦ᵣ v28) ** (.x29 ↦ᵣ v29) ** (.x30 ↦ᵣ v30) ** (.x31 ↦ᵣ v31) **
+      (ExactOkAddr ↦ₘ exactOkW) ** (RuntimeCountAddr ↦ₘ runtimeW))
+    (by
+      repeat' first
+        | apply pcFree_sepConj
+        | exact pcFree_regIs
+        | exact pcFree_memIs) e0
+  -- [1] BEQ prior ntaken
+  have hbr := beq_spec_gen_within .x10 .x0 (152 : BitVec 13) priorW (0 : Word) (P + 4)
+  have hbrC := cpsBranchWithin_extend_code
+    (CodeReq.ofProg_mem_at P (P + 4) pseProg 1 (.BEQ .x10 .x0 (152 : BitVec 13))
+      (by simp only [P, GuestAddrs.eip8037_prior_state_used_exact]; decide)
+      (by rw [pse_length]; decide) rfl (by rw [pse_length]; decide)) hbr
+  have hnt0 := cpsBranchWithin_ntakenStripPure2 hbrC (fun _ hq => by
+    obtain ⟨_, _, _, _, _, hrest⟩ := hq
+    exact absurd ((sepConj_pure_right _).1 hrest).2 hprior)
+  have hnt : cpsTripleWithin 1 (P + 4) (P + 8) pseCode
+      ((.x10 ↦ᵣ priorW) ** (.x0 ↦ᵣ (0 : Word)))
+      ((.x10 ↦ᵣ priorW) ** (.x0 ↦ᵣ (0 : Word))) := by
+    rwa [P4_plus_4] at hnt0
+  have e1F := cpsTripleWithin_frameR
+    ((.x1 ↦ᵣ raIn) ** (.x11 ↦ᵣ outPtr) ** (outPtr ↦ₘ (0 : Word)) **
+      (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
+      (.x28 ↦ᵣ v28) ** (.x29 ↦ᵣ v29) ** (.x30 ↦ᵣ v30) ** (.x31 ↦ᵣ v31) **
+      (ExactOkAddr ↦ₘ exactOkW) ** (RuntimeCountAddr ↦ₘ runtimeW))
+    (by
+      repeat' first
+        | apply pcFree_sepConj
+        | exact pcFree_regIs
+        | exact pcFree_memIs) hnt
+  -- [2-3] la exact_ok
+  have e23F := cpsTripleWithin_frameR
+    ((.x1 ↦ᵣ raIn) ** (.x10 ↦ᵣ priorW) ** (.x11 ↦ᵣ outPtr) **
+      (outPtr ↦ₘ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) **
+      (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
+      (.x28 ↦ᵣ v28) ** (.x29 ↦ᵣ v29) ** (.x30 ↦ᵣ v30) ** (.x31 ↦ᵣ v31) **
+      (ExactOkAddr ↦ₘ exactOkW) ** (RuntimeCountAddr ↦ₘ runtimeW))
+    (by
+      repeat' first
+        | apply pcFree_sepConj
+        | exact pcFree_regIs
+        | exact pcFree_memIs) (pseLaExactOk v5)
+  -- [4] LD exact_ok
+  have haddrE : ExactOkAddr + signExtend12 (0 : BitVec 12) = ExactOkAddr := by
+    rw [se12_zero]; exact BitVec.add_zero ExactOkAddr
+  have e4 :
+      cpsTripleWithin 1 (P + 16) (P + 20) pseCode
+        ((.x5 ↦ᵣ ExactOkAddr) ** (ExactOkAddr ↦ₘ exactOkW))
+        ((.x5 ↦ᵣ exactOkW) ** (ExactOkAddr ↦ₘ exactOkW)) := by
+    have h0 := ld_spec_gen_same_within .x5 ExactOkAddr exactOkW
+      (0 : BitVec 12) (P + 16) (by decide)
+    rw [haddrE] at h0
+    have h0' : cpsTripleWithin 1 (P + 16) ((P + 16) + 4) pseCode
+        ((.x5 ↦ᵣ ExactOkAddr) ** (ExactOkAddr ↦ₘ exactOkW))
+        ((.x5 ↦ᵣ exactOkW) ** (ExactOkAddr ↦ₘ exactOkW)) :=
+      cpsTripleWithin_extend_code
+        (CodeReq.ofProg_mem_at P (P + 16) pseProg 4 (.LD .x5 .x5 (0 : BitVec 12))
+          (by simp only [P, GuestAddrs.eip8037_prior_state_used_exact]; decide)
+          (by rw [pse_length]; decide) rfl (by rw [pse_length]; decide)) h0
+    rwa [P16_plus_4] at h0'
+  have e4F := cpsTripleWithin_frameR
+    ((.x1 ↦ᵣ raIn) ** (.x10 ↦ᵣ priorW) ** (.x11 ↦ᵣ outPtr) **
+      (outPtr ↦ₘ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) **
+      (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
+      (.x28 ↦ᵣ v28) ** (.x29 ↦ᵣ v29) ** (.x30 ↦ᵣ v30) ** (.x31 ↦ᵣ v31) **
+      (RuntimeCountAddr ↦ₘ runtimeW))
+    (by
+      repeat' first
+        | apply pcFree_sepConj
+        | exact pcFree_regIs
+        | exact pcFree_memIs) e4
+  -- [5] BEQ exact_ok ntaken
+  have hbr5 := beq_spec_gen_within .x5 .x0 (144 : BitVec 13) exactOkW (0 : Word) (P + 20)
+  have hbr5C := cpsBranchWithin_extend_code
+    (CodeReq.ofProg_mem_at P (P + 20) pseProg 5 (.BEQ .x5 .x0 (144 : BitVec 13))
+      (by simp only [P, GuestAddrs.eip8037_prior_state_used_exact]; decide)
+      (by rw [pse_length]; decide) rfl (by rw [pse_length]; decide)) hbr5
+  have hnt5_0 := cpsBranchWithin_ntakenStripPure2 hbr5C (fun _ hq => by
+    obtain ⟨_, _, _, _, _, hrest⟩ := hq
+    exact absurd ((sepConj_pure_right _).1 hrest).2 hexact)
+  have hnt5 : cpsTripleWithin 1 (P + 20) (P + 24) pseCode
+      ((.x5 ↦ᵣ exactOkW) ** (.x0 ↦ᵣ (0 : Word)))
+      ((.x5 ↦ᵣ exactOkW) ** (.x0 ↦ᵣ (0 : Word))) := by
+    rwa [P20_plus_4] at hnt5_0
+  have e5F := cpsTripleWithin_frameR
+    ((.x1 ↦ᵣ raIn) ** (.x10 ↦ᵣ priorW) ** (.x11 ↦ᵣ outPtr) **
+      (outPtr ↦ₘ (0 : Word)) **
+      (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
+      (.x28 ↦ᵣ v28) ** (.x29 ↦ᵣ v29) ** (.x30 ↦ᵣ v30) ** (.x31 ↦ᵣ v31) **
+      (ExactOkAddr ↦ₘ exactOkW) ** (RuntimeCountAddr ↦ₘ runtimeW))
+    (by
+      repeat' first
+        | apply pcFree_sepConj
+        | exact pcFree_regIs
+        | exact pcFree_memIs) hnt5
+  -- [6-7] la runtime
+  have e67F := cpsTripleWithin_frameR
+    ((.x1 ↦ᵣ raIn) ** (.x10 ↦ᵣ priorW) ** (.x11 ↦ᵣ outPtr) **
+      (outPtr ↦ₘ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) **
+      (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
+      (.x28 ↦ᵣ v28) ** (.x29 ↦ᵣ v29) ** (.x30 ↦ᵣ v30) ** (.x31 ↦ᵣ v31) **
+      (ExactOkAddr ↦ₘ exactOkW) ** (RuntimeCountAddr ↦ₘ runtimeW))
+    (by
+      repeat' first
+        | apply pcFree_sepConj
+        | exact pcFree_regIs
+        | exact pcFree_memIs) (pseLaRuntime exactOkW)
+  -- [8] LD runtime
+  have haddrR : RuntimeCountAddr + signExtend12 (0 : BitVec 12) = RuntimeCountAddr := by
+    rw [se12_zero]; exact BitVec.add_zero RuntimeCountAddr
+  have e8 :
+      cpsTripleWithin 1 (P + 32) (P + 36) pseCode
+        ((.x5 ↦ᵣ RuntimeCountAddr) ** (RuntimeCountAddr ↦ₘ runtimeW))
+        ((.x5 ↦ᵣ runtimeW) ** (RuntimeCountAddr ↦ₘ runtimeW)) := by
+    have h0 := ld_spec_gen_same_within .x5 RuntimeCountAddr runtimeW
+      (0 : BitVec 12) (P + 32) (by decide)
+    rw [haddrR] at h0
+    have h0' : cpsTripleWithin 1 (P + 32) ((P + 32) + 4) pseCode
+        ((.x5 ↦ᵣ RuntimeCountAddr) ** (RuntimeCountAddr ↦ₘ runtimeW))
+        ((.x5 ↦ᵣ runtimeW) ** (RuntimeCountAddr ↦ₘ runtimeW)) :=
+      cpsTripleWithin_extend_code
+        (CodeReq.ofProg_mem_at P (P + 32) pseProg 8 (.LD .x5 .x5 (0 : BitVec 12))
+          (by simp only [P, GuestAddrs.eip8037_prior_state_used_exact]; decide)
+          (by rw [pse_length]; decide) rfl (by rw [pse_length]; decide)) h0
+    rwa [P32_plus_4] at h0'
+  have e8F := cpsTripleWithin_frameR
+    ((.x1 ↦ᵣ raIn) ** (.x10 ↦ᵣ priorW) ** (.x11 ↦ᵣ outPtr) **
+      (outPtr ↦ₘ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) **
+      (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
+      (.x28 ↦ᵣ v28) ** (.x29 ↦ᵣ v29) ** (.x30 ↦ᵣ v30) ** (.x31 ↦ᵣ v31) **
+      (ExactOkAddr ↦ₘ exactOkW))
+    (by
+      repeat' first
+        | apply pcFree_sepConj
+        | exact pcFree_regIs
+        | exact pcFree_memIs) e8
+  -- [9] BLTU runtime,prior ntaken
+  have hbr9 := bltu_spec_gen_within .x5 .x10 (128 : BitVec 13) runtimeW priorW (P + 36)
+  have hbr9C := cpsBranchWithin_extend_code
+    (CodeReq.ofProg_mem_at P (P + 36) pseProg 9 (.BLTU .x5 .x10 (128 : BitVec 13))
+      (by simp only [P, GuestAddrs.eip8037_prior_state_used_exact]; decide)
+      (by rw [pse_length]; decide) rfl (by rw [pse_length]; decide)) hbr9
+  have hnt9_0 := cpsBranchWithin_ntakenStripPure2 hbr9C (fun _ hq => by
+    obtain ⟨_, _, _, _, _, hrest⟩ := hq
+    exact absurd ((sepConj_pure_right _).1 hrest).2 hruntime)
+  have hnt9 : cpsTripleWithin 1 (P + 36) (P + 40) pseCode
+      ((.x5 ↦ᵣ runtimeW) ** (.x10 ↦ᵣ priorW))
+      ((.x5 ↦ᵣ runtimeW) ** (.x10 ↦ᵣ priorW)) := by
+    rwa [P36_plus_4] at hnt9_0
+  have e9F := cpsTripleWithin_frameR
+    ((.x1 ↦ᵣ raIn) ** (.x11 ↦ᵣ outPtr) ** (outPtr ↦ₘ (0 : Word)) **
+      (.x0 ↦ᵣ (0 : Word)) **
+      (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
+      (.x28 ↦ᵣ v28) ** (.x29 ↦ᵣ v29) ** (.x30 ↦ᵣ v30) ** (.x31 ↦ᵣ v31) **
+      (ExactOkAddr ↦ₘ exactOkW) ** (RuntimeCountAddr ↦ₘ runtimeW))
+    (by
+      repeat' first
+        | apply pcFree_sepConj
+        | exact pcFree_regIs
+        | exact pcFree_memIs) hnt9
+  -- [10] LI x5,16
+  have e10 :
+      cpsTripleWithin 1 (P + 40) (P + 44) pseCode
+        (.x5 ↦ᵣ runtimeW) (.x5 ↦ᵣ (16 : Word)) := by
+    have h0 := li_spec_gen_within .x5 runtimeW (16 : Word) (P + 40) (by decide)
+    have h0' : cpsTripleWithin 1 (P + 40) ((P + 40) + 4) pseCode
+        (.x5 ↦ᵣ runtimeW) (.x5 ↦ᵣ (16 : Word)) :=
+      cpsTripleWithin_extend_code
+        (CodeReq.ofProg_mem_at P (P + 40) pseProg 10 (.LI .x5 (16 : Word))
+          (by simp only [P, GuestAddrs.eip8037_prior_state_used_exact]; decide)
+          (by rw [pse_length]; decide) rfl (by rw [pse_length]; decide)) h0
+    rwa [P40_plus_4] at h0'
+  have e10F := cpsTripleWithin_frameR
+    ((.x1 ↦ᵣ raIn) ** (.x10 ↦ᵣ priorW) ** (.x11 ↦ᵣ outPtr) **
+      (outPtr ↦ₘ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) **
+      (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
+      (.x28 ↦ᵣ v28) ** (.x29 ↦ᵣ v29) ** (.x30 ↦ᵣ v30) ** (.x31 ↦ᵣ v31) **
+      (ExactOkAddr ↦ₘ exactOkW) ** (RuntimeCountAddr ↦ₘ runtimeW))
+    (by
+      repeat' first
+        | apply pcFree_sepConj
+        | exact pcFree_regIs
+        | exact pcFree_memIs) e10
+  -- [11] BLTU 16,prior ntaken
+  have hbr11 := bltu_spec_gen_within .x5 .x10 (120 : BitVec 13) (16 : Word) priorW (P + 44)
+  have hbr11C := cpsBranchWithin_extend_code
+    (CodeReq.ofProg_mem_at P (P + 44) pseProg 11 (.BLTU .x5 .x10 (120 : BitVec 13))
+      (by simp only [P, GuestAddrs.eip8037_prior_state_used_exact]; decide)
+      (by rw [pse_length]; decide) rfl (by rw [pse_length]; decide)) hbr11
+  have hnt11_0 := cpsBranchWithin_ntakenStripPure2 hbr11C (fun _ hq => by
+    obtain ⟨_, _, _, _, _, hrest⟩ := hq
+    exact absurd ((sepConj_pure_right _).1 hrest).2 hpriorLe16)
+  have hnt11 : cpsTripleWithin 1 (P + 44) (P + 48) pseCode
+      ((.x5 ↦ᵣ (16 : Word)) ** (.x10 ↦ᵣ priorW))
+      ((.x5 ↦ᵣ (16 : Word)) ** (.x10 ↦ᵣ priorW)) := by
+    rwa [P44_plus_4] at hnt11_0
+  have e11F := cpsTripleWithin_frameR
+    ((.x1 ↦ᵣ raIn) ** (.x11 ↦ᵣ outPtr) ** (outPtr ↦ₘ (0 : Word)) **
+      (.x0 ↦ᵣ (0 : Word)) **
+      (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
+      (.x28 ↦ᵣ v28) ** (.x29 ↦ᵣ v29) ** (.x30 ↦ᵣ v30) ** (.x31 ↦ᵣ v31) **
+      (ExactOkAddr ↦ₘ exactOkW) ** (RuntimeCountAddr ↦ₘ runtimeW))
+    (by
+      repeat' first
+        | apply pcFree_sepConj
+        | exact pcFree_regIs
+        | exact pcFree_memIs) hnt11
+  -- [12] MV x5,x10 → n=prior
+  have e12 :
+      cpsTripleWithin 1 (P + 48) (P + 52) pseCode
+        ((.x10 ↦ᵣ priorW) ** (.x5 ↦ᵣ (16 : Word)))
+        ((.x10 ↦ᵣ priorW) ** (.x5 ↦ᵣ priorW)) := by
+    have h0 := mv_spec_gen_within .x5 .x10 priorW (16 : Word) (P + 48) (by decide)
+    have h0' : cpsTripleWithin 1 (P + 48) ((P + 48) + 4) pseCode
+        ((.x10 ↦ᵣ priorW) ** (.x5 ↦ᵣ (16 : Word)))
+        ((.x10 ↦ᵣ priorW) ** (.x5 ↦ᵣ priorW)) :=
+      cpsTripleWithin_extend_code
+        (CodeReq.ofProg_mem_at P (P + 48) pseProg 12 (.MV .x5 .x10)
+          (by simp only [P, GuestAddrs.eip8037_prior_state_used_exact]; decide)
+          (by rw [pse_length]; decide) rfl (by rw [pse_length]; decide)) h0
+    rwa [P48_plus_4] at h0'
+  have e12F := cpsTripleWithin_frameR
+    ((.x1 ↦ᵣ raIn) ** (.x11 ↦ᵣ outPtr) ** (outPtr ↦ₘ (0 : Word)) **
+      (.x0 ↦ᵣ (0 : Word)) **
+      (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
+      (.x28 ↦ᵣ v28) ** (.x29 ↦ᵣ v29) ** (.x30 ↦ᵣ v30) ** (.x31 ↦ᵣ v31) **
+      (ExactOkAddr ↦ₘ exactOkW) ** (RuntimeCountAddr ↦ₘ runtimeW))
+    (by
+      repeat' first
+        | apply pcFree_sepConj
+        | exact pcFree_regIs
+        | exact pcFree_memIs) e12
+  -- [13] LI x6,0
+  have e13 :
+      cpsTripleWithin 1 (P + 52) (P + 56) pseCode
+        (.x6 ↦ᵣ v6) (.x6 ↦ᵣ (0 : Word)) := by
+    have h0 := li_spec_gen_within .x6 v6 (0 : Word) (P + 52) (by decide)
+    have h0' : cpsTripleWithin 1 (P + 52) ((P + 52) + 4) pseCode
+        (.x6 ↦ᵣ v6) (.x6 ↦ᵣ (0 : Word)) :=
+      cpsTripleWithin_extend_code
+        (CodeReq.ofProg_mem_at P (P + 52) pseProg 13 (.LI .x6 (0 : Word))
+          (by simp only [P, GuestAddrs.eip8037_prior_state_used_exact]; decide)
+          (by rw [pse_length]; decide) rfl (by rw [pse_length]; decide)) h0
+    rwa [P52_plus_4] at h0'
+  have e13F := cpsTripleWithin_frameR
+    ((.x1 ↦ᵣ raIn) ** (.x10 ↦ᵣ priorW) ** (.x11 ↦ᵣ outPtr) **
+      (outPtr ↦ₘ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) **
+      (.x5 ↦ᵣ priorW) ** (.x7 ↦ᵣ v7) **
+      (.x28 ↦ᵣ v28) ** (.x29 ↦ᵣ v29) ** (.x30 ↦ᵣ v30) ** (.x31 ↦ᵣ v31) **
+      (ExactOkAddr ↦ₘ exactOkW) ** (RuntimeCountAddr ↦ₘ runtimeW))
+    (by
+      repeat' first
+        | apply pcFree_sepConj
+        | exact pcFree_regIs
+        | exact pcFree_memIs) e13
+  -- [14] LI x7,0
+  have e14 :
+      cpsTripleWithin 1 (P + 56) LoopGuard pseCode
+        (.x7 ↦ᵣ v7) (.x7 ↦ᵣ (0 : Word)) := by
+    have h0 := li_spec_gen_within .x7 v7 (0 : Word) (P + 56) (by decide)
+    have h0' : cpsTripleWithin 1 (P + 56) ((P + 56) + 4) pseCode
+        (.x7 ↦ᵣ v7) (.x7 ↦ᵣ (0 : Word)) :=
+      cpsTripleWithin_extend_code
+        (CodeReq.ofProg_mem_at P (P + 56) pseProg 14 (.LI .x7 (0 : Word))
+          (by simp only [P, GuestAddrs.eip8037_prior_state_used_exact]; decide)
+          (by rw [pse_length]; decide) rfl (by rw [pse_length]; decide)) h0
+    rwa [P56_plus_4] at h0'
+  have e14F := cpsTripleWithin_frameR
+    ((.x1 ↦ᵣ raIn) ** (.x10 ↦ᵣ priorW) ** (.x11 ↦ᵣ outPtr) **
+      (outPtr ↦ₘ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) **
+      (.x5 ↦ᵣ priorW) ** (.x6 ↦ᵣ (0 : Word)) **
+      (.x28 ↦ᵣ v28) ** (.x29 ↦ᵣ v29) ** (.x30 ↦ᵣ v30) ** (.x31 ↦ᵣ v31) **
+      (ExactOkAddr ↦ₘ exactOkW) ** (RuntimeCountAddr ↦ₘ runtimeW))
+    (by
+      repeat' first
+        | apply pcFree_sepConj
+        | exact pcFree_regIs
+        | exact pcFree_memIs) e14
+  -- compose
+  have c01 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) e0F e1F
+  have c02 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) c01 e23F
+  have c03 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) c02 e4F
+  have c04 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) c03 e5F
+  have c05 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) c04 e67F
+  have c06 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) c05 e8F
+  have c07 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) c06 e9F
+  have c08 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) c07 e10F
+  have c09 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) c08 e11F
+  have c10 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) c09 e12F
+  have c11 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) c10 e13F
+  have c12 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) c11 e14F
+  change cpsTripleWithin
+    (1+1+2+1+1+2+1+1+1+1+1+1+1) P LoopGuard pseCode _ _ at c12
+  exact cpsTripleWithin_weaken
+    (fun _ hp => by
+      dsimp only [entryPre, nGateSteps] at hp ⊢
+      xperm_hyp hp)
+    (fun _ hq => by
+      dsimp only [loopEntry, nGateSteps] at hq ⊢
+      xperm_hyp hq) c12
+
+#print axioms eip8037PriorStateUsedExact_gatesToLoop_spec_within
+
 end EvmAsm.Codegen.Eip8037PriorStateUsedExactSpec

--- a/EvmAsm/Codegen/Programs/Eip8037PriorStateUsedExactStatusNez.lean
+++ b/EvmAsm/Codegen/Programs/Eip8037PriorStateUsedExactStatusNez.lean
@@ -110,7 +110,6 @@ theorem pseIterStatusNez
     (hne : BitVec.ofNat 64 i ≠ priorW) :
     let iW := BitVec.ofNat 64 i
     let sumW := BitVec.ofNat 64 sum
-    let sumS := BitVec.ofNat 64 (sum + stateGas[i])
     let sumW' := BitVec.ofNat 64 (sum + stateGas[i] + execGas[i])
     let iW' := BitVec.ofNat 64 (i + 1)
     let offW := BitVec.ofNat 64 (8 * i)
@@ -120,7 +119,8 @@ theorem pseIterStatusNez
       (LoopInv raIn priorW outPtr sumW' iW' exactOkW runtimeW
         stateGas status execGas offW
           (TxExecStateGasAddr + offW) (BitVec.ofNat 64 execGas[i]) sumW') := by
-  intro iW sumW sumS sumW' iW' offW
+  intro iW sumW sumW' iW' offW
+  let sumS := BitVec.ofNat 64 (sum + stateGas[i])
   have hGpf : (loopGlobals exactOkW runtimeW stateGas status execGas).pcFree :=
     pcFree_loopGlobals exactOkW runtimeW stateGas status execGas
   have hsumAdd : sumW + BitVec.ofNat 64 stateGas[i] = sumS := by
@@ -259,8 +259,7 @@ theorem pseIterStatusNez
         | exact pcFree_regIs
         | exact pcFree_memIs
         | exact pcFree_wordArray _ _
-        | exact pcFree_wordArrayFrom _ _ _
-        | exact pcFree_loopGlobalsCore _ _) e20core
+        | exact pcFree_wordArrayFrom _ _ _) e20core
   have e20F : cpsTripleWithin 1 (P + 80) (P + 84) pseCode
       ((.x29 ↦ᵣ (TxStateGasAddr + offW)) ** (.x30 ↦ᵣ v30) **
         (.x1 ↦ᵣ raIn) ** (.x10 ↦ᵣ priorW) ** (.x11 ↦ᵣ outPtr) **
@@ -457,8 +456,7 @@ theorem pseIterStatusNez
         | exact pcFree_regIs
         | exact pcFree_memIs
         | exact pcFree_wordArray _ _
-        | exact pcFree_wordArrayFrom _ _ _
-        | exact pcFree_loopGlobalsCore _ _) e27core
+        | exact pcFree_wordArrayFrom _ _ _) e27core
   have e27F : cpsTripleWithin 1 (P + 108) AfterLdStatus pseCode
       ((.x29 ↦ᵣ (TxStatusAddr + offW)) ** (.x30 ↦ᵣ BitVec.ofNat 64 stateGas[i]) **
         (.x1 ↦ᵣ raIn) ** (.x10 ↦ᵣ priorW) ** (.x11 ↦ᵣ outPtr) **
@@ -597,8 +595,7 @@ theorem pseIterStatusNez
         | exact pcFree_regIs
         | exact pcFree_memIs
         | exact pcFree_wordArray _ _
-        | exact pcFree_wordArrayFrom _ _ _
-        | exact pcFree_loopGlobalsCore _ _) e32core
+        | exact pcFree_wordArrayFrom _ _ _) e32core
   have e32F : cpsTripleWithin 1 (P + 128) (P + 132) pseCode
       ((.x29 ↦ᵣ (TxExecStateGasAddr + offW)) ** (.x30 ↦ᵣ BitVec.ofNat 64 status[i]) **
         (.x1 ↦ᵣ raIn) ** (.x10 ↦ᵣ priorW) ** (.x11 ↦ᵣ outPtr) **

--- a/EvmAsm/Codegen/Programs/Eip8037PriorStateUsedExactStatusNez.lean
+++ b/EvmAsm/Codegen/Programs/Eip8037PriorStateUsedExactStatusNez.lean
@@ -1,0 +1,818 @@
+/-
+  Status≠0 one-iter for `eip8037_prior_state_used_exact` (exec gas path).
+-/
+
+import EvmAsm.Codegen.Programs.Eip8037PriorStateUsedExactIter
+import EvmAsm.Codegen.Programs.ChainValidateExtraDataLengthSpec
+import EvmAsm.Rv64.LaResolve
+import EvmAsm.Rv64.SyscallSpecs
+import EvmAsm.Rv64.ControlFlow
+import EvmAsm.Rv64.SAsm.DualReadByteScan
+
+namespace EvmAsm.Codegen.Eip8037PriorStateUsedExactStatusNez
+
+open EvmAsm.Rv64
+open EvmAsm.Codegen
+open EvmAsm.Codegen.Eip8037PriorStateUsedExactModel
+open EvmAsm.Codegen.Eip8037PriorStateUsedExactLoop
+open EvmAsm.Codegen.Eip8037PriorStateUsedExactIter
+open EvmAsm.Codegen.ChainValidateExtraDataLengthSpec
+  (wordArray wordArrayFrom wordArray_split pcFree_wordArray pcFree_wordArrayFrom
+   shiftLeft3_ofNat)
+
+abbrev P : Word := Eip8037PriorStateUsedExactLoop.P
+abbrev pseProg : Program := Eip8037PriorStateUsedExactLoop.pseProg
+abbrev pseCode : CodeReq := Eip8037PriorStateUsedExactLoop.pseCode
+abbrev LoopGuard : Word := Eip8037PriorStateUsedExactLoop.LoopGuard
+abbrev LoopBody : Word := Eip8037PriorStateUsedExactLoop.LoopBody
+abbrev AfterSlli : Word := Eip8037PriorStateUsedExactLoop.AfterSlli
+abbrev AfterLaState : Word := Eip8037PriorStateUsedExactLoop.AfterLaState
+abbrev AfterMvSum : Word := Eip8037PriorStateUsedExactLoop.AfterMvSum
+abbrev AfterLaStatus : Word := Eip8037PriorStateUsedExactLoop.AfterLaStatus
+abbrev AfterLdStatus : Word := Eip8037PriorStateUsedExactLoop.AfterLdStatus
+abbrev AfterStatusSkip : Word := Eip8037PriorStateUsedExactLoop.AfterStatusSkip
+abbrev AfterIncr : Word := Eip8037PriorStateUsedExactLoop.AfterIncr
+abbrev AfterStatusBne : Word := Eip8037PriorStateUsedExactLoop.AfterStatusBne
+abbrev AfterLaExec : Word := Eip8037PriorStateUsedExactLoop.AfterLaExec
+abbrev TxStateGasAddr : Word := Eip8037PriorStateUsedExactLoop.TxStateGasAddr
+abbrev TxStatusAddr : Word := Eip8037PriorStateUsedExactLoop.TxStatusAddr
+abbrev TxExecStateGasAddr : Word := Eip8037PriorStateUsedExactLoop.TxExecStateGasAddr
+
+theorem pse_length : pseProg.length = 43 := Eip8037PriorStateUsedExactLoop.pse_length
+
+private theorem se12_zero : signExtend12 (0 : BitVec 12) = (0 : Word) := by decide
+private theorem se12_one : signExtend12 (1 : BitVec 12) = (1 : Word) := by decide
+private theorem se13_32 : signExtend13 (32 : BitVec 13) = (32 : Word) := by decide
+private theorem se21_m88 : signExtend21 (-88 : BitVec 21) = BitVec.ofInt 64 (-88) := by decide
+
+private theorem ofNat_addi1 (i : Nat) :
+    BitVec.ofNat 64 i + signExtend12 (1 : BitVec 12) = BitVec.ofNat 64 (i + 1) := by
+  rw [se12_one, BitVec.ofNat_add]; rfl
+
+private theorem ofNat_add_lt (a b : Nat) (h : a + b < 2 ^ 64) :
+    BitVec.ofNat 64 a + BitVec.ofNat 64 b = BitVec.ofNat 64 (a + b) := by
+  apply BitVec.eq_of_toNat_eq
+  have ha : a < 2 ^ 64 := Nat.lt_of_le_of_lt (Nat.le_add_right a b) h
+  have hb : b < 2 ^ 64 := Nat.lt_of_le_of_lt (Nat.le_add_left b a) h
+  simp only [BitVec.toNat_add, BitVec.toNat_ofNat, Nat.mod_eq_of_lt ha, Nat.mod_eq_of_lt hb,
+    Nat.mod_eq_of_lt h]
+
+private theorem not_ult_add (s g : Nat) (h : s + g < 2 ^ 64) :
+    ¬BitVec.ult (BitVec.ofNat 64 (s + g)) (BitVec.ofNat 64 s) := by
+  have hs : s < 2 ^ 64 := Nat.lt_of_le_of_lt (Nat.le_add_right s g) h
+  simp only [BitVec.ult_eq_decide, decide_eq_true_eq, BitVec.toNat_ofNat,
+    Nat.mod_eq_of_lt hs, Nat.mod_eq_of_lt h]
+  omega
+
+private theorem AfterLdStatus_plus_4 : AfterLdStatus + 4 = AfterStatusBne := by
+  simp only [AfterLdStatus, AfterStatusBne]; decide
+private theorem AfterLaExec_plus_4 : AfterLaExec + 4 = P + 128 := by
+  simp only [AfterLaExec, P]; decide
+private theorem AfterLaState_plus_4 : AfterLaState + 4 = P + 80 := by
+  simp only [AfterLaState, P]; decide
+private theorem AfterLaStatus_plus_4 : AfterLaStatus + 4 = P + 108 := by
+  simp only [AfterLaStatus, P]; decide
+private theorem AfterStatusSkip_plus_4 : AfterStatusSkip + 4 = AfterIncr := by
+  simp only [AfterStatusSkip, AfterIncr]; decide
+private theorem AfterIncr_back :
+    AfterIncr + signExtend21 (-88 : BitVec 21) = LoopGuard := by
+  simp only [AfterIncr, LoopGuard, se21_m88]
+  decide
+private theorem P80_plus_4 : (P + 80 : Word) + 4 = P + 84 := by simp only [P]; decide
+private theorem P84_plus_4 : (P + 84 : Word) + 4 = P + 88 := by simp only [P]; decide
+private theorem P88_plus_4 : (P + 88 : Word) + 4 = P + 92 := by simp only [P]; decide
+private theorem P92_plus_4 : (P + 92 : Word) + 4 = AfterMvSum := by
+  simp only [AfterMvSum, P]; decide
+private theorem P108_plus_4 : (P + 108 : Word) + 4 = AfterLdStatus := by
+  simp only [AfterLdStatus, P]; decide
+private theorem P128_plus_4 : (P + 128 : Word) + 4 = P + 132 := by simp only [P]; decide
+private theorem P132_plus_4 : (P + 132 : Word) + 4 = P + 136 := by simp only [P]; decide
+private theorem P136_plus_4 : (P + 136 : Word) + 4 = P + 140 := by simp only [P]; decide
+private theorem P140_plus_4 : (P + 140 : Word) + 4 = AfterStatusSkip := by
+  simp only [AfterStatusSkip, P]; decide
+
+set_option maxRecDepth 8000 in
+/-- Status≠0 one-iter: LoopGuard → LoopGuard, sum+=state+exec, i+=1.
+    Requires status[i]≠0 and no u64 overflow on state or exec adds. -/
+theorem pseIterStatusNez
+    (raIn priorW outPtr : Word)
+    (exactOkW runtimeW : Word)
+    (stateGas status execGas : List Nat)
+    (i sum : Nat)
+    (v28 v29 v30 v31 : Word)
+    (hi : i < stateGas.length)
+    (hstat : i < status.length)
+    (hexec : i < execGas.length)
+    (hstatNe : status[i] ≠ 0)
+    (hstatBound : status[i] < 2 ^ 64)
+    (hno : sum + stateGas[i] < 2 ^ 64)
+    (hnoE : sum + stateGas[i] + execGas[i] < 2 ^ 64)
+    (hne : BitVec.ofNat 64 i ≠ priorW) :
+    let iW := BitVec.ofNat 64 i
+    let sumW := BitVec.ofNat 64 sum
+    let sumS := BitVec.ofNat 64 (sum + stateGas[i])
+    let sumW' := BitVec.ofNat 64 (sum + stateGas[i] + execGas[i])
+    let iW' := BitVec.ofNat 64 (i + 1)
+    let offW := BitVec.ofNat 64 (8 * i)
+    cpsTripleWithin 23 LoopGuard LoopGuard pseCode
+      (LoopInv raIn priorW outPtr sumW iW exactOkW runtimeW
+        stateGas status execGas v28 v29 v30 v31)
+      (LoopInv raIn priorW outPtr sumW' iW' exactOkW runtimeW
+        stateGas status execGas offW
+          (TxExecStateGasAddr + offW) (BitVec.ofNat 64 execGas[i]) sumW') := by
+  intro iW sumW sumS sumW' iW' offW
+  have hGpf : (loopGlobals exactOkW runtimeW stateGas status execGas).pcFree :=
+    pcFree_loopGlobals exactOkW runtimeW stateGas status execGas
+  have hsumAdd : sumW + BitVec.ofNat 64 stateGas[i] = sumS := by
+    simpa [sumW, sumS] using ofNat_add_lt sum stateGas[i] hno
+  have hnoUlt : ¬BitVec.ult sumS sumW := by
+    simpa [sumW, sumS] using not_ult_add sum stateGas[i] hno
+  have hsumAddE : sumS + BitVec.ofNat 64 execGas[i] = sumW' := by
+    simpa [sumS, sumW'] using ofNat_add_lt (sum + stateGas[i]) execGas[i] hnoE
+  have hnoUltE : ¬BitVec.ult sumW' sumS := by
+    simpa [sumS, sumW'] using not_ult_add (sum + stateGas[i]) execGas[i] hnoE
+  have hoff : iW <<< 3 = offW := by
+    simpa [iW, offW] using shiftLeft3_ofNat i
+  have hstatW : BitVec.ofNat 64 status[i] ≠ (0 : Word) := by
+    intro heq
+    have hmod : status[i] % 2 ^ 64 = 0 := by
+      have := congrArg BitVec.toNat heq
+      simpa [BitVec.toNat_ofNat, BitVec.toNat_zero] using this
+    have : status[i] = 0 := by
+      have := Nat.mod_eq_of_lt hstatBound
+      omega
+    exact hstatNe this
+  have hsplit := wordArray_split TxStateGasAddr stateGas i hi
+  have hsplitS := wordArray_split TxStatusAddr status i hstat
+  have haddrState :
+      TxStateGasAddr + BitVec.ofNat 64 (8 * i) = TxStateGasAddr + offW := by
+    simp only [offW]
+  have haddrStatus :
+      TxStatusAddr + BitVec.ofNat 64 (8 * i) = TxStatusAddr + offW := by
+    simp only [offW]
+  -- 1. guard ntaken
+  have hguard := pseLoopGuardNtaken raIn priorW outPtr sumW iW exactOkW runtimeW
+    stateGas status execGas v28 v29 v30 v31 hne
+  -- 2. SLLI x28 = 8*i
+  have e16 :
+      cpsTripleWithin 1 LoopBody AfterSlli pseCode
+        ((.x6 ↦ᵣ iW) ** (.x28 ↦ᵣ v28))
+        ((.x6 ↦ᵣ iW) ** (.x28 ↦ᵣ offW)) := by
+    have h0 := slli_spec_gen_within .x28 .x6 v28 iW (3 : BitVec 6) LoopBody (by decide)
+    have h0' : cpsTripleWithin 1 LoopBody (LoopBody + 4) pseCode
+        ((.x6 ↦ᵣ iW) ** (.x28 ↦ᵣ v28))
+        ((.x6 ↦ᵣ iW) ** (.x28 ↦ᵣ (iW <<< 3))) :=
+      cpsTripleWithin_extend_code
+        (CodeReq.ofProg_mem_at P LoopBody pseProg 16
+          (.SLLI .x28 .x6 (3 : BitVec 6))
+          (by simp only [LoopBody]; decide)
+          (by rw [pse_length]; decide) rfl (by rw [pse_length]; decide)) h0
+    have h0'' : cpsTripleWithin 1 LoopBody AfterSlli pseCode
+        ((.x6 ↦ᵣ iW) ** (.x28 ↦ᵣ v28))
+        ((.x6 ↦ᵣ iW) ** (.x28 ↦ᵣ (iW <<< 3))) := by
+      rwa [show LoopBody + 4 = AfterSlli from by simp only [LoopBody, AfterSlli]; decide] at h0'
+    exact cpsTripleWithin_weaken (fun _ hp => hp)
+      (fun _ hq => by rw [← hoff]; exact hq) h0''
+  have e16F := cpsTripleWithin_frameR
+    ((.x1 ↦ᵣ raIn) ** (.x10 ↦ᵣ priorW) ** (.x11 ↦ᵣ outPtr) **
+      (outPtr ↦ₘ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) **
+      (.x5 ↦ᵣ priorW) ** (.x7 ↦ᵣ sumW) **
+      (.x29 ↦ᵣ v29) ** (.x30 ↦ᵣ v30) ** (.x31 ↦ᵣ v31) **
+      loopGlobals exactOkW runtimeW stateGas status execGas)
+    (by
+      repeat' first
+        | exact hGpf
+        | apply pcFree_sepConj
+        | exact pcFree_regIs
+        | exact pcFree_memIs) e16
+  -- 3. la state → x29 = TxStateGasAddr
+  have eLa := cpsTripleWithin_frameR
+    ((.x1 ↦ᵣ raIn) ** (.x10 ↦ᵣ priorW) ** (.x11 ↦ᵣ outPtr) **
+      (outPtr ↦ₘ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) **
+      (.x5 ↦ᵣ priorW) ** (.x6 ↦ᵣ iW) ** (.x7 ↦ᵣ sumW) **
+      (.x28 ↦ᵣ offW) ** (.x30 ↦ᵣ v30) ** (.x31 ↦ᵣ v31) **
+      loopGlobals exactOkW runtimeW stateGas status execGas)
+    (by
+      repeat' first
+        | exact hGpf
+        | apply pcFree_sepConj
+        | exact pcFree_regIs
+        | exact pcFree_memIs) (pseLaStateGas v29)
+  -- 4. ADD x29 += x28
+  have e19 :
+      cpsTripleWithin 1 AfterLaState (P + 80) pseCode
+        ((.x29 ↦ᵣ TxStateGasAddr) ** (.x28 ↦ᵣ offW))
+        ((.x29 ↦ᵣ (TxStateGasAddr + offW)) ** (.x28 ↦ᵣ offW)) := by
+    have h0 := add_spec_gen_rd_eq_rs1_within .x29 .x28 TxStateGasAddr offW AfterLaState (by decide)
+    have h0' : cpsTripleWithin 1 AfterLaState (AfterLaState + 4) pseCode
+        ((.x29 ↦ᵣ TxStateGasAddr) ** (.x28 ↦ᵣ offW))
+        ((.x29 ↦ᵣ (TxStateGasAddr + offW)) ** (.x28 ↦ᵣ offW)) :=
+      cpsTripleWithin_extend_code
+        (CodeReq.ofProg_mem_at P AfterLaState pseProg 19
+          (.ADD .x29 .x29 .x28)
+          (by simp only [AfterLaState]; decide)
+          (by rw [pse_length]; decide) rfl (by rw [pse_length]; decide)) h0
+    rwa [AfterLaState_plus_4] at h0'
+  have e19F := cpsTripleWithin_frameR
+    ((.x1 ↦ᵣ raIn) ** (.x10 ↦ᵣ priorW) ** (.x11 ↦ᵣ outPtr) **
+      (outPtr ↦ₘ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) **
+      (.x5 ↦ᵣ priorW) ** (.x6 ↦ᵣ iW) ** (.x7 ↦ᵣ sumW) **
+      (.x30 ↦ᵣ v30) ** (.x31 ↦ᵣ v31) **
+      loopGlobals exactOkW runtimeW stateGas status execGas)
+    (by
+      repeat' first
+        | exact hGpf
+        | apply pcFree_sepConj
+        | exact pcFree_regIs
+        | exact pcFree_memIs) e19
+  -- 5. LD state cell
+  have e20core :
+      cpsTripleWithin 1 (P + 80) (P + 84) pseCode
+        ((.x29 ↦ᵣ (TxStateGasAddr + offW)) ** (.x30 ↦ᵣ v30) **
+          ((TxStateGasAddr + offW) ↦ₘ BitVec.ofNat 64 stateGas[i]))
+        ((.x29 ↦ᵣ (TxStateGasAddr + offW)) ** (.x30 ↦ᵣ BitVec.ofNat 64 stateGas[i]) **
+          ((TxStateGasAddr + offW) ↦ₘ BitVec.ofNat 64 stateGas[i])) := by
+    have haddr : (TxStateGasAddr + offW) + signExtend12 (0 : BitVec 12) =
+        TxStateGasAddr + offW := by
+      rw [se12_zero]; exact BitVec.add_zero _
+    have h0 := ld_spec_gen_within .x30 .x29 (TxStateGasAddr + offW) v30
+      (BitVec.ofNat 64 stateGas[i]) (0 : BitVec 12) (P + 80) (by decide)
+    rw [haddr] at h0
+    exact cpsTripleWithin_extend_code
+      (CodeReq.ofProg_mem_at P (P + 80) pseProg 20
+        (.LD .x30 .x29 (0 : BitVec 12))
+        (by simp only [P]; decide)
+        (by rw [pse_length]; decide) rfl (by rw [pse_length]; decide)) h0
+  have e20F0 := cpsTripleWithin_frameR
+    (wordArrayFrom TxStateGasAddr 0 (stateGas.take i) **
+      wordArrayFrom TxStateGasAddr (i + 1) (stateGas.drop (i + 1)) **
+      wordArray TxStatusAddr status **
+      wordArray TxExecStateGasAddr execGas **
+      loopGlobalsCore exactOkW runtimeW **
+      (.x1 ↦ᵣ raIn) ** (.x10 ↦ᵣ priorW) ** (.x11 ↦ᵣ outPtr) **
+      (outPtr ↦ₘ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) **
+      (.x5 ↦ᵣ priorW) ** (.x6 ↦ᵣ iW) ** (.x7 ↦ᵣ sumW) **
+      (.x28 ↦ᵣ offW) ** (.x31 ↦ᵣ v31))
+    (by
+      repeat' first
+        | apply pcFree_sepConj
+        | exact pcFree_regIs
+        | exact pcFree_memIs
+        | exact pcFree_wordArray _ _
+        | exact pcFree_wordArrayFrom _ _ _
+        | exact pcFree_loopGlobalsCore _ _) e20core
+  have e20F : cpsTripleWithin 1 (P + 80) (P + 84) pseCode
+      ((.x29 ↦ᵣ (TxStateGasAddr + offW)) ** (.x30 ↦ᵣ v30) **
+        (.x1 ↦ᵣ raIn) ** (.x10 ↦ᵣ priorW) ** (.x11 ↦ᵣ outPtr) **
+        (outPtr ↦ₘ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) **
+        (.x5 ↦ᵣ priorW) ** (.x6 ↦ᵣ iW) ** (.x7 ↦ᵣ sumW) **
+        (.x28 ↦ᵣ offW) ** (.x31 ↦ᵣ v31) **
+        loopGlobals exactOkW runtimeW stateGas status execGas)
+      ((.x29 ↦ᵣ (TxStateGasAddr + offW)) ** (.x30 ↦ᵣ BitVec.ofNat 64 stateGas[i]) **
+        (.x1 ↦ᵣ raIn) ** (.x10 ↦ᵣ priorW) ** (.x11 ↦ᵣ outPtr) **
+        (outPtr ↦ₘ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) **
+        (.x5 ↦ᵣ priorW) ** (.x6 ↦ᵣ iW) ** (.x7 ↦ᵣ sumW) **
+        (.x28 ↦ᵣ offW) ** (.x31 ↦ᵣ v31) **
+        loopGlobals exactOkW runtimeW stateGas status execGas) := by
+    refine cpsTripleWithin_weaken ?_ ?_ e20F0
+    · intro _ hp
+      have hp' := hp
+      rw [loopGlobals_eq, hsplit, haddrState] at hp'
+      xperm_hyp hp'
+    · intro _ hq
+      have hq' := hq
+      rw [loopGlobals_eq, hsplit, haddrState]
+      xperm_hyp hq'
+  -- 6. ADD x31 = sum + state
+  have e21 :
+      cpsTripleWithin 1 (P + 84) (P + 88) pseCode
+        ((.x7 ↦ᵣ sumW) ** (.x30 ↦ᵣ BitVec.ofNat 64 stateGas[i]) ** (.x31 ↦ᵣ v31))
+        ((.x7 ↦ᵣ sumW) ** (.x30 ↦ᵣ BitVec.ofNat 64 stateGas[i]) ** (.x31 ↦ᵣ sumS)) := by
+    have h0 := add_spec_gen_within .x31 .x7 .x30 sumW (BitVec.ofNat 64 stateGas[i]) v31
+      (P + 84) (by decide)
+    have h0' : cpsTripleWithin 1 (P + 84) (P + 84 + 4) pseCode
+        ((.x7 ↦ᵣ sumW) ** (.x30 ↦ᵣ BitVec.ofNat 64 stateGas[i]) ** (.x31 ↦ᵣ v31))
+        ((.x7 ↦ᵣ sumW) ** (.x30 ↦ᵣ BitVec.ofNat 64 stateGas[i]) **
+          (.x31 ↦ᵣ (sumW + BitVec.ofNat 64 stateGas[i]))) :=
+      cpsTripleWithin_extend_code
+        (CodeReq.ofProg_mem_at P (P + 84) pseProg 21
+          (.ADD .x31 .x7 .x30)
+          (by simp only [P]; decide)
+          (by rw [pse_length]; decide) rfl (by rw [pse_length]; decide)) h0
+    have h0'' : cpsTripleWithin 1 (P + 84) (P + 88) pseCode
+        ((.x7 ↦ᵣ sumW) ** (.x30 ↦ᵣ BitVec.ofNat 64 stateGas[i]) ** (.x31 ↦ᵣ v31))
+        ((.x7 ↦ᵣ sumW) ** (.x30 ↦ᵣ BitVec.ofNat 64 stateGas[i]) **
+          (.x31 ↦ᵣ (sumW + BitVec.ofNat 64 stateGas[i]))) := by
+      rwa [P84_plus_4] at h0'
+    exact cpsTripleWithin_weaken (fun _ hp => hp)
+      (fun _ hq => by rw [← hsumAdd]; exact hq) h0''
+  have e21F := cpsTripleWithin_frameR
+    ((.x1 ↦ᵣ raIn) ** (.x10 ↦ᵣ priorW) ** (.x11 ↦ᵣ outPtr) **
+      (outPtr ↦ₘ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) **
+      (.x5 ↦ᵣ priorW) ** (.x6 ↦ᵣ iW) **
+      (.x28 ↦ᵣ offW) ** (.x29 ↦ᵣ (TxStateGasAddr + offW)) **
+      loopGlobals exactOkW runtimeW stateGas status execGas)
+    (by
+      repeat' first
+        | exact hGpf
+        | apply pcFree_sepConj
+        | exact pcFree_regIs
+        | exact pcFree_memIs) e21
+  -- 7. BLTU overflow ntaken
+  have e22 :
+      cpsTripleWithin 1 (P + 88) (P + 92) pseCode
+        ((.x31 ↦ᵣ sumS) ** (.x7 ↦ᵣ sumW))
+        ((.x31 ↦ᵣ sumS) ** (.x7 ↦ᵣ sumW)) := by
+    have hbr := bltu_spec_gen_within .x31 .x7 (76 : BitVec 13) sumS sumW (P + 88)
+    have hbrC := cpsBranchWithin_extend_code
+      (CodeReq.ofProg_mem_at P (P + 88) pseProg 22
+        (.BLTU .x31 .x7 (76 : BitVec 13))
+        (by simp only [P]; decide)
+        (by rw [pse_length]; decide) rfl (by rw [pse_length]; decide)) hbr
+    have hnt0 := cpsBranchWithin_ntakenStripPure2 hbrC (fun _ hq => by
+      obtain ⟨_, _, _, _, _, hrest⟩ := hq
+      exact absurd ((sepConj_pure_right _).1 hrest).2 hnoUlt)
+    rwa [P88_plus_4] at hnt0
+  have e22F := cpsTripleWithin_frameR
+    ((.x1 ↦ᵣ raIn) ** (.x10 ↦ᵣ priorW) ** (.x11 ↦ᵣ outPtr) **
+      (outPtr ↦ₘ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) **
+      (.x5 ↦ᵣ priorW) ** (.x6 ↦ᵣ iW) **
+      (.x28 ↦ᵣ offW) ** (.x29 ↦ᵣ (TxStateGasAddr + offW)) **
+      (.x30 ↦ᵣ BitVec.ofNat 64 stateGas[i]) **
+      loopGlobals exactOkW runtimeW stateGas status execGas)
+    (by
+      repeat' first
+        | exact hGpf
+        | apply pcFree_sepConj
+        | exact pcFree_regIs
+        | exact pcFree_memIs) e22
+  -- 8. MV x7, x31
+  have e23 :
+      cpsTripleWithin 1 (P + 92) AfterMvSum pseCode
+        ((.x31 ↦ᵣ sumS) ** (.x7 ↦ᵣ sumW))
+        ((.x31 ↦ᵣ sumS) ** (.x7 ↦ᵣ sumS)) := by
+    have h0 := mv_spec_gen_within .x7 .x31 sumS sumW (P + 92) (by decide)
+    have h0' : cpsTripleWithin 1 (P + 92) (P + 92 + 4) pseCode
+        ((.x31 ↦ᵣ sumS) ** (.x7 ↦ᵣ sumW))
+        ((.x31 ↦ᵣ sumS) ** (.x7 ↦ᵣ sumS)) :=
+      cpsTripleWithin_extend_code
+        (CodeReq.ofProg_mem_at P (P + 92) pseProg 23
+          (.MV .x7 .x31)
+          (by simp only [P]; decide)
+          (by rw [pse_length]; decide) rfl (by rw [pse_length]; decide)) h0
+    rwa [P92_plus_4] at h0'
+  have e23F := cpsTripleWithin_frameR
+    ((.x1 ↦ᵣ raIn) ** (.x10 ↦ᵣ priorW) ** (.x11 ↦ᵣ outPtr) **
+      (outPtr ↦ₘ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) **
+      (.x5 ↦ᵣ priorW) ** (.x6 ↦ᵣ iW) **
+      (.x28 ↦ᵣ offW) ** (.x29 ↦ᵣ (TxStateGasAddr + offW)) **
+      (.x30 ↦ᵣ BitVec.ofNat 64 stateGas[i]) **
+      loopGlobals exactOkW runtimeW stateGas status execGas)
+    (by
+      repeat' first
+        | exact hGpf
+        | apply pcFree_sepConj
+        | exact pcFree_regIs
+        | exact pcFree_memIs) e23
+  -- 9. la status
+  have eLaSt := cpsTripleWithin_frameR
+    ((.x1 ↦ᵣ raIn) ** (.x10 ↦ᵣ priorW) ** (.x11 ↦ᵣ outPtr) **
+      (outPtr ↦ₘ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) **
+      (.x5 ↦ᵣ priorW) ** (.x6 ↦ᵣ iW) ** (.x7 ↦ᵣ sumS) **
+      (.x28 ↦ᵣ offW) ** (.x30 ↦ᵣ BitVec.ofNat 64 stateGas[i]) **
+      (.x31 ↦ᵣ sumS) **
+      loopGlobals exactOkW runtimeW stateGas status execGas)
+    (by
+      repeat' first
+        | exact hGpf
+        | apply pcFree_sepConj
+        | exact pcFree_regIs
+        | exact pcFree_memIs)
+    (pseLaStatus (TxStateGasAddr + offW))
+  -- 10. ADD x29 += x28
+  have e26 :
+      cpsTripleWithin 1 AfterLaStatus (P + 108) pseCode
+        ((.x29 ↦ᵣ TxStatusAddr) ** (.x28 ↦ᵣ offW))
+        ((.x29 ↦ᵣ (TxStatusAddr + offW)) ** (.x28 ↦ᵣ offW)) := by
+    have h0 := add_spec_gen_rd_eq_rs1_within .x29 .x28 TxStatusAddr offW AfterLaStatus (by decide)
+    have h0' : cpsTripleWithin 1 AfterLaStatus (AfterLaStatus + 4) pseCode
+        ((.x29 ↦ᵣ TxStatusAddr) ** (.x28 ↦ᵣ offW))
+        ((.x29 ↦ᵣ (TxStatusAddr + offW)) ** (.x28 ↦ᵣ offW)) :=
+      cpsTripleWithin_extend_code
+        (CodeReq.ofProg_mem_at P AfterLaStatus pseProg 26
+          (.ADD .x29 .x29 .x28)
+          (by simp only [AfterLaStatus]; decide)
+          (by rw [pse_length]; decide) rfl (by rw [pse_length]; decide)) h0
+    rwa [AfterLaStatus_plus_4] at h0'
+  have e26F := cpsTripleWithin_frameR
+    ((.x1 ↦ᵣ raIn) ** (.x10 ↦ᵣ priorW) ** (.x11 ↦ᵣ outPtr) **
+      (outPtr ↦ₘ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) **
+      (.x5 ↦ᵣ priorW) ** (.x6 ↦ᵣ iW) ** (.x7 ↦ᵣ sumS) **
+      (.x30 ↦ᵣ BitVec.ofNat 64 stateGas[i]) ** (.x31 ↦ᵣ sumS) **
+      loopGlobals exactOkW runtimeW stateGas status execGas)
+    (by
+      repeat' first
+        | exact hGpf
+        | apply pcFree_sepConj
+        | exact pcFree_regIs
+        | exact pcFree_memIs) e26
+  -- 11. LD status
+  have e27core :
+      cpsTripleWithin 1 (P + 108) AfterLdStatus pseCode
+        ((.x29 ↦ᵣ (TxStatusAddr + offW)) ** (.x30 ↦ᵣ BitVec.ofNat 64 stateGas[i]) **
+          ((TxStatusAddr + offW) ↦ₘ BitVec.ofNat 64 status[i]))
+        ((.x29 ↦ᵣ (TxStatusAddr + offW)) ** (.x30 ↦ᵣ BitVec.ofNat 64 status[i]) **
+          ((TxStatusAddr + offW) ↦ₘ BitVec.ofNat 64 status[i])) := by
+    have haddr : (TxStatusAddr + offW) + signExtend12 (0 : BitVec 12) =
+        TxStatusAddr + offW := by
+      rw [se12_zero]; exact BitVec.add_zero _
+    have h0 := ld_spec_gen_within .x30 .x29 (TxStatusAddr + offW)
+      (BitVec.ofNat 64 stateGas[i]) (BitVec.ofNat 64 status[i])
+      (0 : BitVec 12) (P + 108) (by decide)
+    rw [haddr] at h0
+    have h0' : cpsTripleWithin 1 (P + 108) (P + 108 + 4) pseCode
+        ((.x29 ↦ᵣ (TxStatusAddr + offW)) ** (.x30 ↦ᵣ BitVec.ofNat 64 stateGas[i]) **
+          ((TxStatusAddr + offW) ↦ₘ BitVec.ofNat 64 status[i]))
+        ((.x29 ↦ᵣ (TxStatusAddr + offW)) ** (.x30 ↦ᵣ BitVec.ofNat 64 status[i]) **
+          ((TxStatusAddr + offW) ↦ₘ BitVec.ofNat 64 status[i])) :=
+      cpsTripleWithin_extend_code
+        (CodeReq.ofProg_mem_at P (P + 108) pseProg 27
+          (.LD .x30 .x29 (0 : BitVec 12))
+          (by simp only [P]; decide)
+          (by rw [pse_length]; decide) rfl (by rw [pse_length]; decide)) h0
+    rwa [P108_plus_4] at h0'
+  have e27F0 := cpsTripleWithin_frameR
+    (wordArrayFrom TxStatusAddr 0 (status.take i) **
+      wordArrayFrom TxStatusAddr (i + 1) (status.drop (i + 1)) **
+      wordArray TxStateGasAddr stateGas **
+      wordArray TxExecStateGasAddr execGas **
+      loopGlobalsCore exactOkW runtimeW **
+      (.x1 ↦ᵣ raIn) ** (.x10 ↦ᵣ priorW) ** (.x11 ↦ᵣ outPtr) **
+      (outPtr ↦ₘ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) **
+      (.x5 ↦ᵣ priorW) ** (.x6 ↦ᵣ iW) ** (.x7 ↦ᵣ sumS) **
+      (.x28 ↦ᵣ offW) ** (.x31 ↦ᵣ sumS))
+    (by
+      repeat' first
+        | apply pcFree_sepConj
+        | exact pcFree_regIs
+        | exact pcFree_memIs
+        | exact pcFree_wordArray _ _
+        | exact pcFree_wordArrayFrom _ _ _
+        | exact pcFree_loopGlobalsCore _ _) e27core
+  have e27F : cpsTripleWithin 1 (P + 108) AfterLdStatus pseCode
+      ((.x29 ↦ᵣ (TxStatusAddr + offW)) ** (.x30 ↦ᵣ BitVec.ofNat 64 stateGas[i]) **
+        (.x1 ↦ᵣ raIn) ** (.x10 ↦ᵣ priorW) ** (.x11 ↦ᵣ outPtr) **
+        (outPtr ↦ₘ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) **
+        (.x5 ↦ᵣ priorW) ** (.x6 ↦ᵣ iW) ** (.x7 ↦ᵣ sumS) **
+        (.x28 ↦ᵣ offW) ** (.x31 ↦ᵣ sumS) **
+        loopGlobals exactOkW runtimeW stateGas status execGas)
+      ((.x29 ↦ᵣ (TxStatusAddr + offW)) ** (.x30 ↦ᵣ BitVec.ofNat 64 status[i]) **
+        (.x1 ↦ᵣ raIn) ** (.x10 ↦ᵣ priorW) ** (.x11 ↦ᵣ outPtr) **
+        (outPtr ↦ₘ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) **
+        (.x5 ↦ᵣ priorW) ** (.x6 ↦ᵣ iW) ** (.x7 ↦ᵣ sumS) **
+        (.x28 ↦ᵣ offW) ** (.x31 ↦ᵣ sumS) **
+        loopGlobals exactOkW runtimeW stateGas status execGas) := by
+    refine cpsTripleWithin_weaken ?_ ?_ e27F0
+    · intro _ hp
+      have hp' := hp
+      rw [loopGlobals_eq, hsplitS, haddrStatus] at hp'
+      xperm_hyp hp'
+    · intro _ hq
+      have hq' := hq
+      rw [loopGlobals_eq, hsplitS, haddrStatus]
+      xperm_hyp hq'
+  have hsplitE := wordArray_split TxExecStateGasAddr execGas i hexec
+  have haddrExec :
+      TxExecStateGasAddr + BitVec.ofNat 64 (8 * i) = TxExecStateGasAddr + offW := by
+    simp only [offW]
+  -- 12. BEQ status=0 ntaken (status ≠ 0)
+  have e28 :
+      cpsTripleWithin 1 AfterLdStatus AfterStatusBne pseCode
+        ((.x30 ↦ᵣ BitVec.ofNat 64 status[i]) ** (.x0 ↦ᵣ (0 : Word)))
+        ((.x30 ↦ᵣ BitVec.ofNat 64 status[i]) ** (.x0 ↦ᵣ (0 : Word))) := by
+    have hbr := beq_spec_gen_within .x30 .x0 (32 : BitVec 13)
+      (BitVec.ofNat 64 status[i]) (0 : Word) AfterLdStatus
+    have hbrC := cpsBranchWithin_extend_code
+      (CodeReq.ofProg_mem_at P AfterLdStatus pseProg 28
+        (.BEQ .x30 .x0 (32 : BitVec 13))
+        (by simp only [AfterLdStatus]; decide)
+        (by rw [pse_length]; decide) rfl (by rw [pse_length]; decide)) hbr
+    have hnt0 := cpsBranchWithin_ntakenStripPure2 hbrC (fun _ hq => by
+      obtain ⟨_, _, _, _, _, hrest⟩ := hq
+      exact absurd ((sepConj_pure_right _).1 hrest).2 hstatW)
+    rwa [AfterLdStatus_plus_4] at hnt0
+  have e28F := cpsTripleWithin_frameR
+    ((.x1 ↦ᵣ raIn) ** (.x10 ↦ᵣ priorW) ** (.x11 ↦ᵣ outPtr) **
+      (outPtr ↦ₘ (0 : Word)) **
+      (.x5 ↦ᵣ priorW) ** (.x6 ↦ᵣ iW) ** (.x7 ↦ᵣ sumS) **
+      (.x28 ↦ᵣ offW) ** (.x29 ↦ᵣ (TxStatusAddr + offW)) **
+      (.x31 ↦ᵣ sumS) **
+      loopGlobals exactOkW runtimeW stateGas status execGas)
+    (by
+      repeat' first
+        | exact hGpf
+        | apply pcFree_sepConj
+        | exact pcFree_regIs
+        | exact pcFree_memIs) e28
+  -- 13. la exec
+  have eLaEx := cpsTripleWithin_frameR
+    ((.x1 ↦ᵣ raIn) ** (.x10 ↦ᵣ priorW) ** (.x11 ↦ᵣ outPtr) **
+      (outPtr ↦ₘ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) **
+      (.x5 ↦ᵣ priorW) ** (.x6 ↦ᵣ iW) ** (.x7 ↦ᵣ sumS) **
+      (.x28 ↦ᵣ offW) ** (.x30 ↦ᵣ BitVec.ofNat 64 status[i]) **
+      (.x31 ↦ᵣ sumS) **
+      loopGlobals exactOkW runtimeW stateGas status execGas)
+    (by
+      repeat' first
+        | exact hGpf
+        | apply pcFree_sepConj
+        | exact pcFree_regIs
+        | exact pcFree_memIs)
+    (pseLaExec (TxStatusAddr + offW))
+  -- 14. ADD x29 += x28
+  have e31 :
+      cpsTripleWithin 1 AfterLaExec (P + 128) pseCode
+        ((.x29 ↦ᵣ TxExecStateGasAddr) ** (.x28 ↦ᵣ offW))
+        ((.x29 ↦ᵣ (TxExecStateGasAddr + offW)) ** (.x28 ↦ᵣ offW)) := by
+    have h0 := add_spec_gen_rd_eq_rs1_within .x29 .x28 TxExecStateGasAddr offW AfterLaExec (by decide)
+    have h0' : cpsTripleWithin 1 AfterLaExec (AfterLaExec + 4) pseCode
+        ((.x29 ↦ᵣ TxExecStateGasAddr) ** (.x28 ↦ᵣ offW))
+        ((.x29 ↦ᵣ (TxExecStateGasAddr + offW)) ** (.x28 ↦ᵣ offW)) :=
+      cpsTripleWithin_extend_code
+        (CodeReq.ofProg_mem_at P AfterLaExec pseProg 31
+          (.ADD .x29 .x29 .x28)
+          (by simp only [AfterLaExec]; decide)
+          (by rw [pse_length]; decide) rfl (by rw [pse_length]; decide)) h0
+    rwa [AfterLaExec_plus_4] at h0'
+  have e31F := cpsTripleWithin_frameR
+    ((.x1 ↦ᵣ raIn) ** (.x10 ↦ᵣ priorW) ** (.x11 ↦ᵣ outPtr) **
+      (outPtr ↦ₘ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) **
+      (.x5 ↦ᵣ priorW) ** (.x6 ↦ᵣ iW) ** (.x7 ↦ᵣ sumS) **
+      (.x30 ↦ᵣ BitVec.ofNat 64 status[i]) ** (.x31 ↦ᵣ sumS) **
+      loopGlobals exactOkW runtimeW stateGas status execGas)
+    (by
+      repeat' first
+        | exact hGpf
+        | apply pcFree_sepConj
+        | exact pcFree_regIs
+        | exact pcFree_memIs) e31
+  -- 15. LD exec cell
+  have e32core :
+      cpsTripleWithin 1 (P + 128) (P + 132) pseCode
+        ((.x29 ↦ᵣ (TxExecStateGasAddr + offW)) ** (.x30 ↦ᵣ BitVec.ofNat 64 status[i]) **
+          ((TxExecStateGasAddr + offW) ↦ₘ BitVec.ofNat 64 execGas[i]))
+        ((.x29 ↦ᵣ (TxExecStateGasAddr + offW)) ** (.x30 ↦ᵣ BitVec.ofNat 64 execGas[i]) **
+          ((TxExecStateGasAddr + offW) ↦ₘ BitVec.ofNat 64 execGas[i])) := by
+    have haddr : (TxExecStateGasAddr + offW) + signExtend12 (0 : BitVec 12) =
+        TxExecStateGasAddr + offW := by
+      rw [se12_zero]; exact BitVec.add_zero _
+    have h0 := ld_spec_gen_within .x30 .x29 (TxExecStateGasAddr + offW)
+      (BitVec.ofNat 64 status[i]) (BitVec.ofNat 64 execGas[i])
+      (0 : BitVec 12) (P + 128) (by decide)
+    rw [haddr] at h0
+    have h0' : cpsTripleWithin 1 (P + 128) (P + 128 + 4) pseCode
+        ((.x29 ↦ᵣ (TxExecStateGasAddr + offW)) ** (.x30 ↦ᵣ BitVec.ofNat 64 status[i]) **
+          ((TxExecStateGasAddr + offW) ↦ₘ BitVec.ofNat 64 execGas[i]))
+        ((.x29 ↦ᵣ (TxExecStateGasAddr + offW)) ** (.x30 ↦ᵣ BitVec.ofNat 64 execGas[i]) **
+          ((TxExecStateGasAddr + offW) ↦ₘ BitVec.ofNat 64 execGas[i])) :=
+      cpsTripleWithin_extend_code
+        (CodeReq.ofProg_mem_at P (P + 128) pseProg 32
+          (.LD .x30 .x29 (0 : BitVec 12))
+          (by simp only [P]; decide)
+          (by rw [pse_length]; decide) rfl (by rw [pse_length]; decide)) h0
+    rwa [P128_plus_4] at h0'
+  have e32F0 := cpsTripleWithin_frameR
+    (wordArrayFrom TxExecStateGasAddr 0 (execGas.take i) **
+      wordArrayFrom TxExecStateGasAddr (i + 1) (execGas.drop (i + 1)) **
+      wordArray TxStateGasAddr stateGas **
+      wordArray TxStatusAddr status **
+      loopGlobalsCore exactOkW runtimeW **
+      (.x1 ↦ᵣ raIn) ** (.x10 ↦ᵣ priorW) ** (.x11 ↦ᵣ outPtr) **
+      (outPtr ↦ₘ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) **
+      (.x5 ↦ᵣ priorW) ** (.x6 ↦ᵣ iW) ** (.x7 ↦ᵣ sumS) **
+      (.x28 ↦ᵣ offW) ** (.x31 ↦ᵣ sumS))
+    (by
+      repeat' first
+        | apply pcFree_sepConj
+        | exact pcFree_regIs
+        | exact pcFree_memIs
+        | exact pcFree_wordArray _ _
+        | exact pcFree_wordArrayFrom _ _ _
+        | exact pcFree_loopGlobalsCore _ _) e32core
+  have e32F : cpsTripleWithin 1 (P + 128) (P + 132) pseCode
+      ((.x29 ↦ᵣ (TxExecStateGasAddr + offW)) ** (.x30 ↦ᵣ BitVec.ofNat 64 status[i]) **
+        (.x1 ↦ᵣ raIn) ** (.x10 ↦ᵣ priorW) ** (.x11 ↦ᵣ outPtr) **
+        (outPtr ↦ₘ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) **
+        (.x5 ↦ᵣ priorW) ** (.x6 ↦ᵣ iW) ** (.x7 ↦ᵣ sumS) **
+        (.x28 ↦ᵣ offW) ** (.x31 ↦ᵣ sumS) **
+        loopGlobals exactOkW runtimeW stateGas status execGas)
+      ((.x29 ↦ᵣ (TxExecStateGasAddr + offW)) ** (.x30 ↦ᵣ BitVec.ofNat 64 execGas[i]) **
+        (.x1 ↦ᵣ raIn) ** (.x10 ↦ᵣ priorW) ** (.x11 ↦ᵣ outPtr) **
+        (outPtr ↦ₘ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) **
+        (.x5 ↦ᵣ priorW) ** (.x6 ↦ᵣ iW) ** (.x7 ↦ᵣ sumS) **
+        (.x28 ↦ᵣ offW) ** (.x31 ↦ᵣ sumS) **
+        loopGlobals exactOkW runtimeW stateGas status execGas) := by
+    refine cpsTripleWithin_weaken ?_ ?_ e32F0
+    · intro _ hp
+      have hp' := hp
+      rw [loopGlobals_eq, hsplitE, haddrExec] at hp'
+      xperm_hyp hp'
+    · intro _ hq
+      have hq' := hq
+      rw [loopGlobals_eq, hsplitE, haddrExec]
+      xperm_hyp hq'
+  -- 16. ADD x31 = sumS + exec
+  have e33 :
+      cpsTripleWithin 1 (P + 132) (P + 136) pseCode
+        ((.x7 ↦ᵣ sumS) ** (.x30 ↦ᵣ BitVec.ofNat 64 execGas[i]) ** (.x31 ↦ᵣ sumS))
+        ((.x7 ↦ᵣ sumS) ** (.x30 ↦ᵣ BitVec.ofNat 64 execGas[i]) ** (.x31 ↦ᵣ sumW')) := by
+    have h0 := add_spec_gen_within .x31 .x7 .x30 sumS (BitVec.ofNat 64 execGas[i]) sumS
+      (P + 132) (by decide)
+    have h0' : cpsTripleWithin 1 (P + 132) (P + 132 + 4) pseCode
+        ((.x7 ↦ᵣ sumS) ** (.x30 ↦ᵣ BitVec.ofNat 64 execGas[i]) ** (.x31 ↦ᵣ sumS))
+        ((.x7 ↦ᵣ sumS) ** (.x30 ↦ᵣ BitVec.ofNat 64 execGas[i]) **
+          (.x31 ↦ᵣ (sumS + BitVec.ofNat 64 execGas[i]))) :=
+      cpsTripleWithin_extend_code
+        (CodeReq.ofProg_mem_at P (P + 132) pseProg 33
+          (.ADD .x31 .x7 .x30)
+          (by simp only [P]; decide)
+          (by rw [pse_length]; decide) rfl (by rw [pse_length]; decide)) h0
+    have h0'' : cpsTripleWithin 1 (P + 132) (P + 136) pseCode
+        ((.x7 ↦ᵣ sumS) ** (.x30 ↦ᵣ BitVec.ofNat 64 execGas[i]) ** (.x31 ↦ᵣ sumS))
+        ((.x7 ↦ᵣ sumS) ** (.x30 ↦ᵣ BitVec.ofNat 64 execGas[i]) **
+          (.x31 ↦ᵣ (sumS + BitVec.ofNat 64 execGas[i]))) := by
+      rwa [P132_plus_4] at h0'
+    exact cpsTripleWithin_weaken (fun _ hp => hp)
+      (fun _ hq => by rw [← hsumAddE]; exact hq) h0''
+  have e33F := cpsTripleWithin_frameR
+    ((.x1 ↦ᵣ raIn) ** (.x10 ↦ᵣ priorW) ** (.x11 ↦ᵣ outPtr) **
+      (outPtr ↦ₘ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) **
+      (.x5 ↦ᵣ priorW) ** (.x6 ↦ᵣ iW) **
+      (.x28 ↦ᵣ offW) ** (.x29 ↦ᵣ (TxExecStateGasAddr + offW)) **
+      loopGlobals exactOkW runtimeW stateGas status execGas)
+    (by
+      repeat' first
+        | exact hGpf
+        | apply pcFree_sepConj
+        | exact pcFree_regIs
+        | exact pcFree_memIs) e33
+  -- 17. BLTU overflow ntaken on exec add
+  have e34 :
+      cpsTripleWithin 1 (P + 136) (P + 140) pseCode
+        ((.x31 ↦ᵣ sumW') ** (.x7 ↦ᵣ sumS))
+        ((.x31 ↦ᵣ sumW') ** (.x7 ↦ᵣ sumS)) := by
+    have hbr := bltu_spec_gen_within .x31 .x7 (28 : BitVec 13) sumW' sumS (P + 136)
+    have hbrC := cpsBranchWithin_extend_code
+      (CodeReq.ofProg_mem_at P (P + 136) pseProg 34
+        (.BLTU .x31 .x7 (28 : BitVec 13))
+        (by simp only [P]; decide)
+        (by rw [pse_length]; decide) rfl (by rw [pse_length]; decide)) hbr
+    have hnt0 := cpsBranchWithin_ntakenStripPure2 hbrC (fun _ hq => by
+      obtain ⟨_, _, _, _, _, hrest⟩ := hq
+      exact absurd ((sepConj_pure_right _).1 hrest).2 hnoUltE)
+    rwa [P136_plus_4] at hnt0
+  have e34F := cpsTripleWithin_frameR
+    ((.x1 ↦ᵣ raIn) ** (.x10 ↦ᵣ priorW) ** (.x11 ↦ᵣ outPtr) **
+      (outPtr ↦ₘ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) **
+      (.x5 ↦ᵣ priorW) ** (.x6 ↦ᵣ iW) **
+      (.x28 ↦ᵣ offW) ** (.x29 ↦ᵣ (TxExecStateGasAddr + offW)) **
+      (.x30 ↦ᵣ BitVec.ofNat 64 execGas[i]) **
+      loopGlobals exactOkW runtimeW stateGas status execGas)
+    (by
+      repeat' first
+        | exact hGpf
+        | apply pcFree_sepConj
+        | exact pcFree_regIs
+        | exact pcFree_memIs) e34
+  -- 18. MV x7, x31
+  have e35 :
+      cpsTripleWithin 1 (P + 140) AfterStatusSkip pseCode
+        ((.x31 ↦ᵣ sumW') ** (.x7 ↦ᵣ sumS))
+        ((.x31 ↦ᵣ sumW') ** (.x7 ↦ᵣ sumW')) := by
+    have h0 := mv_spec_gen_within .x7 .x31 sumW' sumS (P + 140) (by decide)
+    have h0' : cpsTripleWithin 1 (P + 140) (P + 140 + 4) pseCode
+        ((.x31 ↦ᵣ sumW') ** (.x7 ↦ᵣ sumS))
+        ((.x31 ↦ᵣ sumW') ** (.x7 ↦ᵣ sumW')) :=
+      cpsTripleWithin_extend_code
+        (CodeReq.ofProg_mem_at P (P + 140) pseProg 35
+          (.MV .x7 .x31)
+          (by simp only [P]; decide)
+          (by rw [pse_length]; decide) rfl (by rw [pse_length]; decide)) h0
+    rwa [P140_plus_4] at h0'
+  have e35F := cpsTripleWithin_frameR
+    ((.x1 ↦ᵣ raIn) ** (.x10 ↦ᵣ priorW) ** (.x11 ↦ᵣ outPtr) **
+      (outPtr ↦ₘ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) **
+      (.x5 ↦ᵣ priorW) ** (.x6 ↦ᵣ iW) **
+      (.x28 ↦ᵣ offW) ** (.x29 ↦ᵣ (TxExecStateGasAddr + offW)) **
+      (.x30 ↦ᵣ BitVec.ofNat 64 execGas[i]) **
+      loopGlobals exactOkW runtimeW stateGas status execGas)
+    (by
+      repeat' first
+        | exact hGpf
+        | apply pcFree_sepConj
+        | exact pcFree_regIs
+        | exact pcFree_memIs) e35
+  -- 19. ADDI i++
+  have e36 :
+      cpsTripleWithin 1 AfterStatusSkip AfterIncr pseCode
+        (.x6 ↦ᵣ iW) (.x6 ↦ᵣ iW') := by
+    have h0 := addi_spec_gen_same_within .x6 iW (1 : BitVec 12) AfterStatusSkip (by decide)
+    have h0' : cpsTripleWithin 1 AfterStatusSkip (AfterStatusSkip + 4) pseCode
+        (.x6 ↦ᵣ iW) (.x6 ↦ᵣ (iW + signExtend12 (1 : BitVec 12))) :=
+      cpsTripleWithin_extend_code
+        (CodeReq.ofProg_mem_at P AfterStatusSkip pseProg 36
+          (.ADDI .x6 .x6 (1 : BitVec 12))
+          (by simp only [AfterStatusSkip]; decide)
+          (by rw [pse_length]; decide) rfl (by rw [pse_length]; decide)) h0
+    have h0'' : cpsTripleWithin 1 AfterStatusSkip AfterIncr pseCode
+        (.x6 ↦ᵣ iW) (.x6 ↦ᵣ (iW + signExtend12 (1 : BitVec 12))) := by
+      rwa [AfterStatusSkip_plus_4] at h0'
+    exact cpsTripleWithin_weaken (fun _ hp => hp)
+      (fun _ hq => by
+        have hadd : iW + signExtend12 (1 : BitVec 12) = iW' := by
+          simpa [iW, iW'] using ofNat_addi1 i
+        rw [hadd] at hq
+        exact hq) h0''
+  have e36F := cpsTripleWithin_frameR
+    ((.x1 ↦ᵣ raIn) ** (.x10 ↦ᵣ priorW) ** (.x11 ↦ᵣ outPtr) **
+      (outPtr ↦ₘ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) **
+      (.x5 ↦ᵣ priorW) ** (.x7 ↦ᵣ sumW') **
+      (.x28 ↦ᵣ offW) ** (.x29 ↦ᵣ (TxExecStateGasAddr + offW)) **
+      (.x30 ↦ᵣ BitVec.ofNat 64 execGas[i]) ** (.x31 ↦ᵣ sumW') **
+      loopGlobals exactOkW runtimeW stateGas status execGas)
+    (by
+      repeat' first
+        | exact hGpf
+        | apply pcFree_sepConj
+        | exact pcFree_regIs
+        | exact pcFree_memIs) e36
+  -- 20. JAL back
+  have e37 :
+      cpsTripleWithin 1 AfterIncr LoopGuard pseCode
+        empAssertion empAssertion := by
+    have h0 := jal_x0_spec_gen_within (-88 : BitVec 21) AfterIncr
+    have h0' : cpsTripleWithin 1 AfterIncr
+        (AfterIncr + signExtend21 (-88 : BitVec 21)) pseCode
+        empAssertion empAssertion :=
+      cpsTripleWithin_extend_code
+        (CodeReq.ofProg_mem_at P AfterIncr pseProg 37
+          (.JAL .x0 (-88 : BitVec 21))
+          (by simp only [AfterIncr]; decide)
+          (by rw [pse_length]; decide) rfl (by rw [pse_length]; decide)) h0
+    rwa [AfterIncr_back] at h0'
+  let ambientExit : Assertion :=
+    (.x1 ↦ᵣ raIn) ** (.x10 ↦ᵣ priorW) ** (.x11 ↦ᵣ outPtr) **
+      (outPtr ↦ₘ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) **
+      (.x5 ↦ᵣ priorW) ** (.x6 ↦ᵣ iW') ** (.x7 ↦ᵣ sumW') **
+      (.x28 ↦ᵣ offW) ** (.x29 ↦ᵣ (TxExecStateGasAddr + offW)) **
+      (.x30 ↦ᵣ BitVec.ofNat 64 execGas[i]) ** (.x31 ↦ᵣ sumW') **
+      loopGlobals exactOkW runtimeW stateGas status execGas
+  have hAmbPf : ambientExit.pcFree := by
+    dsimp only [ambientExit]
+    repeat' first
+      | exact hGpf
+      | apply pcFree_sepConj
+      | exact pcFree_regIs
+      | exact pcFree_memIs
+  have e37F0 := cpsTripleWithin_frameR ambientExit hAmbPf e37
+  have e37F : cpsTripleWithin 1 AfterIncr LoopGuard pseCode
+      ambientExit ambientExit := by
+    refine cpsTripleWithin_weaken ?_ ?_ e37F0
+    · intro s hp
+      exact (sepConj_emp_left' ambientExit).symm ▸ hp
+    · intro s hq
+      exact (sepConj_emp_left' ambientExit) ▸ hq
+  -- Compose
+  have c01 := cpsTripleWithin_seq_perm_same_cr
+    (fun _ hp => by dsimp only [LoopInv] at hp; xperm_hyp hp) hguard e16F
+  have c02 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) c01 eLa
+  have c03 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) c02 e19F
+  have c04 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) c03 e20F
+  have c05 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) c04 e21F
+  have c06 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) c05 e22F
+  have c07 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) c06 e23F
+  have c08 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) c07 eLaSt
+  have c09 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) c08 e26F
+  have c10 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) c09 e27F
+  have c11 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) c10 e28F
+  have c12 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) c11 eLaEx
+  have c13 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) c12 e31F
+  have c14 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) c13 e32F
+  have c15 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) c14 e33F
+  have c16 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) c15 e34F
+  have c17 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) c16 e35F
+  have c18 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) c17 e36F
+  have c19 := cpsTripleWithin_seq_perm_same_cr
+    (fun _ hp => by dsimp only [ambientExit] at hp ⊢; xperm_hyp hp) c18 e37F
+  -- 13 prefix + 1 bne + 2 la + 1 add + 1 ld + 1 add + 1 bltu + 1 mv + 1 addi + 1 jal = 23
+  change cpsTripleWithin (1+1+2+1+1+1+1+1+2+1+1+1+2+1+1+1+1+1+1+1) LoopGuard LoopGuard pseCode _ _ at c19
+  exact cpsTripleWithin_weaken
+    (fun _ hp => by dsimp only [LoopInv] at hp ⊢; xperm_hyp hp)
+    (fun _ hq => by
+      dsimp only [LoopInv, ambientExit] at hq ⊢
+      xperm_hyp hq) c19
+
+
+#print axioms pseIterStatusNez
+
+end EvmAsm.Codegen.Eip8037PriorStateUsedExactStatusNez

--- a/EvmAsm/Codegen/Programs/Eip8037PriorStateUsedExactTop.lean
+++ b/EvmAsm/Codegen/Programs/Eip8037PriorStateUsedExactTop.lean
@@ -1,0 +1,197 @@
+/-
+  Top-level success specs for `eip8037_prior_state_used_exact`.
+-/
+
+import EvmAsm.Codegen.Programs.Eip8037PriorStateUsedExactInduct
+import EvmAsm.Codegen.Programs.ChainValidateExtraDataLengthSpec
+import EvmAsm.Rv64.SyscallSpecs
+import EvmAsm.Rv64.SAsm.DualReadByteScan
+
+namespace EvmAsm.Codegen.Eip8037PriorStateUsedExactTop
+
+open EvmAsm.Rv64
+open EvmAsm.Codegen
+open EvmAsm.Codegen.Eip8037PriorStateUsedExactModel
+open EvmAsm.Codegen.Eip8037PriorStateUsedExactSpec
+open EvmAsm.Codegen.Eip8037PriorStateUsedExactLoop
+open EvmAsm.Codegen.Eip8037PriorStateUsedExactInduct
+open EvmAsm.Codegen.ChainValidateExtraDataLengthSpec (wordArray pcFree_wordArray)
+
+abbrev P : Word := Eip8037PriorStateUsedExactSpec.P
+abbrev pseCode : CodeReq := Eip8037PriorStateUsedExactSpec.pseCode
+abbrev LoopGuard : Word := Eip8037PriorStateUsedExactSpec.LoopGuard
+abbrev ExactOkAddr : Word := Eip8037PriorStateUsedExactSpec.ExactOkAddr
+abbrev RuntimeCountAddr : Word := Eip8037PriorStateUsedExactSpec.RuntimeCountAddr
+abbrev TxStateGasAddr : Word := Eip8037PriorStateUsedExactSpec.TxStateGasAddr
+abbrev TxStatusAddr : Word := Eip8037PriorStateUsedExactSpec.TxStatusAddr
+abbrev TxExecStateGasAddr : Word := Eip8037PriorStateUsedExactSpec.TxExecStateGasAddr
+
+/-- Arrays framed across gates (read-only). -/
+def arrayAmbient (stateGas status execGas : List Nat) : Assertion :=
+  wordArray TxStateGasAddr stateGas **
+    wordArray TxStatusAddr status **
+    wordArray TxExecStateGasAddr execGas
+
+theorem pcFree_arrayAmbient (stateGas status execGas : List Nat) :
+    (arrayAmbient stateGas status execGas).pcFree := by
+  unfold arrayAmbient
+  repeat' first
+    | apply pcFree_sepConj
+    | exact pcFree_wordArray _ _
+
+theorem prior_ne_zero_ofNat (n : Nat) (hn : n ≠ 0) (hn64 : n < 2 ^ 64) :
+    BitVec.ofNat 64 n ≠ (0 : Word) := by
+  intro heq
+  have := congrArg BitVec.toNat heq
+  simp only [BitVec.toNat_ofNat, Nat.mod_eq_of_lt hn64] at this
+  exact hn this
+
+/-- Pure model alignment under the success hyps. -/
+theorem priorExactResult_of_success
+    (exactOkW runtimeW priorW : Word)
+    (stateGas status execGas : List Nat)
+    (n finalSum : Nat)
+    (hnW : priorW = BitVec.ofNat 64 n)
+    (hn0 : n ≠ 0)
+    (hn16 : n ≤ 16)
+    (hexact : exactOkW ≠ (0 : Word))
+    (hruntime : ¬ BitVec.ult runtimeW priorW)
+    (hfinal : priorPrefixExact stateGas status execGas n = some finalSum) :
+    priorExactResult exactOkW.toNat runtimeW.toNat n
+      stateGas status execGas = some finalSum := by
+  have hn64 : n < 2 ^ 64 := Nat.lt_of_le_of_lt hn16 (by decide : (16 : Nat) < 2 ^ 64)
+  have hgatesB : priorGatesOkB exactOkW.toNat runtimeW.toNat n = true := by
+    simp only [priorGatesOkB, Bool.and_eq_true, decide_eq_true_eq]
+    refine ⟨⟨?_, ?_⟩, hn16⟩
+    · intro heq
+      apply hexact
+      apply BitVec.eq_of_toNat_eq
+      simp [heq]
+    · have hnot : ¬ runtimeW.toNat < priorW.toNat := by
+        intro hlt
+        apply hruntime
+        exact BitVec.ult_iff_toNat_lt.mpr hlt
+      have hge : runtimeW.toNat ≥ priorW.toNat := Nat.le_of_not_gt hnot
+      have hp : priorW.toNat = n := by
+        rw [hnW, BitVec.toNat_ofNat, Nat.mod_eq_of_lt hn64]
+      simpa [hp] using hge
+  simp only [priorExactResult, hn0, hgatesB, hfinal]
+  -- residual: if False then … else if true=false then … else some finalSum
+  simp
+
+def nSuccessSteps (n : Nat) : Nat := nGateSteps + nLoopFrom n
+
+set_option maxRecDepth 8000 in
+/-- Success path: prior≠0, gates hold, prefixExact succeeds → a0=0 *out=finalSum.
+    Pure model: see `priorExactResult_of_success`. -/
+theorem eip8037PriorStateUsedExact_success_spec_within
+    (raIn priorW outPtr oldOut exactOkW runtimeW : Word)
+    (stateGas status execGas : List Nat)
+    (n finalSum : Nat)
+    (v5 v6 v7 v28 v29 v30 v31 : Word)
+    (hnW : priorW = BitVec.ofNat 64 n)
+    (hn0 : n ≠ 0)
+    (hn16 : n ≤ 16)
+    (hexact : exactOkW ≠ (0 : Word))
+    (hruntime : ¬ BitVec.ult runtimeW priorW)
+    (hpriorLe16 : ¬ BitVec.ult (16 : Word) priorW)
+    (hfinal : priorPrefixExact stateGas status execGas n = some finalSum)
+    (hAllState : n ≤ stateGas.length)
+    (hAllStat : n ≤ status.length)
+    (hAllExec : n ≤ execGas.length)
+    (hAllStatBound : ∀ j < n, status[j]! < 2 ^ 64)
+    (hAllNoOvf : ∀ j < n,
+      ∀ s, priorPrefixExact stateGas status execGas j = some s →
+        s + priorCell stateGas status execGas j < 2 ^ 64)
+    (hret : raIn &&& ~~~(1 : Word) = raIn) :
+    let finalW := BitVec.ofNat 64 finalSum
+    ∃ v28' v29' v30' v31',
+      cpsTripleWithin (nSuccessSteps n) P raIn pseCode
+        (entryPre raIn priorW outPtr oldOut
+          ((.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
+            (.x28 ↦ᵣ v28) ** (.x29 ↦ᵣ v29) ** (.x30 ↦ᵣ v30) ** (.x31 ↦ᵣ v31) **
+            (ExactOkAddr ↦ₘ exactOkW) ** (RuntimeCountAddr ↦ₘ runtimeW) **
+            arrayAmbient stateGas status execGas))
+        (postOk raIn outPtr finalW
+          ((.x5 ↦ᵣ priorW) ** (.x6 ↦ᵣ priorW) ** (.x7 ↦ᵣ finalW) **
+            (.x28 ↦ᵣ v28') ** (.x29 ↦ᵣ v29') ** (.x30 ↦ᵣ v30') ** (.x31 ↦ᵣ v31') **
+            loopGlobals exactOkW runtimeW stateGas status execGas)) := by
+  intro finalW
+  have hn64 : n < 2 ^ 64 := Nat.lt_of_le_of_lt hn16 (by decide : (16 : Nat) < 2 ^ 64)
+  have hprior : priorW ≠ (0 : Word) := by
+    rw [hnW]; exact prior_ne_zero_ofNat n hn0 hn64
+  have hgates := eip8037PriorStateUsedExact_gatesToLoop_spec_within
+    raIn priorW outPtr oldOut exactOkW runtimeW
+    v5 v6 v7 v28 v29 v30 v31 hprior hexact hruntime hpriorLe16
+  have hgatesF := cpsTripleWithin_frameR
+    (arrayAmbient stateGas status execGas)
+    (pcFree_arrayAmbient stateGas status execGas) hgates
+  have hgates' : cpsTripleWithin nGateSteps P LoopGuard pseCode
+      (entryPre raIn priorW outPtr oldOut
+        ((.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
+          (.x28 ↦ᵣ v28) ** (.x29 ↦ᵣ v29) ** (.x30 ↦ᵣ v30) ** (.x31 ↦ᵣ v31) **
+          (ExactOkAddr ↦ₘ exactOkW) ** (RuntimeCountAddr ↦ₘ runtimeW) **
+          arrayAmbient stateGas status execGas))
+      (LoopInv raIn priorW outPtr (0 : Word) (0 : Word) exactOkW runtimeW
+        stateGas status execGas v28 v29 v30 v31) :=
+    cpsTripleWithin_weaken
+      (fun _ hp => by
+        dsimp only [entryPre] at hp ⊢
+        xperm_hyp hp)
+      (fun _ hq => by
+        -- hq: loopEntry ** arrays; goal: LoopInv0
+        unfold loopEntry arrayAmbient at hq
+        unfold LoopInv loopGlobals
+        xperm_hyp hq) hgatesF
+  obtain ⟨v28', v29', v30', v31', hloop⟩ :=
+    pseLoop raIn priorW outPtr exactOkW runtimeW
+      stateGas status execGas n finalSum v28 v29 v30 v31
+      hnW hn16 hfinal hAllState hAllStat hAllExec hAllStatBound hAllNoOvf hret
+  have hcomp := cpsTripleWithin_seq_perm_same_cr
+    (fun _ hp => hp) hgates' hloop
+  refine ⟨v28', v29', v30', v31', ?_⟩
+  simpa [nSuccessSteps] using hcomp
+
+#print axioms eip8037PriorStateUsedExact_success_spec_within
+
+set_option maxRecDepth 8000 in
+/-- Zero prior with ambient arrays/globals framed. -/
+theorem eip8037PriorStateUsedExact_zero_top_spec_within
+    (raIn outPtr oldOut : Word)
+    (v5 v6 v7 v28 v29 v30 v31 : Word)
+    (stateGas status execGas : List Nat)
+    (exactOkW runtimeW : Word)
+    (hret : raIn &&& ~~~(1 : Word) = raIn) :
+    cpsTripleWithin nZeroSteps P raIn pseCode
+      (entryPre raIn (0 : Word) outPtr oldOut
+        ((.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
+          (.x28 ↦ᵣ v28) ** (.x29 ↦ᵣ v29) ** (.x30 ↦ᵣ v30) ** (.x31 ↦ᵣ v31) **
+          (ExactOkAddr ↦ₘ exactOkW) ** (RuntimeCountAddr ↦ₘ runtimeW) **
+          arrayAmbient stateGas status execGas))
+      (postOk raIn outPtr (0 : Word)
+        ((.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
+          (.x28 ↦ᵣ v28) ** (.x29 ↦ᵣ v29) ** (.x30 ↦ᵣ v30) ** (.x31 ↦ᵣ v31) **
+          (ExactOkAddr ↦ₘ exactOkW) ** (RuntimeCountAddr ↦ₘ runtimeW) **
+          arrayAmbient stateGas status execGas)) := by
+  have h0 := eip8037PriorStateUsedExact_zero_spec_within
+    raIn outPtr oldOut v5 v6 v7 v28 v29 v30 v31 hret
+  have h0F := cpsTripleWithin_frameR
+    ((ExactOkAddr ↦ₘ exactOkW) ** (RuntimeCountAddr ↦ₘ runtimeW) **
+      arrayAmbient stateGas status execGas)
+    (by
+      unfold arrayAmbient
+      repeat' first
+        | apply pcFree_sepConj
+        | exact pcFree_memIs
+        | exact pcFree_wordArray _ _) h0
+  exact cpsTripleWithin_weaken
+    (fun _ hp => by
+      dsimp only [entryPre] at hp ⊢
+      xperm_hyp hp)
+    (fun _ hq => by
+      dsimp only [postOk] at hq ⊢
+      xperm_hyp hq) h0F
+
+#print axioms eip8037PriorStateUsedExact_zero_top_spec_within
+
+end EvmAsm.Codegen.Eip8037PriorStateUsedExactTop

--- a/EvmAsm/Codegen/Programs/Imports.lean
+++ b/EvmAsm/Codegen/Programs/Imports.lean
@@ -231,6 +231,7 @@ import EvmAsm.Codegen.Programs.BlockVerdictGasGate
 import EvmAsm.Codegen.Programs.Eip8037PriorStateUsedExactModel
 import EvmAsm.Codegen.Programs.Eip8037PriorStateUsedExactSpec
 import EvmAsm.Codegen.Programs.Eip8037PriorStateUsedExactLoop
+import EvmAsm.Codegen.Programs.Eip8037PriorStateUsedExactIter
 import EvmAsm.Codegen.Programs.BlockVerdictSimpleTransfer
 import EvmAsm.Codegen.Programs.BlockVerdictSimpleTransferPublish
 import EvmAsm.Codegen.Programs.BlockVerdictMultiTx

--- a/EvmAsm/Codegen/Programs/Imports.lean
+++ b/EvmAsm/Codegen/Programs/Imports.lean
@@ -235,6 +235,7 @@ import EvmAsm.Codegen.Programs.Eip8037PriorStateUsedExactIter
 import EvmAsm.Codegen.Programs.Eip8037PriorStateUsedExactStatusNez
 import EvmAsm.Codegen.Programs.Eip8037PriorStateUsedExactInduct
 import EvmAsm.Codegen.Programs.Eip8037PriorStateUsedExactTop
+import EvmAsm.Codegen.Programs.Eip8037PriorStateUsedExactOvf
 import EvmAsm.Codegen.Programs.BlockVerdictSimpleTransfer
 import EvmAsm.Codegen.Programs.BlockVerdictSimpleTransferPublish
 import EvmAsm.Codegen.Programs.BlockVerdictMultiTx

--- a/EvmAsm/Codegen/Programs/Imports.lean
+++ b/EvmAsm/Codegen/Programs/Imports.lean
@@ -234,6 +234,7 @@ import EvmAsm.Codegen.Programs.Eip8037PriorStateUsedExactLoop
 import EvmAsm.Codegen.Programs.Eip8037PriorStateUsedExactIter
 import EvmAsm.Codegen.Programs.Eip8037PriorStateUsedExactStatusNez
 import EvmAsm.Codegen.Programs.Eip8037PriorStateUsedExactInduct
+import EvmAsm.Codegen.Programs.Eip8037PriorStateUsedExactTop
 import EvmAsm.Codegen.Programs.BlockVerdictSimpleTransfer
 import EvmAsm.Codegen.Programs.BlockVerdictSimpleTransferPublish
 import EvmAsm.Codegen.Programs.BlockVerdictMultiTx

--- a/EvmAsm/Codegen/Programs/Imports.lean
+++ b/EvmAsm/Codegen/Programs/Imports.lean
@@ -230,6 +230,7 @@ import EvmAsm.Codegen.Programs.BlockGasRemaining
 import EvmAsm.Codegen.Programs.BlockVerdictGasGate
 import EvmAsm.Codegen.Programs.Eip8037PriorStateUsedExactModel
 import EvmAsm.Codegen.Programs.Eip8037PriorStateUsedExactSpec
+import EvmAsm.Codegen.Programs.Eip8037PriorStateUsedExactLoop
 import EvmAsm.Codegen.Programs.BlockVerdictSimpleTransfer
 import EvmAsm.Codegen.Programs.BlockVerdictSimpleTransferPublish
 import EvmAsm.Codegen.Programs.BlockVerdictMultiTx

--- a/EvmAsm/Codegen/Programs/Imports.lean
+++ b/EvmAsm/Codegen/Programs/Imports.lean
@@ -233,6 +233,7 @@ import EvmAsm.Codegen.Programs.Eip8037PriorStateUsedExactSpec
 import EvmAsm.Codegen.Programs.Eip8037PriorStateUsedExactLoop
 import EvmAsm.Codegen.Programs.Eip8037PriorStateUsedExactIter
 import EvmAsm.Codegen.Programs.Eip8037PriorStateUsedExactStatusNez
+import EvmAsm.Codegen.Programs.Eip8037PriorStateUsedExactInduct
 import EvmAsm.Codegen.Programs.BlockVerdictSimpleTransfer
 import EvmAsm.Codegen.Programs.BlockVerdictSimpleTransferPublish
 import EvmAsm.Codegen.Programs.BlockVerdictMultiTx

--- a/EvmAsm/Codegen/Programs/Imports.lean
+++ b/EvmAsm/Codegen/Programs/Imports.lean
@@ -228,6 +228,8 @@ import EvmAsm.Codegen.Programs.BlockAccessListHash
 import EvmAsm.Codegen.Programs.BlockVerdictModeledSystem
 import EvmAsm.Codegen.Programs.BlockGasRemaining
 import EvmAsm.Codegen.Programs.BlockVerdictGasGate
+import EvmAsm.Codegen.Programs.Eip8037PriorStateUsedExactModel
+import EvmAsm.Codegen.Programs.Eip8037PriorStateUsedExactSpec
 import EvmAsm.Codegen.Programs.BlockVerdictSimpleTransfer
 import EvmAsm.Codegen.Programs.BlockVerdictSimpleTransferPublish
 import EvmAsm.Codegen.Programs.BlockVerdictMultiTx

--- a/EvmAsm/Codegen/Programs/Imports.lean
+++ b/EvmAsm/Codegen/Programs/Imports.lean
@@ -232,6 +232,7 @@ import EvmAsm.Codegen.Programs.Eip8037PriorStateUsedExactModel
 import EvmAsm.Codegen.Programs.Eip8037PriorStateUsedExactSpec
 import EvmAsm.Codegen.Programs.Eip8037PriorStateUsedExactLoop
 import EvmAsm.Codegen.Programs.Eip8037PriorStateUsedExactIter
+import EvmAsm.Codegen.Programs.Eip8037PriorStateUsedExactStatusNez
 import EvmAsm.Codegen.Programs.BlockVerdictSimpleTransfer
 import EvmAsm.Codegen.Programs.BlockVerdictSimpleTransferPublish
 import EvmAsm.Codegen.Programs.BlockVerdictMultiTx

--- a/EvmAsm/Codegen/Programs/Imports.lean
+++ b/EvmAsm/Codegen/Programs/Imports.lean
@@ -236,6 +236,7 @@ import EvmAsm.Codegen.Programs.Eip8037PriorStateUsedExactStatusNez
 import EvmAsm.Codegen.Programs.Eip8037PriorStateUsedExactInduct
 import EvmAsm.Codegen.Programs.Eip8037PriorStateUsedExactTop
 import EvmAsm.Codegen.Programs.Eip8037PriorStateUsedExactOvf
+import EvmAsm.Codegen.Programs.Eip8037PriorStateUsedExactExecOvf
 import EvmAsm.Codegen.Programs.BlockVerdictSimpleTransfer
 import EvmAsm.Codegen.Programs.BlockVerdictSimpleTransferPublish
 import EvmAsm.Codegen.Programs.BlockVerdictMultiTx


### PR DESCRIPTION
## Summary

Fn.Spec for the 43-instr `eip8037_prior_state_used_exact` leaf (a4gbr residual):

### Success paths
- **zero prior** (`prior=0` → `*out=0`, `a0=0`)
- **gates → loop → store sum** under `prior≠0`, exact_ok≠0, runtime≥prior, prior≤16, and overflow-free `priorPrefixExact`

### Fail paths (mid-loop overflow complete)
- **state-gas overflow** (`pseIterStateOvf`): BLTU at P+88 → FailLi, a0=1, *out=0
- **exec-gas overflow** (`pseIterExecOvf`): status≠0 path, BLTU at P+136 → FailLi, a0=1, *out=0

Top theorems:
- `eip8037PriorStateUsedExact_success_spec_within`
- `eip8037PriorStateUsedExact_zero_top_spec_within`
- pure: `priorExactResult_of_success`
- `pseIterStateOvf` / `pseIterExecOvf`

`#print axioms`: propext, Classical.choice, Quot.sound only.

### Out of scope
- Full `eip8037_tx_gas_gate` composition (uses this leaf as sum consumer)
- Top-level fail compose under `priorExactResult = none` (modular iter lemmas ready)

### Files
Model / Spec / Loop / Iter / StatusNez / Induct / Top / Ovf / ExecOvf under `EvmAsm/Codegen/Programs/`

### Test plan
- [x] lake build Ovf + ExecOvf + Top
- [x] classical-3
- [ ] CI green