### PR TITLE
refactor(divmod): remove unused CallSkipLowerBound V4/V5 theorems

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith/CallSkipLowerBoundV4/Algorithm.lean
+++ b/EvmAsm/Evm64/EvmWordArith/CallSkipLowerBoundV4/Algorithm.lean
@@ -38,19 +38,6 @@ open EvmAsm.Rv64
 def algorithmUn21V4 (uHi uLo vTop : Word) : Word :=
   divKTrialCallV4Un21 uHi uLo vTop
 
-/-- Named unfold for `algorithmUn21V4`. -/
-theorem algorithmUn21V4_unfold (uHi uLo vTop : Word) :
-    algorithmUn21V4 uHi uLo vTop =
-      (let un1 := divKTrialCallV4Un1 uLo
-       let q1'' := divKTrialCallV4Q1dd uHi uLo vTop
-       let rhat'' := divKTrialCallV4Rhatdd uHi uLo vTop
-       let cu_rhat_un1 := (rhat'' <<< (32 : BitVec 6).toNat) ||| un1
-       let cu_q1_dlo := q1'' * divKTrialCallV4DLo vTop
-       cu_rhat_un1 - cu_q1_dlo) := by
-  delta algorithmUn21V4
-  delta divKTrialCallV4Un21
-  rfl
-
 /-- The v4 algorithm's Phase-1b output `q1''`.
 
     Named bundle alias for `divKTrialCallV4Q1dd`, matching the role of
@@ -59,29 +46,6 @@ theorem algorithmUn21V4_unfold (uHi uLo vTop : Word) :
 def algorithmQ1PrimeV4 (uHi uLo vTop : Word) : Word :=
   divKTrialCallV4Q1dd uHi uLo vTop
 
-/-- Named unfold for `algorithmQ1PrimeV4`. -/
-theorem algorithmQ1PrimeV4_unfold (uHi uLo vTop : Word) :
-    algorithmQ1PrimeV4 uHi uLo vTop =
-      (let dHi := divKTrialCallV4DHi vTop
-       let dLo := divKTrialCallV4DLo vTop
-       let un1 := divKTrialCallV4Un1 uLo
-       let q1 := rv64_divu uHi dHi
-       let rhat := uHi - q1 * dHi
-       let hi1 := q1 >>> (32 : BitVec 6).toNat
-       let q1c := if hi1 = 0 then q1 else q1 + signExtend12 4095
-       let rhatc := if hi1 = 0 then rhat else rhat + dHi
-       let qDlo := q1c * dLo
-       let rhatUn1 := (rhatc <<< (32 : BitVec 6).toNat) ||| un1
-       let q1' := if BitVec.ult rhatUn1 qDlo then q1c + signExtend12 4095 else q1c
-       let rhat' := if BitVec.ult rhatUn1 qDlo then rhatc + dHi else rhatc
-       let rhatHi2 := rhat' >>> (32 : BitVec 6).toNat
-       let qDlo2 := q1' * dLo
-       let rhatUn1' := (rhat' <<< (32 : BitVec 6).toNat) ||| un1
-       if rhatHi2 = 0 ∧ BitVec.ult rhatUn1' qDlo2 then q1' + signExtend12 4095 else q1') := by
-  delta algorithmQ1PrimeV4
-  delta divKTrialCallV4Q1dd
-  rfl
-
 /-- The v4 algorithm's Phase-2 output `q0''`.
 
     Named bundle alias for `divKTrialCallV4Q0dd`, matching the role of
@@ -89,18 +53,6 @@ theorem algorithmQ1PrimeV4_unfold (uHi uLo vTop : Word) :
 @[irreducible]
 def algorithmQ0PrimeV4 (uHi uLo vTop : Word) : Word :=
   divKTrialCallV4Q0dd uHi uLo vTop
-
-/-- Named unfold for `algorithmQ0PrimeV4`. -/
-theorem algorithmQ0PrimeV4_unfold (uHi uLo vTop : Word) :
-    algorithmQ0PrimeV4 uHi uLo vTop =
-      div128Quot_phase2b_q0'
-        (divKTrialCallV4Q0d uHi uLo vTop)
-        (divKTrialCallV4Rhat2d uHi uLo vTop)
-        (divKTrialCallV4DLo vTop)
-        (divKTrialCallV4Un0 uLo) := by
-  delta algorithmQ0PrimeV4
-  delta divKTrialCallV4Q0dd
-  rfl
 
 /-- Named unfold for `divKTrialCallV4Q1dd`: q1'' after Knuth's classical
     2-correction in Phase-1b. The full 14-step let-chain:
@@ -127,30 +79,6 @@ theorem divKTrialCallV4Q1dd_unfold (uHi uLo vTop : Word) :
        if rhatHi2 = 0 ∧ BitVec.ult rhatUn1' qDlo2 then q1' + signExtend12 4095 else q1') := by
   delta divKTrialCallV4Q1dd; rfl
 
-/-- Named unfold for `divKTrialCallV4Rhatdd`: rhat'' after Knuth's
-    classical 2-correction in Phase-1b. Same 14-step let-chain as
-    `divKTrialCallV4Q1dd_unfold`, returning `rhat'` (or `rhat' + dHi`
-    when the 2nd correction fires) instead of `q1'`. -/
-theorem divKTrialCallV4Rhatdd_unfold (uHi uLo vTop : Word) :
-    divKTrialCallV4Rhatdd uHi uLo vTop =
-      (let dHi := divKTrialCallV4DHi vTop
-       let dLo := divKTrialCallV4DLo vTop
-       let un1 := divKTrialCallV4Un1 uLo
-       let q1 := rv64_divu uHi dHi
-       let rhat := uHi - q1 * dHi
-       let hi1 := q1 >>> (32 : BitVec 6).toNat
-       let q1c := if hi1 = 0 then q1 else q1 + signExtend12 4095
-       let rhatc := if hi1 = 0 then rhat else rhat + dHi
-       let qDlo := q1c * dLo
-       let rhatUn1 := (rhatc <<< (32 : BitVec 6).toNat) ||| un1
-       let q1' := if BitVec.ult rhatUn1 qDlo then q1c + signExtend12 4095 else q1c
-       let rhat' := if BitVec.ult rhatUn1 qDlo then rhatc + dHi else rhatc
-       let rhatHi2 := rhat' >>> (32 : BitVec 6).toNat
-       let qDlo2 := q1' * dLo
-       let rhatUn1' := (rhat' <<< (32 : BitVec 6).toNat) ||| un1
-       if rhatHi2 = 0 ∧ BitVec.ult rhatUn1' qDlo2 then rhat' + dHi else rhat') := by
-  delta divKTrialCallV4Rhatdd; rfl
-
 /-- Named unfold for `divKTrialCallV4Un21`: half-word combine + Q1dd
     subtraction over the Phase-1b 2-correction outputs. -/
 theorem divKTrialCallV4Un21_unfold (uHi uLo vTop : Word) :
