### PR TITLE
docs(agents): document artifact-cache mode pitfalls (never chmod .lake/build; lake env lean gates)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,6 +57,40 @@ callee-first order, against the separation-logic state-assertion vocabulary.
 - `lake build` (library `EvmAsm`, sources under `EvmAsm/`); heartbeat/recursion
   limits are configured globally in `lakefile.toml` — never per-file.
 
+### Artifact-cache mode (`LAKE_ARTIFACT_CACHE=true`)
+
+Many checkouts run with the lake artifact cache enabled (`LAKE_ARTIFACT_CACHE`,
+`LAKE_CACHE_DIR`). Two consequences are easy to misdiagnose, because in both the
+symptom names something other than the cause.
+
+**1. Never `chmod` `.lake/build`.** Cache-materialized build outputs are
+**hardlinks into the cache**, mode `444`. So `chmod -R u+w .lake/build` does not
+just fail to stick — the build-tree entry and the cache entry are *the same
+inode*, so it makes shared cached artifacts writable and lets a later build
+overwrite an inode other checkouts are linked to. If a build output gives
+permission-denied, do one of:
+
+- **delete the specific offending file** — it is regenerable, and deleting it
+  breaks the hardlink so lake writes a fresh private copy;
+- run that one invocation with `LAKE_ARTIFACT_CACHE=false`;
+- `cp --remove-destination` if you need a writable copy of an existing artifact.
+
+Never `chmod`, and never delete `.lake` wholesale.
+
+**2. Tools built on `lake env lean` do not work in cache mode.** In this mode
+lake satisfies a build from the cache *without materializing oleans* into
+`.lake/build/lib/lean`, and `lake env printenv LEAN_PATH` contains **no** cache
+paths — so `lake env lean` cannot resolve a cache-satisfied module. It fails with
+`object file '….olean' … does not exist`, which reads as a **corrupt build**
+rather than a mode incompatibility; the instinctive response (delete `.lake` and
+rebuild) costs an hour and lands in the identical state. Affects
+`check-axioms.sh`, `port-check.sh`, and `check-opcode-tables.sh` (issue #10537).
+
+If a gate cannot run in your checkout, **say so plainly and explain why** — do
+not list it among the gates you ran. CI runs these in a non-cache environment, so
+the gate is still exercised before merge; a gate claimed but not run is worse
+than one openly skipped.
+
 ## Project Structure
 
 ```


### PR DESCRIPTION
Refs #10537. Docs only.

## Why this is an *addition*, not a correction

The bad advice was never in the repo. `grep` for `chmod -R u+w` / `u+w .lake` across all file types returns **zero hits** — it is not in `AGENTS.md`, `CLAUDE.md`, `CODEGEN.md`, or `docs/agents/`. It lived in the agent-brief and fleet-message layer.

The root cause is the *silence*: the repo says nothing about read-only build outputs or about artifact-cache mode at all, and that silence is what invited a wrong answer to be improvised elsewhere. So the fix is to document the correct guidance, not to correct a line that does not exist.

## What is documented

Two pitfalls, and what they have in common is that **the symptom names something other than the cause** — which is why both cost real debugging time:

**1. Never `chmod` `.lake/build`.** Cache-materialized outputs are *hardlinks into the cache* at mode `444`. The build-tree entry and the cache entry are the **same inode**, so `chmod -R u+w .lake/build` doesn't merely fail to stick — it makes shared cached artifacts writable and lets a later build overwrite an inode other checkouts are linked to. The three correct responses are documented instead: delete the specific regenerable file (which breaks the hardlink so lake writes a fresh private copy), `LAKE_ARTIFACT_CACHE=false` for one invocation, or `cp --remove-destination`. Never `chmod`; never delete `.lake` wholesale.

**2. `lake env lean` tools don't work in cache mode.** Lake satisfies a build from the cache *without materializing oleans* into `.lake/build/lib/lean`, and `lake env printenv LEAN_PATH` contains **no** cache paths — so `lake env lean` cannot resolve a cache-satisfied module. It fails with `object file '….olean' … does not exist`, which reads as a **corrupt build** rather than a mode incompatibility; the instinctive `rm -rf .lake && lake build` costs an hour and lands in the identical state, because a cache-satisfied rebuild doesn't materialize oleans either. Names the three affected scripts (`check-axioms.sh`, `port-check.sh`, `check-opcode-tables.sh`) and cross-references #10537.

It closes with the discipline that matters more than either pitfall: **if a gate cannot run in your checkout, say so and explain why — do not list it among the gates you ran.** CI runs these in a non-cache environment so the gate is still exercised before merge, but a gate *claimed* and not run is worse than one openly skipped.

## Provenance of the claims

Every factual claim here was measured on this box rather than inferred:

- hardlink layout and mode: `stat` on cache artifacts (`links=2 mode=444`)
- `LEAN_PATH` contains no cache paths: `lake env printenv LEAN_PATH | grep -c lake-artifact-cache` → `0`
- the olean genuinely absent while `lake build` reports success: `lake build EvmAsm.Progress` → `Fetched`/`Build completed successfully`, and the file still does not exist
- affected-script list: `grep -c 'lake env lean'` per script — and one script coord had listed, `check-asm-to-program.sh`, was **removed** from the list after checking: its only occurrence is in a comment, and it passes clean in a cache-mode checkout

🤖 Generated with [Claude Code](https://claude.com/claude-code)
