### PR TITLE
fix(codegen): emit WARM_ACCESS from SpecRef instead of transcribing it

### DIFF
--- a/EvmAsm/Codegen/Programs/BalCodePreimages.lean
+++ b/EvmAsm/Codegen/Programs/BalCodePreimages.lean
@@ -11,6 +11,7 @@ import EvmAsm.Codegen.Programs.BalCodePreimagesAux
 import EvmAsm.Codegen.Programs.BalCodePreimagesCreateCollision
 import EvmAsm.Codegen.Programs.BalAccountNonstorageFinals
 import EvmAsm.Codegen.Programs.EvmAccessGas
+import EvmAsm.Stateless.SpecRef.Gas
 
 namespace EvmAsm.Codegen
 
@@ -1126,7 +1127,7 @@ def balCodePreimagesValidFunction : String :=
   -- touching env.gasRemaining. s4 is this helper's BAL length, not an env ptr.
   "  li t2, 1; bne s10, t2, .Lbsbd_skip_charge\n" ++
   "  sd s4, 96(sp); ld x20, 104(sp)\n" ++
-  "  ld t0, 568(x20); li t1, 100; bltu t0, t1, .exit_outofgas\n" ++
+  s!"  ld t0, 568(x20); li t1, {EvmAsm.Stateless.SpecRef.GasCosts.WARM_ACCESS}; bltu t0, t1, .exit_outofgas\n" ++
   "  sub t0, t0, t1; sd t0, 568(x20)\n" ++
   "  addi a0, s9, 3; la a1, " ++ runtimeAccessAccountTableLabel ++ "\n" ++
   "  la a2, " ++ runtimeAccessAccountCountLabel ++ "\n" ++

--- a/EvmAsm/Codegen/Programs/BlockVerdictDispatchTx.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictDispatchTx.lean
@@ -526,7 +526,7 @@ def dispatchTxRuntimeCodeFunction : String :=
   -- pre-execution accessed-set membership.
   "  la a0, dtrc_deleg_target; mv a1, s2\n" ++
   "  jal ra, dtrc_delegate_warm_probe\n" ++
-  "  li t1, 3000; beqz a0, .Ldtrc_prior_access_cold\n" ++
+  s!"  li t1, {EvmAsm.Stateless.SpecRef.GasCosts.COLD_ACCOUNT_ACCESS}; beqz a0, .Ldtrc_prior_access_cold\n" ++
   s!"  li t1, {EvmAsm.Stateless.SpecRef.GasCosts.WARM_ACCESS}\n" ++
   ".Ldtrc_prior_access_cold:\n" ++
   "  la t0, runtime_tx_top_frame_regular_gas; ld t2, 0(t0); add t1, t1, t2; sd t1, 0(t0)\n" ++
@@ -546,7 +546,7 @@ def dispatchTxRuntimeCodeFunction : String :=
   -- exported by bal_same_block_delegation_code_resolve).
   "  la a0, bsbd_deleg_target; mv a1, s2\n" ++
   "  jal ra, dtrc_delegate_warm_probe\n" ++
-  "  li t1, 3000; beqz a0, .Ldtrc_sb_access_cold\n" ++
+  s!"  li t1, {EvmAsm.Stateless.SpecRef.GasCosts.COLD_ACCOUNT_ACCESS}; beqz a0, .Ldtrc_sb_access_cold\n" ++
   s!"  li t1, {EvmAsm.Stateless.SpecRef.GasCosts.WARM_ACCESS}\n" ++
   ".Ldtrc_sb_access_cold:\n" ++
   "  la t0, runtime_tx_top_frame_regular_gas; ld t2, 0(t0); add t1, t1, t2; sd t1, 0(t0)\n" ++

--- a/EvmAsm/Codegen/Programs/BlockVerdictDispatchTx.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictDispatchTx.lean
@@ -22,6 +22,7 @@
 import EvmAsm.Rv64.Program
 import EvmAsm.Codegen.Programs.BlockVerdictParams
 import EvmAsm.Codegen.Programs.CommittedStorageLookup
+import EvmAsm.Stateless.SpecRef.Gas
 
 namespace EvmAsm.Codegen
 
