### PR TITLE
fix(codegen): emit the SSTORE gas constants from SpecRef instead of transcribing them

### DIFF
--- a/EvmAsm/Codegen/Programs/SstoreGasRefund.lean
+++ b/EvmAsm/Codegen/Programs/SstoreGasRefund.lean
@@ -9,6 +9,7 @@
 
 import EvmAsm.Rv64.Program
 import EvmAsm.Codegen.Layout
+import EvmAsm.Stateless.SpecRef.Gas
 
 namespace EvmAsm.Codegen
 
@@ -94,7 +95,7 @@ def sstoreGasRefundOutcomeFunction : String :=
   ".Lsgr_access_done:\n" ++
   "  beqz s3, .Lsgr_warm_access_cost\n" ++
   "  bnez s4, .Lsgr_warm_access_cost\n" ++
-  "  li t0, 10000                # clean-changing: STORAGE_WRITE\n" ++
+  s!"  li t0, {EvmAsm.Stateless.SpecRef.GasCosts.STORAGE_WRITE}                # clean-changing: STORAGE_WRITE\n" ++
   "  add s6, s6, t0\n" ++        -- (Amsterdam: no SET split; zero-origin creation is EIP-8037 state gas)
   "  j .Lsgr_refund\n" ++
   ".Lsgr_warm_access_cost:\n" ++
@@ -104,15 +105,15 @@ def sstoreGasRefundOutcomeFunction : String :=
   "  bnez s0, .Lsgr_restore_check\n" ++
   "  bnez s1, .Lsgr_reverse_clear\n" ++
   "  beqz s2, .Lsgr_restore_check\n" ++
-  "  li t0, 12480\n" ++
+  s!"  li t0, {EvmAsm.Stateless.SpecRef.GasCosts.REFUND_STORAGE_CLEAR}\n" ++
   "  add s7, s7, t0\n" ++
   "  j .Lsgr_restore_check\n" ++
   ".Lsgr_reverse_clear:\n" ++
-  "  li t0, 12480\n" ++
+  s!"  li t0, {EvmAsm.Stateless.SpecRef.GasCosts.REFUND_STORAGE_CLEAR}\n" ++
   "  sub s7, s7, t0\n" ++
   ".Lsgr_restore_check:\n" ++
   "  beqz s5, .Lsgr_store\n" ++
-  "  li t0, 10000                # restore: STORAGE_WRITE\n" ++
+  s!"  li t0, {EvmAsm.Stateless.SpecRef.GasCosts.STORAGE_WRITE}                # restore: STORAGE_WRITE\n" ++
   "  add s7, s7, t0\n" ++
   "  beqz s0, .Lsgr_store\n" ++
   "  li t2, 1                    # zero restore: caller credits state gas (EIP-8037)\n" ++

--- a/EvmAsm/Codegen/Programs/SstoreRegularGas.lean
+++ b/EvmAsm/Codegen/Programs/SstoreRegularGas.lean
@@ -37,6 +37,7 @@
 import EvmAsm.Rv64.Program
 import EvmAsm.Codegen.Layout
 import EvmAsm.Codegen.Programs.U256
+import EvmAsm.Stateless.SpecRef.Gas
 
 namespace EvmAsm.Codegen
 
@@ -71,7 +72,7 @@ def sstoreRegularGasFunction : String :=
   "  beqz s3, .Lsrg_warm\n" ++                      -- original != current -> warm-access branch
   "  bnez a0, .Lsrg_warm\n" ++                      -- current == new (no change) -> warm-access branch
 
-  "  li t1, 10000; add t0, t0, t1\n" ++             -- STORAGE_WRITE
+  s!"  li t1, {EvmAsm.Stateless.SpecRef.GasCosts.STORAGE_WRITE}; add t0, t0, t1\n" ++
 
   "  j .Lsrg_done\n" ++
   ".Lsrg_warm:\n" ++

--- a/EvmAsm/Codegen/Programs/Storage.lean
+++ b/EvmAsm/Codegen/Programs/Storage.lean
@@ -60,6 +60,7 @@
 -/
 
 import EvmAsm.Codegen.Dispatch
+import EvmAsm.Stateless.SpecRef.Gas
 import EvmAsm.Codegen.Programs.StaticContext
 import EvmAsm.Rv64.Program
 import EvmAsm.Codegen.Programs.AmsterdamSystemTx
@@ -156,7 +157,7 @@ def sstoreValueTransitionGasAsm : String :=
   "  bnez x15, .Lsstore_clean_changing\n" ++
   "  li x9, 1\n" ++
   ".Lsstore_clean_changing:\n" ++
-  "  li x14, 10000\n" ++             -- STORAGE_WRITE
+  s!"  li x14, {EvmAsm.Stateless.SpecRef.GasCosts.STORAGE_WRITE}\n" ++
   "  j .Lsstore_charge_delta\n" ++
   ".Lsstore_missing_slot:\n" ++
   "  li x9, 0\n" ++
@@ -165,7 +166,7 @@ def sstoreValueTransitionGasAsm : String :=
   ".Lsstore_missing_nonzero:\n" ++   -- missing slot = original = current = 0: creation
   "  li x9, 1\n" ++
 
