### PR TITLE
proof(a4gbr): tx_intrinsic_state_gas success under Extract+TypeDispatch hyps

### DIFF
--- a/EvmAsm/Codegen/Programs/Eip8037TxStateGasSpec.lean
+++ b/EvmAsm/Codegen/Programs/Eip8037TxStateGasSpec.lean
@@ -1,0 +1,151 @@
+/-
+  Fn.Spec for `eip8037_tx_state_gas` (4-instr leaf, bead a4gbr.2).
+
+  Body:
+    t0 = a0 + a1
+    *a5 = t0
+    a0 = 0
+    ret
+
+  a2–a4 ignored (retired v0.5 ABI slots). Used by `tx_intrinsic_state_gas`
+  with a0=a1=0 so *out = 0 (= pureIntrinsicStateGasSuccess).
+-/
+
+import EvmAsm.Rv64.CPSSpec
+import EvmAsm.Rv64.SepLogic
+import EvmAsm.Rv64.SyscallSpecs
+import EvmAsm.Rv64.ControlFlow
+import EvmAsm.Rv64.Tactics.XSimp
+import EvmAsm.Rv64.SAsm.DualReadByteScan
+import EvmAsm.Codegen.Programs.IntrinsicGas
+import EvmAsm.Codegen.GuestAddrs
+
+namespace EvmAsm.Codegen.Eip8037TxStateGasSpec
+
+open EvmAsm.Rv64
+open EvmAsm.Codegen
+
+local macro "pcf" : tactic =>
+  `(tactic| repeat
+      first
+      | apply pcFree_sepConj
+      | exact pcFree_regIs
+      | exact pcFree_regOwn
+      | exact pcFree_memIs
+      | exact pcFree_memOwn
+      | exact pcFree_emp
+      | exact pcFree_pure)
+
+abbrev P : Word := BitVec.ofNat 64 GuestAddrs.eip8037_tx_state_gas
+abbrev etsProg : Program := eip8037TxStateGas_prog
+abbrev etsCode : CodeReq := CodeReq.ofProg P etsProg
+
+theorem ets_length : etsProg.length = 4 := by decide
+
+private theorem se12_zero : signExtend12 (0 : BitVec 12) = (0 : Word) := by decide
+
+private theorem ets_bound : 4 * etsProg.length < 2 ^ 64 := by
+  simp only [ets_length]; decide
+
+private theorem P_plus_4 : P + 4 = P + BitVec.ofNat 64 (4 * 1) := by decide
+private theorem P_plus_8 : P + 8 = P + BitVec.ofNat 64 (4 * 2) := by decide
+private theorem P_plus_12 : P + 12 = P + BitVec.ofNat 64 (4 * 3) := by decide
+
+set_option maxRecDepth 8000 in
+/-- Full leaf: `*outPtr = a0 + a1`, return `a0 = 0`. -/
+theorem eip8037TxStateGas_spec_within
+    (raIn outPtr oldOut a0v a1v a2v a3v a4v t0Old : Word)
+    (hret : (raIn &&& ~~~(1 : Word)) = raIn) :
+    cpsTripleWithin 4 P raIn etsCode
+      ((.x1 ↦ᵣ raIn) ** (.x10 ↦ᵣ a0v) ** (.x11 ↦ᵣ a1v) **
+        (.x12 ↦ᵣ a2v) ** (.x13 ↦ᵣ a3v) ** (.x14 ↦ᵣ a4v) **
+        (.x15 ↦ᵣ outPtr) ** (.x5 ↦ᵣ t0Old) **
+        (outPtr ↦ₘ oldOut) ** (.x0 ↦ᵣ (0 : Word)))
+      ((.x1 ↦ᵣ raIn) ** (.x10 ↦ᵣ (0 : Word)) ** (.x11 ↦ᵣ a1v) **
+        (.x12 ↦ᵣ a2v) ** (.x13 ↦ᵣ a3v) ** (.x14 ↦ᵣ a4v) **
+        (.x15 ↦ᵣ outPtr) ** (.x5 ↦ᵣ (a0v + a1v)) **
+        (outPtr ↦ₘ (a0v + a1v)) ** (.x0 ↦ᵣ (0 : Word))) := by
+  -- [0] ADD x5, x10, x11
+  have h0 := add_spec_gen_within .x5 .x10 .x11 a0v a1v t0Old P (by decide)
+  have h0e := cpsTripleWithin_extend_code
+    (CodeReq.ofProg_mem_at P P etsProg 0 (.ADD .x5 .x10 .x11)
+      (by decide) (by rw [ets_length]; decide) rfl ets_bound) h0
+  have h0F :=
+    cpsTripleWithin_frameR
+      ((.x1 ↦ᵣ raIn) ** (.x12 ↦ᵣ a2v) ** (.x13 ↦ᵣ a3v) ** (.x14 ↦ᵣ a4v) **
+        (.x15 ↦ᵣ outPtr) ** (outPtr ↦ₘ oldOut) ** (.x0 ↦ᵣ (0 : Word)))
+      (by pcf) h0e
+  -- [1] SD x15, x5, 0
+  have h1 := sd_spec_gen_within .x15 .x5 outPtr (a0v + a1v) oldOut
+    (0 : BitVec 12) (P + 4)
+  rw [show outPtr + signExtend12 (0 : BitVec 12) = outPtr from by
+    rw [se12_zero]; exact BitVec.add_zero outPtr] at h1
+  have h1e := cpsTripleWithin_extend_code
+    (CodeReq.ofProg_mem_at P (P + 4) etsProg 1 (.SD .x15 .x5 (0 : BitVec 12))
+      P_plus_4 (by rw [ets_length]; decide) rfl ets_bound) h1
+  have h1F :=
+    cpsTripleWithin_frameR
+      ((.x1 ↦ᵣ raIn) ** (.x10 ↦ᵣ a0v) ** (.x11 ↦ᵣ a1v) **
+        (.x12 ↦ᵣ a2v) ** (.x13 ↦ᵣ a3v) ** (.x14 ↦ᵣ a4v) **
+        (.x0 ↦ᵣ (0 : Word)))
+      (by pcf) h1e
+  -- [2] LI x10, 0
+  have h2 := li_spec_gen_within .x10 a0v (0 : Word) (P + 8) (by decide)
+  have h2e := cpsTripleWithin_extend_code
+    (CodeReq.ofProg_mem_at P (P + 8) etsProg 2 (.LI .x10 (0 : Word))
+      P_plus_8 (by rw [ets_length]; decide) rfl ets_bound) h2
+  have h2F :=
+    cpsTripleWithin_frameR
+      ((.x1 ↦ᵣ raIn) ** (.x11 ↦ᵣ a1v) ** (.x12 ↦ᵣ a2v) ** (.x13 ↦ᵣ a3v) **
+        (.x14 ↦ᵣ a4v) ** (.x15 ↦ᵣ outPtr) ** (.x5 ↦ᵣ (a0v + a1v)) **
+        (outPtr ↦ₘ (a0v + a1v)) ** (.x0 ↦ᵣ (0 : Word)))
+      (by pcf) h2e
+  -- [3] JALR x0, x1, 0
+  have hexit : ((raIn + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word)) = raIn := by
+    have hz : raIn + signExtend12 (0 : BitVec 12) = raIn := by
+      rw [se12_zero]; exact BitVec.add_zero raIn
+    rw [hz, hret]
+  have h3 : cpsTripleWithin 1 (P + 12) raIn etsCode
+      (.x1 ↦ᵣ raIn) (.x1 ↦ᵣ raIn) := by
+    have h0 := jalr_x0_spec_gen_within .x1 raIn (0 : BitVec 12) (P + 12)
+    rw [hexit] at h0
+    exact cpsTripleWithin_extend_code
+      (CodeReq.ofProg_mem_at P (P + 12) etsProg 3 (.JALR .x0 .x1 (0 : BitVec 12))
+        P_plus_12 (by rw [ets_length]; decide) rfl ets_bound) h0
+  -- Frame ordered to match h2F post after xperm: x10 ** x1 ** rest
+  have h3F :=
+    cpsTripleWithin_frameR
+      ((.x10 ↦ᵣ (0 : Word)) ** (.x11 ↦ᵣ a1v) ** (.x12 ↦ᵣ a2v) **
+        (.x13 ↦ᵣ a3v) ** (.x14 ↦ᵣ a4v) ** (.x15 ↦ᵣ outPtr) **
+        (.x5 ↦ᵣ (a0v + a1v)) ** (outPtr ↦ₘ (a0v + a1v)) **
+        (.x0 ↦ᵣ (0 : Word)))
+      (by pcf) h3
+  have c01 :=
+    cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) h0F h1F
+  have c02 :=
+    cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) c01 h2F
+  have c03 :=
+    cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) c02 h3F
+  -- Reshape framed pre to theorem pre (xperm); post already matches.
+  exact cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp) (fun _ hq => hq) c03
+
+set_option maxRecDepth 8000 in
+/-- Specialization: a0=a1=0 → *out=0 (tx_intrinsic success path). -/
+theorem eip8037TxStateGas_zero_out_spec_within
+    (raIn outPtr oldOut a2v a3v a4v t0Old : Word)
+    (hret : (raIn &&& ~~~(1 : Word)) = raIn) :
+    cpsTripleWithin 4 P raIn etsCode
+      ((.x1 ↦ᵣ raIn) ** (.x10 ↦ᵣ (0 : Word)) ** (.x11 ↦ᵣ (0 : Word)) **
+        (.x12 ↦ᵣ a2v) ** (.x13 ↦ᵣ a3v) ** (.x14 ↦ᵣ a4v) **
+        (.x15 ↦ᵣ outPtr) ** (.x5 ↦ᵣ t0Old) **
+        (outPtr ↦ₘ oldOut) ** (.x0 ↦ᵣ (0 : Word)))
+      ((.x1 ↦ᵣ raIn) ** (.x10 ↦ᵣ (0 : Word)) ** (.x11 ↦ᵣ (0 : Word)) **
+        (.x12 ↦ᵣ a2v) ** (.x13 ↦ᵣ a3v) ** (.x14 ↦ᵣ a4v) **
+        (.x15 ↦ᵣ outPtr) ** (.x5 ↦ᵣ (0 : Word)) **
+        (outPtr ↦ₘ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word))) := by
+  have h := eip8037TxStateGas_spec_within raIn outPtr oldOut 0 0 a2v a3v a4v t0Old hret
+  simpa only [BitVec.zero_add] using h
+
+#print axioms eip8037TxStateGas_spec_within
+
+end EvmAsm.Codegen.Eip8037TxStateGasSpec

--- a/EvmAsm/Codegen/Programs/Imports.lean
+++ b/EvmAsm/Codegen/Programs/Imports.lean
@@ -66,6 +66,7 @@ import EvmAsm.Codegen.Programs.TxIntrinsicStateGasEpilogue
 import EvmAsm.Codegen.Programs.TxIntrinsicStateGasExtract
 import EvmAsm.Codegen.Programs.TxIntrinsicStateGasType
 import EvmAsm.Codegen.Programs.TxIntrinsicStateGasEts
+import EvmAsm.Codegen.Programs.TxIntrinsicStateGasTop
 import EvmAsm.Codegen.Programs.RlpRead
 import EvmAsm.Codegen.Programs.RlpListNthItemCallSAsm
 import EvmAsm.Codegen.Programs.RlpWalkCallSAsm

--- a/EvmAsm/Codegen/Programs/Imports.lean
+++ b/EvmAsm/Codegen/Programs/Imports.lean
@@ -60,6 +60,7 @@ import EvmAsm.Codegen.Programs.SelfdestructDescriptors
 import EvmAsm.Codegen.Programs.StatelessGuest
 import EvmAsm.Codegen.Programs.IntrinsicGas
 import EvmAsm.Codegen.Programs.Eip8037TxStateGasSpec
+import EvmAsm.Codegen.Programs.TxIntrinsicStateGasSpec
 import EvmAsm.Codegen.Programs.RlpRead
 import EvmAsm.Codegen.Programs.RlpListNthItemCallSAsm
 import EvmAsm.Codegen.Programs.RlpWalkCallSAsm

--- a/EvmAsm/Codegen/Programs/Imports.lean
+++ b/EvmAsm/Codegen/Programs/Imports.lean
@@ -61,6 +61,7 @@ import EvmAsm.Codegen.Programs.StatelessGuest
 import EvmAsm.Codegen.Programs.IntrinsicGas
 import EvmAsm.Codegen.Programs.Eip8037TxStateGasSpec
 import EvmAsm.Codegen.Programs.TxIntrinsicStateGasSpec
+import EvmAsm.Codegen.Programs.TxIntrinsicStateGasPrologue
 import EvmAsm.Codegen.Programs.RlpRead
 import EvmAsm.Codegen.Programs.RlpListNthItemCallSAsm
 import EvmAsm.Codegen.Programs.RlpWalkCallSAsm

--- a/EvmAsm/Codegen/Programs/Imports.lean
+++ b/EvmAsm/Codegen/Programs/Imports.lean
@@ -62,6 +62,8 @@ import EvmAsm.Codegen.Programs.IntrinsicGas
 import EvmAsm.Codegen.Programs.Eip8037TxStateGasSpec
 import EvmAsm.Codegen.Programs.TxIntrinsicStateGasSpec
 import EvmAsm.Codegen.Programs.TxIntrinsicStateGasPrologue
+import EvmAsm.Codegen.Programs.TxIntrinsicStateGasEpilogue
+import EvmAsm.Codegen.Programs.TxIntrinsicStateGasExtract
 import EvmAsm.Codegen.Programs.RlpRead
 import EvmAsm.Codegen.Programs.RlpListNthItemCallSAsm
 import EvmAsm.Codegen.Programs.RlpWalkCallSAsm

--- a/EvmAsm/Codegen/Programs/Imports.lean
+++ b/EvmAsm/Codegen/Programs/Imports.lean
@@ -64,6 +64,7 @@ import EvmAsm.Codegen.Programs.TxIntrinsicStateGasSpec
 import EvmAsm.Codegen.Programs.TxIntrinsicStateGasPrologue
 import EvmAsm.Codegen.Programs.TxIntrinsicStateGasEpilogue
 import EvmAsm.Codegen.Programs.TxIntrinsicStateGasExtract
+import EvmAsm.Codegen.Programs.TxIntrinsicStateGasType
 import EvmAsm.Codegen.Programs.RlpRead
 import EvmAsm.Codegen.Programs.RlpListNthItemCallSAsm
 import EvmAsm.Codegen.Programs.RlpWalkCallSAsm

--- a/EvmAsm/Codegen/Programs/Imports.lean
+++ b/EvmAsm/Codegen/Programs/Imports.lean
@@ -59,6 +59,7 @@ import EvmAsm.Codegen.Programs.Selfdestruct
 import EvmAsm.Codegen.Programs.SelfdestructDescriptors
 import EvmAsm.Codegen.Programs.StatelessGuest
 import EvmAsm.Codegen.Programs.IntrinsicGas
+import EvmAsm.Codegen.Programs.Eip8037TxStateGasSpec
 import EvmAsm.Codegen.Programs.RlpRead
 import EvmAsm.Codegen.Programs.RlpListNthItemCallSAsm
 import EvmAsm.Codegen.Programs.RlpWalkCallSAsm

--- a/EvmAsm/Codegen/Programs/Imports.lean
+++ b/EvmAsm/Codegen/Programs/Imports.lean
@@ -65,6 +65,7 @@ import EvmAsm.Codegen.Programs.TxIntrinsicStateGasPrologue
 import EvmAsm.Codegen.Programs.TxIntrinsicStateGasEpilogue
 import EvmAsm.Codegen.Programs.TxIntrinsicStateGasExtract
 import EvmAsm.Codegen.Programs.TxIntrinsicStateGasType
+import EvmAsm.Codegen.Programs.TxIntrinsicStateGasEts
 import EvmAsm.Codegen.Programs.RlpRead
 import EvmAsm.Codegen.Programs.RlpListNthItemCallSAsm
 import EvmAsm.Codegen.Programs.RlpWalkCallSAsm

--- a/EvmAsm/Codegen/Programs/IntrinsicGas.lean
+++ b/EvmAsm/Codegen/Programs/IntrinsicGas.lean
@@ -560,15 +560,23 @@ def ziskEip8037ReservoirSplitProbeUnit : BuildUnit := {
     charges; the guest's u64 running counter guards each refund subtraction
     against underflow, so its captured value is always >= 0 — the settled sum
     here mirrors `Uint(max(0, tx_state_gas))`.) -/
+/-- 4-instr leaf: `*a5 = a0 + a1; a0 = 0; ret`.
+    a2–a4 are retired v0.5 args (ignored; kept so `tx_intrinsic_state_gas` ABI stands). -/
+def eip8037TxStateGas_prog : Program :=
+  [ .ADD .x5 .x10 .x11
+  , .SD .x15 .x5 (0 : BitVec 12)
+  , .LI .x10 (0 : Word)
+  , .JALR .x0 .x1 (0 : BitVec 12) ]
+
 def eip8037TxStateGasFunction : String :=
-  "eip8037_tx_state_gas:\n" ++
-  "  # a0=intrinsic_state_gas, a1=state_gas_used (executed), a5=tx_state_gas_out\n" ++
-  "  # a2-a4 are the retired v0.5 refund/error/creation args, ignored; the\n" ++
-  "  # positions are kept so g8zeq.1.3 callers (tx_intrinsic_state_gas) stand.\n" ++
-  "  add t0, a0, a1            # tx_state_gas = intrinsic.state + executed state\n" ++
-  "  sd t0, 0(a5)\n" ++
-  "  li a0, 0\n" ++
-  "  ret"
+  "eip8037_tx_state_gas:\n" ++ emitProgram eip8037TxStateGas_prog
+
+theorem eip8037TxStateGasFunction_eq_prog :
+    eip8037TxStateGasFunction =
+      "eip8037_tx_state_gas:\n" ++ emitProgram eip8037TxStateGas_prog := rfl
+
+#guard eip8037TxStateGasFunction.startsWith "eip8037_tx_state_gas:\n"
+#guard eip8037TxStateGas_prog.length = 4
 
 /-- `zisk_eip8037_tx_state_gas`: focused probe.
     Input layout (after the ziskemu length wrapper at 0x40000000+8):

--- a/EvmAsm/Codegen/Programs/TxIntrinsicStateGasEpilogue.lean
+++ b/EvmAsm/Codegen/Programs/TxIntrinsicStateGasEpilogue.lean
@@ -1,0 +1,126 @@
+/-
+  Frame restore epilogue for `tx_intrinsic_state_gas` (instr 44-53).
+
+  loadSeq ra/s0–s6; ADDI sp,+64; JALR ret.
+  Shared by success (a0=0) and fail (a0=1/2) paths.
+-/
+
+import EvmAsm.Codegen.Programs.TxIntrinsicStateGasPrologue
+import EvmAsm.Rv64.SAsm.AbiFrame
+import EvmAsm.Evm64.CallingConvention
+import EvmAsm.Rv64.Tactics.XSimp
+
+namespace EvmAsm.Codegen.TxIntrinsicStateGasSpec
+
+open EvmAsm.Rv64
+open EvmAsm.Rv64.SAsm
+
+local macro "pcf" : tactic =>
+  `(tactic| repeat
+      first
+      | apply pcFree_sepConj
+      | exact pcFree_regIs
+      | exact pcFree_regOwn
+      | exact pcFree_memIs
+      | exact pcFree_memOwn
+      | exact pcFree_emp
+      | exact pcFree_pure
+      | exact pcFree_regsAt _ _
+      | exact pcFree_frameSlotsSaved _ _ _)
+
+abbrev EpiRestore : Word := T + 176
+abbrev EpiAddi : Word := T + 208
+abbrev EpiJalr : Word := T + 212
+
+theorem tisFrame_hne : ∀ p ∈ tisFrame, p.1 ≠ .x0 := by decide
+
+set_option maxRecDepth 8000 in
+/-- loadSeq + ADDI sp + JALR (instr 44-53). Exit at s.ra when ra is even. -/
+theorem tisEpilogueRestore (sp0 spC : Word) (s cur : TisSaved)
+    (hspC : spC = sp0 + signExtend12 (-64 : BitVec 12))
+    (hret : s.ra &&& ~~~(1 : Word) = s.ra) :
+    cpsTripleWithin 10 EpiRestore s.ra tisCode
+      ((.x2 ↦ᵣ spC) ** regsAt tisFrame (tisSavedVals cur) **
+        frameSlotsSaved tisFrame spC (tisSavedVals s))
+      ((.x1 ↦ᵣ s.ra) ** (.x2 ↦ᵣ sp0) **
+        (.x8 ↦ᵣ s.s0) ** (.x9 ↦ᵣ s.s1) **
+        (.x18 ↦ᵣ s.s2) ** (.x19 ↦ᵣ s.s3) **
+        (.x20 ↦ᵣ s.s4) ** (.x21 ↦ᵣ s.s5) ** (.x22 ↦ᵣ s.s6) **
+        frameSlotsSaved tisFrame spC (tisSavedVals s)) := by
+  have hs0 := loadSeq_spec tisFrame spC (tisSavedVals s) (tisSavedVals cur) (T + 176)
+    (by decide) tisFrame_hne
+  have h_loadMono : ∀ a i,
+      CodeReq.ofProg (T + 176) (loadProg tisFrame) a = some i →
+        tisCode a = some i := by
+    intro a i h_mem
+    exact CodeReq.ofProg_mono_sub T (T + 176) tisProg (loadProg tisFrame) 44
+      (by bv_omega) (by rfl)
+      (by rw [tis_length]; simp [tisFrame, loadProg])
+      (by rw [tis_length]; decide) a i h_mem
+  have hs := cpsTripleWithin_extend_code h_loadMono hs0
+  rw [show T + 176 + BitVec.ofNat 64 (4 * tisFrame.length) = T + 208 from by
+    simp [tisFrame]; bv_omega] at hs
+  have ha0 := addi_spec_gen_same_within .x2 spC (64 : BitVec 12) (T + 208) (by decide)
+  have hsp : spC + signExtend12 (64 : BitVec 12) = sp0 := by
+    rw [hspC]
+    rw [show signExtend12 (-64 : BitVec 12) = (-64 : Word) from by decide,
+      show signExtend12 (64 : BitVec 12) = (64 : Word) from by decide]
+    bv_omega
+  rw [hsp] at ha0
+  have ha := cpsTripleWithin_extend_code
+    (CodeReq.ofProg_mem_at T (T + 208) tisProg 52
+      (.ADDI .x2 .x2 (64 : BitVec 12))
+      (by bv_omega)
+      (by rw [tis_length]; decide) rfl
+      (by rw [tis_length]; decide)) ha0
+  have haF := cpsTripleWithin_frameR
+    (regsAt tisFrame (tisSavedVals s) ** frameSlotsSaved tisFrame spC (tisSavedVals s))
+    (by pcf) ha
+  have hload_addi := cpsTripleWithin_seq_perm_same_cr
+    (fun _ hp => by xperm_hyp hp) hs haF
+  have hpc : (T + 208 : Word) + 4 = T + 212 := by bv_omega
+  rw [hpc] at hload_addi
+  have hjalr0 := EvmAsm.Evm64.ret_spec_within' (T + 212) s.ra
+  rw [hret] at hjalr0
+  have hjalrC := cpsTripleWithin_extend_code
+    (CodeReq.ofProg_mem_at T (T + 212) tisProg 53
+      (.JALR .x0 .x1 (0 : BitVec 12))
+      (by bv_omega)
+      (by rw [tis_length]; decide) rfl
+      (by rw [tis_length]; decide)) hjalr0
+  have hjalrF := cpsTripleWithin_frameR
+    ((.x2 ↦ᵣ sp0) **
+      (.x8 ↦ᵣ s.s0) ** (.x9 ↦ᵣ s.s1) **
+      (.x18 ↦ᵣ s.s2) ** (.x19 ↦ᵣ s.s3) **
+      (.x20 ↦ᵣ s.s4) ** (.x21 ↦ᵣ s.s5) ** (.x22 ↦ᵣ s.s6) **
+      frameSlotsSaved tisFrame spC (tisSavedVals s))
+    (by pcf) hjalrC
+  have hall := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by
+    rw [regsAt_tisFrame] at hp
+    xperm_hyp hp) hload_addi hjalrF
+  have hn : tisFrame.length + 1 + 1 = 10 := by simp [tisFrame]
+  rw [hn] at hall
+  change cpsTripleWithin 10 EpiRestore s.ra tisCode _ _
+  exact cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
+    (fun _ hq => by xperm_hyp hq) hall
+
+set_option maxRecDepth 8000 in
+/-- Success epilogue: frame a0=0 through restore. -/
+theorem tisEpilogueSuccess (sp0 spC : Word) (s cur : TisSaved) (a0v : Word)
+    (hspC : spC = sp0 + signExtend12 (-64 : BitVec 12))
+    (hret : s.ra &&& ~~~(1 : Word) = s.ra) :
+    cpsTripleWithin 10 EpiRestore s.ra tisCode
+      ((.x10 ↦ᵣ a0v) ** (.x2 ↦ᵣ spC) **
+        regsAt tisFrame (tisSavedVals cur) **
+        frameSlotsSaved tisFrame spC (tisSavedVals s))
+      ((.x10 ↦ᵣ a0v) ** (.x1 ↦ᵣ s.ra) ** (.x2 ↦ᵣ sp0) **
+        (.x8 ↦ᵣ s.s0) ** (.x9 ↦ᵣ s.s1) **
+        (.x18 ↦ᵣ s.s2) ** (.x19 ↦ᵣ s.s3) **
+        (.x20 ↦ᵣ s.s4) ** (.x21 ↦ᵣ s.s5) ** (.x22 ↦ᵣ s.s6) **
+        frameSlotsSaved tisFrame spC (tisSavedVals s)) := by
+  have h := tisEpilogueRestore sp0 spC s cur hspC hret
+  have hF := cpsTripleWithin_frameR (.x10 ↦ᵣ a0v) (by exact pcFree_regIs) h
+  exact cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
+    (fun _ hq => by xperm_hyp hq) hF
+
+end EvmAsm.Codegen.TxIntrinsicStateGasSpec