@@ -526,7 +527,7 @@ def dispatchTxRuntimeCodeFunction : String :=
   "  la a0, dtrc_deleg_target; mv a1, s2\n" ++
   "  jal ra, dtrc_delegate_warm_probe\n" ++
   "  li t1, 3000; beqz a0, .Ldtrc_prior_access_cold\n" ++
-  "  li t1, 100\n" ++
+  s!"  li t1, {EvmAsm.Stateless.SpecRef.GasCosts.WARM_ACCESS}\n" ++
   ".Ldtrc_prior_access_cold:\n" ++
   "  la t0, runtime_tx_top_frame_regular_gas; ld t2, 0(t0); add t1, t1, t2; sd t1, 0(t0)\n" ++
   -- Amsterdam prepare_dispatch charges this delegated access before reading
@@ -546,7 +547,7 @@ def dispatchTxRuntimeCodeFunction : String :=
   "  la a0, bsbd_deleg_target; mv a1, s2\n" ++
   "  jal ra, dtrc_delegate_warm_probe\n" ++
   "  li t1, 3000; beqz a0, .Ldtrc_sb_access_cold\n" ++
-  "  li t1, 100\n" ++
+  s!"  li t1, {EvmAsm.Stateless.SpecRef.GasCosts.WARM_ACCESS}\n" ++
   ".Ldtrc_sb_access_cold:\n" ++
   "  la t0, runtime_tx_top_frame_regular_gas; ld t2, 0(t0); add t1, t1, t2; sd t1, 0(t0)\n" ++
   "  la t0, sv_pre_rlp_ptr; ld t1, 0(t0); la t2, dtrc_hdr_ptr; sd t1, 0(t2)\n" ++

--- a/EvmAsm/Codegen/Programs/ChildFrameHandlerTails.lean
+++ b/EvmAsm/Codegen/Programs/ChildFrameHandlerTails.lean
@@ -14,6 +14,7 @@ import EvmAsm.Codegen.Programs.Modexp
 import EvmAsm.Codegen.Programs.PrecompileRuntime
 import EvmAsm.Codegen.Programs.AmsterdamSystemTx
 import EvmAsm.Rv64.Program
+import EvmAsm.Stateless.SpecRef.Gas
 namespace EvmAsm.Codegen
 open EvmAsm.Rv64
 
@@ -53,7 +54,7 @@ def callDelegationAccessChargeAsm (tag : String) : String :=
   "  jal ra, runtime_access_account_charge\n" ++
   "  ld x10, 0(sp); ld x12, 8(sp); ld x13, 16(sp)\n  addi sp, sp, 32\n" ++
   -- add the 100 warm-floor the helper omits, so total = 3000 cold / 100 warm.
-  "  ld t0, 568(x20)\n  li t1, 100\n  bltu t0, t1, .exit_outofgas\n" ++
+  s!"  ld t0, 568(x20)\n  li t1, {EvmAsm.Stateless.SpecRef.GasCosts.WARM_ACCESS}\n  bltu t0, t1, .exit_outofgas\n" ++
   "  sub t0, t0, t1\n  sd t0, 568(x20)\n" ++
   ".Lcdac_done_" ++ tag ++ ":\n"
 

--- a/EvmAsm/Codegen/Programs/EvmAccountWitness.lean
+++ b/EvmAsm/Codegen/Programs/EvmAccountWitness.lean
@@ -9,6 +9,7 @@ import EvmAsm.Codegen.Programs.EvmAccessGas
 import EvmAsm.Codegen.Programs.EvmOpcodes
 import EvmAsm.Codegen.Programs.StateCompose
 import EvmAsm.Codegen.Programs.RuntimeSameBlockCode
+import EvmAsm.Stateless.SpecRef.Gas
 
 namespace EvmAsm.Codegen
 
@@ -288,7 +289,7 @@ private def extcodesizeWitnessTail : HandlerTail :=
     "  ld x13, 24(sp)\n" ++
     "  addi sp, sp, 32\n" ++
     "  ld t0, 568(x20)\n" ++