@@ -175,13 +103,5 @@ theorem divKTrialCallV4Q0dd_unfold (uHi uLo vTop : Word) :
         (divKTrialCallV4DLo vTop)
         (divKTrialCallV4Un0 uLo) := by
   delta divKTrialCallV4Q0dd; rfl
-
-/-- Named unfold for `divKTrialCallV4QHat`: final v4 trial quotient as
-    the half-word combine of `Q1dd` and `Q0dd`. -/
-theorem divKTrialCallV4QHat_unfold (uHi uLo vTop : Word) :
-    divKTrialCallV4QHat uHi uLo vTop =
-      ((divKTrialCallV4Q1dd uHi uLo vTop <<< (32 : BitVec 6).toNat) |||
-        divKTrialCallV4Q0dd uHi uLo vTop) := by
-  delta divKTrialCallV4QHat; rfl
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/EvmWordArith/CallSkipLowerBoundV4/ExactQuotient.lean
+++ b/EvmAsm/Evm64/EvmWordArith/CallSkipLowerBoundV4/ExactQuotient.lean
@@ -34,47 +34,6 @@ theorem div128Quot_v4_ge_floor_of_un21_eq_r1
   div128Quot_v4_ge_q_true_of_un21_eq_r1 uHi uLo vTop
     hvTop_ge huHi_lt_vTop huHi_lt_pow63 hUn21_lt_vTop hUn21_eq_r1
 
-/-- V4 128/64 floor `+1` upper bound when `un21` is the first-step
-    mathematical remainder. This is the floor-shaped surface used by the
-    Knuth-A/qhat path. -/
-theorem div128Quot_v4_le_floor_plus_one_of_un21_eq_r1
-    (uHi uLo vTop : Word)
-    (hvTop_ge : vTop.toNat ≥ 2^63)
-    (huHi_lt_vTop : uHi.toNat < vTop.toNat)
-    (hUn21_lt_pow63 :
-      (divKTrialCallV4Un21 uHi uLo vTop).toNat < 2^63)
-    (hUn21_lt_vTop :
-      (divKTrialCallV4Un21 uHi uLo vTop).toNat < vTop.toNat)
-    (hUn21_eq_r1 :
-      (divKTrialCallV4Un21 uHi uLo vTop).toNat =
-        (uHi.toNat * 2^32 + (divKTrialCallV4Un1 uLo).toNat) % vTop.toNat) :
-    (div128Quot_v4 uHi uLo vTop).toNat ≤
-      (uHi.toNat * 2^64 + uLo.toNat) / vTop.toNat + 1 :=
-  div128Quot_v4_le_q_true_plus_one_of_un21_eq_r1 uHi uLo vTop
-    hvTop_ge huHi_lt_vTop hUn21_lt_pow63 hUn21_lt_vTop hUn21_eq_r1
-
-/-- V4 128/64 floor `+1` upper bound from the Phase-1 low-half no-wrap
-    condition. -/
-theorem div128Quot_v4_le_floor_plus_one_of_no_wrap
-    (uHi uLo vTop : Word)
-    (hvTop_ge : vTop.toNat ≥ 2^63)
-    (huHi_lt_vTop : uHi.toNat < vTop.toNat)
-    (huHi_lt_pow63 : uHi.toNat < 2^63)
-    (hUn21_lt_pow63 :
-      (divKTrialCallV4Un21 uHi uLo vTop).toNat < 2^63)
-    (hUn21_lt_vTop :
-      (divKTrialCallV4Un21 uHi uLo vTop).toNat < vTop.toNat)
-    (h_no_wrap :
-      (divKTrialCallV4Q1dd uHi uLo vTop).toNat *
-          (divKTrialCallV4DLo vTop).toNat ≤
-        ((divKTrialCallV4Rhatdd uHi uLo vTop).toNat % 2^32) * 2^32 +
-          (divKTrialCallV4Un1 uLo).toNat) :
-    (div128Quot_v4 uHi uLo vTop).toNat ≤
-      (uHi.toNat * 2^64 + uLo.toNat) / vTop.toNat + 1 :=
-  div128Quot_v4_le_q_true_plus_one_of_no_wrap uHi uLo vTop
-    hvTop_ge huHi_lt_vTop huHi_lt_pow63
-    hUn21_lt_pow63 hUn21_lt_vTop h_no_wrap
-
 /-- V4 128/64 floor `+1` upper bound in the final Phase-1b high-half-zero
     branch. -/
 theorem div128Quot_v4_le_floor_plus_one_of_rhatdd_hi_zero
@@ -178,45 +137,6 @@ theorem div128Quot_v4_call_skip_ge_val256_div_of_floor
   simp only [] at h_bridge
   rw [h_floor]
   exact h_bridge