--- a/EvmAsm/Codegen/Programs/TxIntrinsicStateGasEts.lean
+++ b/EvmAsm/Codegen/Programs/TxIntrinsicStateGasEts.lean
@@ -1,0 +1,320 @@
+/-
+  Zeros ABI + LD is_creation + eip8037_tx_state_gas call + JAL epilogue
+  (instr 28-38) for `tx_intrinsic_state_gas`.
+
+  Proven leaf: eip8037_tx_state_gas (ets_zero_out_full) writes *out=0, a0=0.
+-/
+
+import EvmAsm.Codegen.Programs.TxIntrinsicStateGasType
+import EvmAsm.Rv64.LaResolve
+import EvmAsm.Rv64.SAsm.AbiFrameCall
+import EvmAsm.Rv64.ControlFlow
+import EvmAsm.Rv64.Tactics.XSimp
+import EvmAsm.Codegen.AsmReloc
+
+namespace EvmAsm.Codegen.TxIntrinsicStateGasSpec
+
+open EvmAsm.Rv64
+open EvmAsm.Rv64.SAsm
+open EvmAsm.Codegen
+open EvmAsm.Codegen.Eip8037TxStateGasSpec
+
+local macro "pcf" : tactic =>
+  `(tactic| repeat
+      first
+      | apply pcFree_sepConj
+      | exact pcFree_regIs
+      | exact pcFree_regOwn
+      | exact pcFree_memIs
+      | exact pcFree_memOwn
+      | exact pcFree_emp
+      | exact pcFree_pure
+      | exact bytesRegion_pcFree _ _
+      | exact pcFree_regsAt _ _
+      | exact pcFree_frameSlotsSaved _ _ _)
+
+abbrev LinkEts : Word := T + 152
+abbrev AfterEtsJal : Word := T + 152
+abbrev EtsEntry : Word := P
+
+abbrev etsJalOff : BitVec 21 :=
+  jalOff GuestAddrs.eip8037_tx_state_gas (GuestAddrs.tx_intrinsic_state_gas + 148)
+
+private theorem se12_zero : signExtend12 (0 : BitVec 12) = (0 : Word) := by decide
+
+/-- LI x20,0; MV a0,x20; LI a1/a2/a3,0 (instr 28-32). -/
+theorem tisEtsZeros (v20 v10 v11 v12 v13 : Word) :
+    cpsTripleWithin 5 AfterTypeBne (T + 132) fullCode
+      ((.x20 ↦ᵣ v20) ** (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ v11) **
+        (.x12 ↦ᵣ v12) ** (.x13 ↦ᵣ v13))
+      ((.x20 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ (0 : Word)) **
+        (.x11 ↦ᵣ (0 : Word)) ** (.x12 ↦ᵣ (0 : Word)) **
+        (.x13 ↦ᵣ (0 : Word))) := by
+  have h0 := li_spec_gen_within .x20 v20 (0 : Word) AfterTypeBne (by decide)
+  have e0 := cpsTripleWithin_extend_code
+    (fun a i hi => tis_mono a i
+      (CodeReq.ofProg_mem_at T AfterTypeBne tisProg 28
+        (.LI .x20 (0 : Word)) (by simp only [AfterTypeBne]; bv_omega)
+        (by rw [tis_length]; decide) rfl (by rw [tis_length]; decide) a i hi)) h0
+  have h1 := mv_spec_gen_within .x10 .x20 (0 : Word) v10 (T + 116) (by decide)
+  have e1 := cpsTripleWithin_extend_code
+    (fun a i hi => tis_mono a i
+      (CodeReq.ofProg_mem_at T (T + 116) tisProg 29
+        (.MV .x10 .x20) (by bv_omega) (by rw [tis_length]; decide) rfl
+        (by rw [tis_length]; decide) a i hi)) h1
+  have h2 := li_spec_gen_within .x11 v11 (0 : Word) (T + 120) (by decide)
+  have e2 := cpsTripleWithin_extend_code
+    (fun a i hi => tis_mono a i
+      (CodeReq.ofProg_mem_at T (T + 120) tisProg 30
+        (.LI .x11 (0 : Word)) (by bv_omega) (by rw [tis_length]; decide) rfl
+        (by rw [tis_length]; decide) a i hi)) h2
+  have h3 := li_spec_gen_within .x12 v12 (0 : Word) (T + 124) (by decide)
+  have e3 := cpsTripleWithin_extend_code
+    (fun a i hi => tis_mono a i
+      (CodeReq.ofProg_mem_at T (T + 124) tisProg 31
+        (.LI .x12 (0 : Word)) (by bv_omega) (by rw [tis_length]; decide) rfl
+        (by rw [tis_length]; decide) a i hi)) h3
+  have h4 := li_spec_gen_within .x13 v13 (0 : Word) (T + 128) (by decide)
+  have e4 := cpsTripleWithin_extend_code
+    (fun a i hi => tis_mono a i
+      (CodeReq.ofProg_mem_at T (T + 128) tisProg 32
+        (.LI .x13 (0 : Word)) (by bv_omega) (by rw [tis_length]; decide) rfl
+        (by rw [tis_length]; decide) a i hi)) h4
+  have e0F := cpsTripleWithin_frameR
+    ((.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ v11) ** (.x12 ↦ᵣ v12) ** (.x13 ↦ᵣ v13))
+    (by pcf) e0
+  -- MV a0,x20 already pins x20=0; frame a1-a3 only
+  have e1F := cpsTripleWithin_frameR
+    ((.x11 ↦ᵣ v11) ** (.x12 ↦ᵣ v12) ** (.x13 ↦ᵣ v13))
+    (by pcf) e1
+  have e2F := cpsTripleWithin_frameR
+    ((.x20 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ (0 : Word)) **
+      (.x12 ↦ᵣ v12) ** (.x13 ↦ᵣ v13))
+    (by pcf) e2
+  have e3F := cpsTripleWithin_frameR
+    ((.x20 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ (0 : Word)) **
+      (.x11 ↦ᵣ (0 : Word)) ** (.x13 ↦ᵣ v13))
+    (by pcf) e3
+  have e4F := cpsTripleWithin_frameR
+    ((.x20 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ (0 : Word)) **
+      (.x11 ↦ᵣ (0 : Word)) ** (.x12 ↦ᵣ (0 : Word)))
+    (by pcf) e4
+  have c01 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) e0F e1F
+  have c02 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) c01 e2F
+  have c03 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) c02 e3F
+  have c04 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) c03 e4F
+  exact cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
+    (fun _ hq => by xperm_hyp hq) c04
+
+/-- `la x5, tis_is_creation` at T+132 → T+140. -/
+theorem tisLaIsCreationEts (v : Word) :
+    cpsTripleWithin 2 (T + 132) (T + 140) fullCode
+      (.x5 ↦ᵣ v) (.x5 ↦ᵣ IsCreationAddr) := by
+  have hau : ∀ a i, CodeReq.singleton (T + 132)
+      (.AUIPC .x5 (Codegen.laHi GuestAddrs.tis_is_creation
+        (GuestAddrs.tx_intrinsic_state_gas + 132)))
+        a = some i → fullCode a = some i := fun a i hi => tis_mono a i
+    (CodeReq.ofProg_mem_at T (T + 132) tisProg 33
+      (.AUIPC .x5 (Codegen.laHi GuestAddrs.tis_is_creation
+        (GuestAddrs.tx_intrinsic_state_gas + 132)))
+      (by bv_omega) (by rw [tis_length]; decide) rfl
+      (by rw [tis_length]; decide) a i hi)
+  have had : ∀ a i, CodeReq.singleton (T + 136)
+      (.ADDI .x5 .x5 (Codegen.laLo GuestAddrs.tis_is_creation
+        (GuestAddrs.tx_intrinsic_state_gas + 132)))
+        a = some i → fullCode a = some i := fun a i hi => tis_mono a i
+    (CodeReq.ofProg_mem_at T (T + 136) tisProg 34
+      (.ADDI .x5 .x5 (Codegen.laLo GuestAddrs.tis_is_creation
+        (GuestAddrs.tx_intrinsic_state_gas + 132)))
+      (by bv_omega) (by rw [tis_length]; decide) rfl
+      (by rw [tis_length]; decide) a i hi)
+  have h := la_materialize_within .x5 v (T + 132) IsCreationAddr
+    (by decide) (by decide) hau had
+  rw [show (T + 132 : Word) + 8 = T + 140 from by bv_omega] at h
+  exact h
+
+/-- LD a4, 0(x5) is_creation (instr 35). -/
+theorem tisEtsLdIsCreation (isCreationVal v14 : Word) :
+    cpsTripleWithin 1 (T + 140) (T + 144) fullCode
+      ((.x5 ↦ᵣ IsCreationAddr) ** (.x14 ↦ᵣ v14) **
+        (IsCreationAddr ↦ₘ isCreationVal))
+      ((.x5 ↦ᵣ IsCreationAddr) ** (.x14 ↦ᵣ isCreationVal) **
+        (IsCreationAddr ↦ₘ isCreationVal)) := by
+  have h0 := ld_spec_gen_within .x14 .x5 IsCreationAddr v14 isCreationVal
+    (0 : BitVec 12) (T + 140) (by decide)
+  rw [show IsCreationAddr + signExtend12 (0 : BitVec 12) = IsCreationAddr from by
+    rw [se12_zero]; exact BitVec.add_zero IsCreationAddr] at h0
+  have e0 := cpsTripleWithin_extend_code
+    (fun a i hi => tis_mono a i
+      (CodeReq.ofProg_mem_at T (T + 140) tisProg 35
+        (.LD .x14 .x5 (0 : BitVec 12)) (by bv_omega)
+        (by rw [tis_length]; decide) rfl (by rw [tis_length]; decide) a i hi)) h0
+  have hpc : (T + 140 : Word) + 4 = T + 144 := by bv_omega
+  rw [hpc] at e0
+  exact e0
+
+/-- MV a5, s2 (outPtr) (instr 36). -/
+theorem tisEtsMvOut (outPtr v15 : Word) :
+    cpsTripleWithin 1 (T + 144) (T + 148) fullCode
+      ((.x18 ↦ᵣ outPtr) ** (.x15 ↦ᵣ v15))
+      ((.x18 ↦ᵣ outPtr) ** (.x15 ↦ᵣ outPtr)) := by
+  have h0 := mv_spec_gen_within .x15 .x18 outPtr v15 (T + 144) (by decide)
+  have e0 := cpsTripleWithin_extend_code
+    (fun a i hi => tis_mono a i
+      (CodeReq.ofProg_mem_at T (T + 144) tisProg 36
+        (.MV .x15 .x18) (by bv_omega) (by rw [tis_length]; decide) rfl
+        (by rw [tis_length]; decide) a i hi)) h0
+  have hpc : (T + 144 : Word) + 4 = T + 148 := by bv_omega
+  rw [hpc] at e0
+  exact e0
+
+/-- Callee footprint for ets (no ra). -/
+def etsCalleeP (outPtr oldOut a2v a3v a4v t0Old : Word) : Assertion :=
+  (.x10 ↦ᵣ (0 : Word)) ** (.x11 ↦ᵣ (0 : Word)) **
+  (.x12 ↦ᵣ a2v) ** (.x13 ↦ᵣ a3v) ** (.x14 ↦ᵣ a4v) **
+  (.x15 ↦ᵣ outPtr) ** (.x5 ↦ᵣ t0Old) **
+  (outPtr ↦ₘ oldOut) ** (.x0 ↦ᵣ (0 : Word))
+
+def etsCalleeQ (outPtr a2v a3v a4v : Word) : Assertion :=
+  (.x10 ↦ᵣ (0 : Word)) ** (.x11 ↦ᵣ (0 : Word)) **
+  (.x12 ↦ᵣ a2v) ** (.x13 ↦ᵣ a3v) ** (.x14 ↦ᵣ a4v) **
+  (.x15 ↦ᵣ outPtr) ** (.x5 ↦ᵣ (0 : Word)) **
+  (outPtr ↦ₘ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word))
+
+theorem etsCalleeP_pcFree (outPtr oldOut a2v a3v a4v t0Old : Word) :
+    (etsCalleeP outPtr oldOut a2v a3v a4v t0Old).pcFree := by
+  unfold etsCalleeP; pcf
+
+set_option maxRecDepth 8000 in
+/-- callWithin eip8037_tx_state_gas under proven zero_out (instr 37). -/
+theorem tisEtsCall
+    (outPtr oldOut a2v a3v a4v t0Old old1 : Word)
+    (hret : (LinkEts &&& ~~~(1 : Word)) = LinkEts) :
+    cpsTripleWithin (1 + 4) (T + 148) LinkEts fullCode
+      ((.x1 ↦ᵣ old1) ** etsCalleeP outPtr oldOut a2v a3v a4v t0Old)
+      ((.x1 ↦ᵣ LinkEts) ** etsCalleeQ outPtr a2v a3v a4v) := by
+  have hcallee0 := ets_zero_out_full LinkEts outPtr oldOut a2v a3v a4v t0Old hret
+  have hcallee : cpsTripleWithin 4 EtsEntry LinkEts fullCode
+      ((.x1 ↦ᵣ LinkEts) ** etsCalleeP outPtr oldOut a2v a3v a4v t0Old)
+      ((.x1 ↦ᵣ LinkEts) ** etsCalleeQ outPtr a2v a3v a4v) := by
+    unfold etsCalleeP etsCalleeQ EtsEntry
+    exact cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
+      (fun _ hq => by xperm_hyp hq) hcallee0
+  have hcall := callWithin_spec (T + 148) EtsEntry old1 etsJalOff 4
+    (by show (T + 148) + signExtend21 etsJalOff = EtsEntry; decide)
+    (fun a i hi => tis_mono a i
+      (CodeReq.ofProg_mem_at T (T + 148) tisProg 37
+        (.JAL .x1 etsJalOff) (by bv_omega) (by rw [tis_length]; decide) rfl
+        (by rw [tis_length]; decide) a i hi))
+    (etsCalleeP_pcFree outPtr oldOut a2v a3v a4v t0Old)
+    hcallee
+  rw [show (T + 148 + 4 : Word) = LinkEts from by
+    simp only [LinkEts]; bv_omega] at hcall
+  exact hcall
+
+/-- JAL x0,+24 LinkEts → EpiRestore (instr 38). -/
+theorem tisEtsJalEpi :
+    cpsTripleWithin 1 LinkEts EpiRestore fullCode
+      empAssertion empAssertion := by
+  have h0 := jal_x0_spec_gen_within (24 : BitVec 21) LinkEts
+  have e0 := cpsTripleWithin_extend_code
+    (fun a i hi => tis_mono a i
+      (CodeReq.ofProg_mem_at T LinkEts tisProg 38
+        (.JAL .x0 (24 : BitVec 21))
+        (by simp only [LinkEts]; bv_omega)
+        (by rw [tis_length]; decide) rfl
+        (by rw [tis_length]; decide) a i hi)) h0
+  have hpc : LinkEts + signExtend21 (24 : BitVec 21) = EpiRestore := by
+    simp only [LinkEts, EpiRestore, T]
+    decide
+  rw [hpc] at e0
+  exact e0
+
+set_option maxRecDepth 8000 in
+/-- Full ets tail: AfterTypeBne → EpiRestore with *out=0, a0=0. -/
+theorem tisEtsSuccess
+    (outPtr oldOut isCreationVal v5 v10 v11 v12 v13 v14 v15 v20 old1 : Word)
+    (hlink : (LinkEts &&& ~~~(1 : Word)) = LinkEts) :
+    cpsTripleWithin (5 + 2 + 1 + 1 + (1 + 4) + 1) AfterTypeBne EpiRestore fullCode
+      ((.x1 ↦ᵣ old1) ** (.x5 ↦ᵣ v5) **
+        (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ v11) ** (.x12 ↦ᵣ v12) ** (.x13 ↦ᵣ v13) **
+        (.x14 ↦ᵣ v14) ** (.x15 ↦ᵣ v15) ** (.x18 ↦ᵣ outPtr) ** (.x20 ↦ᵣ v20) **
+        (IsCreationAddr ↦ₘ isCreationVal) ** (outPtr ↦ₘ oldOut) **
+        (.x0 ↦ᵣ (0 : Word)))
+      ((.x1 ↦ᵣ LinkEts) ** (.x5 ↦ᵣ (0 : Word)) **
+        (.x10 ↦ᵣ (0 : Word)) ** (.x11 ↦ᵣ (0 : Word)) **
+        (.x12 ↦ᵣ (0 : Word)) ** (.x13 ↦ᵣ (0 : Word)) **
+        (.x14 ↦ᵣ isCreationVal) ** (.x15 ↦ᵣ outPtr) **
+        (.x18 ↦ᵣ outPtr) ** (.x20 ↦ᵣ (0 : Word)) **
+        (IsCreationAddr ↦ₘ isCreationVal) ** (outPtr ↦ₘ (0 : Word)) **
+        (.x0 ↦ᵣ (0 : Word))) := by
+  -- zeros
+  have hz := tisEtsZeros v20 v10 v11 v12 v13
+  have hzF := cpsTripleWithin_frameR
+    ((.x1 ↦ᵣ old1) ** (.x5 ↦ᵣ v5) ** (.x14 ↦ᵣ v14) ** (.x15 ↦ᵣ v15) **
+      (.x18 ↦ᵣ outPtr) **
+      (IsCreationAddr ↦ₘ isCreationVal) ** (outPtr ↦ₘ oldOut) **
+      (.x0 ↦ᵣ (0 : Word))) (by pcf) hz
+  -- la is_creation into x5
+  have hla := tisLaIsCreationEts v5
+  have hlaF := cpsTripleWithin_frameR
+    ((.x1 ↦ᵣ old1) ** (.x10 ↦ᵣ (0 : Word)) ** (.x11 ↦ᵣ (0 : Word)) **
+      (.x12 ↦ᵣ (0 : Word)) ** (.x13 ↦ᵣ (0 : Word)) **
+      (.x14 ↦ᵣ v14) ** (.x15 ↦ᵣ v15) ** (.x18 ↦ᵣ outPtr) **
+      (.x20 ↦ᵣ (0 : Word)) **
+      (IsCreationAddr ↦ₘ isCreationVal) ** (outPtr ↦ₘ oldOut) **
+      (.x0 ↦ᵣ (0 : Word))) (by pcf) hla
+  have c01 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) hzF hlaF
+  -- LD a4
+  have hld := tisEtsLdIsCreation isCreationVal v14
+  have hldF := cpsTripleWithin_frameR
+    ((.x1 ↦ᵣ old1) ** (.x10 ↦ᵣ (0 : Word)) ** (.x11 ↦ᵣ (0 : Word)) **
+      (.x12 ↦ᵣ (0 : Word)) ** (.x13 ↦ᵣ (0 : Word)) **
+      (.x15 ↦ᵣ v15) ** (.x18 ↦ᵣ outPtr) ** (.x20 ↦ᵣ (0 : Word)) **
+      (outPtr ↦ₘ oldOut) ** (.x0 ↦ᵣ (0 : Word))) (by pcf) hld
+  have c02 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) c01 hldF
+  -- MV a5,s2
+  have hmv := tisEtsMvOut outPtr v15
+  have hmvF := cpsTripleWithin_frameR
+    ((.x1 ↦ᵣ old1) ** (.x5 ↦ᵣ IsCreationAddr) **
+      (.x10 ↦ᵣ (0 : Word)) ** (.x11 ↦ᵣ (0 : Word)) **
+      (.x12 ↦ᵣ (0 : Word)) ** (.x13 ↦ᵣ (0 : Word)) **
+      (.x14 ↦ᵣ isCreationVal) ** (.x20 ↦ᵣ (0 : Word)) **
+      (IsCreationAddr ↦ₘ isCreationVal) ** (outPtr ↦ₘ oldOut) **
+      (.x0 ↦ᵣ (0 : Word))) (by pcf) hmv
+  have c03 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) c02 hmvF
+  -- call ets (t0Old = IsCreationAddr after la/ld)
+  have hcall := tisEtsCall outPtr oldOut 0 0 isCreationVal IsCreationAddr old1 hlink
+  have hcallF := cpsTripleWithin_frameR
+    ((.x18 ↦ᵣ outPtr) ** (.x20 ↦ᵣ (0 : Word)) **
+      (IsCreationAddr ↦ₘ isCreationVal)) (by pcf) hcall
+  have c04 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by
+    unfold etsCalleeP at *
+    xperm_hyp hp) c03 hcallF
+  -- JAL epi: frame ambient; cancel emp ** ambient
+  let ambient : Assertion :=
+    (.x1 ↦ᵣ LinkEts) ** (.x5 ↦ᵣ (0 : Word)) **
+      (.x10 ↦ᵣ (0 : Word)) ** (.x11 ↦ᵣ (0 : Word)) **
+      (.x12 ↦ᵣ (0 : Word)) ** (.x13 ↦ᵣ (0 : Word)) **
+      (.x14 ↦ᵣ isCreationVal) ** (.x15 ↦ᵣ outPtr) **
+      (.x18 ↦ᵣ outPtr) ** (.x20 ↦ᵣ (0 : Word)) **
+      (IsCreationAddr ↦ₘ isCreationVal) ** (outPtr ↦ₘ (0 : Word)) **
+      (.x0 ↦ᵣ (0 : Word))
+  have hjal := tisEtsJalEpi
+  have hjal0 := cpsTripleWithin_frameR ambient (by unfold ambient; pcf) hjal
+  have hjalF : cpsTripleWithin 1 LinkEts EpiRestore fullCode ambient ambient := by
+    exact cpsTripleWithin_weaken
+      (fun h hp => by
+        show (empAssertion ** ambient) h
+        rwa [sepConj_emp_left' ambient])
+      (fun h hq => by
+        have hq' : (empAssertion ** ambient) h := hq
+        rwa [sepConj_emp_left' ambient] at hq')
+      hjal0
+  have c05 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by
+    unfold etsCalleeQ ambient at *
+    xperm_hyp hp) c04 hjalF
+  exact cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
+    (fun _ hq => by unfold ambient at hq; xperm_hyp hq) c05
+
+end EvmAsm.Codegen.TxIntrinsicStateGasSpec

--- a/EvmAsm/Codegen/Programs/TxIntrinsicStateGasExtract.lean
+++ b/EvmAsm/Codegen/Programs/TxIntrinsicStateGasExtract.lean
@@ -1,0 +1,268 @@
+/-
+  Extract setup + call + success BNE (instr 14-19) for `tx_intrinsic_state_gas`.
+
+  la to_buf / is_creation → jal tx_extract_to_address → bne a0≠0 fail.
+  Success arm under ExtractAssumed named hyp.
+-/
+
+import EvmAsm.Codegen.Programs.TxIntrinsicStateGasEpilogue
+import EvmAsm.Rv64.LaResolve
+import EvmAsm.Rv64.SAsm.AbiFrameCall
+import EvmAsm.Rv64.Tactics.RunBlock
+import EvmAsm.Rv64.Tactics.XSimp
+import EvmAsm.Codegen.AsmReloc
+
+namespace EvmAsm.Codegen.TxIntrinsicStateGasSpec
+
+open EvmAsm.Rv64
+open EvmAsm.Rv64.SAsm
+open EvmAsm.Rv64.Tactics
+open EvmAsm.Codegen
+
+local macro "pcf" : tactic =>
+  `(tactic| repeat
+      first
+      | apply pcFree_sepConj
+      | exact pcFree_regIs
+      | exact pcFree_regOwn
+      | exact pcFree_memIs
+      | exact pcFree_memOwn
+      | exact pcFree_emp
+      | exact pcFree_pure
+      | exact bytesRegion_pcFree _ _
+      | exact pcFree_regsAt _ _
+      | exact pcFree_frameSlotsSaved _ _ _)
+
+abbrev ToBufAddr : Word := BitVec.ofNat 64 GuestAddrs.tis_to_buf
+abbrev IsCreationAddr : Word := BitVec.ofNat 64 GuestAddrs.tis_is_creation
+abbrev TypeAddr : Word := BitVec.ofNat 64 GuestAddrs.tis_type
+abbrev InnerOffAddr : Word := BitVec.ofNat 64 GuestAddrs.tis_inner_off
+abbrev ExtractEntry : Word := BitVec.ofNat 64 GuestAddrs.tx_extract_to_address
+abbrev TypeEntry : Word := BitVec.ofNat 64 GuestAddrs.tx_type_dispatch
+
+abbrev LinkExtract : Word := T + 76
+abbrev AfterExtractBne : Word := T + 80
+abbrev Fail1 : Word := T + 156
+
+abbrev extractJalOff : BitVec 21 :=
+  jalOff GuestAddrs.tx_extract_to_address (GuestAddrs.tx_intrinsic_state_gas + 72)
+
+/-- `la x12, tis_to_buf` at T+56 → T+64. -/
+theorem tisLaToBuf (v : Word) :
+    cpsTripleWithin 2 (T + 56) (T + 64) fullCode
+      (.x12 ↦ᵣ v) (.x12 ↦ᵣ ToBufAddr) := by
+  have hau : ∀ a i, CodeReq.singleton (T + 56)
+      (.AUIPC .x12 (Codegen.laHi GuestAddrs.tis_to_buf
+        (GuestAddrs.tx_intrinsic_state_gas + 56)))
+        a = some i → fullCode a = some i := fun a i hi => tis_mono a i
+    (CodeReq.ofProg_mem_at T (T + 56) tisProg 14
+      (.AUIPC .x12 (Codegen.laHi GuestAddrs.tis_to_buf
+        (GuestAddrs.tx_intrinsic_state_gas + 56)))
+      (by bv_omega) (by rw [tis_length]; decide) rfl
+      (by rw [tis_length]; decide) a i hi)
+  have had : ∀ a i, CodeReq.singleton (T + 60)
+      (.ADDI .x12 .x12 (Codegen.laLo GuestAddrs.tis_to_buf
+        (GuestAddrs.tx_intrinsic_state_gas + 56)))
+        a = some i → fullCode a = some i := fun a i hi => tis_mono a i
+    (CodeReq.ofProg_mem_at T (T + 60) tisProg 15
+      (.ADDI .x12 .x12 (Codegen.laLo GuestAddrs.tis_to_buf
+        (GuestAddrs.tx_intrinsic_state_gas + 56)))
+      (by bv_omega) (by rw [tis_length]; decide) rfl
+      (by rw [tis_length]; decide) a i hi)
+  have h := la_materialize_within .x12 v (T + 56) ToBufAddr
+    (by decide) (by decide) hau had
+  rw [show (T + 56 : Word) + 8 = T + 64 from by bv_omega] at h
+  exact h
+
+/-- `la x13, tis_is_creation` at T+64 → T+72. -/
+theorem tisLaIsCreation (v : Word) :
+    cpsTripleWithin 2 (T + 64) (T + 72) fullCode
+      (.x13 ↦ᵣ v) (.x13 ↦ᵣ IsCreationAddr) := by
+  have hau : ∀ a i, CodeReq.singleton (T + 64)
+      (.AUIPC .x13 (Codegen.laHi GuestAddrs.tis_is_creation
+        (GuestAddrs.tx_intrinsic_state_gas + 64)))
+        a = some i → fullCode a = some i := fun a i hi => tis_mono a i
+    (CodeReq.ofProg_mem_at T (T + 64) tisProg 16
+      (.AUIPC .x13 (Codegen.laHi GuestAddrs.tis_is_creation
+        (GuestAddrs.tx_intrinsic_state_gas + 64)))
+      (by bv_omega) (by rw [tis_length]; decide) rfl
+      (by rw [tis_length]; decide) a i hi)
+  have had : ∀ a i, CodeReq.singleton (T + 68)
+      (.ADDI .x13 .x13 (Codegen.laLo GuestAddrs.tis_is_creation
+        (GuestAddrs.tx_intrinsic_state_gas + 64)))
+        a = some i → fullCode a = some i := fun a i hi => tis_mono a i
+    (CodeReq.ofProg_mem_at T (T + 68) tisProg 17
+      (.ADDI .x13 .x13 (Codegen.laLo GuestAddrs.tis_is_creation
+        (GuestAddrs.tx_intrinsic_state_gas + 64)))
+      (by bv_omega) (by rw [tis_length]; decide) rfl
+      (by rw [tis_length]; decide) a i hi)
+  have h := la_materialize_within .x13 v (T + 64) IsCreationAddr
+    (by decide) (by decide) hau had
+  rw [show (T + 64 : Word) + 8 = T + 72 from by bv_omega] at h
+  exact h
+
+set_option maxRecDepth 8000 in
+/-- Setup: two `la`s (instr 14-17). a0/a1 already txBase/len from prologue. -/
+theorem tisExtractSetup (txBase txLenW outPtr : Word)
+    (v12 v13 : Word) :
+    cpsTripleWithin 4 (T + 56) (T + 72) fullCode
+      ((.x10 ↦ᵣ txBase) ** (.x11 ↦ᵣ txLenW) ** (.x12 ↦ᵣ v12) ** (.x13 ↦ᵣ v13) **
+        (.x18 ↦ᵣ outPtr))
+      ((.x10 ↦ᵣ txBase) ** (.x11 ↦ᵣ txLenW) **
+        (.x12 ↦ᵣ ToBufAddr) ** (.x13 ↦ᵣ IsCreationAddr) **
+        (.x18 ↦ᵣ outPtr)) := by
+  have h0 := tisLaToBuf v12
+  have h0F := cpsTripleWithin_frameR
+    ((.x10 ↦ᵣ txBase) ** (.x11 ↦ᵣ txLenW) ** (.x13 ↦ᵣ v13) ** (.x18 ↦ᵣ outPtr))
+    (by pcf) h0
+  have h1 := tisLaIsCreation v13
+  have h1F := cpsTripleWithin_frameR
+    ((.x10 ↦ᵣ txBase) ** (.x11 ↦ᵣ txLenW) ** (.x12 ↦ᵣ ToBufAddr) **
+      (.x18 ↦ᵣ outPtr))
+    (by pcf) h1
+  have h01 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) h0F h1F
+  exact cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
+    (fun _ hq => by xperm_hyp hq) h01
+
+/-- Callee footprint for extract call (no ra). -/
+def extractCalleeP (txBase lenW : Word) (txBytes : List (BitVec 8)) : Assertion :=
+  (.x10 ↦ᵣ txBase) ** (.x11 ↦ᵣ lenW) **
+  (.x12 ↦ᵣ ToBufAddr) ** (.x13 ↦ᵣ IsCreationAddr) **
+  bytesRegion txBase txBytes **
+  memOwn ToBufAddr ** memOwn IsCreationAddr **
+  regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+  regOwn .x14 ** regOwn .x15 ** regOwn .x16 **
+  regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+  (.x0 ↦ᵣ (0 : Word))
+
+def extractCalleeQ (txBase : Word) (txBytes : List (BitVec 8)) : Assertion :=
+  (.x10 ↦ᵣ (0 : Word)) **
+  bytesRegion txBase txBytes **
+  memOwn ToBufAddr ** memOwn IsCreationAddr **
+  regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+  regOwn .x11 ** regOwn .x12 ** regOwn .x13 **
+  regOwn .x14 ** regOwn .x15 ** regOwn .x16 **
+  regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+  (.x0 ↦ᵣ (0 : Word))
+
+theorem extractCalleeP_pcFree (txBase lenW : Word) (txBytes : List (BitVec 8)) :
+    (extractCalleeP txBase lenW txBytes).pcFree := by
+  unfold extractCalleeP; pcf
+
+set_option maxRecDepth 8000 in
+/-- Call extract under ExtractAssumed; success a0=0 at LinkExtract. -/
+theorem tisExtractCall
+    (asm : ExtractAssumed fullCode)
+    (hentry : asm.entry = ExtractEntry)
+    (txBase lenW : Word) (txBytes : List (BitVec 8))
+    (old1 : Word)
+    (hlen : lenW = BitVec.ofNat 64 txBytes.length) :
+    cpsTripleWithin (1 + nExtractSteps) (T + 72) LinkExtract fullCode
+      ((.x1 ↦ᵣ old1) ** extractCalleeP txBase lenW txBytes)
+      ((.x1 ↦ᵣ LinkExtract) ** extractCalleeQ txBase txBytes) := by
+  have hret : (LinkExtract &&& ~~~(1 : Word)) = LinkExtract := by
+    simp only [LinkExtract, T]; decide
+  have hcallee0 := asm.success_flat LinkExtract txBase lenW
+    ToBufAddr IsCreationAddr txBytes hret hlen
+  have hcallee0' : cpsTripleWithin nExtractSteps asm.entry LinkExtract fullCode
+      ((.x1 ↦ᵣ LinkExtract) ** extractCalleeP txBase lenW txBytes)
+      ((.x1 ↦ᵣ LinkExtract) ** extractCalleeQ txBase txBytes) := by
+    unfold extractCalleeP extractCalleeQ
+    exact cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
+      (fun _ hq => by xperm_hyp hq) hcallee0
+  have hcallee : cpsTripleWithin nExtractSteps ExtractEntry LinkExtract fullCode
+      ((.x1 ↦ᵣ LinkExtract) ** extractCalleeP txBase lenW txBytes)
+      ((.x1 ↦ᵣ LinkExtract) ** extractCalleeQ txBase txBytes) := by
+    rw [← hentry]; exact hcallee0'
+  have hcall := callWithin_spec (T + 72) ExtractEntry old1 extractJalOff nExtractSteps
+    (by show (T + 72) + signExtend21 extractJalOff = ExtractEntry; decide)
+    (fun a i hi => tis_mono a i
+      (CodeReq.ofProg_mem_at T (T + 72) tisProg 18
+        (.JAL .x1 extractJalOff) (by bv_omega) (by rw [tis_length]; decide) rfl
+        (by rw [tis_length]; decide) a i hi))
+    (extractCalleeP_pcFree txBase lenW txBytes)
+    hcallee
+  rw [show (T + 72 + 4 : Word) = LinkExtract from by
+    simp only [LinkExtract]; bv_omega] at hcall
+  exact hcall
+
+set_option maxRecDepth 8000 in
+/-- BNE a0≠0 fail: ntaken when a0=0 → AfterExtractBne. -/
+theorem tisExtractBneOk :
+    cpsTripleWithin 1 LinkExtract AfterExtractBne fullCode
+      ((.x10 ↦ᵣ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)))
+      ((.x10 ↦ᵣ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word))) := by
+  have hbr := bne_spec_gen_within .x10 .x0 (80 : BitVec 13)
+    (0 : Word) (0 : Word) LinkExtract
+  have hbrC := cpsBranchWithin_extend_code
+    (fun a i hi => tis_mono a i
+      (CodeReq.ofProg_mem_at T LinkExtract tisProg 19
+        (.BNE .x10 .x0 (80 : BitVec 13))
+        (by simp only [LinkExtract]; bv_omega)
+        (by rw [tis_length]; decide) rfl
+        (by rw [tis_length]; decide) a i hi)) hbr
+  have hnt := cpsBranchWithin_ntakenStripPure2 hbrC (fun _ hQt => by
+    obtain ⟨_, _, _, _, _, hrest⟩ := hQt
+    exact absurd rfl ((sepConj_pure_right _).1 hrest).2)
+  have hpc : LinkExtract + 4 = AfterExtractBne := by
+    simp only [LinkExtract, AfterExtractBne]; bv_omega
+  rw [hpc] at hnt
+  exact hnt
+
+set_option maxRecDepth 8000 in
+/-- Extract setup + call + BNE ok under ExtractAssumed. -/
+theorem tisExtractSuccess
+    (asm : ExtractAssumed fullCode)
+    (hentry : asm.entry = ExtractEntry)
+    (txBase lenW outPtr : Word) (txBytes : List (BitVec 8))
+    (old1 v12 v13 : Word)
+    (hlen : lenW = BitVec.ofNat 64 txBytes.length) :
+    cpsTripleWithin (4 + (1 + nExtractSteps) + 1) (T + 56) AfterExtractBne fullCode
+      ((.x1 ↦ᵣ old1) ** (.x10 ↦ᵣ txBase) ** (.x11 ↦ᵣ lenW) **
+        (.x12 ↦ᵣ v12) ** (.x13 ↦ᵣ v13) ** (.x18 ↦ᵣ outPtr) **
+        bytesRegion txBase txBytes **
+        memOwn ToBufAddr ** memOwn IsCreationAddr **
+        regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+        regOwn .x14 ** regOwn .x15 ** regOwn .x16 **
+        regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+        (.x0 ↦ᵣ (0 : Word)))
+      ((.x1 ↦ᵣ LinkExtract) ** (.x10 ↦ᵣ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) **
+        (.x18 ↦ᵣ outPtr) **
+        bytesRegion txBase txBytes **
+        memOwn ToBufAddr ** memOwn IsCreationAddr **
+        regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+        regOwn .x11 ** regOwn .x12 ** regOwn .x13 **
+        regOwn .x14 ** regOwn .x15 ** regOwn .x16 **
+        regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31) := by
+  have hsetup := tisExtractSetup txBase lenW outPtr v12 v13
+  have hsetupF := cpsTripleWithin_frameR
+    ((.x1 ↦ᵣ old1) ** bytesRegion txBase txBytes **
+      memOwn ToBufAddr ** memOwn IsCreationAddr **
+      regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+      regOwn .x14 ** regOwn .x15 ** regOwn .x16 **
+      regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+      (.x0 ↦ᵣ (0 : Word))) (by pcf) hsetup
+  have hcall := tisExtractCall asm hentry txBase lenW txBytes old1 hlen
+  have hcallF := cpsTripleWithin_frameR (.x18 ↦ᵣ outPtr) (by exact pcFree_regIs) hcall
+  have h01 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by
+    unfold extractCalleeP at *
+    xperm_hyp hp) hsetupF hcallF
+  have hbne := tisExtractBneOk
+  have hbneF := cpsTripleWithin_frameR
+    ((.x1 ↦ᵣ LinkExtract) ** (.x18 ↦ᵣ outPtr) **
+      bytesRegion txBase txBytes **
+      memOwn ToBufAddr ** memOwn IsCreationAddr **
+      regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+      regOwn .x11 ** regOwn .x12 ** regOwn .x13 **
+      regOwn .x14 ** regOwn .x15 ** regOwn .x16 **
+      regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31)
+    (by pcf) hbne
+  have h12 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by
+    unfold extractCalleeQ at *
+    xperm_hyp hp) h01 hbneF
+  exact cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
+    (fun _ hq => by xperm_hyp hq) h12
+
+end EvmAsm.Codegen.TxIntrinsicStateGasSpec
+
+

