### PR TITLE
fix(harness): apply --limit AFTER the --random shuffle (closes #10596)

### DIFF
--- a/scripts/codegen-eest-stateless-check.sh
+++ b/scripts/codegen-eest-stateless-check.sh
@@ -233,8 +233,10 @@ Options:
   --tag TAG                EEST fixture tag (default $EEST_FIXTURE_TAG or scripts/eest-fixture-tag.txt)
   --no-build               skip lake build + ELF emit (reuse existing gen-out/stateless_guest.elf)
   --no-verdict-debug       do not rerun fixed-size verdict probe on succ mismatches
-  --random                 shuffle fixtures into a random order before --limit; run
-                           repeatedly to sample different subsets and seek discoveries
+  --random                 shuffle the fixture FILE list BEFORE --limit, so the cap
+                           selects a spread across the corpus rather than its front.
+                           Sampling is at file granularity (~4 blocks/file); run
+                           repeatedly with different seeds to seek discoveries
   --seed N                 integer seed for --random (default: auto-generated and printed)
   --reverse                process the selected fixtures last-to-first (applied after --random)
   --preflight-report MODE  emit decoded 200M resource dimensions: budget (default), always, never
@@ -1097,6 +1099,15 @@ verdict_debug_for_case() {
 conv_args=(--fixtures-dir "$FX" --out-dir "$RUN_DIR")
 [[ "$SKIP" != "0" ]] && conv_args+=(--skip "$SKIP")
 [[ "$ALL" -eq 0 ]] && conv_args+=(--limit "$LIMIT")
+# GH #10596: the SHUFFLE must happen before the cap, so it belongs in the
+# converter. Shuffling here (after conversion) only reordered an already
+# truncated manifest.
+if [[ "$RANDOM_ORDER" -eq 1 ]]; then
+  if [[ -z "$RANDOM_SEED" ]]; then
+    RANDOM_SEED="$(python3 -c 'import random; print(random.randint(0, 2**31-1))')"
+  fi
+  conv_args+=(--random --seed "$RANDOM_SEED")
+fi
 [[ -n "$FILTER" ]] && conv_args+=(--filter "$FILTER")
 [[ "$VERIFY_INPUT_PARITY" -eq 1 ]] && conv_args+=(--verify-input-parity)
 [[ "$VERIFY_EXECUTION_SPEC_INPUT" -eq 1 ]] && conv_args+=(--verify-execution-spec-input)
@@ -1126,10 +1137,9 @@ for i in "${!manifestLines[@]}"; do
 done
 
 if [[ "$RANDOM_ORDER" -eq 1 ]]; then
-  if [[ -z "$RANDOM_SEED" ]]; then
-    RANDOM_SEED="$(python3 -c 'import random; print(random.randint(0, 2**31-1))')"
-  fi
-  echo "==> random order: seed=$RANDOM_SEED (pass --seed $RANDOM_SEED to reproduce this run)"
+  # The SELECTION was randomised in the converter above (GH #10596); this
+  # shuffle only randomises the EXECUTION order of what was selected.
+  echo "==> random selection + order: seed=$RANDOM_SEED (pass --seed $RANDOM_SEED to reproduce this run)"
   mapfile -t manifestLines < <(
     printf '%s\n' "${manifestLines[@]}" | python3 -c "
 import sys, random

--- a/scripts/eest-stateless-to-input.py
+++ b/scripts/eest-stateless-to-input.py
@@ -51,6 +51,7 @@ import argparse
 import json
 import os
 import struct
+import random
 import sys
 from pathlib import Path
 
@@ -171,6 +172,17 @@ def main() -> int:
     ap.add_argument("--skip", type=int, default=0, help="skip first N selected invocations")
     ap.add_argument("--limit", type=int, default=0, help="cap invocations (0 = no cap)")
     ap.add_argument(
+        "--random",
+        action="store_true",
+        help="shuffle the fixture FILE list before applying --skip/--limit, so "
+             "the cap selects a spread across the corpus rather than its front "
+             "(GH #10596). Requires --seed.",
+    )
+    ap.add_argument(
+        "--seed", type=int, default=None,
+        help="seed for --random; required with it so a run is reproducible",
+    )
+    ap.add_argument(
         "--filter",
         default="",
         help="keep blocks whose fixture relpath or test label contains this",
@@ -196,6 +208,10 @@ def main() -> int:
         ap.error("--skip must be nonnegative")
     if args.limit < 0:
         ap.error("--limit must be nonnegative")
+    if args.random and args.seed is None:
+        ap.error("--random requires --seed (a run that cannot be reproduced is not a result)")
+    if args.seed is not None and not args.random:
+        ap.error("--seed is meaningless without --random")
 
     fixtures_dir: Path = args.fixtures_dir
     out_dir: Path = args.out_dir
@@ -216,6 +232,22 @@ def main() -> int:
         p for p in fixtures_dir.rglob("*.json")
         if ".meta" not in p.parts
     )
+
+    # GH #10596: --limit is applied AFTER the shuffle, which is what the flag has
+    # always documented. Previously the harness shuffled the manifest the
+    # converter had ALREADY truncated, so `--random --limit N` returned the first
+    # N fixtures in a random ORDER rather than N drawn from the corpus -- and
+    # manifest order tracks fixture family, so the result was a clustered sample
+    # presented as a spread one.
+    #
+    # The shuffle is over the FILE list, not the block list: blocks are streamed
+    # out of each file by `iter_blocks`, so sampling at block granularity would
+    # mean parsing all ~6.3k fixtures up front, which is most of the conversion
+    # cost the cap exists to avoid. At ~4.1 blocks per file the residual is that
+    # a selected file contributes its handful of blocks together; the
+    # family-level clustering that made the old behaviour misleading is gone.
+    if args.random:
+        random.Random(args.seed).shuffle(json_files)
 
     selected = 0
     n = 0


### PR DESCRIPTION
`--random` never reached the converter. `conv_args` carried `--skip`, `--limit`, `--filter` and the verify flags only — so `eest-stateless-to-input.py` walked fixtures **in order**, stopped at `--limit`, and wrote a manifest of the **first N**; the harness then shuffled *that*.

So `--random --limit N` returned the first N fixtures in a random **order**, not N drawn from the corpus. Manifest order tracks fixture family, so the result was a **clustered sample presented as a spread one**.

The shuffle now happens in the converter, before `--skip`/`--limit` — which is what the flag has documented all along (*"shuffle fixtures into a random order before `--limit`"*). **Behaviour now matches the contract**; nobody's expectations move.

## Changes

- converter gains `--random` / `--seed`, shuffling its **file list** before selecting;
- `--random` **requires** `--seed` — a sample that cannot be reproduced is not a result — and `--seed` without `--random` is rejected as meaningless;
- the harness passes both down; its own post-conversion shuffle is kept and re-labelled, since it now randomises only **execution** order;
- the help text is corrected to state the granularity.

## Granularity, stated rather than glossed

The shuffle is over the **file list**, not the block list. Blocks are streamed out of each file by `iter_blocks`, so sampling at block granularity would mean parsing all ~6,334 fixtures up front — most of the conversion cost the cap exists to avoid.

At **~4.1 blocks per file**, the residual is that a selected file contributes its handful of blocks together. The family-level clustering that made the old behaviour misleading is gone; this is not uniform-over-blocks and the help text does not claim it is.

## Proven by the file sets, not by the labels

Converting `--limit 200` with and without `--random`:

| | blocks | distinct files | files in common |
|---|---|---|---|
| without `--random` | 200 | 53 | — |
| with `--random --seed 4242` | 200 | 53 | **0 of 53** |

Disjoint selections. That is the evidence.

**A warning for anyone testing this, because I got it wrong first.** The converter numbers blocks sequentially *as it emits them*, so label prefixes are `00000`–`00199` in **both** cases. I originally cited that prefix range as empirical confirmation of the defect; it cannot distinguish the two behaviours and proved nothing. The code path (`--random` absent from `conv_args`) was the real evidence all along, and the file-set comparison is the real test. #10596 is corrected accordingly — including the regression check it proposed, which was built on the same bad observation and would never have fired.

## Not changed

No emitted bytes, no Lean. Harness only, so no layout regen and no A/B.

🤖 Generated with [Claude Code](https://claude.com/claude-code)