### PR TITLE
fix(verdict): remove BAL nonstorage bailout

### DIFF
--- a/EvmAsm/Codegen/Programs/BlockVerdictFunction.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictFunction.lean
@@ -1190,7 +1190,8 @@ def blockVerdictFunction : String :=
   "  la t0, exec_nonstorage_effect_agg_count; ld a3, 0(t0)\n" ++
   "  la a4, i3djw_skip_list; li a5, 9\n" ++
   "  jal ra, bal_all_accounts_nonstorage_consistent\n" ++
-  "  bnez a0, .Lbv_bal_nonstorage_fail\n" ++
+  "  # Conservative BAL-forward mismatch bail removed: retain the authenticated\n" ++
+  "  # state-root and continue into the independent reverse-coverage check.\n" ++
   -- i3djw.3 (REVERSE covers): every exec NON-STORAGE net-change effect must be PRESENT in
   -- the BAL — catches a hidden account that execution net-changed (balance/nonce) but the
   -- BAL omits. Completes the non-storage compare (forward = BAL declared -> exec reproduces;


### PR DESCRIPTION
## Summary

Removes the conservative forward BAL non-storage comparator reject () after non-storage effects are materialized and aggregated.

The authenticated state-root validation and the independent reverse BAL coverage comparator remain active; this increment only stops rejecting a forward-comparator mismatch before the remaining checks run.

## Bail-removal increment

Per maintainer direction, no pre-merge fixture sweep was run. glm-5 will run the single final unmasked sweep after the full bail-removal batch and report any recovered FRs or re-opened FAs. No merge label requested.