### PR TITLE
harness: make A/B scope and backend explicit, and refuse a vacuous comparison (closes #10533)

### DIFF
--- a/docs/eest-stateless-testing.md
+++ b/docs/eest-stateless-testing.md
@@ -45,11 +45,16 @@ Override that with `EEST_FIXTURES_DIR=/path/to/fixtures` when needed. Use
 
 ## Common Commands
 
-Run the default smoke subset:
+Run a smoke subset (there is no default scope — `--limit N` or `--all` is
+required, and `--backend` likewise):
 
 ```bash
-scripts/codegen-eest-stateless-check.sh
+scripts/codegen-eest-stateless-check.sh --backend spike --limit 50
 ```
+
+`--all` runs the full 26,104-case corpus and is the merge gate for anything
+that changes emitted bytes. A smoke run reports honestly over its N cases and
+reads exactly like a corpus pass, which is why the scope has to be stated.
 
 Run a focused fixture subset:
 
@@ -701,7 +706,6 @@ Important files:
 - `<case>.result.tsv`: per-case harness status and output hex.
 - `stateless_guest.{s,o,elf}`: guest artifacts for this invocation.
 - `eest-baseline.txt`: run summary for this invocation.
-- `gen-out/eest-baseline.txt`: copy of the latest harness summary.
 
 The summary reports:
 

--- a/docs/eest-stateless-testing.md
+++ b/docs/eest-stateless-testing.md
@@ -52,9 +52,22 @@ required, and `--backend` likewise):
 scripts/codegen-eest-stateless-check.sh --backend spike --limit 50
 ```
 
-`--all` runs the full 26,104-case corpus and is the merge gate for anything
-that changes emitted bytes. A smoke run reports honestly over its N cases and
-reads exactly like a corpus pass, which is why the scope has to be stated.
+`--all` runs the full 26,104-case corpus. It is required for a **high-blast-radius**
+change — a gas constant, a shared helper, anywhere path-targeting cannot be
+trusted — and for re-baselining after `main` moves. The full sweep is expensive
+and most of its passing cases re-confirm what is already known, so for a
+**targeted** change prefer a focused set: known-failing cases, plus fixtures
+touching the changed path, plus a random control drawn from the *passing* set
+with a fixed seed. That control is not optional — a set built only from
+known-failing and path-touching cases is blind in the OK→FR direction by
+construction.
+
+**State the scope with every number you report.** A subset run reports honestly
+over its N cases and reads exactly like a corpus pass. A sequential partial is
+depth in *manifest order*, and manifest order tracks fixture family, so it says
+much about the families it reached and nothing about the rest; a random sample
+is the orthogonal breadth half. A number without its scope is the same defect as
+a number without its denominator.
 
 Run a focused fixture subset:
 

--- a/scripts/codegen-eest-stateless-check.sh
+++ b/scripts/codegen-eest-stateless-check.sh
@@ -297,15 +297,19 @@ if [[ "$ALL" -eq 0 && "$LIMIT_SET" -eq 0 ]]; then
   cat >&2 <<'SCOPE_ERR'
 error: a run scope is required (no default).
 
-  --all         the full 26104-case corpus.  This is the MERGE GATE: any change
-                that alters emitted bytes needs a full-corpus A/B before it can
-                land.  Use --backend spike; it is parallel-tolerant.
-  --limit N     a smoke subset of N cases, for iteration.  CANNOT support a
-                corpus verdict.
+  --all         the full 26104-case corpus.  Required for a HIGH-BLAST-RADIUS
+                change -- a gas constant, a shared helper, anywhere you cannot
+                trust path-targeting -- and for re-baselining after main moves.
+                Use --backend spike; it is parallel-tolerant.
+  --limit N     a subset of N cases.  Use for iteration, and for a FOCUSED run
+                on a targeted change: known-failing cases, plus fixtures
+                touching the changed path, plus a random control drawn from the
+                PASSING set (a focused set built only from known-failing and
+                path-touching cases is blind in the OK->FR direction).
 
-Pick deliberately: a smoke run reports honestly over its N cases and reads
-exactly like a corpus pass, so an unscoped run is how a 50-case result gets
-mistaken for a 26104-case one.
+Pick deliberately, and state the scope with every number you report.  A subset
+run reports honestly over its N cases and reads exactly like a corpus pass, so
+an unscoped run is how a 50-case result gets mistaken for a 26104-case one.
 
 (If you invoked a wrapper script rather than this one, add the flag to that
 wrapper's own invocation.)

--- a/scripts/codegen-eest-stateless-check.sh
+++ b/scripts/codegen-eest-stateless-check.sh
@@ -143,13 +143,20 @@ export MALLOC_ARENA_MAX
 ALL=0
 SKIP=0
 LIMIT=50
+# No default scope: --limit N or --all must be chosen explicitly (see the
+# hard error below).  LIMIT keeps a value so the smoke path is unchanged
+# once the flag IS passed; LIMIT_SET records whether it was.
+LIMIT_SET=0
 FILTER=""
 # Default step cap. ziskemu stops at the guest's halt, so this only bounds
 # runaway/very-large runs; a case that halts earlier consumes only the steps it
 # needs. The EIP-8037 state_gas_reservoir max-gas fixture can require more than
 # the default on current ziskemu builds, so high-gas BUDGET rows get one larger
 # retry before they are reported as budget exhaustion.
-BACKEND="${EEST_BACKEND:-ziskemu}"
+# No default backend (GH #10533).  EEST_BACKEND remains an opt-in override
+# for scripted callers; what was removed is the fallback when neither the
+# flag nor the variable is set.
+BACKEND="${EEST_BACKEND:-}"
 STEPS="${EEST_STEPS:-5000000000}"
 BUDGET_RETRY_STEPS="${EEST_BUDGET_RETRY_STEPS:-50000000000}"
 BUDGET_RETRY_MIN_GAS="${EEST_BUDGET_RETRY_MIN_GAS:-100000000}"
@@ -251,7 +258,7 @@ while [[ $# -gt 0 ]]; do
     --all) ALL=1; shift ;;
     --backend) require_arg "$1" "${2:-}"; BACKEND="$2"; shift 2 ;;
     --skip) require_arg "$1" "${2:-}"; SKIP="$2"; shift 2 ;;
-    --limit) require_arg "$1" "${2:-}"; LIMIT="$2"; shift 2 ;;
+    --limit) require_arg "$1" "${2:-}"; LIMIT="$2"; LIMIT_SET=1; shift 2 ;;
     --filter) require_arg "$1" "${2:-}"; FILTER="$2"; shift 2 ;;
     --steps) require_arg "$1" "${2:-}"; STEPS="$2"; shift 2 ;;
     --budget-retry-steps) require_arg "$1" "${2:-}"; BUDGET_RETRY_STEPS="$2"; shift 2 ;;
@@ -282,6 +289,57 @@ while [[ $# -gt 0 ]]; do
     *) echo "unknown arg: $1" >&2; usage >&2; exit 1 ;;
   esac
 done
+
+MISSING_CHOICE=0
+
+if [[ "$ALL" -eq 0 && "$LIMIT_SET" -eq 0 ]]; then
+  MISSING_CHOICE=1
+  cat >&2 <<'SCOPE_ERR'
+error: a run scope is required (no default).
+
+  --all         the full 26104-case corpus.  This is the MERGE GATE: any change
+                that alters emitted bytes needs a full-corpus A/B before it can
+                land.  Use --backend spike; it is parallel-tolerant.
+  --limit N     a smoke subset of N cases, for iteration.  CANNOT support a
+                corpus verdict.
+
+Pick deliberately: a smoke run reports honestly over its N cases and reads
+exactly like a corpus pass, so an unscoped run is how a 50-case result gets
+mistaken for a 26104-case one.
+
+(If you invoked a wrapper script rather than this one, add the flag to that
+wrapper's own invocation.)
+SCOPE_ERR
+fi
+
+if [[ -z "$BACKEND" ]]; then
+  MISSING_CHOICE=1
+  cat >&2 <<'BACKEND_ERR'
+error: --backend is required (no default).
+
+  --backend spike     fast verdict-level A/B gate; parallel-tolerant.
+                      Use for anything whose observable effect is a verdict or
+                      gas outcome, and for full-corpus sweeps (--jobs 30).
+  --backend ziskemu   ground-truth oracle. Use to CONFIRM a divergence Spike
+                      reported, and for probes needing the real loader or the
+                      accelerators. MUST be run serially (--jobs 1): it is
+                      memory-hungry and an earlyoom kill presents as a 0-byte
+                      log plus a non-zero exit that looks like a real failure.
+
+  If Spike and ziskemu disagree, ziskemu wins.
+
+EEST_BACKEND=spike|ziskemu also works, for scripted callers.
+
+If you reached this from one of the codegen-eest-*-check.sh probes rather than
+by running this script directly: those inherited the old silent default and now
+have to say what they mean. Pick the backend for what THAT probe measures, and
+add the flag to its own invocation. Background: GH #10533, GH #10582.
+BACKEND_ERR
+fi
+
+if [[ "$MISSING_CHOICE" -eq 1 ]]; then
+  exit 1
+fi
 
 case "$BACKEND" in
   ziskemu|spike) ;;
@@ -511,6 +569,14 @@ compute_job_cap() {
 }
 
 CPUS="$(nproc 2>/dev/null || echo 1)"
+if [[ "$BACKEND" == "ziskemu" && "$JOBS" != "1" ]]; then
+  echo "==> WARNING: --backend ziskemu forces --jobs 1 (requested: $JOBS)." >&2
+  echo "    ziskemu is memory-hungry; in parallel an earlyoom kill presents as a" >&2
+  echo "    0-byte log plus a non-zero exit that looks like a real failure." >&2
+  echo "    Use --backend spike if you want parallelism (GH #10533)." >&2
+  JOBS=1
+fi
+
 JOBS_REQUESTED="$JOBS"
 JOB_CAP="$(compute_job_cap)"
 if [[ "$JOBS" == "auto" ]]; then
@@ -1503,8 +1569,11 @@ BASELINE="$RUN_DIR/eest-baseline.txt"
 } | tee "$BASELINE"
 
 echo "==> wrote baseline: $BASELINE"
-cp "$BASELINE" "$REPO_ROOT/gen-out/eest-baseline.txt"
-echo "==> updated latest baseline: $REPO_ROOT/gen-out/eest-baseline.txt"
+# No global "latest baseline" copy.  It was only ever a convenience, and during
+# a parallel A/B it is actively wrong: both legs raced to write one file and the
+# second writer silently won, so anyone reading gen-out/eest-baseline.txt got
+# the other leg's numbers.  The per-run baseline above is the authoritative
+# artifact and is already scoped to its own --run-dir.
 
 rc=0
 if [[ "$SPECREF_ORACLE" -eq 1 && "$oracleDiff" -gt 0 ]]; then

--- a/scripts/eest-ab-compare.py
+++ b/scripts/eest-ab-compare.py
@@ -46,11 +46,37 @@ Three ways an A/B number silently becomes meaningless, all hit in practice:
    expected output.)  Coverage is then asserted separately: every candidate case
    must have a base counterpart.
 
+4. THE TWO LEGS ARE THE SAME BUILD.  `git checkout` CARRIES uncommitted changes
+   across branches rather than refusing, so building the "base" leg after
+   switching branches can silently pick up the candidate edit that was never
+   committed.  Both legs then come from one source and the sweep reports a
+   flawless zero.  Measured in practice: a 16-instruction deletion produced two
+   byte-identical ELFs.  Asserted below (self-check 0) by hashing each run dir's
+   own `stateless_guest.elf`.
+
+   This one is the worst of the four, because ZERO DIFF IS THE PREDICTED RESULT
+   for most refactors — the harness bug is indistinguishable from the hypothesis
+   by looking at the output, so it cannot be caught downstream.
+
+   RULE: build BOTH legs from COMMITTED refs, with a clean tree verified
+   between them, per leg rather than once.
+
 A denominator can be destroyed by a lossy join, not only by a truncated
 enumeration.  So before trusting any cross-run comparison, establish that the
 join is SOUND — either injective, or many-to-one with the property that makes
 collapsing harmless asserted rather than assumed.  This script does that
 mechanically, so it does not depend on whoever runs it remembering to.
+
+RELATED, and NOT mechanised here because it happens before a run dir exists:
+COMPARING EMITTED ELFs DIRECTLY.  The linker embeds the object filename, so
+emitting to `-o base` and `-o cand` makes the two ELFs differ at the `base.o`
+vs `cand.o` string even when the change is byte-neutral — a false defect.
+Re-emitting under a third name to "control" for it reproduces the fault and
+looks like nondeterministic emission.  Emit BOTH legs under the SAME output
+name, then copy them apart.  An output path is an input to the linker.
+General form of all of the above: A COMPARISON IS ONLY AS CLEAN AS THE THINGS
+IT HOLDS EQUAL, and when layers disagree — `.s` and `.o` identical but `.elf`
+differing — suspect the layer that differs from the others, not the change.
 
 Exit status: 0 if every self-check passed AND no new false accepts appeared;
 1 otherwise.  A failed self-check NEVER reports a verdict.
@@ -99,6 +125,21 @@ def read_manifest(run_dir: str) -> dict[str, tuple[str, str, str]]:
             if len(cols) >= 7:
                 rows[cols[0]] = (cols[1], cols[2], cols[6])
     return rows
+
+
+def guest_elf_digest(run_dir: str) -> str | None:
+    """sha256 of the run dir's own `stateless_guest.elf`, or None if absent.
+
+    Absent when the run used `--no-build` with a `GUEST_ELF` override pointing
+    outside the run dir; in that case self-check 0 cannot run and says so
+    rather than passing silently.
+    """
+    path = os.path.join(run_dir, "stateless_guest.elf")
+    try:
+        with open(path, "rb") as handle:
+            return hashlib.sha256(handle.read()).hexdigest()
+    except OSError:
+        return None
 
 
 def succ(hexstr: str) -> str | None:
@@ -190,6 +231,26 @@ def main() -> int:
     print(f"candidate {cand_dir}: {len(cand_res)} scored / {len(cand_man)} manifest rows")
 
     ok = True
+
+    # Self-check 0: the two legs must be DIFFERENT artifacts.  Comparing a
+    # build to itself yields a flawless zero delta that means nothing, and the
+    # ways it happens are silent: `git checkout` carries uncommitted changes
+    # across branches, so building "base" after switching branches can pick up
+    # the candidate edit that was never committed.  Zero diff is also the
+    # PREDICTED result for many refactors, so the bug is indistinguishable from
+    # the hypothesis by looking at the output -- it has to be caught here.
+    base_elf, cand_elf = guest_elf_digest(base_dir), guest_elf_digest(cand_dir)
+    if base_elf is None or cand_elf is None:
+        missing = [n for n, d in (("base", base_elf), ("candidate", cand_elf)) if d is None]
+        print(f"note: self-check 0 NOT RUN -- no stateless_guest.elf in {', '.join(missing)} "
+              "run dir (GUEST_ELF override?); cannot confirm the two legs are distinct builds")
+    elif base_elf == cand_elf:
+        print(f"!! BOTH LEGS ARE THE SAME BUILD: sha256 {base_elf[:16]}... "
+              "-- this comparison is vacuous. Build each leg from a COMMITTED ref "
+              "with a clean tree verified between them.")
+        ok = False
+    else:
+        print(f"guest ELF: base {base_elf[:16]}... != candidate {cand_elf[:16]}... (distinct builds)")
 
     # Self-check 2: denominators.  A candidate may be a deliberate --limit
     # sample; a BASE that did not score every row cannot anchor a delta.


### PR DESCRIPTION
Four changes, one theme: **the A/B harness should not silently choose for you, and should refuse a comparison that cannot mean anything.** Each came out of a real failure today; none is speculative.

## 1. No default backend — closes #10533

**#10533 was decided and never implemented.** The maintainer ruled on it, explicitly rejecting a flipped default because that "only relocates the same footgun" — but the tree still had `BACKEND="${EEST_BACKEND:-ziskemu}"`, and omitting `--backend` passed straight through. Cited here as *a decision recorded on an open issue*, not as shipped precedent.

**`EEST_BACKEND` survives** as an opt-in override, per the issue; only the fallback when *neither* the flag nor the variable is set is gone.

The error text is **the maintainer's, extracted from the issue body programmatically rather than retyped** — verbatim-by-construction rather than verbatim-by-care. Two clauses appended: the env-var note, and a pointer for readers who arrived via a sibling probe rather than this script.

## 2. No default scope

`--limit N` or `--all` must be chosen. The message names `--all` as the full 26,104-case corpus — required for a **high-blast-radius** change (a gas constant, a shared helper, anywhere path-targeting cannot be trusted) and for re-baselining — and `--limit N` as the focused mode: known-failing, plus path-touching, plus **a random control drawn from the passing set**. That control is flagged as not optional, because a set built only from known-failing and path-touching cases is blind in the OK→FR direction by construction.

An earlier revision of this PR said `--all` is *the merge gate for anything that changes emitted bytes*. That was true when written and is now too strong, and as written it would have told a future reader that #10581 — which changes emitted bytes and was gated on a partial plus a random sample — was illegitimate. Corrected in `7ff27f4f8`. The general lesson: the backend message ages well because it describes the two **backends**, which have not changed; the sentence that aged badly described **our practice**, which did. Prefer describing the tool over describing the workflow.

The message also carries the one sentence that explains why the flag exists:

> a smoke run reports honestly over its N cases and reads exactly like a corpus pass

That is not hypothetical. I launched today's A/B without a scope flag, got a clean result in 17 seconds, and nearly reported it — the default is 50. What caught it was going to look up the scored row count in order to quote a denominator.

## 3. `--backend ziskemu` clamps `--jobs` to 1, loudly

Warning plus clamp rather than an error, as #10533 asks: `--jobs` has a legitimate auto-derived value, so the point is that the caller is *told*.

**Design note — the split was considered and deliberately not taken.** A finer behaviour is available: hard-error when `--jobs > 1` was passed *explicitly* (the caller stated a preference, so silently overruling it is the same defect this PR is about) while silently clamping when `--jobs` resolved from `auto` (no preference to override). I did not implement it, for two reasons. The issue asks for "a warning plus an automatic clamp", and the warning already tells the caller in both cases, which is the property it says matters. And distinguishing explicit from auto needs a second `*_SET` sentinel on a flag that also accepts the literal `auto`, which is more machinery than the difference earns. Recorded so a future reader can see the simpler behaviour was chosen rather than overlooked.

## 4. Self-check 0 — refuse a vacuous comparison

`eest-ab-compare.py` now hashes each run dir's `stateless_guest.elf` and **refuses a verdict if they match**. Comparing a build to itself yields a flawless zero that means nothing, and the way it happens is silent: `git checkout` carries uncommitted changes across branches, so building "base" after switching can pick up the candidate edit that was never committed. **That happened today** — a 16-instruction deletion produced two byte-identical ELFs.

It has to be mechanised rather than remembered, because **zero diff is the predicted result for most refactors**: the harness bug is indistinguishable from the hypothesis by looking at the output.

When `--no-build` + a `GUEST_ELF` override puts the ELF outside the run dir, the check **prints NOT RUN** rather than passing silently — a self-check that quietly does not apply is worse than none.

The docstring also records two hazards that cannot be mechanised there: the **linker embeds the object filename**, so emitting to `-o base` and `-o cand` makes two ELFs differ even when the change is byte-neutral (this produced a false defect today, one step from spending a sweep slot); and **do not probe a tool by running it while it is in use** — confirming a default behaviourally started a real ziskemu run against a live sweep when reading the source had already answered it.

## Also: the global baseline write is removed

Both legs of a parallel A/B raced to write `gen-out/eest-baseline.txt` and the second writer silently won, so a reader got the other leg's numbers. The per-run copy is already authoritative. **No code reads the global one** — every sibling script reads its own `"$RUN_DIR/eest-baseline.txt"`; the two doc references are updated.

## Caller audit

70 invocation sites across 66 files, reconstructed across backslash continuations (a same-line match reports *zero* sites with a scope flag — the tell that continuations are involved). Two apparent callers were case-statement path patterns, established by reading them.

- **Scope flag: zero callers break.** One casualty, a bare invocation in `docs/eest-stateless-testing.md` whose heading read "Run the default smoke subset" — naming the default being removed. Fixed here.
- **Backend flag: 61 sites now error, deliberately.** Tracked in **#10582**, which is explicitly *not* a work queue: these probes express no backend intent anywhere, so any bulk answer would be an invention. The maintainer's call is to choose per probe at the moment someone needs it, when the context that determines the answer exists.
- **Zero CI callers** — the only `.github` reference is `labeler.yml` matching the path for size-labelling, followed and read rather than assumed absent.
- **Dockerfile unaffected**: its `CMD` supplies `--all`.

A finding worth flagging from that audit: **55 of the 61 sites run the ziskemu oracle at `--jobs 2`.** #10533 reads as though its footgun fired once, on its author. It is the standing configuration of the family.

## Controls

Against the patched script: neither flag → **both** errors; `--all` alone → backend only; `EEST_BACKEND=spike --all` → neither; `--backend spike` alone → scope only; `--backend bogus --all` → neither of these, original invalid-value error preserved.

Self-check 0: same build → refuses, exit 1; distinct builds → reports distinct, does not fire; ELF absent → prints NOT RUN.

Jobs clamp exercised on a copy (ziskemu+8 warns and clamps, ziskemu+1 silent, spike+8 silent); the live file is byte-identical to that copy except the baseline removal 1500 lines away, so those transfer.

**Both missing flags report together** rather than fail-fast. An early draft exited on the scope error, so a caller missing both learned about scope, fixed it, re-ran, and only then learned about backend. Fail-fast is wrong for *independent* validation errors — it makes the user's cost proportional to how many things they got wrong when it could be constant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
