### PR TITLE
docs(codegen): correct the clampToArena=false warrant — 3 of 16 sites rely on unreachability, not a caller bound

### DIFF
--- a/EvmAsm/Codegen/Programs/EvmMemoryGas.lean
+++ b/EvmAsm/Codegen/Programs/EvmMemoryGas.lean
@@ -142,12 +142,29 @@ def memoryArenaLimitAsm (tag limitReg : String) : String :=
     `clampToArena` has NO default: every call site must state its claim, so a
     future caller cannot inherit the wrong one silently.
 
-    * `clampToArena = false` asserts **the caller has already proved
-      `rounded ≤ frame limit`** (via `memConstOffsetOogGuardAsm`,
-      `memDynamicArenaOogGuardAsm`, or its own arena bail). The fresh-zero loop
-      then runs to exactly `x13 + rounded`, and its `beq` equality exit is safe
-      because both endpoints are 32-byte multiples and `current < rounded`, so
-      the pointer lands exactly on the end.
+    * `clampToArena = false` asserts that `rounded ≤ frame limit` holds, on
+      **either** of two warrants — and which one applies differs by call site:
+
+      (a) **The caller bounds it.** Verified for `memConstOffsetOogGuardAsm`
+          (MSTORE8), `memDynamicArenaOogGuardAsm` (the COPY family),
+          `returnRevertMemoryGasAsm`, and `callMemoryExpansionGasAsm` (both
+          windows) — each calls `memoryArenaLimitAsm` and bails past the bound.
+      (b) **The range cannot exceed the dense bound within the per-tx REGULAR
+          gas cap.** Exceeding it costs ≈3.4e7 at depth 0 and ≈6.4e7 nested,
+          against a 1.68e7 cap — see the affordability analysis in GH #10535,
+          now kernel-enforced by `Codegen/MemoryBudgetGuard.lean` (#10540).
+
+      Sites relying on **(b), not (a)**: `h_KECCAK256` (`keccakRangeGuardAsm`
+      deliberately omits an arena bound — GH #10521), LOG0..LOG4
+      (`logDynamicGasAsm`), and the CREATE initcode range
+      (`ChildFrameCreateTail`). If `MemoryBudgetGuard` ever fails, those three
+      are the call sites that stop being safe, and they must gain a caller-side
+      bound — or `clampToArena = true` — before any arena resize.
+
+      Either warrant gives the same property, and the fresh-zero loop then runs
+      to exactly `x13 + rounded`, so its `beq` equality exit is safe: both
+      endpoints are 32-byte multiples and `current < rounded`, so the pointer
+      lands exactly on the end.
     * `clampToArena = true` is for callers that deliberately allow
       `rounded > frame limit` — today only `updateActiveMemorySizeConstSparseAsm`
       (MLOAD/MSTORE), whose beyond-dense bytes are served by the sparse word


### PR DESCRIPTION
Follow-up to #10544 (merged as `dd5199ee1`), whose `clampToArena` docstring overclaims. **Docstring only — no emitted bytes, therefore no sweep and no A/B.**

## The overclaim

#10544 states that `clampToArena = false` asserts *"the caller has already proved `rounded ≤ frame limit`"*. Measured, that is false at **3 of the 16** `false` sites — occurrences of `memoryArenaLimitAsm` per guard:

| guard | bounds? | claim holds? |
|---|---|---|
| `memConstOffsetOogGuardAsm` (MSTORE8) | 1 | ✓ |
| `returnRevertMemoryGasAsm` | 1 | ✓ |
| `callMemoryExpansionGasAsm` (both windows) | 2 | ✓ |
| `memDynamicArenaOogGuardAsm` (COPY family) | 1 | ✓ |
| `keccakRangeGuardAsm` | **0** | ✗ |
| `logDynamicGasAsm` | **0** | ✗ |
| `ChildFrameCreateTail` initcode | **0** | ✗ |

The keccak half was **already recorded in #10521** — that `keccakRangeGuardAsm` performs no arena bound check, unlike its three siblings. So the docstring asserted of all sixteen callers something already documented as untrue of one of them.

## Behaviour is unaffected; the *warrant* differs

Those three are safe by #10535's affordability analysis — exceeding the dense bound costs ≈3.4 × 10⁷ at depth 0 and ≈6.4 × 10⁷ nested, against a 1.68 × 10⁷ cap — now kernel-enforced by `MemoryBudgetGuard` (#10540).

But the *source* of the safety is **coincidence-class** (externally-guarded gas arithmetic) rather than **construction-class** (a caller-side bound). That is the distinction the memory-family work turned on, and the old text erased it. A future caller reading it would pass `false` believing the guards cover them.

## The fix

The `false` case now states **two** admissible warrants — (a) the caller bounds it, naming the four guards that qualify; (b) the range cannot exceed the dense bound within the per-tx regular gas cap — and names keccak, LOG and CREATE-initcode as relying on (b). It records the consequence too: **if `MemoryBudgetGuard` ever fails, those three are exactly the sites that stop being safe**, and must gain a caller-side bound or `clampToArena = true` before any arena resize.

That turns the docstring from a false blanket claim into a per-site map of which invariant each call site actually depends on.

## No-emitted-bytes argument

Structural rather than by comparison: all 20 added lines sit inside the `/-- … -/` block, and **none contains a string literal or `++`**, so no emitted string can change. `textSizeBytes` stays `0x611c0`. `lake build` green (4750 jobs).

Found by re-examining my own merged change under a lens I had not been holding when I wrote it.