### PR TITLE
docs(codegen): record the pool-end/block-bloom zero-slack layout invariant

### DIFF
--- a/EvmAsm/Codegen/Programs/BlockVerdictDataSectionTail.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictDataSectionTail.lean
@@ -74,6 +74,25 @@ def ziskStatelessVerdictV2DataSectionTail : String :=
   "\nbaap_storage_values:\n  .zero " ++ toString (bsrMaxBalItems * bsrPathBytes) ++
   "\n  .zero " ++ toString (frameArrayBytes - 2 * (bsrMaxStateChanges * bsrEncodedAccountBytes) - (bsrMaxBalItems * baapStorageDescBytes) - 2 * (bsrMaxBalItems * bsrPathBytes)) ++
   "\ncall_frame_arena_end:\n" ++ "\n" ++
+  -- LAYOUT INVARIANT — `rb_running_block_bloom` is IMMEDIATELY adjacent to
+  -- `evm_memory_pool_end`, with ZERO bytes of slack. The `.balign 8` below is a
+  -- no-op here: `evm_memory_pool` is itself 8-aligned and `evmMemoryPoolBytes`
+  -- is a multiple of 8, so the bloom starts at exactly `evm_memory_pool_end`.
+  -- Verified in the linked image (`gen-out/stateless_guest.elf`): both symbols
+  -- resolve to 0xbbb19b60.
+  --
+  -- CONSEQUENCE, and it is a soundness one: ANY overshoot in ANY loop that
+  -- fills or zeroes the pool corrupts VERDICT STATE, not padding. The running
+  -- block bloom feeds the receipt root, so an off-by-a-few-bytes write here is
+  -- an accept/reject flip rather than a memory-safety curiosity. This is why
+  -- the clamped fill loop's `bgeu` exit must be EXACT — see the alignment
+  -- precondition on `clampToArena` in `Programs/EvmMemoryGas.lean` and the
+  -- `clampEnd_alignment_*` pins in `Codegen/MemoryBudgetGuard.lean`.
+  --
+  -- DO NOT insert padding here to create slack. Padding would hide this
+  -- constraint rather than state it, and would silently absorb exactly the
+  -- off-by-N bugs that should fail loudly. The adjacency is a property of the
+  -- image that constrains every future pool-touching change; keep it stated.
   ".balign 8\n" ++
   "evm_memory_pool:\n  .zero " ++ toString evmMemoryPoolBytes ++ "\n" ++
   "evm_memory_pool_end:\n" ++

--- a/EvmAsm/Codegen/Programs/EvmMemoryGas.lean
+++ b/EvmAsm/Codegen/Programs/EvmMemoryGas.lean
@@ -218,6 +218,16 @@ def memoryArenaLimitAsm (tag limitReg : String) : String :=
       BOTH constants 8-aligned. That half is arithmetic, so it is pinned by
       `Codegen/MemoryBudgetGuard.lean`'s `clampEnd_alignment_*` guards.
 
+    TRIGGER for the nested half: it is unguarded *only* because the end IS the
+    label, so nothing arithmetic can drift it. **If you ever change that end to
+    be computed rather than to reduce to `evm_memory_pool_end` itself, it moves
+    from construction class to coincidence class and needs a pin alongside the
+    depth-0 ones.** That half is also the one whose overshoot is most costly:
+    `rb_running_block_bloom` begins at *exactly* `evm_memory_pool_end` with zero
+    bytes of slack (verified in the linked image; see the layout invariant at
+    the pool's emission site in `Programs/BlockVerdictDataSectionTail.lean`), so
+    an inexact exit there corrupts verdict state rather than padding.
+
     Gas and MSIZE semantics are deliberately UNCHANGED by the clamp — the charge
     stays the full spec `extend_memory.cost` and `env+488` still records the full
     `ceil32(offset+size)`. Only the *materialization* is bounded, which loses no


### PR DESCRIPTION
Stacked on #10555. Records, at the site where the layout is defined, a property of the linked image that until now was discoverable only by disassembling it.

## The invariant

`rb_running_block_bloom` begins at **exactly** `evm_memory_pool_end`, with **zero bytes of slack**. From `gen-out/stateless_guest.elf`:

```
b5b19b60  evm_memory_pool
bbb19b60  evm_memory_pool_end       <- pool + 0x6000000 exactly (96 MiB)
bbb19b60  rb_running_block_bloom    <- same address; zero slack
```

The `.balign 8` between the two labels is a **no-op**: `evm_memory_pool` is itself 8-aligned and `evmMemoryPoolBytes` is a multiple of 8, so the directive adds no padding. The adjacency is therefore not incidental to the current constant values — it follows from them, and it holds in the shipped image.

## Why it is worth stating

**It reclassifies the clamped fill loop's exit exactness from hygiene to soundness.** #10554 ruled out an up-to-7-byte overshoot past the clamped end. What sits at the far end of that write turns out to be the running block-bloom accumulator, which feeds the receipt root — so an off-by-a-few-bytes write there is an **accept/reject flip**, not a memory-safety curiosity.

That is the same reclassification #10521/#10522 went through, by the same mechanism: the severity of an out-of-bounds write is determined by what happens to be adjacent, which is a fact about the *image* and not about the loop. Nothing in the source said what followed the pool.

It also constrains every **future** pool-touching change, not just the clamp. Any loop that fills, zeroes, or copies into the pool has zero margin at the top end.

## Explicitly: do not add padding here

The comment says so. Inserting slack would *hide* the constraint rather than state it, and would silently absorb exactly the off-by-N bugs that should fail loudly. A guard band converts a reproducible wrong-verdict into an invisible near-miss.

## Second change: the transition condition, as a trigger

#10554 guarded the depth-0 half of the alignment argument and deliberately left the nested half unguarded, because there the clamped end reduces algebraically to the `evm_memory_pool_end` **label** — the assembler owns that alignment and nothing arithmetic can drift it. That call stands.

But the nested half is the one sitting against the sensitive neighbour, so the docstring now states the trigger rather than leaving it as an observation: **if that end ever becomes a computed value instead of reducing to the label, it moves from construction class to coincidence class and needs a pin alongside the depth-0 `clampEnd_alignment_*` guards.** A future editor changing the reduction will read the condition at the point where they would break it.

## Verification

- `lake build EvmAsm.Codegen.Programs.BlockVerdictDataSectionTail EvmAsm.Codegen.Programs.EvmMemoryGas` — green (1021 jobs).
- **Comment-only.** Every added line is a Lean `--` comment; zero added lines contain a string literal or `++`, so the emitted asm is unchanged by construction and no layout pin moves. Worth being precise about here, since the comment is inserted *between* `++` operands of the data-section emission — if it altered the emitted string, `RegionMap.textSizeBytes` and the whole address map would shift.
- The two addresses were read from the linked ELF's symbol table, not inferred from the source directives. `.text` reads `0x611c0`, matching the current pin.