-    "  li t1, 100\n" ++
+    s!"  li t1, {EvmAsm.Stateless.SpecRef.GasCosts.WARM_ACCESS}\n" ++
     "  bltu t0, t1, .exit_outofgas\n" ++
     "  sub t0, t0, t1\n" ++
     "  sd t0, 568(x20)\n" ++

--- a/EvmAsm/Codegen/Programs/NoopHalt.lean
+++ b/EvmAsm/Codegen/Programs/NoopHalt.lean
@@ -11,6 +11,7 @@ import EvmAsm.Codegen.Programs.EvmMemoryGas
 import EvmAsm.Codegen.Programs.Selfdestruct
 import EvmAsm.Codegen.Programs.StaticContext
 import EvmAsm.Rv64.Program
+import EvmAsm.Stateless.SpecRef.Gas
 
 namespace EvmAsm.Codegen
 
@@ -515,7 +516,7 @@ private def selfdestructTailAsm : String :=
   -- x10 restore clobbers it.
   "  beqz a0, .L_selfdestruct_access_floor_done\n" ++
   "  ld t0, 568(x20)\n" ++
-  "  li t1, 100\n" ++
+  s!"  li t1, {EvmAsm.Stateless.SpecRef.GasCosts.WARM_ACCESS}\n" ++
   "  bltu t0, t1, .exit_outofgas\n" ++
   "  sub t0, t0, t1\n" ++
   "  sd t0, 568(x20)\n" ++

--- a/EvmAsm/Codegen/Programs/SstoreRegularGas.lean
+++ b/EvmAsm/Codegen/Programs/SstoreRegularGas.lean
@@ -65,7 +65,7 @@ def sstoreRegularGasFunction : String :=
   "  li t0, 3000\n" ++                              -- COLD_STORAGE_ACCESS
   "  j .Lsrg_cold_done\n" ++
   ".Lsrg_warm_access:\n" ++
-  "  li t0, 100\n" ++                               -- WARM_ACCESS
+  s!"  li t0, {EvmAsm.Stateless.SpecRef.GasCosts.WARM_ACCESS}\n" ++                     -- WARM_ACCESS
 
   ".Lsrg_cold_done:\n" ++
   -- clean-changing = original_eq_current && !current_eq_new


### PR DESCRIPTION
Closes the codegen half of #10572. **Stacked on #10579**, which established this pattern in the same family. Byte-identical emission, so no sweep.

## The count in the issue is wrong, and the classification is the real work

#10572 reports **28** occurrences in the emitted image. There are **13** exact `li <reg>, 100` — verified on two independently built images (`ddbb5b5c…` and `cd57510f…`), so it's a property of the guest, not my instrument.

An **unanchored** match hits 82 lines: 40×`100000`, 13×`100`, 11×`10000`, 8×`1000`, 6×`100018`, 3×`1000000000`, 1×`100001`. Prefix bleed is live and large here — but it doesn't produce 28 either, and I could not reconstruct that figure under any anchoring I tried. Stating that rather than inventing a derivation.

**Of 17 source candidates, 8 are the warm-access charge and 9 are unrelated uses of the number 100.** Five of the nine are one recurring idiom — a status-code decade remap (`li 100; add`, 1→101) across `Block`, `Tx`, `TxTotalBlobGas`, `Withdrawal`, `WithdrawalBlockSummary`. The rest are a multiplier in `ReceiptRecords` and three probe seeds. **Editing by literal would have made nine wrong edits on the most frequently executed gas path in the interpreter.**

## Substituted here — 7 sites

| site | why it is WARM_ACCESS |
|---|---|
| `EvmAccountWitness.lean:291` | `ld 568(x20)` / `bltu` / `sub` construct |
| `NoopHalt.lean:518` | same construct |
| `BalCodePreimages.lean:1129` | the one-line construct verbatim |
| `ChildFrameHandlerTails.lean:56` | comment: *"add the 100 warm-floor the helper omits, so total = 3000 cold / 100 warm"* |
| `BlockVerdictDispatchTx.lean:529` | warm arm of `li t1, 3000; beqz …; li t1, 100` |
| `BlockVerdictDispatchTx.lean:549` | second site, same shape |
| `SstoreRegularGas.lean:67` | commented `-- WARM_ACCESS`; probe-only routine |

