### PR TITLE
fix(scripts): eest-run-monitor silently reported fail=0 past ARG_MAX

### DIFF
--- a/scripts/eest-run-monitor.sh
+++ b/scripts/eest-run-monitor.sh
@@ -82,7 +82,17 @@ snapshot() {
   selected=0
   [[ -f "$MANIFEST" ]] && selected="$(wc -l < "$MANIFEST" | tr -d ' ')"
   completed="$(find "$RUN_DIR" -maxdepth 1 -name '*.result.tsv' 2>/dev/null | wc -l | tr -d ' ')"
-  running="$(pgrep -fc "ziskemu .*${RUN_DIR}" || true)"
+  # Count in-flight workers for EITHER backend. Two bugs were fixed here:
+  #  * matching only `ziskemu` reported 0 for Spike-backed runs, and Spike is
+  #    the normal full-corpus backend — so the column read "nothing running"
+  #    for exactly the runs where it mattered most;
+  #  * `pgrep -f '<backend> .*RUN_DIR'` OVER-counts, because the harness's
+  #    per-case `bash` wrappers carry the backend name and the run dir in their
+  #    own command lines too (observed 53 matches for 22 real workers).
+  # So: select on the process NAME (-C, same list as the `ps` block below) and
+  # filter on the run dir appearing in the args.
+  running="$(ps -o comm=,args= -C ziskemu -C spike -C spike_run 2>/dev/null \
+    | awk -v run="$RUN_DIR" 'index($0, run) { n++ } END { print n+0 }')"
   note=""
   if [[ -n "$PID" ]]; then
     if kill -0 "$PID" 2>/dev/null; then
@@ -92,21 +102,46 @@ snapshot() {
     fi
   fi
 
+  # The result-file list is STREAMED on stdin (NUL-separated) and each file is
+  # opened by awk via getline. It must never be passed as argv: a full-corpus
+  # run dir holds tens of thousands of files (72,393 observed for a
+  # 26,104-fixture sweep), which exceeds ARG_MAX, so `awk … "$RUN_DIR"/*` never
+  # execs. That failure USED to fall through to `echo "0 0 0 …"`, printing
+  # `fail=0` — a broken instrument that reads as a clean sweep. It also
+  # degraded silently *as a run progressed*: correct while few files existed,
+  # all-zero once the count crossed the limit.
+  #
+  # The fallback now emits `ERR` per field rather than zeros, and stderr is NOT
+  # suppressed, so a failure is unmistakable and its cause is visible.
   read -r ok err full succ root tail fail rod < <(
-    awk -F '\t' '
-      BEGIN { ok=err=full=succ=root=tail=fail=rod=0 }
-      FNR==NR {
-        expected_by_label[$1] = substr($3, 1, 210)
-        rel[$1] = $7
-        next
+    # `-print` (newline-separated), NOT `-print0`: `RS` is global in awk, so a
+    # NUL record separator would also apply to the `getline < file` reads below,
+    # making each whole file a single record — which silently mis-parses the
+    # manifest into one giant record and yields wrong counts rather than an
+    # error. Result-file names are harness-generated (`<label>.result.tsv`) and
+    # contain no newlines, so newline separation is safe here.
+    find "$RUN_DIR" -maxdepth 1 -name '*.result.tsv' -print \
+    | awk -v manifest="$MANIFEST" '
+      BEGIN {
+        ok=err=full=succ=root=tail=fail=rod=0
+        while ((getline mline < manifest) > 0) {
+          n = split(mline, mc, "\t")
+          if (n >= 3) expected_by_label[mc[1]] = substr(mc[3], 1, 210)
+        }
+        close(manifest)
       }
       {
-        label = FILENAME
+        path = $0
+        if (path == "") next
+        label = path
         sub(/^.*\//, "", label)
         sub(/\.result\.tsv$/, "", label)
-        if ($1 != "OK") { err++; next }
+        if ((getline rline < path) <= 0) { close(path); next }
+        close(path)
+        split(rline, rf, "\t")
+        if (rf[1] != "OK") { err++; next }
         ok++
-        actual = $2
+        actual = rf[2]
         expected = expected_by_label[label]
         r = (substr(actual, 1, 64) == substr(expected, 1, 64))
         s = (substr(actual, 65, 2) == substr(expected, 65, 2))
@@ -121,13 +156,16 @@ snapshot() {
         }
       }
       END { print ok, err, full, succ, root, tail, fail, rod }
-    ' "$MANIFEST" "$RUN_DIR"/*.result.tsv 2>/dev/null || echo "0 0 0 0 0 0 0 0"
+    ' || echo "ERR ERR ERR ERR ERR ERR ERR ERR"
   )
 
-  printf '%s run=%s selected=%s completed=%s ok=%s err=%s full=%s succ=%s root=%s tail=%s fail=%s root_only=%s ziskemu=%s %s\n' \
+  # `workers=` rather than `ziskemu=`: the column counts either backend now, and
+  # a backend-specific label invited the same Spike-blind misreading the count
+  # itself had.
+  printf '%s run=%s selected=%s completed=%s ok=%s err=%s full=%s succ=%s root=%s tail=%s fail=%s root_only=%s workers=%s %s\n' \
     "$now" "$RUN_DIR" "$selected" "$completed" "$ok" "$err" "$full" "$succ" "$root" "$tail" "$fail" "$rod" "$running" "$note"
 
-  ps -o pid,ppid,rss,comm,args -C ziskemu 2>/dev/null \
+  ps -o pid,ppid,rss,comm,args -C ziskemu -C spike -C spike_run 2>/dev/null \
     | awk -v run="$RUN_DIR" 'NR == 1 || index($0, run) { print "  " $0 }'
 }
 

--- a/scripts/eest-run-monitor.sh
+++ b/scripts/eest-run-monitor.sh
@@ -81,6 +81,14 @@ snapshot() {
   now="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
   selected=0
   [[ -f "$MANIFEST" ]] && selected="$(wc -l < "$MANIFEST" | tr -d ' ')"
+  # Residual hole in the NR >= completed assertion below: if RUN_DIR vanishes
+  # mid-run, BOTH enumerations fail, so completed=0 and NR=0 and the assertion
+  # passes with zeros. The directory is only checked once at startup, so check it
+  # per snapshot and say so loudly rather than reporting a clean-looking run.
+  if [[ ! -d "$RUN_DIR" ]]; then
+    printf '%s run=%s DIRECTORY MISSING -- counters unavailable\n' "$now" "$RUN_DIR"
+    return 0
+  fi
   completed="$(find "$RUN_DIR" -maxdepth 1 -name '*.result.tsv' 2>/dev/null | wc -l | tr -d ' ')"
   # Count in-flight workers for EITHER backend. Two bugs were fixed here:
   #  * matching only `ziskemu` reported 0 for Spike-backed runs, and Spike is
@@ -102,8 +110,8 @@ snapshot() {
     fi
   fi
 
-  # The result-file list is STREAMED on stdin (NUL-separated) and each file is
-  # opened by awk via getline. It must never be passed as argv: a full-corpus
+  # The result-file list is STREAMED on stdin and each file is opened by awk via
+  # getline. It must never be passed as argv: a full-corpus
   # run dir holds tens of thousands of files (72,393 observed for a
   # 26,104-fixture sweep), which exceeds ARG_MAX, so `awk … "$RUN_DIR"/*` never
   # execs. That failure USED to fall through to `echo "0 0 0 …"`, printing
@@ -121,10 +129,12 @@ snapshot() {
     # error. Result-file names are harness-generated (`<label>.result.tsv`) and
     # contain no newlines, so newline separation is safe here.
     find "$RUN_DIR" -maxdepth 1 -name '*.result.tsv' -print \
-    | awk -v manifest="$MANIFEST" '
+    | awk -v manifest="$MANIFEST" -v completed="$completed" '
       BEGIN {
         ok=err=full=succ=root=tail=fail=rod=0
+        mrows = 0
         while ((getline mline < manifest) > 0) {
+          mrows++
           n = split(mline, mc, "\t")
           if (n >= 3) expected_by_label[mc[1]] = substr(mc[3], 1, 210)
         }
@@ -136,6 +146,11 @@ snapshot() {
         label = path
         sub(/^.*\//, "", label)
         sub(/\.result\.tsv$/, "", label)
+        # FIRST LINE ONLY. Equivalent to the old per-line argv pass iff every
+        # *.result.tsv holds exactly one record, which is the current harness
+        # format ("<STATUS>\t<output_hex>"). The NR >= completed assertion below
+        # is what makes a future multi-line format fail loudly instead of
+        # silently counting one row per file.
         if ((getline rline < path) <= 0) { close(path); next }
         close(path)
         split(rline, rf, "\t")
@@ -155,7 +170,30 @@ snapshot() {
           if (!r && s && t) rod++
         }
       }
-      END { print ok, err, full, succ, root, tail, fail, rod }
+      END {
+        # DENOMINATOR ASSERTION -- the oracle lives in the script, not in the
+        # operator head. The `|| echo ERR` on this pipeline is NOT sufficient on
+        # its own: the pipeline exit status is awks, so if `find` fails and awk
+        # succeeds over EMPTY input, awk prints a well-formed "0 0 0 ..." and the
+        # fallback never fires -- reproducing the exact silent-zeros defect this
+        # rewrite exists to remove.
+        #
+        # `completed` was counted independently by the safe `find` above, so
+        # require NR >= completed. Deliberately >= and not ==: the run is LIVE,
+        # the awk pass runs strictly after the count, and the directory grows in
+        # between (observed completed=9799 with NR=9804 on a live sweep), so
+        # exact equality would false-alarm on every healthy snapshot. NR BELOW
+        # the independent count is the real signal -- it catches a failed
+        # enumeration, a truncated list, a partially consumed stream, and a
+        # multi-record result format, i.e. the invariant rather than one failure
+        # mode. A manifest that failed to load is caught too: it would leave
+        # every expectation empty and silently count every row as a failure.
+        if (NR < completed || (completed > 0 && mrows == 0)) {
+          print "ERR ERR ERR ERR ERR ERR ERR ERR"
+          exit 0
+        }
+        print ok, err, full, succ, root, tail, fail, rod
+      }
     ' || echo "ERR ERR ERR ERR ERR ERR ERR ERR"
   )
 


### PR DESCRIPTION
Fixes #10536. **Monitoring-only** — touches no guest code, no Lean, no emitted bytes, so no sweep and no A/B.

## The defect

`snapshot()` passed `"$RUN_DIR"/*.result.tsv` as `awk` argv. A full-corpus run dir holds tens of thousands of files (**72,393** observed for a 26,104-fixture sweep), so past `ARG_MAX` `awk` never execs, `2>/dev/null` hid the *"Argument list too long"*, and `|| echo "0 0 0 0 0 0 0 0"` fired — printing `fail=0`.

**The glob was only the trigger; the zeros were the defect.** The failure did not look like a broken instrument, it looked like *a clean sweep with zero failures*. And it degraded **as a run progressed**: accurate while few files existed, silently all-zero once the count crossed the limit — an instrument that breaks precisely when there is more data, in the reassuring direction.

## Changes

1. **Stream the file list** — `find -maxdepth 1 -name … -print` on stdin, each result file opened via `getline`. No exec argv, no limit.
2. **Replace the numeric fallback with `ERR` per field**, and stop suppressing stderr. A broken instrument can no longer be misread as a passing run, and its cause is visible.
3. **Count workers for either backend, by process NAME.** Matching only `ziskemu` reported `0` for Spike-backed runs — and Spike is the normal full-corpus backend, so the column read "nothing running" for exactly the runs where it mattered most. But `pgrep -f '<backend> .*RUN_DIR'` *over*-counts: the harness's per-case `bash` wrappers carry both the backend name and the run dir in their own command lines (**53 matches for 22 real workers**). So selection is on `ps -C` names, filtered on the run dir in args. Column renamed `ziskemu=` → `workers=`; the `ps` detail block covers both backends too.
4. **`-print`, not `-print0`.** `RS` is global in awk, so a NUL record separator also applies to the `getline < file` reads — collapsing the manifest into a single record and producing **wrong counts silently** rather than an error. I hit this while writing the fix (first attempt returned `full=0 succ=1 fail=26104`); the code comment records it so the next person doesn't "harden" it back.

## Test — red then green, on real data

Used my own in-flight base-side run dir rather than a synthetic one.

**Red** — the old form on a 26,104-fixture dir:
```
$ awk 'END{print NR}' gen-out/eest-sc-fix2/*.result.tsv
bash: /usr/bin/awk: Argument list too long
```

**Green** — the fixed monitor on the same dir:
```
completed=26104 ok=26104 err=0 full=26036 succ=26036 root=26104 tail=26104 fail=68 root_only=0
```
Every field matches **two independent sources**: my own comparator, and the harness's own summary (`total 26104, fail 68, full match 26036, succ match 26036, root match 26104, tail match 26104`).

**Worker count**: `workers=21` against a live Spike run — correctly scoped to this run dir while 40 `spike_run` processes existed box-wide (a second lane was sweeping) — and `workers=0` against a completed run.

**Also**: `bash -n` clean; `ERR` fallback verified to render as `fail=ERR`, not `fail=0`. (`shellcheck` is not installed on this box.)

## Repo-wide sweep for the pattern (issue part 3)

Grepped `scripts/` for globs passed as argv over run-growing directories, and for `ls GLOB | wc -l`. **Exactly one genuinely exposed site — this one.** The distinction that determines exposure:

| site | shape | exposed? |
|---|---|---|
| `eest-run-monitor.sh:124` | glob as `awk` **argv** | **yes — fixed here** |
| `progress-report.sh:113` | `ls scripts/codegen-*.sh \| wc -l` | same shape, **not exposed** — fixed set of ~200 scripts, orders of magnitude under the limit |
| `codegen-zisk-account-apply-storage-check.sh:63` | `for f in "$VDIR"/*.input` | **no** — a `for` glob is expanded in-process by bash, never an exec argv |
| `check-opcode-structure.sh:90` | `for d in "$OPDIR"/*/` | **no** — same reason |
| `shape-census.py:176` | Python `glob.glob` | **no** — in-process, no argv |

So the rule is: **a glob is unbounded only when it becomes an `exec` argv.** `for x in glob` and in-process globbing are safe at any scale; `cmd glob` is not. Worth knowing because the two read identically at a glance — and it is why my own A/B comparator (Python `glob.glob`) was never at risk while my progress counter (`ls | wc -l`) was.

I left `progress-report.sh:113` alone deliberately: it is the same shape but cannot trigger, and changing it would be churn without a defect. Flagging it here so the choice is visible rather than an oversight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
