### PR TITLE
fix(verdict): reject nonstorage effect log overflow

### DIFF
--- a/EvmAsm/Codegen/Programs/BlockVerdictFunction.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictFunction.lean
@@ -1192,6 +1192,11 @@ def blockVerdictFunction : String :=
   -- >1 value effect in the tx. Aggregating to last-post fixes that, matches the multi-tx path,
   -- and yields a SORTED agg (enables a future binary-search comparator). Behavior-preserving for
   -- the single-touch common case (0-regress). The helper resets agg_count + preserves s-regs.
+  -- Fail closed if an effect producer overflowed its bounded log. The multi-tx
+  -- validation tail applies the same rule; comparing a truncated prefix would
+  -- otherwise leave later execution effects outside both directions of the
+  -- authenticated BAL reconciliation.
+  "  la t0, exec_nonstorage_effect_overflow; ld t0, 0(t0); bnez t0, .Lbv_bal_nonstorage_fail\n" ++
   "  la a0, exec_nonstorage_effect_log; la t0, exec_nonstorage_effect_count; ld a1, 0(t0)\n" ++
   "  la a2, exec_nonstorage_effect_agg; la a3, exec_nonstorage_effect_agg_count; li a4, " ++ toString nonstorageEffectLogCap ++ "\n" ++
   "  jal ra, nonstorage_effect_aggregate\n" ++


### PR DESCRIPTION
Closes the single-transaction nonstorage reconciliation truncation seam. Before aggregating and checking 44/45, reject if exec_nonstorage_effect_overflow is set.

The multi-transaction path already guards this condition. A value-bearing CALL appends both caller-debit and callee-credit records, so the prior 32,768-record capacity rationale based on one record per 10,400-gas CALL was unsound. This fail-closed guard preserves soundness while the capacity is raised separately.

Validation:
- lake build EvmAsm.Codegen.Programs.BlockVerdictFunction
- git diff --check

No merge.