**The eighth is deliberately left alone.** `SstoreGasRefund.lean:92` is the warm arm of the dead gas accumulator that **#10581 deletes**. Substituting it here would collide with that PR; leaving it means the two land cleanly in either merge order.

**Merge order: no dependency, verified rather than assumed.** The two PRs touch **disjoint file sets** — `git diff --name-only` on each against their shared base intersects to nothing. #10581 removes two `li …, 100` lines (`li s6, 100` and the warm arm at `:92`), both inside `SstoreGasRefund.lean`, which this PR does not touch. So no site of this PR vanishes if #10581 lands first, and no count here needs re-deriving afterwards.

**Which counts this PR is stated against:** the #10579 tip — 13 exact `li <reg>, 100` in the emitted image, 8 of them warm-access. After #10581 lands the emitted total drops to 11 (both removals are non-warm-access under my classification: the `s6` init and its warm arm feed the dead accumulator), while the warm-access count stays 8. Verified against both legs of #10581's own A/B pair rather than predicted.

## The adjacent cold arm is substituted too (`7b9e7cafa`)

Substituting only the warm arm left a puzzling adjacency: at both delegated-code sites the cold arm sits on the line *immediately above* as a bare `3000`. Half the pair interpolated and half not invites the reader to wonder whether the `3000` was considered and rejected.

**Which spec symbol it is was established by reading, not by value.** `COLD_ACCOUNT_ACCESS` and `COLD_STORAGE_ACCESS` are *both* 3000 today, so byte-identity cannot discriminate between them, and picking the wrong one would bake in a tie that silently breaks the moment a fork reprices one of them. `amsterdam/vm/eoa_delegation.py:157-160` settles it:

```python
if delegated_address in evm.accessed_addresses:
    delegation_gas_cost = GasCosts.WARM_ACCESS
else:
    delegation_gas_cost = GasCosts.COLD_ACCOUNT_ACCESS
```

That is exactly the guest's structure — warm probe, then one arm each — so the cold arm is `COLD_ACCOUNT_ACCESS`. The guest's own comment agrees: *"warm (100) vs cold (3000) delegated-code access by pre-execution accessed-set membership."*

Both sites now carry the pair, so neither arm can drift away from the other.

## Byte-identical emission

Emitted `.s` sha256 `cd57510f413dded94225564233c061d9c9d330d4c19bcf6f75f856a50131b398` before and after, both legs emitted **under the same output name** (the linker embeds the object filename — differing `-o` names produce a spurious ELF difference, per #10579).

**That gate earned its keep on the first run.** My initial edit over-escaped the newline: the source carried `\\n`, so the guest emitted a *literal* backslash-n instead of a line break, silently fusing two instructions onto one line:

```
-  ld t0, 568(x20); li t1, 100; bltu t0, t1, .exit_outofgas
-  sub t0, t0, t1; sd t0, 568(x20)
+  ld t0, 568(x20); li t1, 100; bltu t0, t1, .exit_outofgas\n  sub t0, t0, t1; sd t0, 568(x20)
```

The build was clean and **every source gate passed**. Only the `.s` diff caught it. A byte-identity check on a change predicted to be byte-identical sounds like ceremony right up until it isn't.

## Method note

Edits are applied by **line number with a content assertion** rather than by string match, because the target string recurs and the indents differ per file. An earlier string-based attempt aborted on a wrong indent guess, which is the failure mode working as intended.

The emitted-image anchor must allow **semicolon-joined** forms — `ld t0, 568(x20); li t1, 100; bltu …` is one line, and a `^\s*li` anchor silently drops those. That cost me two sites (11 vs the true 13) until a by-value count disagreed with my by-construct count and I asked which was lying.

## Gates

**Run:** build clean; `check-forbidden-tactics` OK; `check-no-warnings` 0; `check-unimported` 0 orphans; `check-layering` OK; `check-file-size` OK; `check-no-hardcoded-guest-pc` OK.

**Not run:** `check-axioms` (cannot execute under `LAKE_ARTIFACT_CACHE`, #10537). `check-asm-to-program` and `check-region-map` are unaffected — emitted bytes are unchanged, so no layout regen is required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

