### PR TITLE
fix(scripts): pin the unmapped backstop below __BSS_END__

### DIFF
--- a/scripts/check-region-map.sh
+++ b/scripts/check-region-map.sh
@@ -105,9 +105,10 @@ symaddr() { "$READELF" -sW "$ELF" | awk -v n="$1" '$8==n {print $2; exit}'; }
 python3 - "$(symaddr call_frame_arena)" "$(symaddr basr_values)" "$(symaddr basr_accounts)" \
   "$(symaddr bv_system_storage_log)" "$(symaddr baap_storage_desc)" "$(symaddr baap_storage_paths)" \
   "$(symaddr baap_storage_values)" \
-  "0x$BSS_BASE" "0x$BSS_SIZE" "$(symaddr evm_memory_pool)" "$(symaddr evm_memory_pool_end)" <<'PY' || fail=1
+  "0x$BSS_BASE" "0x$BSS_SIZE" "$(symaddr evm_memory_pool)" "$(symaddr evm_memory_pool_end)" \
+  "$(symaddr evm_memory)" <<'PY' || fail=1
 import sys
-(cfa, bval, bacc, syslog, desc, paths, vals, bbase, bsize, pool, pend) = [int(x,16) for x in sys.argv[1:]]
+(cfa, bval, bacc, syslog, desc, paths, vals, bbase, bsize, pool, pend, emem) = [int(x,16) for x in sys.argv[1:]]
 # RegionMap constants (kept in sync with BlockVerdictParams.lean).
 S = 100018*256          # bsrMaxStateChanges*bsrEncodedAccountBytes
 syslogL = 32768*128     # bvSystemStorageLogBytes (4ch8f.73: 2*16384 rows, standalone)
@@ -141,6 +142,29 @@ bad |= (not sys_ok)
 pool_ok = pool == cfa + frameArrayBytes and pend - pool == 0x6000000 and pend <= bbase + bsize
 print(f"  {'OK  ' if pool_ok else 'DRIFT'} evm_memory_pool adjacent, 96 MiB, and within .bss")
 bad |= (not pool_ok)
+# GH #10557: SECOND LINE OF DEFENCE for the memory-clamp fill loops. An overshoot
+# past a dense arena's top end corrupts whatever is mapped above it -- and
+# rb_running_block_bloom sits at exactly evm_memory_pool_end with zero slack, so
+# on that boundary an off-by-N reaches verdict state (see the layout invariant at
+# the pool's emission site in Programs/BlockVerdictDataSectionTail.lean).
+#
+# The mitigation that costs nothing is that ONE of the two arenas ends exactly at
+# __BSS_END__, whose neighbour is ~7.2 MiB of UNMAPPED address space: nothing
+# there can be corrupted into a committed value. Today that is evm_memory
+# (evm_memory + 0x400000 == __BSS_END__ exactly). This is a COINCIDENCE between an
+# arena size and a section layout, not a construction, so it is pinned here --
+# appending any new .bss section would otherwise silently push both arenas away
+# from the boundary and remove the backstop with no other signal.
+#
+# Deliberately written as "whichever arena is last", not "evm_memory is last", so
+# it survives the #10557 reorder that would put evm_memory_pool at the top
+# instead. It fails only if NEITHER arena ends at __BSS_END__.
+bss_end = bbase + bsize
+backstop_ok = bss_end in (emem + 0x400000, pend)
+which = "evm_memory" if bss_end == emem + 0x400000 else ("evm_memory_pool" if bss_end == pend else "NEITHER")
+print(f"  {'OK  ' if backstop_ok else 'DRIFT'} a dense arena ends at __BSS_END__ "
+      f"(unmapped backstop): {which}")
+bad |= (not backstop_ok)
 sys.exit(1 if bad else 0)
 PY
 


### PR DESCRIPTION
Follows #10556's layout invariant and the analysis in #10557. Scripts only.

## What this pins

An overshoot past a dense memory arena's top end corrupts whatever is mapped above it — and `rb_running_block_bloom` sits at **exactly** `evm_memory_pool_end` with zero slack (#10556), so on that boundary an off-by-N reaches verdict state.

The mitigation that costs nothing is already present in the image, by accident: **one of the two arenas ends exactly at `__BSS_END__`**, whose neighbour is ~7.2 MiB of **unmapped** address space. Nothing there can be corrupted into a committed value, because nothing is there.

```
evm_memory                            bee557c0
+ rootRuntimeMemoryArenaLimitBytes      400000
= depth-0 clamp end                   bf2557c0   exact coincidence with…
__BSS_END__                           bf2557c0
.sszscratch                           bf980000   next mapped section
unmapped gap                            72a840   ≈ 7.2 MiB
```

That is a **coincidence between an arena size and a section layout**, not a construction — nothing relates `rootRuntimeMemoryArenaLimitBytes` to where the linker happens to end `.bss`. By the coincidence-vs-construction rule this needs an external check: appending any new `.bss` section would push both arenas away from the boundary and remove the backstop **with no other signal**.

## Why here and not in `MemoryBudgetGuard`

It cannot be a `decide` theorem: the invariant relates a Lean constant to a **link-time address**, which Lean cannot see. `check-region-map.sh` is the right home — it already reads ELF symbols with `readelf` and exists to gate link-layout drift.

## Written to survive the reorder it may enable

The check asserts *"whichever arena ends at `__BSS_END__`"*, not *"`evm_memory` ends at `__BSS_END__`"*. #10557 contemplates moving `evm_memory_pool` to the top so the **unpinned, construction-class** boundary gets the backstop instead of the already-pinned one. Written the narrow way, this gate would have blocked that improvement; written this way it permits either layout and fails only if **neither** arena is last. It also prints which one provides the backstop, so the output records the current choice:

```
  OK   a dense arena ends at __BSS_END__ (unmapped backstop): evm_memory
```

## Verification

- **Green**: `OK … : evm_memory`, whole script passes.
- **Red-tested**: perturbing the offset to `0x400008` yields `DRIFT … (unmapped backstop): NEITHER` and the script takes its failure path (`check-region-map: DRIFT detected`). Restored, re-verified green. A gate that has never been observed to fail is not yet a gate.
- Scripts only — no Lean, no emitted guest bytes, no layout pin moves.

## One limit stated explicitly

This pins that **nothing in the image** sits above the last arena. It does **not** establish that a store into that gap *faults* — that is a property of each backend's memory model (ziskemu, Spike, the prover), which I have not checked. A zkVM might permit such a store or treat it as an unconstrained cell. So the guarantee here is "no mapped neighbour to corrupt", which is weaker than "the write is refused", and #10557 carries the stronger question.
