### PR TITLE
fix(verdict): fall back from bounded BAL storage bailout

### DIFF
--- a/EvmAsm/Codegen/Programs/BalAccountApplyPostFields.lean
+++ b/EvmAsm/Codegen/Programs/BalAccountApplyPostFields.lean
@@ -487,6 +487,20 @@ def balAccountApplyPostFieldsFunction : String :=
   ".Lbaap_multi_apply_call:\n" ++
   "  la a5, aps_newsroot\n" ++
   "  jal ra, mpt_bounded_storage_root\n" ++
+  "  bnez a0, .Lbaap_multi_apply_legacy\n" ++
+  "  j .Lbaap_multi_set_account\n" ++
+  "# Conservative bounded-builder bailout fallback: preserve the legacy exact\n" ++
+  "# storage replay instead of rejecting a valid BAL row. This is intentionally\n" ++
+  "# isolated so the normal route remains bounded and the unmasked behavior can\n" ++
+  "# be measured independently.\n" ++
+  ".Lbaap_multi_apply_legacy:\n" ++
+  "  la t0, baap_storage_empty_flag; ld t0, 0(t0); bnez t0, .Lbaap_multi_legacy_empty\n" ++
+  "  la t0, baap_storage_root_ptr; ld a0, 0(t0); la t0, aps_witness_ptr; ld a1, 0(t0); la t0, aps_witness_len; ld a2, 0(t0); j .Lbaap_multi_legacy_args\n" ++
+  ".Lbaap_multi_legacy_empty:\n" ++
+  "  la a0, aps_empty_root; mv a1, zero; mv a2, zero\n" ++
+  ".Lbaap_multi_legacy_args:\n" ++
+  "  la a3, baap_storage_desc; la t0, baap_sc_out_count; ld a4, 0(t0); la a5, aps_newsroot\n" ++
+  "  jal ra, mpt_state_root_ins\n" ++
   "  bnez a0, .Lbaap_fail_storage_apply\n" ++
   ".Lbaap_multi_set_account:\n" ++
   "  mv a0, s6; mv a1, s7; la a2, aps_newsroot; la a3, baap_tmp2; la a4, baap_tmp2_len\n" ++


### PR DESCRIPTION
## Summary

Removes the conservative BAL storage-replay rejection at `.Lbaap_fail_storage_apply`. The bounded storage-root builder remains the normal path; when it returns nonzero, the exact same normalized descriptors are replayed through the pre-existing legacy `mpt_state_root_ins` path instead of rejecting the block.

## Why now

This is a bail-removal increment requested by the maintainer. The previous reject masks the actual behavior of valid EIP-7928 storage shapes (for example, the current `bsr=113 → baap=501` storage-root path).

## Validation / exposure

- Codegen build and stateless guest link succeed.
- Per maintainer direction, no pre-merge fixture sweep was run: glm-5 will run the unmasked post-merge sweep and report FRs and any re-opened FAs.
- The fallback re-enters the legacy storage-root implementation only for shapes the bounded builder cannot handle; this deliberately makes that route measurable and must be included in the post-merge reachability/soundness audit.

No merge label requested.