### PR TITLE
fix(debug): resolve verdict-debug probe link closure

### DIFF
--- a/EvmAsm/Codegen/Programs/BlockVerdictV2.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictV2.lean
@@ -143,6 +143,13 @@ def ziskStatelessVerdictV2ProbeUnit : BuildUnit := {
     btiScanTuplesFunction ++ "\n" ++
     btiScanStorageChangesFunction ++ "\n" ++
     balTxsIndependentFunction ++ "\n" ++
+    -- Keep the standalone verdict-debug ELF's multi-tx closure in lockstep
+    -- with the guest closure: the runtime dispatcher reaches this whitelist
+    -- gate, and the post-dispatch verdict reaches the withdrawal effect walk.
+    -- These are diagnostic-only emissions; verdict code is unchanged.
+    brpsfAddr20EqFunction ++ "\n" ++
+    balStorageWhitelistCleanFunction ++ "\n" ++
+    blockVerdictWithdrawalNonstorageEffectsFunction ++ "\n" ++
     multiTxNthContextFunction ++ "\n" ++
     rlpFieldToU64Function ++ "\n" ++
     -- bmvmx.3.2: mirror the guest closure's per-tx sender-recovery stack so this


### PR DESCRIPTION
Restores the standalone zisk_stateless_verdict_v2 diagnostic ELF closure by emitting the existing multi-tx whitelist and withdrawal nonstorage-effect callees (plus the whitelist address helper) in the probe-only prologue.

No verdict logic changes.

Validation:
- lake exe codegen --program zisk_stateless_verdict_v2 --halt linux93 emits and links verdict.elf.
- scripts/codegen-zisk-stateless-verdict-debug-smoke.sh passes for normal and patched probe variants.

The older full-run sample inputs 00197, 01114, 01329, 03200, and 25235 all return verdict=1, bv_fail=0 on current main; their result.tsv files are also OK, so they are not current failure representatives.