-
-/-- V4 call-skip val256 lower bound from explicit `un21 = r1` exactness
-    evidence and a supplied 128/64 upper bound. -/
-theorem div128Quot_v4_call_skip_ge_val256_div_of_un21_eq_r1_of_le
-    (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
-    (hb3nz : b3 ≠ 0)
-    (hshift_nz : (clzResult b3).1 ≠ 0)
-    (hcall : isCallTrialN4 a3 b2 b3) :
-    let shift := (clzResult b3).1.toNat % 64
-    let antiShift := (signExtend12 (0 : BitVec 12) - (clzResult b3).1).toNat % 64
-    let b3' := (b3 <<< shift) ||| (b2 >>> antiShift)
-    let u4 := a3 >>> antiShift
-    let u3 := (a3 <<< shift) ||| (a2 >>> antiShift)
-    (divKTrialCallV4Un21 u4 u3 b3').toNat < b3'.toNat →
-    (divKTrialCallV4Un21 u4 u3 b3').toNat =
-      (u4.toNat * 2^32 + (divKTrialCallV4Un1 u3).toNat) % b3'.toNat →
-    (div128Quot_v4 u4 u3 b3').toNat ≤
-      (u4.toNat * 2^64 + u3.toNat) / b3'.toNat →
-    val256 a0 a1 a2 a3 / val256 b0 b1 b2 b3 ≤
-      (div128Quot_v4 u4 u3 b3').toNat := by
-  intro shift antiShift b3' u4 u3 hUn21_lt_vTop hUn21_eq_r1 h_le
-  have hb3'_ge : b3'.toNat ≥ 2^63 :=
-    b3_prime_ge_pow63 b3 b2 hb3nz _
-  have hu4_lt_b3' : u4.toNat < b3'.toNat :=
-    isCallTrialN4_toNat_lt a3 b2 b3 hcall
-  have h_shift_pos : 1 ≤ (clzResult b3).1.toNat := by
-    rcases Nat.eq_zero_or_pos (clzResult b3).1.toNat with h_zero | h_pos
-    · exfalso
-      apply hshift_nz
-      exact BitVec.eq_of_toNat_eq (by simp [h_zero])
-    · exact h_pos
-  have hu4_lt_pow63 : u4.toNat < 2^63 :=
-    u_top_lt_pow63_of_shift_nz a3 (clzResult b3).1 h_shift_pos
-      (clzResult_fst_toNat_le b3)
-  have h_floor := div128Quot_v4_eq_floor_of_un21_eq_r1_of_le
-    u4 u3 b3' hb3'_ge hu4_lt_b3' hu4_lt_pow63
-    hUn21_lt_vTop hUn21_eq_r1 h_le
-  exact div128Quot_v4_call_skip_ge_val256_div_of_floor
-    a0 a1 a2 a3 b0 b1 b2 b3 hb3nz hshift_nz h_floor
 
 /-- V4 call-skip val256 lower bound from explicit `un21 = r1` exactness
     evidence, without requiring the matching 128/64 upper bound. -/

--- a/EvmAsm/Evm64/EvmWordArith/CallSkipLowerBoundV4/Phase1bBound.lean
+++ b/EvmAsm/Evm64/EvmWordArith/CallSkipLowerBoundV4/Phase1bBound.lean
@@ -412,27 +412,6 @@ theorem divKTrialCallV4Q1c_toNat_of_dHi_pow32_le_uHi
   rw [if_neg hhi]
   exact phase1a_q1_dec_toNat_of_hi_ne_zero q1 hhi
 
-/-- In the wide-`uHi` regime, the Phase-1a corrected remainder is
-    `rhat + dHi`. -/
-theorem divKTrialCallV4Rhatc_eq_of_dHi_pow32_le_uHi
-    (uHi vTop : Word)
-    (hvTop_ge : vTop.toNat ≥ 2^63)
-    (huHi_ge_dHi_pow32 :
-      (divKTrialCallV4DHi vTop).toNat * 2^32 ≤ uHi.toNat) :
-    let dHi := divKTrialCallV4DHi vTop
-    let q1 := rv64_divu uHi dHi
-    let rhat := uHi - q1 * dHi
-    let hi1 := q1 >>> (32 : BitVec 6).toNat
-    let rhatc := if hi1 = 0 then rhat else rhat + dHi
-    rhatc = rhat + dHi := by
-  intro dHi q1 rhat hi1 rhatc
-  have hhi : q1 >>> (32 : BitVec 6).toNat ≠ (0 : Word) := by
-    simpa [dHi, q1] using
-      divKTrialCallV4Q1_hi_ne_zero_of_dHi_pow32_le_uHi
-        uHi vTop hvTop_ge huHi_ge_dHi_pow32
-  show (if hi1 = 0 then rhat else rhat + dHi) = rhat + dHi
-  rw [if_neg hhi]
-
 /-- In the wide-`uHi` regime, the Phase-1a corrected quotient is at most
     `2^32`. -/
 theorem divKTrialCallV4Q1c_le_pow32_of_dHi_pow32_le_uHi
@@ -490,36 +469,6 @@ theorem divKTrialCallV4Q1c_le_pow32_of_dHi_pow32_le_uHi
     exact (Nat.div_le_iff_le_mul_add_pred hdHi_pos).mpr h_uHi_le
   rw [h_q1c_eq]
   omega
-
-/-- In the wide-`uHi` regime, the V4 pre-second-correction quotient is at most
-    `2^32`. -/
-theorem algorithmQ1dV4_le_pow32_of_dHi_pow32_le_uHi
-    (uHi uLo vTop : Word)
-    (hvTop_ge : vTop.toNat ≥ 2^63)
-    (huHi_lt_vTop : uHi.toNat < vTop.toNat)
-    (huHi_ge_dHi_pow32 :
-      (divKTrialCallV4DHi vTop).toNat * 2^32 ≤ uHi.toNat) :
-    (algorithmQ1dV4 uHi uLo vTop).toNat ≤ 2^32 := by
-  let dHi := divKTrialCallV4DHi vTop
-  let dLo := divKTrialCallV4DLo vTop
-  let un1 := divKTrialCallV4Un1 uLo
-  let q1 := rv64_divu uHi dHi
-  let rhat := uHi - q1 * dHi
-  let hi1 := q1 >>> (32 : BitVec 6).toNat
-  let q1c := if hi1 = 0 then q1 else q1 + signExtend12 4095
-  let rhatc := if hi1 = 0 then rhat else rhat + dHi
-  let rhatUn1 := (rhatc <<< (32 : BitVec 6).toNat) ||| un1
-  have h_q1c_le : q1c.toNat ≤ 2^32 := by
-    have h := divKTrialCallV4Q1c_le_pow32_of_dHi_pow32_le_uHi
-      uHi vTop hvTop_ge huHi_lt_vTop huHi_ge_dHi_pow32
-    simpa [dHi, q1, hi1, q1c] using h
-  have h_prime_le : (algorithmQ1dV4 uHi uLo vTop).toNat ≤ q1c.toNat := by
-    rw [algorithmQ1dV4_unfold]
-    unfold algorithmQ1Prime
-    have h := div128Quot_q1_prime_le_q1c q1c dLo rhatUn1
-    simpa [dHi, dLo, un1, q1, rhat, hi1, q1c, rhatc, rhatUn1,
-      divKTrialCallV4DHi, divKTrialCallV4DLo, divKTrialCallV4Un1] using h
-  exact le_trans h_prime_le h_q1c_le
 
 /-- If the first Phase-1b correction fires, the V4 pre-second-correction
     quotient satisfies the Knuth-style `qTrue + 1` upper bound. -/
@@ -919,70 +868,6 @@ theorem algorithmQ1dV4_dLo_overshoot_le_vTop_of_uHi_lt_dHi_pow32_closed
   exact algorithmQ1dV4_dLo_overshoot_le_vTop_of_uHi_lt_dHi_pow32
     uHi uLo vTop hvTop_ge huHi_lt_vTop huHi_lt_dHi_pow32
     (algorithmQ1dV4_rhatd_post uHi uLo vTop hvTop_ge)
-
-/-- Narrow-call V4 Phase-1b post-condition after the second correction.
-
-    This composes the generic Phase-2b fire/no-fire bounds with the V4
-    pre-second-correction pair and the narrow-regime overshoot discharge. -/
-theorem divKTrialCallV4_phase1b_dLo_bound_of_uHi_lt_dHi_pow32
-    (uHi uLo vTop : Word)
-    (hvTop_ge : vTop.toNat ≥ 2^63)
-    (huHi_lt_vTop : uHi.toNat < vTop.toNat)
-    (huHi_lt_dHi_pow32 :
-      uHi.toNat < (divKTrialCallV4DHi vTop).toNat * 2^32) :
-    (divKTrialCallV4Q1dd uHi uLo vTop).toNat *
-        (divKTrialCallV4DLo vTop).toNat ≤
-      (divKTrialCallV4Rhatdd uHi uLo vTop).toNat * 2^32 +
-        (divKTrialCallV4Un1 uLo).toNat := by
-  let q := algorithmQ1dV4 uHi uLo vTop
-  let rhat := algorithmRhatdV4 uHi uLo vTop
-  let dHi := divKTrialCallV4DHi vTop
-  let dLo := divKTrialCallV4DLo vTop
-  let un := divKTrialCallV4Un1 uLo
-  have h_q_le : q.toNat ≤ 2^32 + 1 := by
-    simpa [q] using algorithmQ1dV4_le_pow32_plus_one uHi uLo vTop hvTop_ge huHi_lt_vTop
-  have h_dLo_lt : dLo.toNat < 2^32 := by
-    simpa [dLo] using divKTrialCallV4DLo_lt_pow32 vTop
-  have h_un_lt : un.toNat < 2^32 := by
-    simpa [un] using divKTrialCallV4Un1_lt_pow32 uLo
-  have h_no_wrap_q : (q * dLo).toNat = q.toNat * dLo.toNat := by
-    simpa [q, dLo] using algorithmQ1dV4_dLo_no_wrap uHi uLo vTop hvTop_ge huHi_lt_vTop
-  have h_overshoot : q.toNat * dLo.toNat ≤
-      rhat.toNat * 2^32 + un.toNat + dHi.toNat * 2^32 + dLo.toNat := by
-    simpa [q, rhat, dHi, dLo, un] using
-      algorithmQ1dV4_dLo_overshoot_le_vTop_of_uHi_lt_dHi_pow32_closed
-        uHi uLo vTop hvTop_ge huHi_lt_vTop huHi_lt_dHi_pow32
-  by_cases h_guard : rhat >>> (32 : BitVec 6).toNat = (0 : Word) ∧
-    BitVec.ult ((rhat <<< (32 : BitVec 6).toNat) ||| un) (q * dLo)
-  · have h_guard_full := h_guard
-    obtain ⟨h_rhat_hi_zero, h_ult⟩ := h_guard
-    have h_dHi_lt : dHi.toNat < 2^32 := by
-      unfold dHi divKTrialCallV4DHi
-      exact Word_ushiftRight_32_lt_pow32
-    have h_no_wrap_rhat : (rhat + dHi).toNat = rhat.toNat + dHi.toNat :=
-      phase2b_rhat_add_dHi_no_wrap_of_hi_zero rhat dHi h_rhat_hi_zero h_dHi_lt
-    have h_q_pos : q.toNat ≥ 1 :=
-      phase2b_q_pos_of_fire_ult q dLo ((rhat <<< (32 : BitVec 6).toNat) ||| un) h_ult
-    obtain ⟨h_qeq, h_bound⟩ := div128Quot_phase2b_q0'_dLo_bound_fire_case
-      q rhat dLo dHi un h_no_wrap_rhat h_q_pos h_rhat_hi_zero h_ult h_overshoot
-    rw [divKTrialCallV4Q1dd_eq_phase2b_algorithm,
-      divKTrialCallV4Rhatdd_eq_phase2b_algorithm]
-    change (div128Quot_phase2b_q0' q rhat dLo un).toNat * dLo.toNat ≤
-      (if rhat >>> (32 : BitVec 6).toNat = (0 : Word) ∧
-        BitVec.ult ((rhat <<< (32 : BitVec 6).toNat) ||| un) (q * dLo) then
-        rhat + dHi else rhat).toNat * 2^32 + un.toNat
-    rw [h_qeq, if_pos h_guard_full]
-    exact h_bound
-  · obtain ⟨h_qeq, h_bound⟩ := div128Quot_phase2b_q0'_dLo_bound_no_fire
-      q rhat dLo un h_q_le h_dLo_lt h_un_lt h_no_wrap_q h_guard
-    rw [divKTrialCallV4Q1dd_eq_phase2b_algorithm,
-      divKTrialCallV4Rhatdd_eq_phase2b_algorithm]
-    change (div128Quot_phase2b_q0' q rhat dLo un).toNat * dLo.toNat ≤
-      (if rhat >>> (32 : BitVec 6).toNat = (0 : Word) ∧
-        BitVec.ult ((rhat <<< (32 : BitVec 6).toNat) ||| un) (q * dLo) then
-        rhat + dHi else rhat).toNat * 2^32 + un.toNat
-    rw [h_qeq, if_neg h_guard]
-    exact h_bound
 
 /-- V4 Phase-1b post-condition after the second correction. -/
 theorem divKTrialCallV4_phase1b_dLo_bound

--- a/EvmAsm/Evm64/EvmWordArith/CallSkipLowerBoundV4/Q1ddUndershootFromWideUn21.lean
+++ b/EvmAsm/Evm64/EvmWordArith/CallSkipLowerBoundV4/Q1ddUndershootFromWideUn21.lean
@@ -227,18 +227,4 @@ theorem divKTrialCallV4Q1dd_lt_q_true_1_of_un21_ge_vTop
       _ < vTop.toNat := h_mod_lt
   exact absurd h_un21_lt (Nat.not_lt.2 hUn21_ge_vTop)
 
-/-- Equivalent form: `un21 ≥ vTop ⇒ Q1dd + 1 ≤ q_true_1` (Nat-friendly
-    rephrasing for downstream consumers). -/
-theorem divKTrialCallV4Q1dd_succ_le_q_true_1_of_un21_ge_vTop
-    (uHi uLo vTop : Word)
-    (hvTop_ge : vTop.toNat ≥ 2^63)
-    (huHi_lt_vTop : uHi.toNat < vTop.toNat)
-    (hUn21_ge_vTop :
-      (divKTrialCallV4Un21 uHi uLo vTop).toNat ≥ vTop.toNat) :
-    (divKTrialCallV4Q1dd uHi uLo vTop).toNat + 1 ≤
-      (uHi.toNat * 2^32 + (divKTrialCallV4Un1 uLo).toNat) / vTop.toNat :=
-  Nat.succ_le_of_lt
-    (divKTrialCallV4Q1dd_lt_q_true_1_of_un21_ge_vTop
-      uHi uLo vTop hvTop_ge huHi_lt_vTop hUn21_ge_vTop)
-
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/EvmWordArith/CallSkipLowerBoundV4/QuotientBounds.lean
+++ b/EvmAsm/Evm64/EvmWordArith/CallSkipLowerBoundV4/QuotientBounds.lean
@@ -1026,57 +1026,6 @@ theorem divKTrialCallV4Q0d_gt_q_true_0_of_ult
   exact divKTrialCallV4Q0d_gt_q_true_0_of_prod_gt uHi uLo vTop
     hDen_pos h_bridge.1 h_bridge.2 hProd_gt
 
-/-- V4 second-correction lower bound in the `un21 < 2^63` range.
-
-    This combines the first-correction lower bound with the full second
-    correction branch split. If the second product check fires, the `ult`
-    bridge proves the strict-overestimate witness needed to preserve the
-    lower bound through the decrement. -/
-theorem divKTrialCallV4Q0dd_ge_q_true_0_of_un21_lt_pow63
-    (uHi uLo vTop : Word)
-    (hdHi_ge : (divKTrialCallV4DHi vTop).toNat ≥ 2^31)
-    (hdHi_lt : (divKTrialCallV4DHi vTop).toNat < 2^32)
-    (hdLo_lt : (divKTrialCallV4DLo vTop).toNat < 2^32)
-    (hUn21_lt_pow63 : (divKTrialCallV4Un21 uHi uLo vTop).toNat < 2^63)
-    (hUn21_lt_vTop :
-      (divKTrialCallV4Un21 uHi uLo vTop).toNat <
-        (divKTrialCallV4DHi vTop).toNat * 2^32 +
-          (divKTrialCallV4DLo vTop).toNat) :
-    ((divKTrialCallV4Un21 uHi uLo vTop).toNat * 2^32 +
-        (divKTrialCallV4Un0 uLo).toNat) /
-      ((divKTrialCallV4DHi vTop).toNat * 2^32 +
-        (divKTrialCallV4DLo vTop).toNat) ≤
-    (divKTrialCallV4Q0dd uHi uLo vTop).toNat := by
-  have hQ0d_ge :
-      ((divKTrialCallV4Un21 uHi uLo vTop).toNat * 2^32 +
-          (divKTrialCallV4Un0 uLo).toNat) /
-        ((divKTrialCallV4DHi vTop).toNat * 2^32 +
-          (divKTrialCallV4DLo vTop).toNat) ≤
-      (divKTrialCallV4Q0d uHi uLo vTop).toNat :=
-    divKTrialCallV4Q0d_ge_q_true_0_of_un21_lt_pow63 uHi uLo vTop
-      hdHi_ge hdHi_lt hdLo_lt hUn21_lt_pow63 hUn21_lt_vTop
-  by_cases hRhat2d_hi_zero :
-      divKTrialCallV4Rhat2d uHi uLo vTop >>> (32 : BitVec 6).toNat = 0
-  · by_cases hUlt :
-        BitVec.ult
-          ((divKTrialCallV4Rhat2d uHi uLo vTop <<< (32 : BitVec 6).toNat) |||
-            divKTrialCallV4Un0 uLo)
-          (divKTrialCallV4Q0d uHi uLo vTop * divKTrialCallV4DLo vTop)
-    · have hQ0d_gt :
-          ((divKTrialCallV4Un21 uHi uLo vTop).toNat * 2^32 +
-              (divKTrialCallV4Un0 uLo).toNat) /
-            ((divKTrialCallV4DHi vTop).toNat * 2^32 +
-              (divKTrialCallV4DLo vTop).toNat) <
-          (divKTrialCallV4Q0d uHi uLo vTop).toNat :=
-        divKTrialCallV4Q0d_gt_q_true_0_of_ult uHi uLo vTop
-          hdHi_ge hdHi_lt hdLo_lt hUn21_lt_vTop hRhat2d_hi_zero hUlt
-      exact divKTrialCallV4Q0dd_ge_q_true_0_of_q0d_gt_of_fire uHi uLo vTop
-        hQ0d_gt hRhat2d_hi_zero hUlt
-    · exact divKTrialCallV4Q0dd_ge_q_true_0_of_q0d_ge_of_rhat2d_hi_eq_zero_of_no_ult
-        uHi uLo vTop hQ0d_ge hRhat2d_hi_zero hUlt
-  · exact divKTrialCallV4Q0dd_ge_q_true_0_of_q0d_ge_of_rhat2d_hi_ne
-      uHi uLo vTop hQ0d_ge hRhat2d_hi_zero
-
 /-- V4 second-correction lower bound in the `un21 < DHi * 2^32` range.
 
     This is the wider easy Phase-2 range where the first-correction lower

--- a/EvmAsm/Evm64/EvmWordArith/CallSkipLowerBoundV4/Un21LevelUB.lean
+++ b/EvmAsm/Evm64/EvmWordArith/CallSkipLowerBoundV4/Un21LevelUB.lean
@@ -196,30 +196,4 @@ theorem divKTrialCallV4Q0dd_le_q_true_0_plus_one_of_rhat2c_lt_pow32
       uHi uLo vTop hdHi_ge hdHi_lt hdLo_lt hUn21_lt_vTop h_rhat2c_lt
   exact le_trans (divKTrialCallV4Q0dd_le_q0d uHi uLo vTop) h_q0d_le
 
-/-- **Combined un21-level Q0dd UB closure**: under just normalisation +
-    `un21 < vTop`, `Q0dd ≤ q_true_0 + 1`.  Case-splits on `rhat2c < 2^32`
-    vs `≥ 2^32`, dispatching to the narrow (above) or wide
-    (PR #7063) branch.  Symmetric to
-    `div128Quot_q0_prime_ge_q_true_0_un21_level` on the LB side. -/
-theorem divKTrialCallV4Q0dd_le_q_true_0_plus_one_of_un21_lt_vTop
-    (uHi uLo vTop : Word)
-    (hdHi_ge : (divKTrialCallV4DHi vTop).toNat ≥ 2^31)
-    (hdHi_lt : (divKTrialCallV4DHi vTop).toNat < 2^32)
-    (hdLo_lt : (divKTrialCallV4DLo vTop).toNat < 2^32)
-    (hUn21_lt_vTop :
-      (divKTrialCallV4Un21 uHi uLo vTop).toNat <
-        (divKTrialCallV4DHi vTop).toNat * 2^32 +
-          (divKTrialCallV4DLo vTop).toNat) :
-    (divKTrialCallV4Q0dd uHi uLo vTop).toNat ≤
-      ((divKTrialCallV4Un21 uHi uLo vTop).toNat * 2^32 +
-          (divKTrialCallV4Un0 uLo).toNat) /
-        ((divKTrialCallV4DHi vTop).toNat * 2^32 +
-          (divKTrialCallV4DLo vTop).toNat) + 1 := by
-  by_cases h_rhat2c_lt : (divKTrialCallV4Rhat2c uHi uLo vTop).toNat < 2^32
-  · exact divKTrialCallV4Q0dd_le_q_true_0_plus_one_of_rhat2c_lt_pow32
-      uHi uLo vTop hdHi_ge hdHi_lt hdLo_lt hUn21_lt_vTop h_rhat2c_lt
-  · push Not at h_rhat2c_lt
-    exact divKTrialCallV4Q0dd_le_q_true_0_plus_one_of_rhat2c_ge_pow32
-      uHi uLo vTop hdHi_ge hdHi_lt hdLo_lt hUn21_lt_vTop h_rhat2c_lt
-
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/EvmWordArith/CallSkipLowerBoundV5/Algorithm.lean
+++ b/EvmAsm/Evm64/EvmWordArith/CallSkipLowerBoundV5/Algorithm.lean
@@ -28,120 +28,17 @@ open EvmAsm.Rv64
 def algorithmUn21V5 (uHi uLo vTop : Word) : Word :=
   divKTrialCallV5Un21 uHi uLo vTop
 
-/-- Named unfold for `algorithmUn21V5`. -/
-theorem algorithmUn21V5_unfold (uHi uLo vTop : Word) :
-    algorithmUn21V5 uHi uLo vTop =
-      (let un1 := divKTrialCallV5Un1 uLo
-       let q1'' := divKTrialCallV5Q1dd uHi uLo vTop
-       let rhat'' := divKTrialCallV5Rhatdd uHi uLo vTop
-       let cu_rhat_un1 := (rhat'' <<< (32 : BitVec 6).toNat) ||| un1
-       let cu_q1_dlo := q1'' * divKTrialCallV5DLo vTop
-       cu_rhat_un1 - cu_q1_dlo) := by
-  delta algorithmUn21V5
-  delta divKTrialCallV5Un21
-  rfl
-
 /-- The v5 algorithm's Phase-1b output `q1''`. Named bundle alias for
     `divKTrialCallV5Q1dd`. -/
 @[irreducible]
 def algorithmQ1PrimeV5 (uHi uLo vTop : Word) : Word :=
   divKTrialCallV5Q1dd uHi uLo vTop
 
-/-- Named unfold for `algorithmQ1PrimeV5`. Note the v5 Phase-1a uses the
-    capped `q1cCap := 0xFFFFFFFF` value and recomputed `rhatc`, and the
-    Phase-1b 1st correction is guarded by `rhatc >>> 32 = 0`. -/
-theorem algorithmQ1PrimeV5_unfold (uHi uLo vTop : Word) :
-    algorithmQ1PrimeV5 uHi uLo vTop =
-      (let dHi := divKTrialCallV5DHi vTop
-       let dLo := divKTrialCallV5DLo vTop
-       let un1 := divKTrialCallV5Un1 uLo
-       let q1 := rv64_divu uHi dHi
-       let rhat := uHi - q1 * dHi
-       let hi1 := q1 >>> (32 : BitVec 6).toNat
-       let q1cCap : Word := (BitVec.allOnes 64) >>> (32 : BitVec 6).toNat
-       let q1c := if hi1 = 0 then q1 else q1cCap
-       let rhatc := if hi1 = 0 then rhat else uHi - q1c * dHi
-       let qDlo := q1c * dLo
-       let rhatUn1 := (rhatc <<< (32 : BitVec 6).toNat) ||| un1
-       let phase1bFire1 :=
-         decide (rhatc >>> (32 : BitVec 6).toNat = 0) && BitVec.ult rhatUn1 qDlo
-       let q1' := if phase1bFire1 then q1c + signExtend12 4095 else q1c
-       let rhat' := if phase1bFire1 then rhatc + dHi else rhatc
-       let rhatHi2 := rhat' >>> (32 : BitVec 6).toNat
-       let qDlo2 := q1' * dLo
-       let rhatUn1' := (rhat' <<< (32 : BitVec 6).toNat) ||| un1
-       if rhatHi2 = 0 ∧ BitVec.ult rhatUn1' qDlo2 then q1' + signExtend12 4095 else q1') := by
-  delta algorithmQ1PrimeV5
-  delta divKTrialCallV5Q1dd
-  rfl
-
 /-- The v5 algorithm's Phase-2 output `q0''`. Named bundle alias for
     `divKTrialCallV5Q0dd`. -/
 @[irreducible]
 def algorithmQ0PrimeV5 (uHi uLo vTop : Word) : Word :=
   divKTrialCallV5Q0dd uHi uLo vTop
-
-/-- Named unfold for `algorithmQ0PrimeV5`. -/
-theorem algorithmQ0PrimeV5_unfold (uHi uLo vTop : Word) :
-    algorithmQ0PrimeV5 uHi uLo vTop =
-      div128Quot_phase2b_q0'
-        (divKTrialCallV5Q0d uHi uLo vTop)
-        (divKTrialCallV5Rhat2d uHi uLo vTop)
-        (divKTrialCallV5DLo vTop)
-        (divKTrialCallV5Un0 uLo) := by
-  delta algorithmQ0PrimeV5
-  delta divKTrialCallV5Q0dd
-  rfl
-
-/-- Named unfold for `divKTrialCallV5Q1dd`: q1'' after the V5 Phase-1a
-    cap + V5 guarded Phase-1b 1st correction + Phase-1b 2nd D3
-    correction. -/
-theorem divKTrialCallV5Q1dd_unfold (uHi uLo vTop : Word) :
-    divKTrialCallV5Q1dd uHi uLo vTop =
-      (let dHi := divKTrialCallV5DHi vTop
-       let dLo := divKTrialCallV5DLo vTop
-       let un1 := divKTrialCallV5Un1 uLo
-       let q1 := rv64_divu uHi dHi
-       let rhat := uHi - q1 * dHi
-       let hi1 := q1 >>> (32 : BitVec 6).toNat
-       let q1cCap : Word := (BitVec.allOnes 64) >>> (32 : BitVec 6).toNat
-       let q1c := if hi1 = 0 then q1 else q1cCap
-       let rhatc := if hi1 = 0 then rhat else uHi - q1c * dHi
-       let qDlo := q1c * dLo
-       let rhatUn1 := (rhatc <<< (32 : BitVec 6).toNat) ||| un1
-       let phase1bFire1 :=
-         decide (rhatc >>> (32 : BitVec 6).toNat = 0) && BitVec.ult rhatUn1 qDlo
-       let q1' := if phase1bFire1 then q1c + signExtend12 4095 else q1c
-       let rhat' := if phase1bFire1 then rhatc + dHi else rhatc
-       let rhatHi2 := rhat' >>> (32 : BitVec 6).toNat
-       let qDlo2 := q1' * dLo
-       let rhatUn1' := (rhat' <<< (32 : BitVec 6).toNat) ||| un1
-       if rhatHi2 = 0 ∧ BitVec.ult rhatUn1' qDlo2 then q1' + signExtend12 4095 else q1') := by
-  delta divKTrialCallV5Q1dd; rfl
-
-/-- Named unfold for `divKTrialCallV5Rhatdd`. -/
-theorem divKTrialCallV5Rhatdd_unfold (uHi uLo vTop : Word) :
-    divKTrialCallV5Rhatdd uHi uLo vTop =
-      (let dHi := divKTrialCallV5DHi vTop
-       let dLo := divKTrialCallV5DLo vTop
-       let un1 := divKTrialCallV5Un1 uLo
-       let q1 := rv64_divu uHi dHi
-       let rhat := uHi - q1 * dHi
-       let hi1 := q1 >>> (32 : BitVec 6).toNat
-       let q1cCap : Word := (BitVec.allOnes 64) >>> (32 : BitVec 6).toNat
-       let q1c := if hi1 = 0 then q1 else q1cCap
-       let rhatc := if hi1 = 0 then rhat else uHi - q1c * dHi
-       let qDlo := q1c * dLo
-       let rhatUn1 := (rhatc <<< (32 : BitVec 6).toNat) ||| un1
-       let phase1bFire1 :=
-         decide (rhatc >>> (32 : BitVec 6).toNat = 0) && BitVec.ult rhatUn1 qDlo
-       let q1' := if phase1bFire1 then q1c + signExtend12 4095 else q1c
-       let rhat' := if phase1bFire1 then rhatc + dHi else rhatc
-       let rhatHi2 := rhat' >>> (32 : BitVec 6).toNat
-       let qDlo2 := q1' * dLo
-       let rhatUn1' := (rhat' <<< (32 : BitVec 6).toNat) ||| un1
-       if rhatHi2 = 0 ∧ BitVec.ult rhatUn1' qDlo2 then rhat' + dHi else rhat') := by
-  delta divKTrialCallV5Rhatdd; rfl
 
 /-- Named unfold for `divKTrialCallV5Un21`. -/
 theorem divKTrialCallV5Un21_unfold (uHi uLo vTop : Word) :
@@ -153,24 +50,6 @@ theorem divKTrialCallV5Un21_unfold (uHi uLo vTop : Word) :
        let cu_q1_dlo := q1'' * divKTrialCallV5DLo vTop
        cu_rhat_un1 - cu_q1_dlo) := by
   delta divKTrialCallV5Un21; rfl
-
-/-- Named unfold for `divKTrialCallV5Q0dd`. -/
-theorem divKTrialCallV5Q0dd_unfold (uHi uLo vTop : Word) :
-    divKTrialCallV5Q0dd uHi uLo vTop =
-      div128Quot_phase2b_q0'
-        (divKTrialCallV5Q0d uHi uLo vTop)
-        (divKTrialCallV5Rhat2d uHi uLo vTop)
-        (divKTrialCallV5DLo vTop)
-        (divKTrialCallV5Un0 uLo) := by
-  delta divKTrialCallV5Q0dd; rfl
-
-/-- Named unfold for `divKTrialCallV5QHat`: final V5 trial quotient as
-    the half-word combine of `Q1dd` and `Q0dd`. -/
-theorem divKTrialCallV5QHat_unfold (uHi uLo vTop : Word) :
-    divKTrialCallV5QHat uHi uLo vTop =
-      ((divKTrialCallV5Q1dd uHi uLo vTop <<< (32 : BitVec 6).toNat) |||
-        divKTrialCallV5Q0dd uHi uLo vTop) := by
-  delta divKTrialCallV5QHat; rfl
 
 -- ============================================================================
 -- Phase-1a + Phase-1b-fire-guard algorithm bundles for V5.

--- a/EvmAsm/Evm64/EvmWordArith/CallSkipLowerBoundV5/CapBounds.lean
+++ b/EvmAsm/Evm64/EvmWordArith/CallSkipLowerBoundV5/CapBounds.lean
@@ -58,11 +58,4 @@ theorem algorithmQ0cV5_lt_pow32 (uHi uLo vTop : Word) :
     rw [v5_capCap_toNat]
     omega
 
-/-- Bridge: `divKTrialCallV5Q0c` (the irreducible) inherits Q0c's cap
-    bound via the `_eq_algorithm` equation. -/
-theorem divKTrialCallV5Q0c_lt_pow32 (uHi uLo vTop : Word) :
-    (divKTrialCallV5Q0c uHi uLo vTop).toNat < 2^32 := by
-  rw [divKTrialCallV5Q0c_eq_algorithm]
-  exact algorithmQ0cV5_lt_pow32 uHi uLo vTop
-
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/EvmWordArith/Div128CallSkipClose.lean
+++ b/EvmAsm/Evm64/EvmWordArith/Div128CallSkipClose.lean
@@ -483,30 +483,6 @@ theorem div128Quot_call_skip_le_val256_div
   simp only [] at h_mul
   exact (Nat.le_div_iff_mul_le hv_pos).mpr h_mul
 
-/-- **Direct call-skip KB-6 upper bound.**
-
-    Wrapper around the stronger skip-borrow result
-    `div128Quot_call_skip_le_val256_div`. This is the direct #1337 follow-up
-    surface for callers that need the Knuth-B `+2` shape without going through
-    the false `Div128(All)PhasesNoWrapInv` bridge. -/
-theorem div128Quot_call_skip_le_q_true_plus_two_direct
-    (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
-    (hb3nz : b3 ≠ 0)
-    (hshift_nz : (clzResult b3).1 ≠ 0)
-    (hskip : isSkipBorrowN4Call a0 a1 a2 a3 b0 b1 b2 b3) :
-    let shift := (clzResult b3).1.toNat % 64
-    let antiShift := (signExtend12 (0 : BitVec 12) - (clzResult b3).1).toNat % 64
-    let b3' := (b3 <<< shift) ||| (b2 >>> antiShift)
-    let u4 := a3 >>> antiShift
-    let u3 := (a3 <<< shift) ||| (a2 >>> antiShift)
-    (div128Quot u4 u3 b3').toNat ≤
-      val256 a0 a1 a2 a3 / val256 b0 b1 b2 b3 + 2 := by
-  intro shift antiShift b3' u4 u3
-  have h := div128Quot_call_skip_le_val256_div
-    a0 a1 a2 a3 b0 b1 b2 b3 hb3nz hshift_nz hskip
-  simp only [] at h
-  exact Nat.le_trans h (Nat.le_add_right _ _)
-
 -- ============================================================================
 -- Pure-Nat digit-tightness utilities (used downstream by Phase 1/2 tight)
 -- ============================================================================
@@ -540,57 +516,6 @@ theorem digit_tight_of_le_and_ge {q1 q0 q_true_1 q_true_0 : Nat}
   refine ⟨h_q1_eq, ?_⟩
   rw [h_q1_eq] at h_le
   omega
-
-/-- **q_true_full digit lower bound (pure Nat).** The full 2-digit true
-    quotient is at least `q_true_1 * 2^32`, where `q_true_1` is the Phase 1
-    abstract first digit. Proof: multiply Phase 1 Euclidean by `2^32`,
-    bound `div_un0 ≥ 0`. -/
-theorem q_true_full_ge_q_true_1_mul_pow32_nat
-    {uHi div_un1 div_un0 dHi dLo : Nat}
-    (hvTop_pos : 0 < dHi * 2^32 + dLo) :
-    (uHi * 2^32 + div_un1) / (dHi * 2^32 + dLo) * 2^32 ≤
-      (uHi * 2^64 + div_un1 * 2^32 + div_un0) / (dHi * 2^32 + dLo) := by
-  set vTop_nat := dHi * 2^32 + dLo
-  set q_true_1 := (uHi * 2^32 + div_un1) / vTop_nat
-  have h_euc : q_true_1 * vTop_nat ≤ uHi * 2^32 + div_un1 :=
-    Nat.div_mul_le_self _ _
-  have h_le : q_true_1 * 2^32 * vTop_nat ≤
-      uHi * 2^64 + div_un1 * 2^32 + div_un0 := by
-    have h_rearr : q_true_1 * 2^32 * vTop_nat = q_true_1 * vTop_nat * 2^32 := by ring
-    have h_mul : q_true_1 * vTop_nat * 2^32 ≤ (uHi * 2^32 + div_un1) * 2^32 :=
-      Nat.mul_le_mul_right _ h_euc
-    have h_expand : (uHi * 2^32 + div_un1) * 2^32 =
-        uHi * 2^64 + div_un1 * 2^32 := by ring
-    linarith
-  exact (Nat.le_div_iff_mul_le hvTop_pos).mpr h_le
-
-/-- **q_true_full digit upper bound (pure Nat).** The full 2-digit true
-    quotient is strictly less than `(q_true_1 + 1) * 2^32`. Proof: from
-    `Nat.lt_mul_div_succ`, `vTop * (q_true_1 + 1) > uHi * 2^32 + div_un1`;
-    multiply by `2^32` and bound `div_un0 < 2^32`. -/
-theorem q_true_full_lt_q_true_1_succ_mul_pow32_nat
-    {uHi div_un1 div_un0 dHi dLo : Nat}
-    (hvTop_pos : 0 < dHi * 2^32 + dLo)
-    (hdiv_un0_lt : div_un0 < 2^32) :
-    (uHi * 2^64 + div_un1 * 2^32 + div_un0) / (dHi * 2^32 + dLo) <
-      ((uHi * 2^32 + div_un1) / (dHi * 2^32 + dLo) + 1) * 2^32 := by
-  set vTop_nat := dHi * 2^32 + dLo
-  set q_true_1 := (uHi * 2^32 + div_un1) / vTop_nat
-  have h_lt : uHi * 2^32 + div_un1 < vTop_nat * (q_true_1 + 1) :=
-    Nat.lt_mul_div_succ _ hvTop_pos
-  have h_num_lt : uHi * 2^64 + div_un1 * 2^32 + div_un0 <
-      vTop_nat * (q_true_1 + 1) * 2^32 := by
-    have h_plus_one : uHi * 2^32 + div_un1 + 1 ≤ vTop_nat * (q_true_1 + 1) := h_lt
-    have : (uHi * 2^32 + div_un1 + 1) * 2^32 ≤
-        vTop_nat * (q_true_1 + 1) * 2^32 :=
-      Nat.mul_le_mul_right _ h_plus_one
-    have h_expand_lhs : (uHi * 2^32 + div_un1 + 1) * 2^32 =
-        uHi * 2^64 + div_un1 * 2^32 + 2^32 := by ring
-    linarith
-  have h_eq_rearr : vTop_nat * (q_true_1 + 1) * 2^32 =
-      ((q_true_1 + 1) * 2^32) * vTop_nat := by ring
-  rw [h_eq_rearr] at h_num_lt
-  exact (Nat.div_lt_iff_lt_mul hvTop_pos).mpr h_num_lt
 
 /-- **CLZ-normalized strict KB-6d**: `div128Quot ≤ val256(a)/val256(b) + 2`
     in the call-trial CLZ-normalized form, under the all-phases no-wrap


### PR DESCRIPTION
Removes 25 unreferenced theorems left over from the V4/V5 CallSkipLowerBound iterations (Issue #61, batch 2 following #10430).

## What's removed
Each theorem verified zero references outside its declaring file (`ext_files=1`) and zero intra-file references (`in_self=1`) via `rg -l -w -F` / `rg -c -w -F`:

- **CallSkipLowerBoundV4/Algorithm.lean** (5 `_unfold` lemmas)
- **CallSkipLowerBoundV4/ExactQuotient.lean** (3 bound lemmas)
- **CallSkipLowerBoundV4/Phase1bBound.lean** (3 phase-1b bound lemmas)
- **CallSkipLowerBoundV4/Q1ddUndershootFromWideUn21.lean** (1)
- **CallSkipLowerBoundV4/QuotientBounds.lean** (1)
- **CallSkipLowerBoundV4/Un21LevelUB.lean** (1)
- **CallSkipLowerBoundV5/Algorithm.lean** (7 `_unfold` lemmas)
- **CallSkipLowerBoundV5/CapBounds.lean** (1)
- **Div128CallSkipClose.lean** (3 direct/split lemmas)

## Intentionally retained
- **Counterexample files** (`Un21WideUHiCounterexample.lean`, `V4QHatBoundCounterexamples.lean`): these are kernel-checked constructive counterexamples that pin the negative answer to beads (e.g. `evm-asm-9iqmw.7.1.4.1.9`) and document why V4 fails / V5 is needed. They are standalone self-contained refutations by design — the dead-leaf criterion misfires on them. Kept per the `when unsure KEEP` rule and the #10430 precedent (bead-tagged substantive lemmas retained).
- **CallSkipLowerBoundV2 subtree**: fully self-referential (no external references); flagged separately for a strategic whole-subtree decision rather than removed here.
- All `@[irreducible]` defs and externally-referenced `_unfold` lemmas are kept.

## Verification
Deletion-only change (569 deletions, 0 additions). `lake build EvmAsm.Evm64.EvmWordArith` green (1177 jobs); `scripts/check-forbidden-tactics.sh` OK.

Co-Authored-By: glm-5 <glm-5@ai>