### PR TITLE
fix(verdict): raise execCodeEffectLogCap 128KB->1.5MB for full 200M-block deployed-code

### DIFF
--- a/EvmAsm/Codegen/Programs/CreateCodeEffectLog.lean
+++ b/EvmAsm/Codegen/Programs/CreateCodeEffectLog.lean
@@ -35,10 +35,23 @@ namespace EvmAsm.Codegen
 open EvmAsm.Rv64
 
 /-- Capacity (bytes) of the code-effect log heap. Each entry is
-    `round8(48 + code_len)`; deployed code is ≤ 32768 (Amsterdam EIP-7907), so 128 KiB holds
-    several created contracts. On overflow the producer sets
-    `exec_code_effect_overflow` and the consumer must stay conservative. -/
-def execCodeEffectLogCap : Nat := 131072
+    `round8(48 + code_len)`; deployed code is ≤ 32768 (Amsterdam EIP-7907).
+
+    Gas-derived bound for the full 200M block target. Code deposit charges
+    `CODE_DEPOSIT_PER_BYTE = 200` gas/byte, so the total deployed bytecode in a
+    `bsrStateRootBlockGasLimit`-gas block is at most `200M / 200 = 1,000,000`
+    bytes. Accounting for the 32,000-gas CREATE base (which lowers the realized
+    byte budget) and the per-record `+48` overhead, the worst case is reached by
+    ~30 near-max (32,768-byte) deploys: `Σcᵢ ≤ 200M/200 - 160·N` gives
+    `Σcᵢ ≈ 983,040` and arena `Σ round8(48+cᵢ) ≈ 984 KiB` (~0.94 MiB realized,
+    1.0 MiB absolute ceiling); the EIP-7907 large-code extra gas only lowers
+    this, and the empty-CREATE / EIP-7702 delegation marker paths (48-byte
+    records) are less arena-bytes-per-gas-efficient so cannot exceed it. The
+    cap therefore reserves 1.5 MiB (≈50% margin over the 1.0 MiB ceiling).
+
+    On overflow the producer sets `exec_code_effect_overflow` and the consumer
+    must stay conservative. -/
+def execCodeEffectLogCap : Nat := 1572864
 
 /-! ## create_record_code_effect
 


### PR DESCRIPTION
Raises `execCodeEffectLogCap` from 128 KiB to 1.5 MiB so a full 200M-gas block can never over-reject on deployed-code volume.

## Gas-bound derivation
Code deposit charges `CODE_DEPOSIT_PER_BYTE = 200` gas/byte (Amsterdam `vm/gas.py:82`). Total deployed bytecode in a `bsrStateRootBlockGasLimit` (200M) block is therefore at most `200M / 200 = ~1.0 MiB`. Accounting for the 32,000-gas CREATE base, the worst case is reached by ~30 near-max (32,768-byte) deploys: `Σcᵢ ≤ (200M − 32000·N)/200` gives `Σcᵢ ≈ 983,040` and arena `Σ round8(48+cᵢ) ≈ 984 KiB` (~0.94 MiB realized, 1.0 MiB absolute ceiling). EIP-7907 large-code extra gas only lowers this; empty-CREATE / EIP-7702 delegation markers (48-byte records) are less arena-bytes-per-gas-efficient so cannot exceed it.

New cap = 1,572,864 (1.5 MiB, ~50% margin over the 1.0 MiB ceiling).

## Change
One constant: `def execCodeEffectLogCap : Nat := 131072` → `1572864` (`CreateCodeEffectLog.lean:41`). The overflow-guard literal (`:68`), the `.zero` reservation (`:155`), and the EIP-7702 teer writer embed (`TxIntrinsicStateGas.lean:818`) all derive from this def, so the change propagates on re-emit. No record-format or `bv_fail=46` comparator change; no in-bounds theorem references the cap (consumers walk by count via `find_code_effect_by_address`).

## Footprint + scope
- `.bss` grows +1.37 MiB (<3% of the ~50 MiB headroom under the 500 MiB ziskemu ceiling).
- The region-map/symbol-addresses regen drift (cap shift resizes `.bss` layout) is merge-bot-handled.

## Frontier impact
LATENT full-block-robustness fix: a 200M block deploying >128 KiB of code currently over-rejects. Not on the current 766/595 fixture frontier, so it will not shift the sweep.

Co-Authored-By: glm-5 <glm-5@ai>