--- a/EvmAsm/Codegen/Programs/TxIntrinsicStateGasPrologue.lean
+++ b/EvmAsm/Codegen/Programs/TxIntrinsicStateGasPrologue.lean
@@ -1,0 +1,173 @@
+/-
+  Prologue (instr 0–13) for `tx_intrinsic_state_gas`.
+
+  allocate 64-byte frame → storeSeq ra/s0–s6 → MV ABI a0–a2 into
+  s0/s1/s2 and restore a0/a1 from s0/s1. Leaves PC at T+56 (la extract).
+-/
+
+import EvmAsm.Codegen.Programs.TxIntrinsicStateGasSpec
+import EvmAsm.Rv64.SAsm.AbiFrame
+import EvmAsm.Rv64.Tactics.RunBlock
+import EvmAsm.Rv64.Tactics.XSimp
+
+namespace EvmAsm.Codegen.TxIntrinsicStateGasSpec
+
+open EvmAsm.Rv64
+open EvmAsm.Rv64.SAsm
+open EvmAsm.Rv64.Tactics
+
+local macro "pcf" : tactic =>
+  `(tactic| repeat
+      first
+      | apply pcFree_sepConj
+      | exact pcFree_regIs
+      | exact pcFree_regOwn
+      | exact pcFree_memIs
+      | exact pcFree_memOwn
+      | exact pcFree_emp
+      | exact pcFree_pure)
+
+theorem regsAt_tisFrame (s : TisSaved) :
+    regsAt tisFrame (tisSavedVals s) =
+      ((.x1 ↦ᵣ s.ra) ** (.x8 ↦ᵣ s.s0) ** (.x9 ↦ᵣ s.s1) **
+        (.x18 ↦ᵣ s.s2) ** (.x19 ↦ᵣ s.s3) ** (.x20 ↦ᵣ s.s4) **
+        (.x21 ↦ᵣ s.s5) ** (.x22 ↦ᵣ s.s6)) := by
+  simp [tisFrame, regsAt, tisSavedVals, sepConj_emp_right']
+
+theorem frameSlotsSaved_tisFrame (spC : Word) (s : TisSaved) :
+    frameSlotsSaved tisFrame spC (tisSavedVals s) =
+      ((spC + signExtend12 (0 : BitVec 12) ↦ₘ s.ra) **
+        (spC + signExtend12 (8 : BitVec 12) ↦ₘ s.s0) **
+        (spC + signExtend12 (16 : BitVec 12) ↦ₘ s.s1) **
+        (spC + signExtend12 (24 : BitVec 12) ↦ₘ s.s2) **
+        (spC + signExtend12 (32 : BitVec 12) ↦ₘ s.s3) **
+        (spC + signExtend12 (40 : BitVec 12) ↦ₘ s.s4) **
+        (spC + signExtend12 (48 : BitVec 12) ↦ₘ s.s5) **
+        (spC + signExtend12 (56 : BitVec 12) ↦ₘ s.s6)) := by
+  simp [tisFrame, frameSlotsSaved, tisSavedVals, sepConj_emp_right']
+
+/-- ABI args + temps carried through the prologue. -/
+def prologueAbiRest
+    (txBase txLenW outPtr : Word)
+    (old5 old6 old7 old13 old14 old15 old16 : Word) : Assertion :=
+  (.x10 ↦ᵣ txBase) ** (.x11 ↦ᵣ txLenW) ** (.x12 ↦ᵣ outPtr) **
+  (.x5 ↦ᵣ old5) ** (.x6 ↦ᵣ old6) ** (.x7 ↦ᵣ old7) **
+  (.x13 ↦ᵣ old13) ** (.x14 ↦ᵣ old14) ** (.x15 ↦ᵣ old15) ** (.x16 ↦ᵣ old16) **
+  regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+  (.x0 ↦ᵣ (0 : Word))
+
+/-- Post-prologue (PC = T+56): frame saved, ABI in s0/s1/s2, a0/a1 restored. -/
+def prologuePost (spC : Word) (s : TisSaved)
+    (txBase txLenW outPtr : Word)
+    (old5 old6 old7 old13 old14 old15 old16 : Word) : Assertion :=
+  (.x2 ↦ᵣ spC) **
+  (.x1 ↦ᵣ s.ra) **
+  (.x8 ↦ᵣ txBase) ** (.x9 ↦ᵣ txLenW) ** (.x18 ↦ᵣ outPtr) **
+  (.x19 ↦ᵣ s.s3) ** (.x20 ↦ᵣ s.s4) ** (.x21 ↦ᵣ s.s5) ** (.x22 ↦ᵣ s.s6) **
+  frameSlotsSaved tisFrame spC (tisSavedVals s) **
+  prologueAbiRest txBase txLenW outPtr old5 old6 old7 old13 old14 old15 old16
+
+set_option maxRecDepth 8000 in
+/-- Five ABI moves (instr 9-13): s0=a0, s1=a1, s2=a2, a0=s0, a1=s1. -/
+theorem tisAbiMoves
+    (txBase txLenW outPtr : Word)
+    (cs0 cs1 cs2 : Word) :
+    cpsTripleWithin 5 (T + 36) (T + 56) tisCode
+      ((.x8 ↦ᵣ cs0) ** (.x9 ↦ᵣ cs1) ** (.x18 ↦ᵣ cs2) **
+        (.x10 ↦ᵣ txBase) ** (.x11 ↦ᵣ txLenW) ** (.x12 ↦ᵣ outPtr))
+      ((.x8 ↦ᵣ txBase) ** (.x9 ↦ᵣ txLenW) ** (.x18 ↦ᵣ outPtr) **
+        (.x10 ↦ᵣ txBase) ** (.x11 ↦ᵣ txLenW) ** (.x12 ↦ᵣ outPtr)) := by
+  have h0 := mv_spec_gen_within .x8 .x10 txBase cs0 (T + 36) (by decide)
+  have h1 := mv_spec_gen_within .x9 .x11 txLenW cs1 (T + 40) (by decide)
+  have h2 := mv_spec_gen_within .x18 .x12 outPtr cs2 (T + 44) (by decide)
+  have h3 := mv_spec_gen_within .x10 .x8 txBase txBase (T + 48) (by decide)
+  have h4 := mv_spec_gen_within .x11 .x9 txLenW txLenW (T + 52) (by decide)
+  have e0 := cpsTripleWithin_extend_code
+    (CodeReq.ofProg_mem_at T (T + 36) tisProg 9
+      (.MV .x8 .x10) (by bv_omega) (by rw [tis_length]; decide) rfl
+      (by rw [tis_length]; decide)) h0
+  have e1 := cpsTripleWithin_extend_code
+    (CodeReq.ofProg_mem_at T (T + 40) tisProg 10
+      (.MV .x9 .x11) (by bv_omega) (by rw [tis_length]; decide) rfl
+      (by rw [tis_length]; decide)) h1
+  have e2 := cpsTripleWithin_extend_code
+    (CodeReq.ofProg_mem_at T (T + 44) tisProg 11
+      (.MV .x18 .x12) (by bv_omega) (by rw [tis_length]; decide) rfl
+      (by rw [tis_length]; decide)) h2
+  have e3 := cpsTripleWithin_extend_code
+    (CodeReq.ofProg_mem_at T (T + 48) tisProg 12
+      (.MV .x10 .x8) (by bv_omega) (by rw [tis_length]; decide) rfl
+      (by rw [tis_length]; decide)) h3
+  have e4 := cpsTripleWithin_extend_code
+    (CodeReq.ofProg_mem_at T (T + 52) tisProg 13
+      (.MV .x11 .x9) (by bv_omega) (by rw [tis_length]; decide) rfl
+      (by rw [tis_length]; decide)) h4
+  runBlock e0 e1 e2 e3 e4
+
+set_option maxRecDepth 8000 in
+/-- Frame allocate + storeSeq (instr 0-8): 1 ADDI + 8 SD. -/
+theorem tisFrameSave (sp0 spC : Word) (s : TisSaved)
+    (hspC : spC = sp0 + signExtend12 (-64 : BitVec 12)) :
+    cpsTripleWithin 9 T (T + 36) tisCode
+      ((.x2 ↦ᵣ sp0) ** regsAt tisFrame (tisSavedVals s) **
+        frameSlotsOwn tisFrame spC)
+      ((.x2 ↦ᵣ spC) ** regsAt tisFrame (tisSavedVals s) **
+        frameSlotsSaved tisFrame spC (tisSavedVals s)) := by
+  have ha0 := addi_spec_gen_same_within .x2 sp0 (-64 : BitVec 12) T (by decide)
+  rw [← hspC] at ha0
+  have ha := cpsTripleWithin_extend_code
+    (CodeReq.ofProg_mem_at T T tisProg 0
+      (.ADDI .x2 .x2 (-64 : BitVec 12)) rfl
+      (by rw [tis_length]; decide) rfl
+      (by rw [tis_length]; decide)) ha0
+  have haF := cpsTripleWithin_frameR
+    (regsAt tisFrame (tisSavedVals s) ** frameSlotsOwn tisFrame spC) (by pcf) ha
+  have hs0 := storeSeq_spec tisFrame spC (tisSavedVals s) (T + 4) (by decide)
+  have h_storeMono : ∀ a i,
+      CodeReq.ofProg (T + 4) (storeProg tisFrame) a = some i →
+        tisCode a = some i := by
+    intro a i h_mem
+    exact CodeReq.ofProg_mono_sub T (T + 4) tisProg (storeProg tisFrame) 1
+      (by bv_omega) rfl
+      (by rw [tis_length]; simp [tisFrame, storeProg])
+      (by rw [tis_length]; decide) a i h_mem
+  have hs := cpsTripleWithin_extend_code h_storeMono hs0
+  rw [show T + 4 + BitVec.ofNat 64 (4 * tisFrame.length) = T + 36 from by
+    simp [tisFrame]; bv_omega] at hs
+  exact cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) haF hs
+
+set_option maxRecDepth 8000 in
+/-- Full prologue: frame save + ABI moves (instr 0-13 to T+56). -/
+theorem tisPrologue (sp0 spC : Word) (s : TisSaved)
+    (txBase txLenW outPtr : Word)
+    (old5 old6 old7 old13 old14 old15 old16 : Word)
+    (hspC : spC = sp0 + signExtend12 (-64 : BitVec 12)) :
+    cpsTripleWithin 14 T (T + 56) tisCode
+      ((.x2 ↦ᵣ sp0) ** regsAt tisFrame (tisSavedVals s) **
+        frameSlotsOwn tisFrame spC **
+        prologueAbiRest txBase txLenW outPtr old5 old6 old7 old13 old14 old15 old16)
+      (prologuePost spC s txBase txLenW outPtr
+        old5 old6 old7 old13 old14 old15 old16) := by
+  have hsave := tisFrameSave sp0 spC s hspC
+  have hsaveF := cpsTripleWithin_frameR
+    (prologueAbiRest txBase txLenW outPtr old5 old6 old7 old13 old14 old15 old16)
+    (by pcf) hsave
+  have hmv := tisAbiMoves txBase txLenW outPtr s.s0 s.s1 s.s2
+  have hmvF := cpsTripleWithin_frameR
+    ((.x2 ↦ᵣ spC) ** (.x1 ↦ᵣ s.ra) **
+      (.x19 ↦ᵣ s.s3) ** (.x20 ↦ᵣ s.s4) ** (.x21 ↦ᵣ s.s5) ** (.x22 ↦ᵣ s.s6) **
+      frameSlotsSaved tisFrame spC (tisSavedVals s) **
+      (.x5 ↦ᵣ old5) ** (.x6 ↦ᵣ old6) ** (.x7 ↦ᵣ old7) **
+      (.x13 ↦ᵣ old13) ** (.x14 ↦ᵣ old14) ** (.x15 ↦ᵣ old15) ** (.x16 ↦ᵣ old16) **
+      regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+      (.x0 ↦ᵣ (0 : Word))) (by pcf) hmv
+  have h01 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by
+    rw [regsAt_tisFrame] at hp
+    unfold prologueAbiRest at hp
+    xperm_hyp hp) hsaveF hmvF
+  exact cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
+    (fun _ hq => by
+      unfold prologuePost prologueAbiRest
+      xperm_hyp hq) h01
+
+end EvmAsm.Codegen.TxIntrinsicStateGasSpec

--- a/EvmAsm/Codegen/Programs/TxIntrinsicStateGasSpec.lean
+++ b/EvmAsm/Codegen/Programs/TxIntrinsicStateGasSpec.lean
@@ -119,27 +119,27 @@ def nTisSuccessSteps : Nat := 64 + nExtractSteps + nTypeSteps + 16
 
 /-- Assumed success contract for `tx_extract_to_address` (still asm string).
 
-    ABI: a0=tx, a1=len, a2=to_buf, a3=is_creation_out → a0=0 on success.
-    Side effects on scratch buffers are left unconstrained (regOwn/memOwn). -/
+    ABI: a0=txBase, a1=len, a2=to_buf, a3=is_creation_out → a0=0 on success.
+    RO tx blob ambient; scratch out-cells owned (side effects unconstrained). -/
 structure ExtractAssumed (cr : CodeReq) where
   entry : Word
   success_flat :
-    ∀ (ret loadPtr lenW toBuf isCreationPtr : Word)
-      (bs : List (BitVec 8)) (off len : Nat),
+    ∀ (ret txBase lenW toBuf isCreationPtr : Word)
+      (txBytes : List (BitVec 8)),
       (ret &&& ~~~(1 : Word)) = ret →
-      loadPtr = BitVec.ofNat 64 off →  -- simplified; ambient region separate
-      off + len ≤ bs.length →
-      lenW = BitVec.ofNat 64 len →
+      lenW = BitVec.ofNat 64 txBytes.length →
       cpsTripleWithin nExtractSteps entry ret cr
-        ((.x1 ↦ᵣ ret) ** (.x10 ↦ᵣ loadPtr) ** (.x11 ↦ᵣ lenW) **
+        ((.x1 ↦ᵣ ret) ** (.x10 ↦ᵣ txBase) ** (.x11 ↦ᵣ lenW) **
           (.x12 ↦ᵣ toBuf) ** (.x13 ↦ᵣ isCreationPtr) **
-          bytesRegion loadPtr ((bs.drop off).take len) **
+          bytesRegion txBase txBytes **
+          memOwn toBuf ** memOwn isCreationPtr **
           regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
           regOwn .x14 ** regOwn .x15 ** regOwn .x16 **
           regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
           (.x0 ↦ᵣ (0 : Word)))
         ((.x1 ↦ᵣ ret) ** (.x10 ↦ᵣ (0 : Word)) **
-          bytesRegion loadPtr ((bs.drop off).take len) **
+          bytesRegion txBase txBytes **
+          memOwn toBuf ** memOwn isCreationPtr **
           regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
           regOwn .x11 ** regOwn .x12 ** regOwn .x13 **
           regOwn .x14 ** regOwn .x15 ** regOwn .x16 **
@@ -148,26 +148,26 @@ structure ExtractAssumed (cr : CodeReq) where
 
 /-- Assumed success contract for `tx_type_dispatch` (45-instr Program).
 
-    ABI: a0=tx, a1=len, a2=type_out, a3=inner_off_out → a0=0 on success. -/
+    ABI: a0=txBase, a1=len, a2=type_out, a3=inner_off_out → a0=0 on success. -/
 structure TypeDispatchAssumed (cr : CodeReq) where
   entry : Word
   success_flat :
-    ∀ (ret loadPtr lenW typePtr innerPtr : Word)
-      (bs : List (BitVec 8)) (off len : Nat),
+    ∀ (ret txBase lenW typePtr innerPtr : Word)
+      (txBytes : List (BitVec 8)),
       (ret &&& ~~~(1 : Word)) = ret →
-      loadPtr = BitVec.ofNat 64 off →
-      off + len ≤ bs.length →
-      lenW = BitVec.ofNat 64 len →
+      lenW = BitVec.ofNat 64 txBytes.length →
       cpsTripleWithin nTypeSteps entry ret cr
-        ((.x1 ↦ᵣ ret) ** (.x10 ↦ᵣ loadPtr) ** (.x11 ↦ᵣ lenW) **
+        ((.x1 ↦ᵣ ret) ** (.x10 ↦ᵣ txBase) ** (.x11 ↦ᵣ lenW) **
           (.x12 ↦ᵣ typePtr) ** (.x13 ↦ᵣ innerPtr) **
-          bytesRegion loadPtr ((bs.drop off).take len) **
+          bytesRegion txBase txBytes **
+          memOwn typePtr ** memOwn innerPtr **
           regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
           regOwn .x14 ** regOwn .x15 ** regOwn .x16 **
           regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
           (.x0 ↦ᵣ (0 : Word)))
         ((.x1 ↦ᵣ ret) ** (.x10 ↦ᵣ (0 : Word)) **
-          bytesRegion loadPtr ((bs.drop off).take len) **
+          bytesRegion txBase txBytes **
+          memOwn typePtr ** memOwn innerPtr **
           regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
           regOwn .x11 ** regOwn .x12 ** regOwn .x13 **
           regOwn .x14 ** regOwn .x15 ** regOwn .x16 **

--- a/EvmAsm/Codegen/Programs/TxIntrinsicStateGasSpec.lean
+++ b/EvmAsm/Codegen/Programs/TxIntrinsicStateGasSpec.lean
@@ -1,0 +1,204 @@
+/-
+  Fn.Spec for `tx_intrinsic_state_gas` (54-instr, a4gbr.2).
+
+  Success path (post EIP-2780):
+    frame → extract OK → type_dispatch OK → zeros ABI →
+    eip8037_tx_state_gas (proven: *out = 0+0) → epilogue
+    a0 = 0 ∧ *out = pureIntrinsicStateGasSuccess (= 0)
+
+  Callees still unproven as full Programs for extract (string) and
+  type_dispatch (45-instr Program, no Spec yet). Success arms are
+  **named hypotheses** (ExtractAssumed / TypeDispatchAssumed), not axioms.
+  eip8037_tx_state_gas is fully proven (Eip8037TxStateGasSpec).
+
+  Honest frame: 64B stack in pre/post (restored). Discharge of
+  IntrinsicAssumed.success_flat may need a thin adapter that frames
+  stackFree outside the array's assumed footprint, or a small extension
+  of IntrinsicAssumed to carry sp/frame — tracked with the leaf PR.
+-/
+
+import EvmAsm.Codegen.Programs.TxIntrinsicStateGasProg
+import EvmAsm.Codegen.Programs.Eip8037TxStateGasSpec
+import EvmAsm.Codegen.Programs.BlockVerdictTxStateGasArrayModel
+import EvmAsm.Codegen.Programs.TxExtract
+import EvmAsm.Rv64.CPSSpec
+import EvmAsm.Rv64.SepLogic
+import EvmAsm.Rv64.SyscallSpecs
+import EvmAsm.Rv64.ControlFlow
+import EvmAsm.Rv64.SAsm.AbiFrame
+import EvmAsm.Rv64.SAsm.DualReadByteScan
+import EvmAsm.Rv64.SAsm.TwoExitLoop
+import EvmAsm.Rv64.Tactics.XSimp
+import EvmAsm.Codegen.GuestAddrs
+
+namespace EvmAsm.Codegen.TxIntrinsicStateGasSpec
+
+open EvmAsm.Rv64
+open EvmAsm.Rv64.SAsm
+open EvmAsm.Codegen
+open EvmAsm.Codegen.BlockVerdictTxStateGasArrayModel
+open EvmAsm.Codegen.Eip8037TxStateGasSpec
+
+local macro "pcf" : tactic =>
+  `(tactic| repeat
+      first
+      | apply pcFree_sepConj
+      | exact pcFree_regIs
+      | exact pcFree_regOwn
+      | exact pcFree_memIs
+      | exact pcFree_memOwn
+      | exact pcFree_emp
+      | exact pcFree_pure)
+
+abbrev T : Word := BitVec.ofNat 64 GuestAddrs.tx_intrinsic_state_gas
+abbrev tisProg : Program := txIntrinsicStateGas_prog
+abbrev tisCode : CodeReq := CodeReq.ofProg T tisProg
+
+theorem tis_length : tisProg.length = 54 := by decide
+
+/-- Full linked code: intrinsic + proven eip8037_tx_state_gas leaf. -/
+def fullCode : CodeReq := tisCode.union etsCode
+
+theorem tis_bound : 4 * tisProg.length < 2 ^ 64 := by
+  simp only [tis_length]; decide
+
+theorem ets_length' : etsProg.length = 4 := ets_length
+
+/-- Adjacent: ets @ 0x80029704 (4 instr) then tis @ 0x80029714. -/
+theorem tis_ets_disjoint : tisCode.Disjoint etsCode := by
+  unfold tisCode etsCode T P
+  apply CodeReq.Disjoint.ofProg_ranges
+  · rw [tis_length]; decide
+  · rw [ets_length']; decide
+  · rw [tis_length, ets_length']; decide
+
+theorem ets_mono :
+    ∀ a i, etsCode a = some i → fullCode a = some i := by
+  intro a i hi
+  unfold fullCode
+  exact CodeReq.mono_union_right tis_ets_disjoint (fun _ _ h => h) a i hi
+
+theorem tis_mono :
+    ∀ a i, tisCode a = some i → fullCode a = some i := by
+  intro a i hi
+  unfold fullCode
+  exact CodeReq.union_mono_left a i hi
+
+/-- 8-slot frame: ra, s0–s6 (x8,x9,x18–x22). -/
+def tisFrame : FrameDesc :=
+  [(.x1, 0), (.x8, 8), (.x9, 16),
+   (.x18, 24), (.x19, 32), (.x20, 40), (.x21, 48), (.x22, 56)]
+
+theorem tisFrame_length : tisFrame.length = 8 := by decide
+
+structure TisSaved where
+  ra : Word
+  s0 : Word
+  s1 : Word
+  s2 : Word
+  s3 : Word
+  s4 : Word
+  s5 : Word
+  s6 : Word
+
+def tisSavedVals (s : TisSaved) : Reg → Word
+  | .x1  => s.ra
+  | .x8  => s.s0
+  | .x9  => s.s1
+  | .x18 => s.s2
+  | .x19 => s.s3
+  | .x20 => s.s4
+  | .x21 => s.s5
+  | .x22 => s.s6
+  | _ => 0
+
+/-- Step budgets (over-approx; mono). -/
+def nExtractSteps : Nat := 512
+def nTypeSteps : Nat := 128
+def nTisSuccessSteps : Nat := 64 + nExtractSteps + nTypeSteps + 16
+
+/-- Assumed success contract for `tx_extract_to_address` (still asm string).
+
+    ABI: a0=tx, a1=len, a2=to_buf, a3=is_creation_out → a0=0 on success.
+    Side effects on scratch buffers are left unconstrained (regOwn/memOwn). -/
+structure ExtractAssumed (cr : CodeReq) where
+  entry : Word
+  success_flat :
+    ∀ (ret loadPtr lenW toBuf isCreationPtr : Word)
+      (bs : List (BitVec 8)) (off len : Nat),
+      (ret &&& ~~~(1 : Word)) = ret →
+      loadPtr = BitVec.ofNat 64 off →  -- simplified; ambient region separate
+      off + len ≤ bs.length →
+      lenW = BitVec.ofNat 64 len →
+      cpsTripleWithin nExtractSteps entry ret cr
+        ((.x1 ↦ᵣ ret) ** (.x10 ↦ᵣ loadPtr) ** (.x11 ↦ᵣ lenW) **
+          (.x12 ↦ᵣ toBuf) ** (.x13 ↦ᵣ isCreationPtr) **
+          bytesRegion loadPtr ((bs.drop off).take len) **
+          regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+          regOwn .x14 ** regOwn .x15 ** regOwn .x16 **
+          regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+          (.x0 ↦ᵣ (0 : Word)))
+        ((.x1 ↦ᵣ ret) ** (.x10 ↦ᵣ (0 : Word)) **
+          bytesRegion loadPtr ((bs.drop off).take len) **
+          regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+          regOwn .x11 ** regOwn .x12 ** regOwn .x13 **
+          regOwn .x14 ** regOwn .x15 ** regOwn .x16 **
+          regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+          (.x0 ↦ᵣ (0 : Word)))
+
+/-- Assumed success contract for `tx_type_dispatch` (45-instr Program).
+
+    ABI: a0=tx, a1=len, a2=type_out, a3=inner_off_out → a0=0 on success. -/
+structure TypeDispatchAssumed (cr : CodeReq) where
+  entry : Word
+  success_flat :
+    ∀ (ret loadPtr lenW typePtr innerPtr : Word)
+      (bs : List (BitVec 8)) (off len : Nat),
+      (ret &&& ~~~(1 : Word)) = ret →
+      loadPtr = BitVec.ofNat 64 off →
+      off + len ≤ bs.length →
+      lenW = BitVec.ofNat 64 len →
+      cpsTripleWithin nTypeSteps entry ret cr
+        ((.x1 ↦ᵣ ret) ** (.x10 ↦ᵣ loadPtr) ** (.x11 ↦ᵣ lenW) **
+          (.x12 ↦ᵣ typePtr) ** (.x13 ↦ᵣ innerPtr) **
+          bytesRegion loadPtr ((bs.drop off).take len) **
+          regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+          regOwn .x14 ** regOwn .x15 ** regOwn .x16 **
+          regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+          (.x0 ↦ᵣ (0 : Word)))
+        ((.x1 ↦ᵣ ret) ** (.x10 ↦ᵣ (0 : Word)) **
+          bytesRegion loadPtr ((bs.drop off).take len) **
+          regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+          regOwn .x11 ** regOwn .x12 ** regOwn .x13 **
+          regOwn .x14 ** regOwn .x15 ** regOwn .x16 **
+          regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+          (.x0 ↦ᵣ (0 : Word)))
+
+/-- Combined leaf hypotheses for the intrinsic success path. -/
+structure TisCalleeAssumptions (cr : CodeReq) where
+  extract : ExtractAssumed cr
+  typeDispatch : TypeDispatchAssumed cr
+
+/-- Pure pin: success *out = 0. -/
+theorem pure_out_eq :
+    pureIntrinsicStateGasSuccess = 0 := rfl
+
+/-- Re-export proven ets leaf under fullCode mono (for callWithin). -/
+theorem ets_zero_out_full
+    (raIn outPtr oldOut a2v a3v a4v t0Old : Word)
+    (hret : (raIn &&& ~~~(1 : Word)) = raIn) :
+    cpsTripleWithin 4 P raIn fullCode
+      ((.x1 ↦ᵣ raIn) ** (.x10 ↦ᵣ (0 : Word)) ** (.x11 ↦ᵣ (0 : Word)) **
+        (.x12 ↦ᵣ a2v) ** (.x13 ↦ᵣ a3v) ** (.x14 ↦ᵣ a4v) **
+        (.x15 ↦ᵣ outPtr) ** (.x5 ↦ᵣ t0Old) **
+        (outPtr ↦ₘ oldOut) ** (.x0 ↦ᵣ (0 : Word)))
+      ((.x1 ↦ᵣ raIn) ** (.x10 ↦ᵣ (0 : Word)) ** (.x11 ↦ᵣ (0 : Word)) **
+        (.x12 ↦ᵣ a2v) ** (.x13 ↦ᵣ a3v) ** (.x14 ↦ᵣ a4v) **
+        (.x15 ↦ᵣ outPtr) ** (.x5 ↦ᵣ (0 : Word)) **
+        (outPtr ↦ₘ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word))) := by
+  have h := eip8037TxStateGas_zero_out_spec_within raIn outPtr oldOut a2v a3v a4v t0Old hret
+  exact cpsTripleWithin_extend_code ets_mono h
+
+#print axioms ets_zero_out_full
+
+end EvmAsm.Codegen.TxIntrinsicStateGasSpec

--- a/EvmAsm/Codegen/Programs/TxIntrinsicStateGasTop.lean
+++ b/EvmAsm/Codegen/Programs/TxIntrinsicStateGasTop.lean
@@ -1,0 +1,684 @@
+/-
+  Top success theorem for `tx_intrinsic_state_gas` under TisCalleeAssumptions.
+
+  Composition:
+    prologue (14) ;; extract ;; type ;; ets (proven *out=0) ;; epilogue (10)
+  → a0 = 0 ∧ *out = pureIntrinsicStateGasSuccess (= 0), frame restored.
+
+  Extract/type are named hypotheses; ets is fully proven.
+-/
+
+import EvmAsm.Codegen.Programs.TxIntrinsicStateGasEts
+import EvmAsm.Codegen.Programs.TxIntrinsicStateGasEpilogue
+import EvmAsm.Rv64.SAsm.AbiFrameCall
+import EvmAsm.Rv64.Tactics.XSimp
+
+namespace EvmAsm.Codegen.TxIntrinsicStateGasSpec
+
+open EvmAsm.Rv64
+open EvmAsm.Rv64.SAsm
+open EvmAsm.Codegen
+
+local macro "pcf" : tactic =>
+  `(tactic| repeat
+      first
+      | apply pcFree_sepConj
+      | exact pcFree_regIs
+      | exact pcFree_regOwn
+      | exact pcFree_memIs
+      | exact pcFree_memOwn
+      | exact pcFree_emp
+      | exact pcFree_pure
+      | exact bytesRegion_pcFree _ _
+      | exact pcFree_regsAt _ _
+      | exact pcFree_frameSlotsSaved _ _ _
+      | exact pcFree_frameSlotsOwn _ _)
+
+def nTisTopSteps : Nat := 14 + (4 + (1 + nExtractSteps) + 1) +
+  (6 + (1 + nTypeSteps) + 1) + (5 + 2 + 1 + 1 + (1 + 4) + 1) + 10
+
+private theorem prologue_full
+    (sp0 spC : Word) (s : TisSaved)
+    (txBase txLenW outPtr : Word)
+    (old5 old6 old7 old13 old14 old15 old16 : Word)
+    (hspC : spC = sp0 + signExtend12 (-64 : BitVec 12)) :
+    cpsTripleWithin 14 T (T + 56) fullCode
+      ((.x2 ↦ᵣ sp0) ** regsAt tisFrame (tisSavedVals s) **
+        frameSlotsOwn tisFrame spC **
+        prologueAbiRest txBase txLenW outPtr old5 old6 old7 old13 old14 old15 old16)
+      (prologuePost spC s txBase txLenW outPtr
+        old5 old6 old7 old13 old14 old15 old16) :=
+  cpsTripleWithin_extend_code tis_mono
+    (tisPrologue sp0 spC s txBase txLenW outPtr
+      old5 old6 old7 old13 old14 old15 old16 hspC)
+
+private theorem epi_full
+    (sp0 spC : Word) (s cur : TisSaved) (a0v : Word)
+    (hspC : spC = sp0 + signExtend12 (-64 : BitVec 12))
+    (hret : s.ra &&& ~~~(1 : Word) = s.ra) :
+    cpsTripleWithin 10 EpiRestore s.ra fullCode
+      ((.x10 ↦ᵣ a0v) ** (.x2 ↦ᵣ spC) **
+        regsAt tisFrame (tisSavedVals cur) **
+        frameSlotsSaved tisFrame spC (tisSavedVals s))
+      ((.x10 ↦ᵣ a0v) ** (.x1 ↦ᵣ s.ra) ** (.x2 ↦ᵣ sp0) **
+        (.x8 ↦ᵣ s.s0) ** (.x9 ↦ᵣ s.s1) **
+        (.x18 ↦ᵣ s.s2) ** (.x19 ↦ᵣ s.s3) **
+        (.x20 ↦ᵣ s.s4) ** (.x21 ↦ᵣ s.s5) ** (.x22 ↦ᵣ s.s6) **
+        frameSlotsSaved tisFrame spC (tisSavedVals s)) :=
+  cpsTripleWithin_extend_code tis_mono
+    (tisEpilogueSuccess sp0 spC s cur a0v hspC hret)
+
+/-- Saved body frame including x18 (s2/out). -/
+def bodyFrame (spC : Word) (s : TisSaved) (txBase lenW outPtr : Word) : Assertion :=
+  (.x2 ↦ᵣ spC) **
+  (.x8 ↦ᵣ txBase) ** (.x9 ↦ᵣ lenW) ** (.x18 ↦ᵣ outPtr) **
+  (.x19 ↦ᵣ s.s3) ** (.x20 ↦ᵣ s.s4) ** (.x21 ↦ᵣ s.s5) ** (.x22 ↦ᵣ s.s6) **
+  frameSlotsSaved tisFrame spC (tisSavedVals s)
+
+/-- Extract owns x18; frame across extract excludes it. -/
+def bodyFrameNoX18 (spC : Word) (s : TisSaved) (txBase lenW : Word) : Assertion :=
+  (.x2 ↦ᵣ spC) **
+  (.x8 ↦ᵣ txBase) ** (.x9 ↦ᵣ lenW) **
+  (.x19 ↦ᵣ s.s3) ** (.x20 ↦ᵣ s.s4) ** (.x21 ↦ᵣ s.s5) ** (.x22 ↦ᵣ s.s6) **
+  frameSlotsSaved tisFrame spC (tisSavedVals s)
+
+def bodyFrameAfterEts (spC : Word) (s : TisSaved)
+    (txBase lenW outPtr : Word) : Assertion :=
+  (.x2 ↦ᵣ spC) **
+  (.x8 ↦ᵣ txBase) ** (.x9 ↦ᵣ lenW) ** (.x18 ↦ᵣ outPtr) **
+  (.x19 ↦ᵣ s.s3) ** (.x20 ↦ᵣ (0 : Word)) ** (.x21 ↦ᵣ s.s5) ** (.x22 ↦ᵣ s.s6) **
+  frameSlotsSaved tisFrame spC (tisSavedVals s)
+
+def bodyScratch : Assertion :=
+  regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+  regOwn .x11 ** regOwn .x12 ** regOwn .x13 **
+  regOwn .x14 ** regOwn .x15 ** regOwn .x16 **
+  regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31
+
+def bodyPayload (txBase : Word) (txBytes : List (BitVec 8))
+    (outPtr oldOut : Word) : Assertion :=
+  bytesRegion txBase txBytes **
+  memOwn ToBufAddr ** memOwn IsCreationAddr **
+  memOwn TypeAddr ** memOwn InnerOffAddr **
+  (outPtr ↦ₘ oldOut)
+
+def bodyPayloadOk (txBase : Word) (txBytes : List (BitVec 8))
+    (outPtr : Word) : Assertion :=
+  bytesRegion txBase txBytes **
+  memOwn ToBufAddr ** memOwn IsCreationAddr **
+  memOwn TypeAddr ** memOwn InnerOffAddr **
+  (outPtr ↦ₘ (0 : Word))
+
+private theorem pack6
+    (v5 v6 v7 v14 v15 v16 : Word) :
+    ∀ h, ((.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
+      (.x14 ↦ᵣ v14) ** (.x15 ↦ᵣ v15) ** (.x16 ↦ᵣ v16)) h →
+    (regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+      regOwn .x14 ** regOwn .x15 ** regOwn .x16) h := by
+  intro h hp
+  exact sepConj_mono (regIs_to_regOwn .x5 v5)
+    (sepConj_mono (regIs_to_regOwn .x6 v6)
+      (sepConj_mono (regIs_to_regOwn .x7 v7)
+        (sepConj_mono (regIs_to_regOwn .x14 v14)
+          (sepConj_mono (regIs_to_regOwn .x15 v15)
+            (regIs_to_regOwn .x16 v16))))) h hp
+
+private theorem pack_ets_temps (isC outPtr : Word) :
+    ∀ h, ((.x5 ↦ᵣ (0 : Word)) ** (.x11 ↦ᵣ (0 : Word)) **
+      (.x12 ↦ᵣ (0 : Word)) ** (.x13 ↦ᵣ (0 : Word)) **
+      (.x14 ↦ᵣ isC) ** (.x15 ↦ᵣ outPtr) **
+      regOwn .x6 ** regOwn .x7 ** regOwn .x16 **
+      regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31) h →
+    bodyScratch h := by
+  intro h hp
+  unfold bodyScratch
+  have hp' :=
+    sepConj_mono (regIs_to_regOwn .x5 (0 : Word))
+      (sepConj_mono (regIs_to_regOwn .x11 (0 : Word))
+        (sepConj_mono (regIs_to_regOwn .x12 (0 : Word))
+          (sepConj_mono (regIs_to_regOwn .x13 (0 : Word))
+            (sepConj_mono (regIs_to_regOwn .x14 isC)
+              (sepConj_mono (regIs_to_regOwn .x15 outPtr)
+                (fun _ hh => hh)))))) h hp
+  xperm_hyp hp'
+
+private theorem prologue_to_extractPre
+    (spC : Word) (s : TisSaved)
+    (txBase lenW outPtr oldOut : Word) (txBytes : List (BitVec 8))
+    (old5 old6 old7 old13 old14 old15 old16 : Word) :
+    ∀ h,
+      (prologuePost spC s txBase lenW outPtr
+          old5 old6 old7 old13 old14 old15 old16 **
+        bodyPayload txBase txBytes outPtr oldOut) h →
+      (((.x1 ↦ᵣ s.ra) ** (.x10 ↦ᵣ txBase) ** (.x11 ↦ᵣ lenW) **
+          (.x12 ↦ᵣ outPtr) ** (.x13 ↦ᵣ old13) ** (.x18 ↦ᵣ outPtr) **
+          bytesRegion txBase txBytes **
+          memOwn ToBufAddr ** memOwn IsCreationAddr **
+          regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+          regOwn .x14 ** regOwn .x15 ** regOwn .x16 **
+          regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+          (.x0 ↦ᵣ (0 : Word))) **
+        (bodyFrameNoX18 spC s txBase lenW **
+          memOwn TypeAddr ** memOwn InnerOffAddr **
+          (outPtr ↦ₘ oldOut))) h := by
+  intro h hp
+  unfold prologuePost prologueAbiRest bodyPayload at hp
+  have hp1 :
+      (((.x5 ↦ᵣ old5) ** (.x6 ↦ᵣ old6) ** (.x7 ↦ᵣ old7) **
+          (.x14 ↦ᵣ old14) ** (.x15 ↦ᵣ old15) ** (.x16 ↦ᵣ old16)) **
+        ((.x1 ↦ᵣ s.ra) ** (.x10 ↦ᵣ txBase) ** (.x11 ↦ᵣ lenW) **
+          (.x12 ↦ᵣ outPtr) ** (.x13 ↦ᵣ old13) ** (.x18 ↦ᵣ outPtr) **
+          bytesRegion txBase txBytes **
+          memOwn ToBufAddr ** memOwn IsCreationAddr **
+          regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+          (.x0 ↦ᵣ (0 : Word)) **
+          (.x2 ↦ᵣ spC) **
+          (.x8 ↦ᵣ txBase) ** (.x9 ↦ᵣ lenW) **
+          (.x19 ↦ᵣ s.s3) ** (.x20 ↦ᵣ s.s4) ** (.x21 ↦ᵣ s.s5) **
+          (.x22 ↦ᵣ s.s6) **
+          frameSlotsSaved tisFrame spC (tisSavedVals s) **
+          memOwn TypeAddr ** memOwn InnerOffAddr **
+          (outPtr ↦ₘ oldOut))) h := by
+    xperm_hyp hp
+  have hp2 :=
+    sepConj_mono (pack6 old5 old6 old7 old14 old15 old16)
+      (fun _ hh => hh) h hp1
+  unfold bodyFrameNoX18
+  xperm_hyp hp2
+
+private theorem extractPost_to_body
+    (spC : Word) (s : TisSaved)
+    (txBase lenW outPtr oldOut : Word) (txBytes : List (BitVec 8)) :
+    ∀ h,
+      ((((.x1 ↦ᵣ LinkExtract) ** (.x10 ↦ᵣ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) **
+          (.x18 ↦ᵣ outPtr) **
+          bytesRegion txBase txBytes **
+          memOwn ToBufAddr ** memOwn IsCreationAddr **
+          regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+          regOwn .x11 ** regOwn .x12 ** regOwn .x13 **
+          regOwn .x14 ** regOwn .x15 ** regOwn .x16 **
+          regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31) **
+        (bodyFrameNoX18 spC s txBase lenW **
+          memOwn TypeAddr ** memOwn InnerOffAddr **
+          (outPtr ↦ₘ oldOut))) h) →
+      ((.x1 ↦ᵣ LinkExtract) ** (.x10 ↦ᵣ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) **
+        bodyFrame spC s txBase lenW outPtr **
+        bodyPayload txBase txBytes outPtr oldOut **
+        bodyScratch) h := by
+  intro h hp
+  unfold bodyFrameNoX18 at hp
+  unfold bodyFrame bodyPayload bodyScratch
+  xperm_hyp hp
+
+set_option maxRecDepth 8000 in
+theorem tisExtractFramed
+    (asm : ExtractAssumed fullCode)
+    (hentry : asm.entry = ExtractEntry)
+    (spC : Word) (s : TisSaved)
+    (txBase lenW outPtr oldOut : Word) (txBytes : List (BitVec 8))
+    (old5 old6 old7 old13 old14 old15 old16 : Word)
+    (hlen : lenW = BitVec.ofNat 64 txBytes.length) :
+    cpsTripleWithin (4 + (1 + nExtractSteps) + 1) (T + 56) AfterExtractBne fullCode
+      (prologuePost spC s txBase lenW outPtr
+        old5 old6 old7 old13 old14 old15 old16 **
+        bodyPayload txBase txBytes outPtr oldOut)
+      ((.x1 ↦ᵣ LinkExtract) ** (.x10 ↦ᵣ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) **
+        bodyFrame spC s txBase lenW outPtr **
+        bodyPayload txBase txBytes outPtr oldOut **
+        bodyScratch) := by
+  have hex0 := tisExtractSuccess asm hentry txBase lenW outPtr txBytes
+    s.ra outPtr old13 hlen
+  have hexF := cpsTripleWithin_frameR
+    (bodyFrameNoX18 spC s txBase lenW **
+      memOwn TypeAddr ** memOwn InnerOffAddr **
+      (outPtr ↦ₘ oldOut))
+    (by unfold bodyFrameNoX18; pcf) hex0
+  exact cpsTripleWithin_weaken
+    (prologue_to_extractPre spC s txBase lenW outPtr oldOut txBytes
+      old5 old6 old7 old13 old14 old15 old16)
+    (extractPost_to_body spC s txBase lenW outPtr oldOut txBytes) hexF
+
+private def typePreConcrete (spC : Word) (s : TisSaved)
+    (txBase lenW outPtr oldOut : Word) (txBytes : List (BitVec 8))
+    (v11 v12 v13 : Word) : Assertion :=
+  (.x1 ↦ᵣ LinkExtract) ** (.x10 ↦ᵣ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) **
+  bodyFrame spC s txBase lenW outPtr **
+  bodyPayload txBase txBytes outPtr oldOut **
+  regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+  (.x11 ↦ᵣ v11) ** (.x12 ↦ᵣ v12) ** (.x13 ↦ᵣ v13) **
+  regOwn .x14 ** regOwn .x15 ** regOwn .x16 **
+  regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31
+
+private theorem typeCore
+    (asm : TypeDispatchAssumed fullCode)
+    (hentry : asm.entry = TypeEntry)
+    (spC : Word) (s : TisSaved)
+    (txBase lenW outPtr oldOut : Word) (txBytes : List (BitVec 8))
+    (v11 v12 v13 : Word)
+    (hlen : lenW = BitVec.ofNat 64 txBytes.length) :
+    cpsTripleWithin (6 + (1 + nTypeSteps) + 1) AfterExtractBne AfterTypeBne fullCode
+      (typePreConcrete spC s txBase lenW outPtr oldOut txBytes v11 v12 v13)
+      ((.x1 ↦ᵣ LinkType) ** (.x10 ↦ᵣ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) **
+        bodyFrame spC s txBase lenW outPtr **
+        bodyPayload txBase txBytes outPtr oldOut **
+        bodyScratch) := by
+  have hty0 := tisTypeSuccess asm hentry txBase lenW outPtr txBytes
+    LinkExtract 0 v11 v12 v13 hlen
+  have htyF := cpsTripleWithin_frameR
+    ((.x2 ↦ᵣ spC) **
+      (.x19 ↦ᵣ s.s3) ** (.x20 ↦ᵣ s.s4) ** (.x21 ↦ᵣ s.s5) ** (.x22 ↦ᵣ s.s6) **
+      frameSlotsSaved tisFrame spC (tisSavedVals s) **
+      memOwn ToBufAddr ** memOwn IsCreationAddr **
+      (outPtr ↦ₘ oldOut))
+    (by pcf) hty0
+  exact cpsTripleWithin_weaken
+    (fun _ hp => by
+      unfold typePreConcrete bodyFrame bodyPayload at *
+      xperm_hyp hp)
+    (fun _ hq => by
+      unfold bodyFrame bodyPayload bodyScratch at *
+      xperm_hyp hq) htyF
+
+set_option maxRecDepth 8000 in
+theorem tisTypeFramed
+    (asm : TypeDispatchAssumed fullCode)
+    (hentry : asm.entry = TypeEntry)
+    (spC : Word) (s : TisSaved)
+    (txBase lenW outPtr oldOut : Word) (txBytes : List (BitVec 8))
+    (hlen : lenW = BitVec.ofNat 64 txBytes.length) :
+    cpsTripleWithin (6 + (1 + nTypeSteps) + 1) AfterExtractBne AfterTypeBne fullCode
+      ((.x1 ↦ᵣ LinkExtract) ** (.x10 ↦ᵣ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) **
+        bodyFrame spC s txBase lenW outPtr **
+        bodyPayload txBase txBytes outPtr oldOut **
+        bodyScratch)
+      ((.x1 ↦ᵣ LinkType) ** (.x10 ↦ᵣ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) **
+        bodyFrame spC s txBase lenW outPtr **
+        bodyPayload txBase txBytes outPtr oldOut **
+        bodyScratch) := by
+  have hcore (v11 v12 v13 : Word) :=
+    typeCore asm hentry spC s txBase lenW outPtr oldOut txBytes v11 v12 v13 hlen
+  -- rightmost peels: x13, then x12, then x11
+  have h13 : cpsTripleWithin (6 + (1 + nTypeSteps) + 1) AfterExtractBne AfterTypeBne fullCode
+      (((.x1 ↦ᵣ LinkExtract) ** (.x10 ↦ᵣ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) **
+          bodyFrame spC s txBase lenW outPtr **
+          bodyPayload txBase txBytes outPtr oldOut **
+          regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+          regOwn .x11 ** regOwn .x12 **
+          regOwn .x14 ** regOwn .x15 ** regOwn .x16 **
+          regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31) **
+        regOwn .x13)
+      ((.x1 ↦ᵣ LinkType) ** (.x10 ↦ᵣ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) **
+        bodyFrame spC s txBase lenW outPtr **
+        bodyPayload txBase txBytes outPtr oldOut **
+        bodyScratch) := by
+    refine cpsTripleWithin_of_forall_regIs_to_regOwn (r := .x13) (fun v13 => ?_)
+    have h12 : cpsTripleWithin (6 + (1 + nTypeSteps) + 1) AfterExtractBne AfterTypeBne fullCode
+        (((.x1 ↦ᵣ LinkExtract) ** (.x10 ↦ᵣ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) **
+            bodyFrame spC s txBase lenW outPtr **
+            bodyPayload txBase txBytes outPtr oldOut **
+            regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+            regOwn .x11 **
+            regOwn .x14 ** regOwn .x15 ** regOwn .x16 **
+            regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+            (.x13 ↦ᵣ v13)) **
+          regOwn .x12)
+        ((.x1 ↦ᵣ LinkType) ** (.x10 ↦ᵣ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) **
+          bodyFrame spC s txBase lenW outPtr **
+          bodyPayload txBase txBytes outPtr oldOut **
+          bodyScratch) := by
+      refine cpsTripleWithin_of_forall_regIs_to_regOwn (r := .x12) (fun v12 => ?_)
+      have h11 : cpsTripleWithin (6 + (1 + nTypeSteps) + 1) AfterExtractBne AfterTypeBne fullCode
+          (((.x1 ↦ᵣ LinkExtract) ** (.x10 ↦ᵣ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) **
+              bodyFrame spC s txBase lenW outPtr **
+              bodyPayload txBase txBytes outPtr oldOut **
+              regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+              regOwn .x14 ** regOwn .x15 ** regOwn .x16 **
+              regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+              (.x12 ↦ᵣ v12) ** (.x13 ↦ᵣ v13)) **
+            regOwn .x11)
+          ((.x1 ↦ᵣ LinkType) ** (.x10 ↦ᵣ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) **
+            bodyFrame spC s txBase lenW outPtr **
+            bodyPayload txBase txBytes outPtr oldOut **
+            bodyScratch) := by
+        refine cpsTripleWithin_of_forall_regIs_to_regOwn (r := .x11) (fun v11 => ?_)
+        exact cpsTripleWithin_weaken
+          (fun _ hp => by
+            unfold typePreConcrete bodyFrame bodyPayload at *
+            xperm_hyp hp)
+          (fun _ hq => hq)
+          (hcore v11 v12 v13)
+      exact cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
+        (fun _ hq => hq) h11
+    exact cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
+      (fun _ hq => hq) h12
+  exact cpsTripleWithin_weaken
+    (fun _ hp => by unfold bodyScratch at hp; xperm_hyp hp)
+    (fun _ hq => hq) h13
+
+/-- Ets core under concrete isC + temps. -/
+private theorem etsCore
+    (spC : Word) (s : TisSaved)
+    (txBase lenW outPtr oldOut : Word) (txBytes : List (BitVec 8))
+    (isC v5 v11 v12 v13 v14 v15 : Word)
+    (hlink : (LinkEts &&& ~~~(1 : Word)) = LinkEts) :
+    cpsTripleWithin (5 + 2 + 1 + 1 + (1 + 4) + 1) AfterTypeBne EpiRestore fullCode
+      ((.x1 ↦ᵣ LinkType) ** (.x10 ↦ᵣ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) **
+        bodyFrame spC s txBase lenW outPtr **
+        bytesRegion txBase txBytes **
+        memOwn ToBufAddr ** (IsCreationAddr ↦ₘ isC) **
+        memOwn TypeAddr ** memOwn InnerOffAddr **
+        (outPtr ↦ₘ oldOut) **
+        (.x5 ↦ᵣ v5) ** regOwn .x6 ** regOwn .x7 **
+        (.x11 ↦ᵣ v11) ** (.x12 ↦ᵣ v12) ** (.x13 ↦ᵣ v13) **
+        (.x14 ↦ᵣ v14) ** (.x15 ↦ᵣ v15) ** regOwn .x16 **
+        regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31)
+      ((.x1 ↦ᵣ LinkEts) ** (.x10 ↦ᵣ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) **
+        bodyFrameAfterEts spC s txBase lenW outPtr **
+        bodyPayloadOk txBase txBytes outPtr **
+        bodyScratch) := by
+  have hets0 := tisEtsSuccess outPtr oldOut isC v5 0 v11 v12 v13 v14 v15 s.s4
+    LinkType hlink
+  have hetsF := cpsTripleWithin_frameR
+    ((.x2 ↦ᵣ spC) **
+      (.x8 ↦ᵣ txBase) ** (.x9 ↦ᵣ lenW) **
+      (.x19 ↦ᵣ s.s3) ** (.x21 ↦ᵣ s.s5) ** (.x22 ↦ᵣ s.s6) **
+      frameSlotsSaved tisFrame spC (tisSavedVals s) **
+      bytesRegion txBase txBytes **
+      memOwn ToBufAddr ** memOwn TypeAddr ** memOwn InnerOffAddr **
+      regOwn .x6 ** regOwn .x7 ** regOwn .x16 **
+      regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31)
+    (by pcf) hets0
+  exact cpsTripleWithin_weaken
+    (fun _ hp => by unfold bodyFrame at *; xperm_hyp hp)
+    (fun h hq => by
+      have hq1 :
+          (((.x5 ↦ᵣ (0 : Word)) ** (.x11 ↦ᵣ (0 : Word)) **
+              (.x12 ↦ᵣ (0 : Word)) ** (.x13 ↦ᵣ (0 : Word)) **
+              (.x14 ↦ᵣ isC) ** (.x15 ↦ᵣ outPtr) **
+              regOwn .x6 ** regOwn .x7 ** regOwn .x16 **
+              regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31) **
+            ((.x1 ↦ᵣ LinkEts) ** (.x10 ↦ᵣ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) **
+              (.x2 ↦ᵣ spC) **
+              (.x8 ↦ᵣ txBase) ** (.x9 ↦ᵣ lenW) ** (.x18 ↦ᵣ outPtr) **
+              (.x19 ↦ᵣ s.s3) ** (.x20 ↦ᵣ (0 : Word)) **
+              (.x21 ↦ᵣ s.s5) ** (.x22 ↦ᵣ s.s6) **
+              frameSlotsSaved tisFrame spC (tisSavedVals s) **
+              bytesRegion txBase txBytes **
+              memOwn ToBufAddr ** (IsCreationAddr ↦ₘ isC) **
+              memOwn TypeAddr ** memOwn InnerOffAddr **
+              (outPtr ↦ₘ (0 : Word)))) h := by
+        xperm_hyp hq
+      have hq2 :=
+        sepConj_mono (pack_ets_temps isC outPtr) (fun _ hh => hh) h hq1
+      have hq3 :
+          ((.x1 ↦ᵣ LinkEts) ** (.x10 ↦ᵣ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) **
+              bodyFrameAfterEts spC s txBase lenW outPtr **
+              bytesRegion txBase txBytes **
+              memOwn ToBufAddr ** (IsCreationAddr ↦ₘ isC) **
+              memOwn TypeAddr ** memOwn InnerOffAddr **
+              (outPtr ↦ₘ (0 : Word)) **
+              bodyScratch) h := by
+        unfold bodyFrameAfterEts bodyScratch at *
+        xperm_hyp hq2
+      -- pull IsCreation rightmost for mono, then memIs→memOwn
+      have hq4 :
+          (((.x1 ↦ᵣ LinkEts) ** (.x10 ↦ᵣ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) **
+              bodyFrameAfterEts spC s txBase lenW outPtr **
+              bytesRegion txBase txBytes **
+              memOwn ToBufAddr **
+              memOwn TypeAddr ** memOwn InnerOffAddr **
+              (outPtr ↦ₘ (0 : Word)) **
+              bodyScratch) **
+            (IsCreationAddr ↦ₘ isC)) h := by
+        xperm_hyp hq3
+      have hq5 :=
+        sepConj_mono (fun _ x => x)
+          (memIs_implies_memOwn (a := IsCreationAddr) (v := isC)) h hq4
+      unfold bodyPayloadOk bodyFrameAfterEts bodyScratch at *
+      xperm_hyp hq5) hetsF
+
+set_option maxRecDepth 8000 in
+theorem tisEtsFramed
+    (spC : Word) (s : TisSaved)
+    (txBase lenW outPtr oldOut : Word) (txBytes : List (BitVec 8))
+    (hlink : (LinkEts &&& ~~~(1 : Word)) = LinkEts) :
+    cpsTripleWithin (5 + 2 + 1 + 1 + (1 + 4) + 1) AfterTypeBne EpiRestore fullCode
+      ((.x1 ↦ᵣ LinkType) ** (.x10 ↦ᵣ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) **
+        bodyFrame spC s txBase lenW outPtr **
+        bodyPayload txBase txBytes outPtr oldOut **
+        bodyScratch)
+      ((.x1 ↦ᵣ LinkEts) ** (.x10 ↦ᵣ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) **
+        bodyFrameAfterEts spC s txBase lenW outPtr **
+        bodyPayloadOk txBase txBytes outPtr **
+        bodyScratch) := by
+  have hcore (isC v5 v11 v12 v13 v14 v15 : Word) :=
+    etsCore spC s txBase lenW outPtr oldOut txBytes isC v5 v11 v12 v13 v14 v15 hlink
+  -- peel rightmost: temps then IsCreation (rebuild with owns rightmost stepwise)
+  have hpeel : cpsTripleWithin (5 + 2 + 1 + 1 + (1 + 4) + 1) AfterTypeBne EpiRestore fullCode
+      (((.x1 ↦ᵣ LinkType) ** (.x10 ↦ᵣ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) **
+          bodyFrame spC s txBase lenW outPtr **
+          bytesRegion txBase txBytes **
+          memOwn ToBufAddr **
+          memOwn TypeAddr ** memOwn InnerOffAddr **
+          (outPtr ↦ₘ oldOut) **
+          regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+          regOwn .x11 ** regOwn .x12 ** regOwn .x13 **
+          regOwn .x14 ** regOwn .x15 ** regOwn .x16 **
+          regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31) **
+        memOwn IsCreationAddr)
+      ((.x1 ↦ᵣ LinkEts) ** (.x10 ↦ᵣ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) **
+        bodyFrameAfterEts spC s txBase lenW outPtr **
+        bodyPayloadOk txBase txBytes outPtr **
+        bodyScratch) := by
+    refine cpsTripleWithin_of_forall_memIs_to_memOwn (a := IsCreationAddr) (fun isC => ?_)
+    -- now peel x5 rightmost
+    have hx5 : cpsTripleWithin (5 + 2 + 1 + 1 + (1 + 4) + 1) AfterTypeBne EpiRestore fullCode
+        (((.x1 ↦ᵣ LinkType) ** (.x10 ↦ᵣ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) **
+            bodyFrame spC s txBase lenW outPtr **
+            bytesRegion txBase txBytes **
+            memOwn ToBufAddr ** (IsCreationAddr ↦ₘ isC) **
+            memOwn TypeAddr ** memOwn InnerOffAddr **
+            (outPtr ↦ₘ oldOut) **
+            regOwn .x6 ** regOwn .x7 **
+            regOwn .x11 ** regOwn .x12 ** regOwn .x13 **
+            regOwn .x14 ** regOwn .x15 ** regOwn .x16 **
+            regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31) **
+          regOwn .x5)
+        ((.x1 ↦ᵣ LinkEts) ** (.x10 ↦ᵣ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) **
+          bodyFrameAfterEts spC s txBase lenW outPtr **
+          bodyPayloadOk txBase txBytes outPtr **
+          bodyScratch) := by
+      refine cpsTripleWithin_of_forall_regIs_to_regOwn (r := .x5) (fun v5 => ?_)
+      have hx15 : cpsTripleWithin (5 + 2 + 1 + 1 + (1 + 4) + 1) AfterTypeBne EpiRestore fullCode
+          (((.x1 ↦ᵣ LinkType) ** (.x10 ↦ᵣ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) **
+              bodyFrame spC s txBase lenW outPtr **
+              bytesRegion txBase txBytes **
+              memOwn ToBufAddr ** (IsCreationAddr ↦ₘ isC) **
+              memOwn TypeAddr ** memOwn InnerOffAddr **
+              (outPtr ↦ₘ oldOut) **
+              (.x5 ↦ᵣ v5) ** regOwn .x6 ** regOwn .x7 **
+              regOwn .x11 ** regOwn .x12 ** regOwn .x13 **
+              regOwn .x14 ** regOwn .x16 **
+              regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31) **
+            regOwn .x15)
+          ((.x1 ↦ᵣ LinkEts) ** (.x10 ↦ᵣ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) **
+            bodyFrameAfterEts spC s txBase lenW outPtr **
+            bodyPayloadOk txBase txBytes outPtr **
+            bodyScratch) := by
+        refine cpsTripleWithin_of_forall_regIs_to_regOwn (r := .x15) (fun v15 => ?_)
+        have hx14 : cpsTripleWithin (5 + 2 + 1 + 1 + (1 + 4) + 1) AfterTypeBne EpiRestore fullCode
+            (((.x1 ↦ᵣ LinkType) ** (.x10 ↦ᵣ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) **
+                bodyFrame spC s txBase lenW outPtr **
+                bytesRegion txBase txBytes **
+                memOwn ToBufAddr ** (IsCreationAddr ↦ₘ isC) **
+                memOwn TypeAddr ** memOwn InnerOffAddr **
+                (outPtr ↦ₘ oldOut) **
+                (.x5 ↦ᵣ v5) ** regOwn .x6 ** regOwn .x7 **
+                regOwn .x11 ** regOwn .x12 ** regOwn .x13 **
+                regOwn .x16 **
+                regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+                (.x15 ↦ᵣ v15)) **
+              regOwn .x14)
+            ((.x1 ↦ᵣ LinkEts) ** (.x10 ↦ᵣ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) **
+              bodyFrameAfterEts spC s txBase lenW outPtr **
+              bodyPayloadOk txBase txBytes outPtr **
+              bodyScratch) := by
+          refine cpsTripleWithin_of_forall_regIs_to_regOwn (r := .x14) (fun v14 => ?_)
+          have hx13 : cpsTripleWithin (5 + 2 + 1 + 1 + (1 + 4) + 1) AfterTypeBne EpiRestore fullCode
+              (((.x1 ↦ᵣ LinkType) ** (.x10 ↦ᵣ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) **
+                  bodyFrame spC s txBase lenW outPtr **
+                  bytesRegion txBase txBytes **
+                  memOwn ToBufAddr ** (IsCreationAddr ↦ₘ isC) **
+                  memOwn TypeAddr ** memOwn InnerOffAddr **
+                  (outPtr ↦ₘ oldOut) **
+                  (.x5 ↦ᵣ v5) ** regOwn .x6 ** regOwn .x7 **
+                  regOwn .x11 ** regOwn .x12 **
+                  regOwn .x16 **
+                  regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+                  (.x14 ↦ᵣ v14) ** (.x15 ↦ᵣ v15)) **
+                regOwn .x13)
+              ((.x1 ↦ᵣ LinkEts) ** (.x10 ↦ᵣ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) **
+                bodyFrameAfterEts spC s txBase lenW outPtr **
+                bodyPayloadOk txBase txBytes outPtr **
+                bodyScratch) := by
+            refine cpsTripleWithin_of_forall_regIs_to_regOwn (r := .x13) (fun v13 => ?_)
+            have hx12 : cpsTripleWithin (5 + 2 + 1 + 1 + (1 + 4) + 1) AfterTypeBne EpiRestore fullCode
+                (((.x1 ↦ᵣ LinkType) ** (.x10 ↦ᵣ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) **
+                    bodyFrame spC s txBase lenW outPtr **
+                    bytesRegion txBase txBytes **
+                    memOwn ToBufAddr ** (IsCreationAddr ↦ₘ isC) **
+                    memOwn TypeAddr ** memOwn InnerOffAddr **
+                    (outPtr ↦ₘ oldOut) **
+                    (.x5 ↦ᵣ v5) ** regOwn .x6 ** regOwn .x7 **
+                    regOwn .x11 **
+                    regOwn .x16 **
+                    regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+                    (.x13 ↦ᵣ v13) ** (.x14 ↦ᵣ v14) ** (.x15 ↦ᵣ v15)) **
+                  regOwn .x12)
+                ((.x1 ↦ᵣ LinkEts) ** (.x10 ↦ᵣ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) **
+                  bodyFrameAfterEts spC s txBase lenW outPtr **
+                  bodyPayloadOk txBase txBytes outPtr **
+                  bodyScratch) := by
+              refine cpsTripleWithin_of_forall_regIs_to_regOwn (r := .x12) (fun v12 => ?_)
+              have hx11 : cpsTripleWithin (5 + 2 + 1 + 1 + (1 + 4) + 1) AfterTypeBne EpiRestore fullCode
+                  (((.x1 ↦ᵣ LinkType) ** (.x10 ↦ᵣ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) **
+                      bodyFrame spC s txBase lenW outPtr **
+                      bytesRegion txBase txBytes **
+                      memOwn ToBufAddr ** (IsCreationAddr ↦ₘ isC) **
+                      memOwn TypeAddr ** memOwn InnerOffAddr **
+                      (outPtr ↦ₘ oldOut) **
+                      (.x5 ↦ᵣ v5) ** regOwn .x6 ** regOwn .x7 **
+                      regOwn .x16 **
+                      regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+                      (.x12 ↦ᵣ v12) ** (.x13 ↦ᵣ v13) **
+                      (.x14 ↦ᵣ v14) ** (.x15 ↦ᵣ v15)) **
+                    regOwn .x11)
+                  ((.x1 ↦ᵣ LinkEts) ** (.x10 ↦ᵣ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) **
+                    bodyFrameAfterEts spC s txBase lenW outPtr **
+                    bodyPayloadOk txBase txBytes outPtr **
+                    bodyScratch) := by
+                refine cpsTripleWithin_of_forall_regIs_to_regOwn (r := .x11) (fun v11 => ?_)
+                exact cpsTripleWithin_weaken
+                  (fun _ hp => by xperm_hyp hp)
+                  (fun _ hq => hq)
+                  (hcore isC v5 v11 v12 v13 v14 v15)
+              exact cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
+                (fun _ hq => hq) hx11
+            exact cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
+              (fun _ hq => hq) hx12
+          exact cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
+            (fun _ hq => hq) hx13
+        exact cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
+          (fun _ hq => hq) hx14
+      exact cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
+        (fun _ hq => hq) hx15
+    exact cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
+      (fun _ hq => hq) hx5
+  exact cpsTripleWithin_weaken
+    (fun _ hp => by unfold bodyPayload bodyScratch at hp; xperm_hyp hp)
+    (fun _ hq => hq) hpeel
+
+/-- Live saved-register values at EpiRestore after ets success. -/
+def etsCurSaved (s : TisSaved) (txBase lenW outPtr : Word) : TisSaved :=
+  { ra := LinkEts, s0 := txBase, s1 := lenW, s2 := outPtr
+    s3 := s.s3, s4 := 0, s5 := s.s5, s6 := s.s6 }
+
+/-- Reshape ets post → epi pre (regsAt cur + payload). -/
+private theorem etsPost_to_epiPre
+    (spC : Word) (s : TisSaved)
+    (txBase lenW outPtr : Word) (txBytes : List (BitVec 8)) :
+    ∀ h,
+      ((.x1 ↦ᵣ LinkEts) ** (.x10 ↦ᵣ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) **
+        bodyFrameAfterEts spC s txBase lenW outPtr **
+        bodyPayloadOk txBase txBytes outPtr **
+        bodyScratch) h →
+      (((.x10 ↦ᵣ (0 : Word)) ** (.x2 ↦ᵣ spC) **
+          regsAt tisFrame (tisSavedVals (etsCurSaved s txBase lenW outPtr)) **
+          frameSlotsSaved tisFrame spC (tisSavedVals s)) **
+        (bodyPayloadOk txBase txBytes outPtr ** bodyScratch **
+          (.x0 ↦ᵣ (0 : Word)))) h := by
+  intro h hp
+  unfold bodyFrameAfterEts bodyPayloadOk bodyScratch at hp
+  unfold bodyPayloadOk bodyScratch
+  rw [regsAt_tisFrame]
+  simp only [etsCurSaved]
+  xperm_hyp hp
+
+set_option maxRecDepth 8000 in
+theorem txIntrinsicStateGas_success_spec_within
+    (asm : TisCalleeAssumptions fullCode)
+    (hextract : asm.extract.entry = ExtractEntry)
+    (htype : asm.typeDispatch.entry = TypeEntry)
+    (sp0 spC : Word) (s : TisSaved)
+    (txBase lenW outPtr oldOut : Word)
+    (txBytes : List (BitVec 8))
+    (old5 old6 old7 old13 old14 old15 old16 : Word)
+    (hspC : spC = sp0 + signExtend12 (-64 : BitVec 12))
+    (hret : s.ra &&& ~~~(1 : Word) = s.ra)
+    (hlen : lenW = BitVec.ofNat 64 txBytes.length)
+    (hlink : (LinkEts &&& ~~~(1 : Word)) = LinkEts) :
+    cpsTripleWithin nTisTopSteps T s.ra fullCode
+      ((.x2 ↦ᵣ sp0) ** regsAt tisFrame (tisSavedVals s) **
+        frameSlotsOwn tisFrame spC **
+        prologueAbiRest txBase lenW outPtr old5 old6 old7 old13 old14 old15 old16 **
+        bodyPayload txBase txBytes outPtr oldOut)
+      ((.x10 ↦ᵣ (0 : Word)) ** (.x1 ↦ᵣ s.ra) ** (.x2 ↦ᵣ sp0) **
+        (.x8 ↦ᵣ s.s0) ** (.x9 ↦ᵣ s.s1) **
+        (.x18 ↦ᵣ s.s2) ** (.x19 ↦ᵣ s.s3) **
+        (.x20 ↦ᵣ s.s4) ** (.x21 ↦ᵣ s.s5) ** (.x22 ↦ᵣ s.s6) **
+        frameSlotsSaved tisFrame spC (tisSavedVals s) **
+        bodyPayloadOk txBase txBytes outPtr **
+        bodyScratch ** (.x0 ↦ᵣ (0 : Word))) := by
+  have hpro0 := prologue_full sp0 spC s txBase lenW outPtr
+    old5 old6 old7 old13 old14 old15 old16 hspC
+  have hpro := cpsTripleWithin_frameR
+    (bodyPayload txBase txBytes outPtr oldOut)
+    (by unfold bodyPayload; pcf) hpro0
+  have hex := tisExtractFramed asm.extract hextract spC s
+    txBase lenW outPtr oldOut txBytes
+    old5 old6 old7 old13 old14 old15 old16 hlen
+  have c01 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) hpro hex
+  have hty := tisTypeFramed asm.typeDispatch htype spC s
+    txBase lenW outPtr oldOut txBytes hlen
+  have c02 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) c01 hty
+  have hets := tisEtsFramed spC s txBase lenW outPtr oldOut txBytes hlink
+  have c03 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) c02 hets
+  have hepi0 := epi_full sp0 spC s (etsCurSaved s txBase lenW outPtr) 0 hspC hret
+  have hepi := cpsTripleWithin_frameR
+    (bodyPayloadOk txBase txBytes outPtr ** bodyScratch **
+      (.x0 ↦ᵣ (0 : Word)))
+    (by unfold bodyPayloadOk bodyScratch; pcf) hepi0
+  have c04 := cpsTripleWithin_seq_perm_same_cr
+    (etsPost_to_epiPre spC s txBase lenW outPtr txBytes) c03 hepi
+  have hle : 14 + (4 + (1 + nExtractSteps) + 1) + (6 + (1 + nTypeSteps) + 1) +
+      (5 + 2 + 1 + 1 + (1 + 4) + 1) + 10 ≤ nTisTopSteps := by
+    simp only [nTisTopSteps]; omega
+  have c04' := cpsTripleWithin_mono_nSteps hle c04
+  exact cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
+    (fun _ hq => by
+      unfold bodyPayloadOk bodyScratch at *
+      xperm_hyp hq) c04'
+
+#print axioms txIntrinsicStateGas_success_spec_within
+
+end EvmAsm.Codegen.TxIntrinsicStateGasSpec

--- a/EvmAsm/Codegen/Programs/TxIntrinsicStateGasType.lean
+++ b/EvmAsm/Codegen/Programs/TxIntrinsicStateGasType.lean
@@ -1,0 +1,288 @@
+/-
+  Type-dispatch setup + call + success BNE (instr 20-27) for
+  `tx_intrinsic_state_gas`, under TypeDispatchAssumed.
+-/
+
+import EvmAsm.Codegen.Programs.TxIntrinsicStateGasExtract
+import EvmAsm.Rv64.LaResolve
+import EvmAsm.Rv64.SAsm.AbiFrameCall
+import EvmAsm.Rv64.Tactics.RunBlock
+import EvmAsm.Rv64.Tactics.XSimp
+import EvmAsm.Codegen.AsmReloc
+
+namespace EvmAsm.Codegen.TxIntrinsicStateGasSpec
+
+open EvmAsm.Rv64
+open EvmAsm.Rv64.SAsm
+open EvmAsm.Rv64.Tactics
+open EvmAsm.Codegen
+
+local macro "pcf" : tactic =>
+  `(tactic| repeat
+      first
+      | apply pcFree_sepConj
+      | exact pcFree_regIs
+      | exact pcFree_regOwn
+      | exact pcFree_memIs
+      | exact pcFree_memOwn
+      | exact pcFree_emp
+      | exact pcFree_pure
+      | exact bytesRegion_pcFree _ _
+      | exact pcFree_regsAt _ _
+      | exact pcFree_frameSlotsSaved _ _ _)
+
+abbrev LinkType : Word := T + 108
+abbrev AfterTypeBne : Word := T + 112
+abbrev Fail2 : Word := T + 168
+
+abbrev typeJalOff : BitVec 21 :=
+  jalOff GuestAddrs.tx_type_dispatch (GuestAddrs.tx_intrinsic_state_gas + 104)
+
+/-- Restore a0/a1 from s0/s1 (instr 20-21). -/
+theorem tisTypeAbiRestore (txBase txLenW : Word) (v10 v11 : Word) :
+    cpsTripleWithin 2 AfterExtractBne (T + 88) fullCode
+      ((.x8 ↦ᵣ txBase) ** (.x9 ↦ᵣ txLenW) ** (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ v11))
+      ((.x8 ↦ᵣ txBase) ** (.x9 ↦ᵣ txLenW) **
+        (.x10 ↦ᵣ txBase) ** (.x11 ↦ᵣ txLenW)) := by
+  have h0 := mv_spec_gen_within .x10 .x8 txBase v10 AfterExtractBne (by decide)
+  have e0 := cpsTripleWithin_extend_code
+    (fun a i hi => tis_mono a i
+      (CodeReq.ofProg_mem_at T AfterExtractBne tisProg 20
+        (.MV .x10 .x8) (by simp only [AfterExtractBne]; bv_omega)
+        (by rw [tis_length]; decide) rfl (by rw [tis_length]; decide) a i hi)) h0
+  have h1 := mv_spec_gen_within .x11 .x9 txLenW v11 (T + 84) (by decide)
+  have e1 := cpsTripleWithin_extend_code
+    (fun a i hi => tis_mono a i
+      (CodeReq.ofProg_mem_at T (T + 84) tisProg 21
+        (.MV .x11 .x9) (by bv_omega) (by rw [tis_length]; decide) rfl
+        (by rw [tis_length]; decide) a i hi)) h1
+  -- mv a0,s0 already pins x8; frame only x9/x11
+  have e0F := cpsTripleWithin_frameR
+    ((.x9 ↦ᵣ txLenW) ** (.x11 ↦ᵣ v11)) (by pcf) e0
+  -- mv a1,s1 already pins x9; frame x8/x10
+  have e1F := cpsTripleWithin_frameR
+    ((.x8 ↦ᵣ txBase) ** (.x10 ↦ᵣ txBase)) (by pcf) e1
+  have h01 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) e0F e1F
+  exact cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
+    (fun _ hq => by xperm_hyp hq) h01
+
+/-- `la x12, tis_type` at T+88 → T+96. -/
+theorem tisLaType (v : Word) :
+    cpsTripleWithin 2 (T + 88) (T + 96) fullCode
+      (.x12 ↦ᵣ v) (.x12 ↦ᵣ TypeAddr) := by
+  have hau : ∀ a i, CodeReq.singleton (T + 88)
+      (.AUIPC .x12 (Codegen.laHi GuestAddrs.tis_type
+        (GuestAddrs.tx_intrinsic_state_gas + 88)))
+        a = some i → fullCode a = some i := fun a i hi => tis_mono a i
+    (CodeReq.ofProg_mem_at T (T + 88) tisProg 22
+      (.AUIPC .x12 (Codegen.laHi GuestAddrs.tis_type
+        (GuestAddrs.tx_intrinsic_state_gas + 88)))
+      (by bv_omega) (by rw [tis_length]; decide) rfl
+      (by rw [tis_length]; decide) a i hi)
+  have had : ∀ a i, CodeReq.singleton (T + 92)
+      (.ADDI .x12 .x12 (Codegen.laLo GuestAddrs.tis_type
+        (GuestAddrs.tx_intrinsic_state_gas + 88)))
+        a = some i → fullCode a = some i := fun a i hi => tis_mono a i
+    (CodeReq.ofProg_mem_at T (T + 92) tisProg 23
+      (.ADDI .x12 .x12 (Codegen.laLo GuestAddrs.tis_type
+        (GuestAddrs.tx_intrinsic_state_gas + 88)))
+      (by bv_omega) (by rw [tis_length]; decide) rfl
+      (by rw [tis_length]; decide) a i hi)
+  have h := la_materialize_within .x12 v (T + 88) TypeAddr
+    (by decide) (by decide) hau had
+  rw [show (T + 88 : Word) + 8 = T + 96 from by bv_omega] at h
+  exact h
+
+/-- `la x13, tis_inner_off` at T+96 → T+104. -/
+theorem tisLaInnerOff (v : Word) :
+    cpsTripleWithin 2 (T + 96) (T + 104) fullCode
+      (.x13 ↦ᵣ v) (.x13 ↦ᵣ InnerOffAddr) := by
+  have hau : ∀ a i, CodeReq.singleton (T + 96)
+      (.AUIPC .x13 (Codegen.laHi GuestAddrs.tis_inner_off
+        (GuestAddrs.tx_intrinsic_state_gas + 96)))
+        a = some i → fullCode a = some i := fun a i hi => tis_mono a i
+    (CodeReq.ofProg_mem_at T (T + 96) tisProg 24
+      (.AUIPC .x13 (Codegen.laHi GuestAddrs.tis_inner_off
+        (GuestAddrs.tx_intrinsic_state_gas + 96)))
+      (by bv_omega) (by rw [tis_length]; decide) rfl
+      (by rw [tis_length]; decide) a i hi)
+  have had : ∀ a i, CodeReq.singleton (T + 100)
+      (.ADDI .x13 .x13 (Codegen.laLo GuestAddrs.tis_inner_off
+        (GuestAddrs.tx_intrinsic_state_gas + 96)))
+        a = some i → fullCode a = some i := fun a i hi => tis_mono a i
+    (CodeReq.ofProg_mem_at T (T + 100) tisProg 25
+      (.ADDI .x13 .x13 (Codegen.laLo GuestAddrs.tis_inner_off
+        (GuestAddrs.tx_intrinsic_state_gas + 96)))
+      (by bv_omega) (by rw [tis_length]; decide) rfl
+      (by rw [tis_length]; decide) a i hi)
+  have h := la_materialize_within .x13 v (T + 96) InnerOffAddr
+    (by decide) (by decide) hau had
+  rw [show (T + 96 : Word) + 8 = T + 104 from by bv_omega] at h
+  exact h
+
+set_option maxRecDepth 8000 in
+/-- Type setup: MV a0/a1 + two las (instr 20-25) → T+104. -/
+theorem tisTypeSetup (txBase txLenW : Word) (v10 v11 v12 v13 : Word) :
+    cpsTripleWithin 6 AfterExtractBne (T + 104) fullCode
+      ((.x8 ↦ᵣ txBase) ** (.x9 ↦ᵣ txLenW) **
+        (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ v11) ** (.x12 ↦ᵣ v12) ** (.x13 ↦ᵣ v13))
+      ((.x8 ↦ᵣ txBase) ** (.x9 ↦ᵣ txLenW) **
+        (.x10 ↦ᵣ txBase) ** (.x11 ↦ᵣ txLenW) **
+        (.x12 ↦ᵣ TypeAddr) ** (.x13 ↦ᵣ InnerOffAddr)) := by
+  have hmv := tisTypeAbiRestore txBase txLenW v10 v11
+  have hmvF := cpsTripleWithin_frameR
+    ((.x12 ↦ᵣ v12) ** (.x13 ↦ᵣ v13)) (by pcf) hmv
+  have h0 := tisLaType v12
+  have h0F := cpsTripleWithin_frameR
+    ((.x8 ↦ᵣ txBase) ** (.x9 ↦ᵣ txLenW) **
+      (.x10 ↦ᵣ txBase) ** (.x11 ↦ᵣ txLenW) ** (.x13 ↦ᵣ v13)) (by pcf) h0
+  have h1 := tisLaInnerOff v13
+  have h1F := cpsTripleWithin_frameR
+    ((.x8 ↦ᵣ txBase) ** (.x9 ↦ᵣ txLenW) **
+      (.x10 ↦ᵣ txBase) ** (.x11 ↦ᵣ txLenW) ** (.x12 ↦ᵣ TypeAddr)) (by pcf) h1
+  have c01 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) hmvF h0F
+  have c12 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) c01 h1F
+  exact cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
+    (fun _ hq => by xperm_hyp hq) c12
+
+def typeCalleeP (txBase lenW : Word) (txBytes : List (BitVec 8)) : Assertion :=
+  (.x10 ↦ᵣ txBase) ** (.x11 ↦ᵣ lenW) **
+  (.x12 ↦ᵣ TypeAddr) ** (.x13 ↦ᵣ InnerOffAddr) **
+  bytesRegion txBase txBytes **
+  memOwn TypeAddr ** memOwn InnerOffAddr **
+  regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+  regOwn .x14 ** regOwn .x15 ** regOwn .x16 **
+  regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+  (.x0 ↦ᵣ (0 : Word))
+
+def typeCalleeQ (txBase : Word) (txBytes : List (BitVec 8)) : Assertion :=
+  (.x10 ↦ᵣ (0 : Word)) **
+  bytesRegion txBase txBytes **
+  memOwn TypeAddr ** memOwn InnerOffAddr **
+  regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+  regOwn .x11 ** regOwn .x12 ** regOwn .x13 **
+  regOwn .x14 ** regOwn .x15 ** regOwn .x16 **
+  regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+  (.x0 ↦ᵣ (0 : Word))
+
+theorem typeCalleeP_pcFree (txBase lenW : Word) (txBytes : List (BitVec 8)) :
+    (typeCalleeP txBase lenW txBytes).pcFree := by
+  unfold typeCalleeP; pcf
+
+set_option maxRecDepth 8000 in
+theorem tisTypeCall
+    (asm : TypeDispatchAssumed fullCode)
+    (hentry : asm.entry = TypeEntry)
+    (txBase lenW : Word) (txBytes : List (BitVec 8))
+    (old1 : Word)
+    (hlen : lenW = BitVec.ofNat 64 txBytes.length) :
+    cpsTripleWithin (1 + nTypeSteps) (T + 104) LinkType fullCode
+      ((.x1 ↦ᵣ old1) ** typeCalleeP txBase lenW txBytes)
+      ((.x1 ↦ᵣ LinkType) ** typeCalleeQ txBase txBytes) := by
+  have hret : (LinkType &&& ~~~(1 : Word)) = LinkType := by
+    simp only [LinkType, T]; decide
+  have hcallee0 := asm.success_flat LinkType txBase lenW
+    TypeAddr InnerOffAddr txBytes hret hlen
+  have hcallee0' : cpsTripleWithin nTypeSteps asm.entry LinkType fullCode
+      ((.x1 ↦ᵣ LinkType) ** typeCalleeP txBase lenW txBytes)
+      ((.x1 ↦ᵣ LinkType) ** typeCalleeQ txBase txBytes) := by
+    unfold typeCalleeP typeCalleeQ
+    exact cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
+      (fun _ hq => by xperm_hyp hq) hcallee0
+  have hcallee : cpsTripleWithin nTypeSteps TypeEntry LinkType fullCode
+      ((.x1 ↦ᵣ LinkType) ** typeCalleeP txBase lenW txBytes)
+      ((.x1 ↦ᵣ LinkType) ** typeCalleeQ txBase txBytes) := by
+    rw [← hentry]; exact hcallee0'
+  have hcall := callWithin_spec (T + 104) TypeEntry old1 typeJalOff nTypeSteps
+    (by show (T + 104) + signExtend21 typeJalOff = TypeEntry; decide)
+    (fun a i hi => tis_mono a i
+      (CodeReq.ofProg_mem_at T (T + 104) tisProg 26
+        (.JAL .x1 typeJalOff) (by bv_omega) (by rw [tis_length]; decide) rfl
+        (by rw [tis_length]; decide) a i hi))
+    (typeCalleeP_pcFree txBase lenW txBytes)
+    hcallee
+  rw [show (T + 104 + 4 : Word) = LinkType from by
+    simp only [LinkType]; bv_omega] at hcall
+  exact hcall
+
+set_option maxRecDepth 8000 in
+theorem tisTypeBneOk :
+    cpsTripleWithin 1 LinkType AfterTypeBne fullCode
+      ((.x10 ↦ᵣ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)))
+      ((.x10 ↦ᵣ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word))) := by
+  have hbr := bne_spec_gen_within .x10 .x0 (60 : BitVec 13)
+    (0 : Word) (0 : Word) LinkType
+  have hbrC := cpsBranchWithin_extend_code
+    (fun a i hi => tis_mono a i
+      (CodeReq.ofProg_mem_at T LinkType tisProg 27
+        (.BNE .x10 .x0 (60 : BitVec 13))
+        (by simp only [LinkType]; bv_omega)
+        (by rw [tis_length]; decide) rfl
+        (by rw [tis_length]; decide) a i hi)) hbr
+  have hnt := cpsBranchWithin_ntakenStripPure2 hbrC (fun _ hQt => by
+    obtain ⟨_, _, _, _, _, hrest⟩ := hQt
+    exact absurd rfl ((sepConj_pure_right _).1 hrest).2)
+  have hpc : LinkType + 4 = AfterTypeBne := by
+    simp only [LinkType, AfterTypeBne]; bv_omega
+  rw [hpc] at hnt
+  exact hnt
+
+set_option maxRecDepth 8000 in
+/-- Type path AfterExtractBne → AfterTypeBne under TypeDispatchAssumed. -/
+theorem tisTypeSuccess
+    (asm : TypeDispatchAssumed fullCode)
+    (hentry : asm.entry = TypeEntry)
+    (txBase lenW outPtr : Word) (txBytes : List (BitVec 8))
+    (old1 v10 v11 v12 v13 : Word)
+    (hlen : lenW = BitVec.ofNat 64 txBytes.length) :
+    cpsTripleWithin (6 + (1 + nTypeSteps) + 1) AfterExtractBne AfterTypeBne fullCode
+      ((.x1 ↦ᵣ old1) ** (.x8 ↦ᵣ txBase) ** (.x9 ↦ᵣ lenW) **
+        (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ v11) ** (.x12 ↦ᵣ v12) ** (.x13 ↦ᵣ v13) **
+        (.x18 ↦ᵣ outPtr) **
+        bytesRegion txBase txBytes **
+        memOwn TypeAddr ** memOwn InnerOffAddr **
+        regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+        regOwn .x14 ** regOwn .x15 ** regOwn .x16 **
+        regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+        (.x0 ↦ᵣ (0 : Word)))
+      ((.x1 ↦ᵣ LinkType) ** (.x10 ↦ᵣ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)) **
+        (.x8 ↦ᵣ txBase) ** (.x9 ↦ᵣ lenW) ** (.x18 ↦ᵣ outPtr) **
+        bytesRegion txBase txBytes **
+        memOwn TypeAddr ** memOwn InnerOffAddr **
+        regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+        regOwn .x11 ** regOwn .x12 ** regOwn .x13 **
+        regOwn .x14 ** regOwn .x15 ** regOwn .x16 **
+        regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31) := by
+  have hsetup := tisTypeSetup txBase lenW v10 v11 v12 v13
+  have hsetupF := cpsTripleWithin_frameR
+    ((.x1 ↦ᵣ old1) ** (.x18 ↦ᵣ outPtr) **
+      bytesRegion txBase txBytes **
+      memOwn TypeAddr ** memOwn InnerOffAddr **
+      regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+      regOwn .x14 ** regOwn .x15 ** regOwn .x16 **
+      regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
+      (.x0 ↦ᵣ (0 : Word))) (by pcf) hsetup
+  have hcall := tisTypeCall asm hentry txBase lenW txBytes old1 hlen
+  have hcallF := cpsTripleWithin_frameR
+    ((.x8 ↦ᵣ txBase) ** (.x9 ↦ᵣ lenW) ** (.x18 ↦ᵣ outPtr)) (by pcf) hcall
+  have h01 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by
+    unfold typeCalleeP at *
+    xperm_hyp hp) hsetupF hcallF
+  have hbne := tisTypeBneOk
+  have hbneF := cpsTripleWithin_frameR
+    ((.x1 ↦ᵣ LinkType) ** (.x8 ↦ᵣ txBase) ** (.x9 ↦ᵣ lenW) **
+      (.x18 ↦ᵣ outPtr) **
+      bytesRegion txBase txBytes **
+      memOwn TypeAddr ** memOwn InnerOffAddr **
+      regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+      regOwn .x11 ** regOwn .x12 ** regOwn .x13 **
+      regOwn .x14 ** regOwn .x15 ** regOwn .x16 **
+      regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31)
+    (by pcf) hbne
+  have h12 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by
+    unfold typeCalleeQ at *
+    xperm_hyp hp) h01 hbneF
+  exact cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp)
+    (fun _ hq => by xperm_hyp hq) h12
+
+end EvmAsm.Codegen.TxIntrinsicStateGasSpec