-  "  li x14, 10000\n" ++             -- STORAGE_WRITE
+  s!"  li x14, {EvmAsm.Stateless.SpecRef.GasCosts.STORAGE_WRITE}\n" ++
 
   "  j .Lsstore_charge_delta\n" ++
   ".Lsstore_dirty_or_noop:\n" ++


### PR DESCRIPTION
Supersedes #10577, which pinned these constants with theorems. Substitution is the better fix and #10577 should be closed unmerged — see "Why not the pin" below.

Closes the codegen half of #10574.

## What changes

Seven emission sites held bare copies of two spec quantities. Each is now interpolated from the SpecRef symbol, so the emitted text is **computed from** the constant rather than **transcribed from** it.

```lean
-  "  li x14, 10000\n" ++             -- STORAGE_WRITE
+  s!"  li x14, {EvmAsm.Stateless.SpecRef.GasCosts.STORAGE_WRITE}\n" ++
```

**12480 is the better half.** SpecRef *derives* it at `Gas.lean:81-82` as `(STORAGE_WRITE + COLD_STORAGE_ACCESS) * 4800 / 5000`, so the guest now inherits **the derivation**, not its output. That kills the exact hazard #10574 named — a fixer updating `STORAGE_WRITE` had no cue that a refund constant three files away moved with it. It cannot exist once the expression is the source.

## Completeness — every site, labelled by what consumes it

| site | destination | status |
|---|---|---|
| `Storage.lean:159` | debits the gas cell `568(x20)` | **LIVE — actually charges gas** |
| `Storage.lean:168` | debits the gas cell `568(x20)` | **LIVE — actually charges gas** |
| `SstoreGasRefund.lean:115` | `add s7`, read via `srfd_out+8` | **LIVE** |
| `SstoreGasRefund.lean:107` | `add s7` (12480) | **LIVE** |
| `SstoreGasRefund.lean:111` | `sub s7` (12480) | **LIVE** |
| `SstoreGasRefund.lean:97` | `add s6` — accumulator no caller reads | **DEAD** |
| `SstoreRegularGas.lean:74` | returns in `a0` | **PROBE-ONLY** — no production call site |

The dead and probe-only sites are substituted too, deliberately: a census that leaves survivors goes stale the moment someone greps for the literal and finds one.

**`EvmAccessGas.lean:553` also emits `li t1, 10000` and is NOT touched.** It writes a gas-budget *seed* straight to `568(x20)` in a seed routine — same number, different quantity. Established by reading its context, not by the absence of a comment.

The two `Storage.lean` sites are the ones that actually charge `STORAGE_WRITE`, and they are in a file #10574 never mentions — which is why the census matters more than the pin did.

## Why not the pin (#10577)

A pin fires only when someone edits SpecRef, and — as review of #10577 established — a theorem `REFUND_STORAGE_CLEAR = 12480` **mentions no guest emission at all**. Neither of that PR's theorems did. A wrong guest literal passes both. The guest linkage lived entirely in prose.

Substitution inverts it: the guest cannot disagree with SpecRef because it no longer holds an independent copy, and by `MemoryBudgetGuard`'s own admission test the relationship becomes **construction class**, which needs no pin. Remove the mechanism rather than adding a promise — a pin is a promise that someone reads a docstring and edits five sites correctly; this removes the five sites.

(`REFUND_STORAGE_CLEAR` also already had a tripwire at `SpecRef/Gas.lean:229`, so one of #10577's two theorems was a duplicate of an existing check.)

## Byte-identical emission — verified, not asserted

| artifact | before | after |
|---|---|---|
| emitted `.s` | `cd57510f413dded94225564233c061d9c9d330d4c19bcf6f75f856a50131b398` | **same** |
| `.o` | byte-identical | byte-identical |
| linked `.elf` | `736bf904a40c1378a3d4830c90b3ecfae721078b50175a98349f53141b8487c4` | **same** |

**No corpus sweep required.**

*Method note, because the naive version of this test is misleading:* a plain `base.elf` vs `cand.elf` compare **differs**, at byte 502826 — the linker embeds the object filename, and the two runs used different output names. The valid test is to emit the candidate source under the baseline's output name, which is the matching ELF sha above. The `.s` and `.o` equality is the primary evidence; the ELF is confirmation.

## Gates

**Run:** build clean; `check-layering` OK (L1 makes Codegen a pure sink, so Codegen → SpecRef is allowed, and `Programs/BlockVerdictTxStateGasArrayModel.lean` already imports SpecRef — precedented, not novel); `check-forbidden-tactics` OK; `check-no-warnings` 0; `check-unimported` 0 orphans; `check-file-size` OK; `check-no-hardcoded-guest-pc` OK.

**Not run:** `scripts/check-axioms.sh` — cannot execute under `LAKE_ARTIFACT_CACHE` (#10537). Stated rather than claimed.

## Not in scope

The `+100` over-count in `SstoreGasRefund.lean:83`'s dead accumulator is tracked in #10576 and now scoped as *delete the duplicate accumulator* rather than repair it. That one changes emitted bytes on purpose and needs a full-corpus A/B.

🤖 Generated with [Claude Code](https://claude.com/claude-code)