### PR TITLE
chore: batch-merge #10553, #10554

### DIFF
--- a/EvmAsm/Codegen/MemoryBudgetGuard.lean
+++ b/EvmAsm/Codegen/MemoryBudgetGuard.lean
@@ -131,6 +131,41 @@ the guards are constraining a real, non-degenerate configuration. -/
 
 theorem minRemainingPoolBytes_pos : 0 < minRemainingPoolBytes := by decide
 
+/-! ## Guard 3 — 8-alignment of the clamped fill end (GH #10522)
+
+`updateActiveMemorySizeAsm`'s clamped fresh-zero loop (`clampToArena = true`)
+stores with `sd` and steps the pointer by 8, exiting on `bgeu ptr, end`. That
+exit is **exact only if the clamped end is 8-aligned**: a misaligned end lets the
+pointer step OVER it, so the loop exits having written the 8 bytes at the
+previous position — overshooting by up to 7 bytes past the bound the clamp exists
+to enforce, i.e. reintroducing a smaller form of the defect it fixes.
+
+Two paths, and only one of them needs a guard:
+
+* **nested** — the clamped end reduces algebraically to `evm_memory_pool_end`
+  (`x13 + (pool_end - x13)`), so its alignment is the assembler's `.balign 8`
+  rather than arithmetic. Nothing to pin beyond the size below.
+* **depth 0** — the end is `x13 + rootRuntimeMemoryArenaLimitBytes`, which needs
+  both terms 8-aligned. `x13` is the `.balign 32` `evm_memory` label; the limit is
+  a constant, so it is pinned here.
+
+`evmMemoryPoolBytes` is pinned too: `pool_end`'s alignment follows from an
+8-aligned base *and* an 8-aligned size, so a size change could break the nested
+path even though the base is assembler-aligned. -/
+
+theorem clampEnd_alignment_root : rootRuntimeMemoryArenaLimitBytes % 8 = 0 := by
+  decide
+
+theorem clampEnd_alignment_pool : evmMemoryPoolBytes % 8 = 0 := by
+  decide
+
+/-- The nested path's clamped end is `pool_end`, whose offset from the pool base
+    is the whole pool; both the 32-byte-multiple MSIZE accumulation and the pool
+    size must keep it 8-aligned. Stated over the derived floor for the same
+    reason `minRemainingPoolBytes` is. -/
+theorem clampEnd_alignment_minRemaining : minRemainingPoolBytes % 8 = 0 := by
+  decide
+
 /-- A frame can afford ≈ 2.805 MiB (91_917 words), so the guards are not holding
     because memory is unaffordable in general — only past the dense bounds. -/
 theorem affordable_memory_is_substantial :

--- a/EvmAsm/Codegen/Programs/EvmMemoryGas.lean
+++ b/EvmAsm/Codegen/Programs/EvmMemoryGas.lean
@@ -178,6 +178,21 @@ def memoryArenaLimitAsm (tag limitReg : String) : String :=
     The clamp and the `beq`→`bgeu` swap are therefore a single change, not two:
     the equality exit is unsafe exactly when the end can be clamped downward.
 
+    **ALIGNMENT PRECONDITION (`clampToArena = true`): the frame limit must be
+    8-aligned.** The fill loop stores with `sd` and steps the pointer by 8, so
+    the `bgeu` exit is *exact* only if the clamped end is a multiple of 8. A
+    misaligned end would let the pointer step OVER it, exiting after writing the
+    8 bytes at the previous position — overshooting by up to 7 bytes past the
+    very bound the clamp exists to enforce, i.e. a smaller version of the bug
+    being fixed. It holds on both paths today, for different reasons:
+    * nested — the clamped end reduces algebraically to the `evm_memory_pool_end`
+      LABEL (`x13 + (pool_end - x13)`), so its alignment is the assembler's
+      (`.balign 8`, and `evmMemoryPoolBytes` is 8-aligned). Construction, not
+      arithmetic.
+    * depth 0 — the end is `x13 + rootRuntimeMemoryArenaLimitBytes`, which needs
+      BOTH constants 8-aligned. That half is arithmetic, so it is pinned by
+      `Codegen/MemoryBudgetGuard.lean`'s `clampEnd_alignment_*` guards.
+
     Gas and MSIZE semantics are deliberately UNCHANGED by the clamp — the charge
     stays the full spec `extend_memory.cost` and `env+488` still records the full
     `ceil32(offset+size)`. Only the *materialization* is bounded, which loses no

