### PR TITLE
fix(codegen): pin the clamped fill end's 8-alignment; state it as a precondition (#10522)

### DIFF
--- a/EvmAsm/Codegen/MemoryBudgetGuard.lean
+++ b/EvmAsm/Codegen/MemoryBudgetGuard.lean
@@ -131,6 +131,41 @@ the guards are constraining a real, non-degenerate configuration. -/
 
 theorem minRemainingPoolBytes_pos : 0 < minRemainingPoolBytes := by decide
 
+/-! ## Guard 3 — 8-alignment of the clamped fill end (GH #10522)
+
+`updateActiveMemorySizeAsm`'s clamped fresh-zero loop (`clampToArena = true`)
+stores with `sd` and steps the pointer by 8, exiting on `bgeu ptr, end`. That
+exit is **exact only if the clamped end is 8-aligned**: a misaligned end lets the
+pointer step OVER it, so the loop exits having written the 8 bytes at the
+previous position — overshooting by up to 7 bytes past the bound the clamp exists
+to enforce, i.e. reintroducing a smaller form of the defect it fixes.
+
+Two paths, and only one of them needs a guard:
+
+* **nested** — the clamped end reduces algebraically to `evm_memory_pool_end`
+  (`x13 + (pool_end - x13)`), so its alignment is the assembler's `.balign 8`
+  rather than arithmetic. Nothing to pin beyond the size below.
+* **depth 0** — the end is `x13 + rootRuntimeMemoryArenaLimitBytes`, which needs
+  both terms 8-aligned. `x13` is the `.balign 32` `evm_memory` label; the limit is
+  a constant, so it is pinned here.
+
+`evmMemoryPoolBytes` is pinned too: `pool_end`'s alignment follows from an
+8-aligned base *and* an 8-aligned size, so a size change could break the nested
+path even though the base is assembler-aligned. -/
+
+theorem clampEnd_alignment_root : rootRuntimeMemoryArenaLimitBytes % 8 = 0 := by
+  decide
+
+theorem clampEnd_alignment_pool : evmMemoryPoolBytes % 8 = 0 := by
+  decide
+
+/-- The nested path's clamped end is `pool_end`, whose offset from the pool base
+    is the whole pool; both the 32-byte-multiple MSIZE accumulation and the pool
+    size must keep it 8-aligned. Stated over the derived floor for the same
+    reason `minRemainingPoolBytes` is. -/
+theorem clampEnd_alignment_minRemaining : minRemainingPoolBytes % 8 = 0 := by
+  decide
+
 /-- A frame can afford ≈ 2.805 MiB (91_917 words), so the guards are not holding
     because memory is unaffordable in general — only past the dense bounds. -/
 theorem affordable_memory_is_substantial :

--- a/EvmAsm/Codegen/Programs/EvmMemoryGas.lean
+++ b/EvmAsm/Codegen/Programs/EvmMemoryGas.lean
@@ -178,6 +178,21 @@ def memoryArenaLimitAsm (tag limitReg : String) : String :=
     The clamp and the `beq`→`bgeu` swap are therefore a single change, not two:
     the equality exit is unsafe exactly when the end can be clamped downward.
 
+    **ALIGNMENT PRECONDITION (`clampToArena = true`): the frame limit must be
+    8-aligned.** The fill loop stores with `sd` and steps the pointer by 8, so
+    the `bgeu` exit is *exact* only if the clamped end is a multiple of 8. A
+    misaligned end would let the pointer step OVER it, exiting after writing the
+    8 bytes at the previous position — overshooting by up to 7 bytes past the
+    very bound the clamp exists to enforce, i.e. a smaller version of the bug
+    being fixed. It holds on both paths today, for different reasons:
+    * nested — the clamped end reduces algebraically to the `evm_memory_pool_end`
+      LABEL (`x13 + (pool_end - x13)`), so its alignment is the assembler's
+      (`.balign 8`, and `evmMemoryPoolBytes` is 8-aligned). Construction, not
+      arithmetic.
+    * depth 0 — the end is `x13 + rootRuntimeMemoryArenaLimitBytes`, which needs
+      BOTH constants 8-aligned. That half is arithmetic, so it is pinned by
+      `Codegen/MemoryBudgetGuard.lean`'s `clampEnd_alignment_*` guards.
+
     Gas and MSIZE semantics are deliberately UNCHANGED by the clamp — the charge
     stays the full spec `extend_memory.cost` and `env+488` still records the full
     `ceil32(offset+size)`. Only the *materialization* is bounded, which loses no


### PR DESCRIPTION
Follow-up to #10544. **The behaviour is correct today** — this states a precondition I left unstated and pins the half of it that rests on arithmetic. Docstring + three `decide` theorems; **no emitted bytes**, so no sweep and no A/B.

## The hazard

The clamped fresh-zero loop stores with `sd` and steps the pointer by 8, exiting on `bgeu ptr, end`. That exit is **exact only if the clamped end is 8-aligned.**

A misaligned end lets the pointer step *over* it, so the loop exits having written the 8 bytes at the previous position — **overshooting by up to 7 bytes past the very bound the clamp exists to enforce.** The clamp would be reintroducing a smaller form of the defect it fixes.

I changed a store loop's bound in #10544 without stating an alignment argument, and `AGENTS.md` lists alignment as a critical rule precisely because that is easy to do.

## Why it holds — and why only half needs a guard

| path | clamped end | warrant |
|---|---|---|
| nested | `x13 + (pool_end − x13)` = **`evm_memory_pool_end`** | reduces algebraically to a **label**; alignment is the assembler's `.balign 8`. **Construction, not arithmetic.** |
| depth 0 | `x13 + rootRuntimeMemoryArenaLimitBytes` | needs **both** terms 8-aligned. `x13` is the `.balign 32` `evm_memory` label; the limit is a constant — **arithmetic, so pinned.** |

That is the coincidence-vs-construction split from #10540 appearing *inside a single clamp*: one path is maintained by the assembler, the other by two constants that nothing enforced.

## Added guards

```
clampEnd_alignment_root          rootRuntimeMemoryArenaLimitBytes % 8 = 0
clampEnd_alignment_pool          evmMemoryPoolBytes % 8 = 0
clampEnd_alignment_minRemaining  minRemainingPoolBytes % 8 = 0
```

`evmMemoryPoolBytes` is pinned too, which is not redundant: `pool_end`'s alignment needs an 8-aligned base **and** an 8-aligned size, so a size change could break the *nested* path even though its base is assembler-aligned.

## Verification

**Red-tested** — setting `rootRuntimeMemoryArenaLimitBytes` to `0x400004` fails the build on `clampEnd_alignment_root`; restored, `lake build` green at 4750 jobs. (Per the lesson from #10540's review: after touching a guard, re-witness the *failure*, not the success.)

**No emitted bytes**, argued structurally: every added line in `EvmMemoryGas.lean` is inside the `/-- … -/` block and **zero** contain a string literal or `++`, so no emitted string can change; the new theorems emit nothing.

## Note on how this was found

Not by an error. By re-reading `AGENTS.md`'s critical rules against my own merged change — the same path that found the skipped PLAN.md protocol in #10553. It is also the *second* unstated premise in this one parameter: #10551 corrected `clampToArena`'s claim about which sites bound the range, and this is a different missing precondition on the same flag. **Fixing one gap in a contract does not audit the rest of it.**
