### PR TITLE
docs: scope the hpDecode "total agreement" claims to the guest mirror (GH #10528)

### DIFF
--- a/EvmAsm/Codegen/Programs/HpDecodeNibblesSAsm.lean
+++ b/EvmAsm/Codegen/Programs/HpDecodeNibblesSAsm.lean
@@ -16,12 +16,26 @@
   up-counting nibble loop (`bgeu i, len` top guard — `upLoop_spec`).
 
   The genuine post is stated against `hdnRes`, the guest-exact decode
-  mirror, which (post bead evm-asm-3umhl) IS the spec-side
-  `EvmAsm.Evm64.hpDecode` (`MptAssertions.lean`): the guest is lenient on
-  the even-path padding nibble exactly like execution-specs
-  `compact_to_nibbles` (amsterdam/incremental_mpt.py:878-889), so
-  `hdnRes_eq_hpDecode` is a total definitional agreement and
-  `hdnRes_hpEncode` the round-trip on every hex-prefix encoding.
+  mirror, which (post bead evm-asm-3umhl) IS `EvmAsm.Evm64.hpDecode`
+  (`MptAssertions.lean`), so `hdnRes_eq_hpDecode` is a total definitional
+  agreement and `hdnRes_hpEncode` the round-trip on every hex-prefix
+  encoding.
+
+  ## What that agreement is NOT (GH #10528)
+
+  `hpDecode` is a **guest mirror**, not the SpecRef port. The proved chain
+  is `guest -> hdnRes -> hpDecode`; the further link
+  `hpDecode -> SpecRef.compact_to_nibbles` is **not stated anywhere, and
+  would be false if it were**. `hpDecode` rejects a head nibble `>= 4`
+  (`MptAssertions.lean:155`), while `compact_to_nibbles`
+  (`SpecRef/IncrementalMpt.lean:76-86`, mirroring
+  `amsterdam/incremental_mpt.py:878-889`) masks bits 2-3 away and accepts.
+  So the guest is STRICTER than the spec here -- a false-reject shape, not
+  a soundness gap -- and the divergence is pinned in by
+  `#guard hdnRes [0x4a] = none` below.
+
+  What `evm-asm-3umhl` relaxed was the EVEN-PATH PADDING NIBBLE, a
+  different divergence; the head-nibble one it did not touch.
 -/
 
 import EvmAsm.Codegen.Programs.BytesToNibblesSAsm
@@ -113,8 +127,12 @@ theorem hdnProg_eq :
 def hdnRes (bs : List (BitVec 8)) : Option (Bool × List (BitVec 8)) :=
   EvmAsm.Evm64.hpDecode bs
 
-/-- **Total agreement** with the spec-side `hpDecode`
-    (`MptAssertions.lean`) — definitional after `evm-asm-3umhl`. -/
+/-- **Total agreement with `hpDecode`** (`MptAssertions.lean`) —
+    definitional after `evm-asm-3umhl`.
+
+    `hpDecode` is the GUEST MIRROR, not the SpecRef port: this says nothing
+    about `SpecRef.compact_to_nibbles`, which accepts head nibbles the guest
+    rejects. See the module docstring and GH #10528. -/
 theorem hdnRes_eq_hpDecode (bs : List (BitVec 8)) :
     hdnRes bs = EvmAsm.Evm64.hpDecode bs := rfl
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -272,10 +272,14 @@ All deleted spec files have been recreated. See **Pending: Recreate Deleted Spec
   sibling of `countdownLoop_spec`): `hp_decode_nibbles_spec` is the
   whole-routine `abiFrame_spec` contract against the guest-exact decode
   `hdnRes` = `hpDecode` (`hdnRes_eq_hpDecode` is a TOTAL definitional
-  agreement post `evm-asm-3umhl`: the guest ignores the even-path
-  padding nibble exactly like execution-specs `compact_to_nibbles` —
-  the original strict-reject divergence was relaxed away with a guest
-  re-emit + full EEST A/B).
+  agreement post `evm-asm-3umhl`, which relaxed the EVEN-PATH PADDING
+  NIBBLE divergence with a guest re-emit + full EEST A/B).
+  **That agreement is with `hpDecode`, a GUEST MIRROR — not with SpecRef**
+  (GH #10528). `hpDecode` still rejects a head nibble `≥ 4` where
+  `SpecRef.compact_to_nibbles` masks bits 2–3 and accepts, so the guest is
+  stricter than the spec on that input: a false-reject shape, not a
+  soundness gap. No theorem relates `hpDecode` to `compact_to_nibbles`, and
+  the divergence is pinned by `#guard hdnRes [0x4a] = none`.
 - **Transient store recipe** (`EvmAsm/Evm64/Transient/`, TSTORE done; TLOAD next):
   Body-as-Program `evm_tstore` (`StoreProgram.lean`) is the la-FREE append core
   (`li 0xa0830000` concrete base, `slli`+`add` for `base+128*n`); the handler


### PR DESCRIPTION
Three statements read as total agreement between the guest and **the spec**. What is proved is total agreement between the guest and `hpDecode` — a **guest mirror**.

The further link, `hpDecode` → `SpecRef.compact_to_nibbles`, is **not stated anywhere and would be false if it were**:

| | head nibble ≥ 4 |
|---|---|
| `hpDecode` (`Evm64/MptAssertions.lean:155`) | returns `none` — rejects |
| `SpecRef.compact_to_nibbles` (`SpecRef/IncrementalMpt.lean:76-86`) | masks bits 2–3 away — **accepts** |

SpecRef mirrors `amsterdam/incremental_mpt.py:878-889` faithfully; the guest is **stricter than the spec** on that input.

That is a false-**reject** shape, not a soundness gap, and `FA = 0` is unaffected. But a reader who took "total agreement with the spec" at face value would conclude the decoder is spec-exact when it is provably not — the #10580 hazard, an authoritative-sounding statement that no longer matches the tree, in the place a reader will trust.

## Verified there is no bridge, rather than assuming its absence

Grepping `compact_to_nibbles` across all of `EvmAsm/` outside its defining file returns only prose comments, one `#guard` **internal to SpecRef**, and a registry name. **No theorem, no guard, no `rfl` relates the two.** The proved chain terminates at the mirror.

## A second inaccuracy, in PLAN.md

The entry attributed the relaxation of *"the original strict-reject divergence"* to `evm-asm-3umhl`. That bead relaxed the **even-path padding nibble** — a different divergence. The head-nibble strict reject was never touched and is still live.

It is in fact **pinned**: `HpDecodeNibblesSAsm.lean:211` carries `#guard hdnRes [0x4a] = none`, a build-time assertion that the guest rejects an input the spec accepts. So the divergence is deliberate and load-bearing in the proof set, not drift — worth knowing before anyone reaches for the guest side, because the fix is not one-sided.

## Scope

**Docs only.** No proof, no definition, no emitted byte changes. The divergence itself is untouched and remains #10528's to decide; this fixes only the *claims about it*, which are wrong regardless of which closing shape that issue takes — relax the guest and delete the guard, or keep it strict and state a refinement on the well-formed domain.

**Gates run:** module builds clean; `check-no-warnings` 0; `check-forbidden-tactics` OK; `check-file-size` OK. No layout regen or A/B needed — nothing emitted changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)