### PR TITLE
fix(create): preserve pre-existing target balance in effect log

### DIFF
--- a/EvmAsm/Codegen/Programs/NoopHalt.lean
+++ b/EvmAsm/Codegen/Programs/NoopHalt.lean
@@ -191,8 +191,11 @@ private def returnRevertTail (kind : Nat) (rollbackAsm : String := "")
 " ++
       "  la a0, create_address_be\n  add a1, x13, x14\n  mv a2, x15\n" ++
       "  jal ra, create_record_code_effect\n" ++
-      -- i3djw.2 / drj99.1 part 3: record the created account's NON-STORAGE effect (pre absent 0/0;
-      -- post nonce=1, balance = C's FINAL balance). The final balance is C's LIVE selfBalance (env+32),
+      -- i3djw.2 / drj99.1 part 3: record the created account's NON-STORAGE effect (pre balance captured
+      -- before the CREATE frame; post nonce=1, balance = C's FINAL balance). The target may already be
+      -- present with a nonzero balance, so its pre balance is nse_create_pre_bal rather than a fabricated
+      -- zero: updateBuilderFromTx records a balance change only when the actual block pre/post differ.
+      -- The final balance is C's LIVE selfBalance (env+32),
       -- NOT the CALLVALUE endowment: the initcode may CALL value out, so the created account ends at
       -- E - net_out. env+32 was credited the endowment at create_frame_descend (drj99.1 part 2) and
       -- debited by each byte-order-correct outgoing value-CALL (drj99.1 part 4), so it holds the true
@@ -204,7 +207,7 @@ private def returnRevertTail (kind : Nat) (rollbackAsm : String := "")
       ".Lrr_crendow_" ++ toString kind ++ ":\n" ++
       "  lbu t3, 0(t1)\n  sb t3, 0(t0)\n  addi t1, t1, -1\n  addi t0, t0, 1\n  addi t2, t2, -1\n  bnez t2, .Lrr_crendow_" ++ toString kind ++ "\n" ++
       "  addi sp, sp, -48\n  sd x10, 0(sp)\n  sd x12, 8(sp)\n  sd x13, 16(sp)\n  sd x14, 24(sp)\n  sd x15, 32(sp)\n" ++
-      "  la a0, create_address_be\n  la a1, nse_zero_bal\n  la a2, nse_create_post_bal\n  li a3, 0\n  li a4, 1\n" ++
+      "  la a0, create_address_be\n  la a1, nse_create_pre_bal\n  la a2, nse_create_post_bal\n  li a3, 0\n  li a4, 1\n" ++
       "  jal ra, record_nonstorage_effect\n" ++
       "  ld x10, 0(sp)\n  ld x12, 8(sp)\n  ld x13, 16(sp)\n  ld x14, 24(sp)\n  ld x15, 32(sp)\n  addi sp, sp, 48\n" ++
       -- drj99.1 part 1: a SUCCESSFUL CREATE deposit must pass success=1 to frame_return so the child


### PR DESCRIPTION
Fixes a code-44 false reject for successful CREATE/CREATE2 into a pre-existing, balance-only target.

NoopHalt recorded the CREATE deposit with pre_balance = 0, although execution-specs updateBuilderFromTx uses the account's actual block-pre balance. For a target with pre/post balance 1, the BAL correctly declares only nonce and code changes, while the guest fabricated a 0-to-1 balance effect. The deposit now uses the pre-frame nse_create_pre_bal snapshot.

Validation on a fresh generated guest ELF (EEST v0.6.2, Spike):
- bal_create_existing_target: 4/4 exact full matches (CREATE and CREATE2, success and pre-frame-failure variants).
- filter=create, limit=100: failures reduced 6 to 4; both existing-target success false rejects clear, with the remaining four in separate authorization/SELFDESTRUCT shapes.

No merge.