### PR DESCRIPTION
## Summary
- Fn.Spec success path for 54-instr `tx_intrinsic_state_gas` under named leaf hyps
- **Proven:** frame prologue/epilogue, zeros+LD+`eip8037_tx_state_gas` (4-instr convert+spec), compose top
- **Assumptions (hyps, not axioms):** `ExtractAssumed`, `TypeDispatchAssumed` for still-string / unproven callees
- Top: `txIntrinsicStateGas_success_spec_within` — a0=0, *out=0 (= pureIntrinsicStateGasSuccess post EIP-2780), frame restored
- `#print axioms`: propext, Classical.choice, Quot.sound only

## Scope
- Success path only (fail a0=1/2 residual)
- Matches array PR IntrinsicAssumed *out=0 post (honest frame present; adapter note for stack IntrinsicAssumed without sp)
- TEER remains prover1; full eip8037_tx_gas_gate residual

## Files
- `Eip8037TxStateGasSpec.lean` — 4-instr leaf
- `TxIntrinsicStateGas{Spec,Prologue,Epilogue,Extract,Type,Ets,Top}.lean`
- convert `eip8037TxStateGas_prog` in IntrinsicGas.lean

## Test plan
- [x] `lake build EvmAsm.Codegen.Programs.TxIntrinsicStateGasTop` green classical-3
- [ ] CI file-size / unimported / axioms