### PR TITLE
docs(codegen): warn that the memory-gas role/register mapping varies by call site

### DIFF
--- a/EvmAsm/Codegen/MemoryBudgetGuard.lean
+++ b/EvmAsm/Codegen/MemoryBudgetGuard.lean
@@ -3,6 +3,29 @@
 
   Build-time guard for the memory-budget coincidence (GH #10522, #10535).
 
+  ## Scope: this is the home for constant-relationship invariants generally
+
+  It was created for one such invariant and has since taken on three distinct
+  remits: a guard on #10522's unreachability precondition, a guard on the
+  achievable steps-per-gas constant `k` that the top theorem's fuel is derived
+  from (#10552), and a guard on the clamped fill loop's exit exactness
+  (`clampEnd_alignment_*`). **If you need to pin a relationship between guest
+  constants that nothing else enforces, add it here rather than starting a
+  second file** — and note the new remit in this list, so the next person finds
+  it too.
+
+  The test for whether an assertion belongs here is *coincidence vs
+  construction*: a relationship that holds because several independently
+  editable constants happen to line up is a coincidence and needs a
+  kernel-checked pin; one where the check and the checked value are the same
+  symbol is maintained by construction and a pin would be redundant ceremony.
+  State which of the two you have, and where a bound has both halves, guard
+  only the coincidental half and say why the other needs nothing (see the
+  nested-vs-depth-0 split on `clampEnd_alignment_*`). Pin the quantity that is
+  *used*, not the ones it is computed from — `minRemainingPoolBytes` rather
+  than only `evmMemoryPoolBytes`, `SpecRef.MEMORY_PER_WORD` rather than a
+  local copy.
+
   ## What this file protects
 
   Three constants currently sit in a relationship that makes two latent defects

--- a/EvmAsm/Codegen/Programs/BlockVerdictDataSectionTail.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictDataSectionTail.lean
@@ -74,6 +74,25 @@ def ziskStatelessVerdictV2DataSectionTail : String :=
   "\nbaap_storage_values:\n  .zero " ++ toString (bsrMaxBalItems * bsrPathBytes) ++
   "\n  .zero " ++ toString (frameArrayBytes - 2 * (bsrMaxStateChanges * bsrEncodedAccountBytes) - (bsrMaxBalItems * baapStorageDescBytes) - 2 * (bsrMaxBalItems * bsrPathBytes)) ++
   "\ncall_frame_arena_end:\n" ++ "\n" ++
+  -- LAYOUT INVARIANT — `rb_running_block_bloom` is IMMEDIATELY adjacent to
+  -- `evm_memory_pool_end`, with ZERO bytes of slack. The `.balign 8` below is a
+  -- no-op here: `evm_memory_pool` is itself 8-aligned and `evmMemoryPoolBytes`
+  -- is a multiple of 8, so the bloom starts at exactly `evm_memory_pool_end`.
+  -- Verified in the linked image (`gen-out/stateless_guest.elf`): both symbols
+  -- resolve to 0xbbb19b60.
+  --
+  -- CONSEQUENCE, and it is a soundness one: ANY overshoot in ANY loop that
+  -- fills or zeroes the pool corrupts VERDICT STATE, not padding. The running
+  -- block bloom feeds the receipt root, so an off-by-a-few-bytes write here is
+  -- an accept/reject flip rather than a memory-safety curiosity. This is why
+  -- the clamped fill loop's `bgeu` exit must be EXACT — see the alignment
+  -- precondition on `clampToArena` in `Programs/EvmMemoryGas.lean` and the
+  -- `clampEnd_alignment_*` pins in `Codegen/MemoryBudgetGuard.lean`.
+  --
+  -- DO NOT insert padding here to create slack. Padding would hide this
+  -- constraint rather than state it, and would silently absorb exactly the
+  -- off-by-N bugs that should fail loudly. The adjacency is a property of the
+  -- image that constrains every future pool-touching change; keep it stated.
   ".balign 8\n" ++
   "evm_memory_pool:\n  .zero " ++ toString evmMemoryPoolBytes ++ "\n" ++
   "evm_memory_pool_end:\n" ++

--- a/EvmAsm/Codegen/Programs/EvmMemoryGas.lean
+++ b/EvmAsm/Codegen/Programs/EvmMemoryGas.lean
@@ -218,6 +218,16 @@ def memoryArenaLimitAsm (tag limitReg : String) : String :=
       BOTH constants 8-aligned. That half is arithmetic, so it is pinned by
       `Codegen/MemoryBudgetGuard.lean`'s `clampEnd_alignment_*` guards.
 
+    TRIGGER for the nested half: it is unguarded *only* because the end IS the
+    label, so nothing arithmetic can drift it. **If you ever change that end to
+    be computed rather than to reduce to `evm_memory_pool_end` itself, it moves
+    from construction class to coincidence class and needs a pin alongside the
+    depth-0 ones.** That half is also the one whose overshoot is most costly:
+    `rb_running_block_bloom` begins at *exactly* `evm_memory_pool_end` with zero
+    bytes of slack (verified in the linked image; see the layout invariant at
+    the pool's emission site in `Programs/BlockVerdictDataSectionTail.lean`), so
+    an inexact exit there corrupts verdict state rather than padding.
+
     Gas and MSIZE semantics are deliberately UNCHANGED by the clamp — the charge
     stays the full spec `extend_memory.cost` and `env+488` still records the full
     `ceil32(offset+size)`. Only the *materialization* is bounded, which loses no

--- a/EvmAsm/Codegen/Programs/EvmMemoryGas.lean
+++ b/EvmAsm/Codegen/Programs/EvmMemoryGas.lean
@@ -135,7 +135,32 @@ def memoryArenaLimitAsm (tag limitReg : String) : String :=
     Register use: `offsetReg` and `roundedReg` are preserved across the
     block; `lengthReg` is preserved (so MCOPY can keep the copy length in
     it across two calls); `maskReg`, `currentReg`, and `gasTmpReg` are
-    clobbered as scratch.
+    clobbered as scratch. Verified at all 17 call sites: the three
+    preserved roles never share a register with the three clobbered ones.
+
+    **The role→register mapping is NOT uniform across call sites, so reason
+    about roles and never about register numbers.** Two verified examples:
+    `x17` is `currentReg` at the `codecopy`/`extcodecopy`/`log`/`call_*`
+    sites but `roundedReg` at the `mcopy_*`/`returndatacopy` ones, and `x18`
+    is `maskReg` at `codecopy` but `currentReg` at `mcopy_src`. So a claim of
+    the form 'x17 holds the rounded size' is true at some sites and false at
+    others. (The sparse/const wrappers below thread these roles through as
+    parameters, so an opcode's effective assignment is set by *its* caller,
+    not visible here — one more reason to reason by role.)
+
+    Consequence for editors: **do not introduce a hardcoded register into
+    this block.** A literal `xN` here is `maskReg` at one site and
+    `roundedReg` at another, so it would silently clobber a value the caller
+    is entitled to keep, at only some sites — the worst failure shape to
+    debug. The block currently hardcodes only `x13` (EVM-memory base) and
+    `x20` (frame base), and both are safe *because they are read-only*:
+    `x20` appears solely as a load/store base and `x13` solely as an `add`
+    source, neither ever as a destination. That is a property of today's
+    body, not one anything enforces — if you make either a destination, or
+    add a third literal, the clobber list above stops being complete. (The
+    sibling helper `keccakWordGasAsm` does hardcode `x5`, which *is*
+    `maskReg` at the CALL/LOG sites; it is safe only because it is never
+    reached from inside this block.)
 
     ## `clampToArena` — ONE coupled invariant, do not take half of it
 


### PR DESCRIPTION
Stacked on #10554 (`fix/clamp-alignment-precondition`), because the paragraph this edits sits in the same docstring that PR touches. #10554 is already labeled `merge!`, so this is a separate PR rather than an amendment.

## Why

Auditing `updateActiveMemorySizeAsm`'s register-use contract (the fourth claim on that helper, after the warrant in #10551 and the alignment precondition in #10554) found it **sound but resting on an unstated hazard**.

The role→register mapping is **not uniform across the 17 call sites**:

| site shape | `roundedReg` | `currentReg` | `maskReg` |
|---|---|---|---|
| `codecopy`, `extcodecopy`, `log*`, `call_*` | `x16` | `x17` | `x18` / `x5` |
| `mcopy_src`, `mcopy_dst`, `returndatacopy` | `x17` | `x18` | `x19` |
| `ChildFrameCreateTail` | `x18` | `x19` | `x23` |

So *"x17 holds the rounded size"* is true at some sites and false at others. The sparse/const wrappers thread these roles through as parameters, so an opcode's effective assignment is set by its own caller and is not visible at the helper at all.

**The consequence is for future editors.** A hardcoded `xN` added to this block would be `maskReg` at one site and `roundedReg` at another — silently clobbering a value the caller is entitled to keep, at only *some* call sites. That is the worst failure shape to debug, and nothing in the contract warned about it.

The block *does* hardcode two registers today — `x13` (EVM-memory base) and `x20` (frame base) — and both are safe **only because they are read-only**: `x20` appears solely as a load/store base (`ld …(x20)` / `sd …(x20)`), `x13` solely as an `add` source, neither ever as a destination. That is a property of the current body, not one anything enforces. If either becomes a destination, or a third literal appears, the clobber list stops being complete. (The sibling `keccakWordGasAsm` does hardcode `x5`, which **is** `maskReg` at the CALL/LOG sites; it is safe only because it is never reached from inside this block.)

Also records the verified result: the three preserved roles never share a register with the three clobbered ones, at any of the 17 sites.

## Second change: what `MemoryBudgetGuard` has become

It was created for one invariant and has since taken on **three distinct remits** in one session — a guard on #10522's unreachability precondition, a guard on the achievable steps-per-gas constant `k` behind the top theorem's fuel (#10552), and a guard on the clamped fill loop's exit exactness (`clampEnd_alignment_*`). Its header now says it is the home for constant-relationship invariants *generally*, so the next person needing one finds it instead of starting a second file, and asks them to add their remit to the list.

It also records the three rules that came out of using it:

- **coincidence vs construction** — independently-editable constants that happen to line up need a kernel-checked pin; a check against the same symbol as the checked value is maintained by construction and a pin is redundant ceremony;
- where a bound has both halves, **guard only the coincidental half and say why the other needs nothing** (the nested-vs-depth-0 split on `clampEnd_alignment_*`) — otherwise a guard file accumulates assertions nobody can justify later;
- **pin the quantity that is used, not its inputs** — `minRemainingPoolBytes` rather than only `evmMemoryPoolBytes`; `SpecRef.MEMORY_PER_WORD` rather than a local copy.

## Verification

- `lake build EvmAsm.Codegen.MemoryBudgetGuard EvmAsm.Codegen.Programs.EvmMemoryGas` — green.
- **Comment-only, so no emitted guest bytes change and no layout pin moves.** Checked mechanically: zero added lines contain a string literal or `++`. (The check first flagged one line — prose double-quotes inside the docstring, a false positive; I switched them to single quotes so the heuristic stays a clean zero and remains useful.)
- No counts are asserted that I could not re-derive: an earlier draft said "eight sites and six others," which I removed in favour of named, verified examples. A durable docstring is exactly where a recited-from-memory number does the most damage.

## Contract status after this

| claim on `clampToArena` / the block | outcome |
|---|---|
| which sites bound the range | **defect** → #10551 |
| the fill loop's `end` is 8-aligned | **unstated precondition** → #10554 |
| register preservation | sound; **verified**, hazard now documented → this PR |
| the recorded mark is the *unclamped* size | sound; verified (see #10554 discussion) |

Two of four were defects; two were sound but unverified. The last one matters most: the clamp bounds the *physical zero-fill* only, while the EVM-visible `active_memory_size` stays the true rounded value gas pricing requires. Had it clamped the recorded mark, later expansions would have been under-priced — and a byte-identical corpus A/B **would not necessarily have caught it**, since the divergence only appears where the clamp binds and the clamp never binds on reachable inputs. Only reading what the store commits could distinguish the safe version of the change from the unsafe one.