--- a/PLAN.md
+++ b/PLAN.md
@@ -188,6 +188,25 @@ All deleted spec files have been recreated. See **Pending: Recreate Deleted Spec
 
 ### Infrastructure — RV64 only, no sorry
 
+- **Memory-budget contingency guard** (`EvmAsm/Codegen/MemoryBudgetGuard.lean`,
+  GH #10540): kernel-checked (`decide`, classical-3) assertions that the
+  MLOAD/MSTORE sparse path is unaffordable under `TX_MAX_GAS_LIMIT` — exceeding
+  the depth-0 dense arena costs ≈3.4e7 and the nested pool floor ≈6.4e7 against
+  a 1.68e7 cap. Turns a coincidence between three independently-editable
+  constants (`rootRuntimeMemoryArenaLimitBytes`, `evmMemoryPoolBytes`,
+  `SpecRef.TX_MAX_GAS_LIMIT`) into a build failure. Includes non-vacuity pins
+  (91_917 words affordable, 91_918 not) so the guards constrain a real
+  configuration. **Ordering constraint**: if it ever fails, the sparse path goes
+  live, #10522's write becomes reachable, and the global 4096-entry sparse cap
+  becomes a reachable FR — see #10535.
+- **A/B comparator with self-checks** (`scripts/eest-ab-compare.py`, GH #10546):
+  compares two `codegen-eest-stateless-check` run dirs and **refuses to report a
+  verdict** unless three assertions hold — both sides scored every manifest row
+  (no short denominator), the join is sound (keyed on `sha256` of each case's
+  input bytes, with within-group output consistency asserted since the key is
+  many-to-one), and coverage is total. Enumerates in-process, so no `ARG_MAX`
+  exposure. Exists because all three failure modes were hit in practice and each
+  fails in the direction that *looks like a pass*.
 - **Separation-logic state-assertion vocabulary** (layout-faithful Assertions
   over the guest's structured arenas, each with a proven faithfulness tie;
   all headline lemmas fenced as `Progress.lean` witnesses):
@@ -480,6 +499,19 @@ All deleted spec files have been recreated. See **Pending: Recreate Deleted Spec
   `InitCodeCostSAsm.lean` verifies `init_code_cost` byte-identically with a
   writable dword post (`a0 = 0`, output `= gasPerWord * ((len + 31) >> 5)`
   under exact RV64 wrapping semantics).
+  **SCOPE (GH #10524): these five dynamic-gas leaves are reachable ONLY from
+  `zisk_*` probe `BuildUnit`s — the opcode dispatcher does not call them.** It
+  uses six separate inline asm helpers in `Programs/EvmMemoryGas.lean` /
+  `EvmMcopyGas.lean` (`updateActiveMemorySizeAsm`, `copyWordGasAsm`,
+  `keccakWordGasAsm`, `logDynamicGasAsm`, `expDynamicGasAsm`,
+  `mcopyDynamicGasAsm`) which compute *different* functions — base costs folded
+  differently, and wrap/`mulhu` guards present on one side only. So these
+  triples do not currently constrain the emitted guest's gas arithmetic, and the
+  `_byte_tie` pins guard each leaf against its own `Program`, not against the
+  dispatcher. Both live gas defects found in this area were in the inline
+  versions with no counterpart in the proven leaf (#10521 keccak `ceil32` wrap,
+  fixed; #10523 MCOPY missing `mulhu`). Do not cite these leaves as coverage for
+  opcode gas metering.
   Byte-reverse copies (`whileS`, runtime length, read-only src + writable dst):
   `SwrRevLeBeSAsm.lean` (`swrRevLeBeFn_spec`, `dst = (src[0..len)).reverse`,
   byte-identity fully pinned to `swrRevLeBe_prog`; pre REQUIRES src/dst


### PR DESCRIPTION
Batches #10553 (docs(plan): record probe-only gas-leaf scope and two new infra items) and #10554 (fix(codegen): pin the clamped fill end's 8-alignment; state it as a precondition, #10522) into one integration branch to amortize CI.

Both PRs authored by pirapira, both had fully green CI at batch time. Merged cleanly with no conflicts, verified up to date with main. Diff is docstring additions + two new decide-based guard theorems in MemoryBudgetGuard.lean (no existing theorem statements touched). Clean-env `lake build` (4750/4750, RC=0) and all 21 check-*.sh gates green on the first pass.