### PR TITLE
fix(harness): sample random EEST blocks uniformly

### DIFF
--- a/scripts/codegen-eest-stateless-check.sh
+++ b/scripts/codegen-eest-stateless-check.sh
@@ -95,8 +95,8 @@
 #                        execution-specs run_stateless_guest's input path
 #     --specref-oracle   also run SpecRef on each input and fail on any
 #                        byte-for-byte guest↔SpecRef divergence
-#     --random           shuffle fixtures into a random order before applying
-#                        --limit; use to sample a different subset on each run
+#     --random           sample individual stateless blocks uniformly before
+#                        applying --limit; use a seed to reproduce a sample
 #                        and discover failures outside the default first-N fixtures
 #     --seed N           integer seed for --random (default: auto-generated and
 #                        printed so any discovery run can be exactly reproduced)
@@ -233,10 +233,9 @@ Options:
   --tag TAG                EEST fixture tag (default $EEST_FIXTURE_TAG or scripts/eest-fixture-tag.txt)
   --no-build               skip lake build + ELF emit (reuse existing gen-out/stateless_guest.elf)
   --no-verdict-debug       do not rerun fixed-size verdict probe on succ mismatches
-  --random                 shuffle the fixture FILE list BEFORE --limit, so the cap
-                           selects a spread across the corpus rather than its front.
-                           Sampling is at file granularity (~4 blocks/file); run
-                           repeatedly with different seeds to seek discoveries
+  --random                 after --filter, sample individual stateless blocks
+                           uniformly WITHOUT replacement BEFORE --limit
+                           (requires --seed)
   --seed N                 integer seed for --random (default: auto-generated and printed)
   --reverse                process the selected fixtures last-to-first (applied after --random)
   --preflight-report MODE  emit decoded 200M resource dimensions: budget (default), always, never
@@ -1137,18 +1136,11 @@ for i in "${!manifestLines[@]}"; do
 done
 
 if [[ "$RANDOM_ORDER" -eq 1 ]]; then
-  # The SELECTION was randomised in the converter above (GH #10596); this
-  # shuffle only randomises the EXECUTION order of what was selected.
-  echo "==> random selection + order: seed=$RANDOM_SEED (pass --seed $RANDOM_SEED to reproduce this run)"
-  mapfile -t manifestLines < <(
-    printf '%s\n' "${manifestLines[@]}" | python3 -c "
-import sys, random
-lines = sys.stdin.read().splitlines()
-random.Random(int(sys.argv[1])).shuffle(lines)
-print('\n'.join(lines))
-" "$RANDOM_SEED"
-  )
-  selection="$selection, random(seed=$RANDOM_SEED)"
+  # The converter sampled individual blocks with this seed; preserve that
+  # selected order rather than building a second full permutation merely to
+  # alter execution order.
+  echo "==> random block selection: seed=$RANDOM_SEED (pass --seed $RANDOM_SEED to reproduce this run)"
+  selection="$selection, random-blocks(seed=$RANDOM_SEED)"
 fi
 
 if [[ "$REVERSE_ORDER" -eq 1 ]]; then

--- a/scripts/eest-stateless-to-input.py
+++ b/scripts/eest-stateless-to-input.py
@@ -36,6 +36,11 @@ Usage:
 per-block EEST test label contains the given substring.  ``--skip`` drops the
 first N selected stateless blocks after filtering, then ``--limit`` caps the
 number of guest invocations emitted.
+``--random --seed S`` first enumerates the filtered block rows and samples the
+requested cap uniformly without replacement.  The positive control for this
+mode is the sampled failure count: it should track the corpus failure rate;
+an all-pass draw from a corpus with roughly a thousand failures signals a
+clustered selection rather than evidence that the screen is clean.
 ``--verify-input-parity`` unpacks each emitted ziskemu input and checks that
 the guest-visible blob is byte-for-byte the fixture's ``statelessInputBytes``.
 ``--verify-execution-spec-input`` additionally decodes that same blob through
@@ -174,9 +179,9 @@ def main() -> int:
     ap.add_argument(
         "--random",
         action="store_true",
-        help="shuffle the fixture FILE list before applying --skip/--limit, so "
-             "the cap selects a spread across the corpus rather than its front "
-             "(GH #10596). Requires --seed.",
+        help="sample stateless blocks uniformly without replacement before "
+             "applying --skip/--limit; --filter narrows the population first. "
+             "Requires --seed.",
     )
     ap.add_argument(
         "--seed", type=int, default=None,
@@ -233,26 +238,122 @@ def main() -> int:
         if ".meta" not in p.parts
     )
 
-    # GH #10596: --limit is applied AFTER the shuffle, which is what the flag has
-    # always documented. Previously the harness shuffled the manifest the
-    # converter had ALREADY truncated, so `--random --limit N` returned the first
-    # N fixtures in a random ORDER rather than N drawn from the corpus -- and
-    # manifest order tracks fixture family, so the result was a clustered sample
-    # presented as a spread one.
-    #
-    # The shuffle is over the FILE list, not the block list: blocks are streamed
-    # out of each file by `iter_blocks`, so sampling at block granularity would
-    # mean parsing all ~6.3k fixtures up front, which is most of the conversion
-    # cost the cap exists to avoid. At ~4.1 blocks per file the residual is that
-    # a selected file contributes its handful of blocks together; the
-    # family-level clustering that made the old behaviour misleading is gone.
-    if args.random:
-        random.Random(args.seed).shuffle(json_files)
-
     selected = 0
     n = 0
     used_labels: set[str] = set()
     with manifest_path.open("w") as mf:
+        def write_block(
+            label: str,
+            ib: bytes,
+            ob: bytes,
+            gas_limit: int,
+            relpath: str,
+        ) -> bool:
+            nonlocal n
+            # Make the label unique across fixtures by prefixing a counter.
+            # Truncate the descriptive part so the on-disk filename stays
+            # within the OS limit (255 bytes) -- blob test names with full
+            # parametrization can be 200+ chars. The counter prefix already
+            # guarantees uniqueness; the collision guard handles truncation
+            # clashes.
+            uniq = f"{n:05d}_{label[:96]}"
+            if uniq in used_labels:
+                uniq = f"{uniq}_{len(used_labels)}"
+            used_labels.add(uniq)
+
+            input_file = out_dir / f"{uniq}.input"
+            packed = pack_ziskemu_input(ib)
+            if args.verify_input_parity or decode_spec_input is not None:
+                try:
+                    recovered = unpack_ziskemu_input(packed)
+                except ValueError as exc:
+                    print(
+                        f"  error: ziskemu input packing mismatch for "
+                        f"{relpath} {label}: {exc}",
+                        file=sys.stderr,
+                    )
+                    return False
+                if recovered != ib:
+                    print(
+                        f"  error: ziskemu input blob differs from "
+                        f"statelessInputBytes for {relpath} {label}",
+                        file=sys.stderr,
+                    )
+                    return False
+            if decode_spec_input is not None:
+                try:
+                    decode_spec_input(ib)
+                except Exception as exc:
+                    print(
+                        f"  error: execution-specs cannot decode "
+                        f"statelessInputBytes for {relpath} {label}: {exc}",
+                        file=sys.stderr,
+                    )
+                    return False
+            if run_spec is not None:
+                spec_output = run_spec(ib)
+                if spec_output != ob:
+                    print(
+                        f"  error: run_stateless_guest output differs from "
+                        f"statelessOutputBytes for {relpath} {label}",
+                        file=sys.stderr,
+                    )
+                    print(f"    spec:    {spec_output.hex()}", file=sys.stderr)
+                    print(f"    fixture: {ob.hex()}", file=sys.stderr)
+                    return False
+            input_file.write_bytes(packed)
+            succ_bit = ob[32] if len(ob) > 32 else -1
+            mf.write(
+                "\t".join(
+                    [
+                        uniq,
+                        str(input_file),
+                        ob.hex(),
+                        str(succ_bit),
+                        str(len(ib)),
+                        str(gas_limit),
+                        relpath,
+                    ]
+                )
+                + "\n"
+            )
+            n += 1
+            return True
+
+        if args.random:
+            # A fixture file often contains several blocks from the same
+            # scenario. Shuffling files therefore samples fixture families,
+            # not the individual blocks that the harness executes. Enumerate
+            # the filtered block population, then draw rows directly.
+            candidates = []
+            for fp in json_files:
+                relpath = str(fp.relative_to(fixtures_dir))
+                for label, ib, ob, gas_limit in iter_blocks(fp):
+                    if args.filter and args.filter not in relpath and args.filter not in label:
+                        continue
+                    candidates.append((label, ib, ob, gas_limit, relpath))
+
+            if args.limit == 0 and args.skip == 0:
+                # `--all --random` selects every row already; avoid creating a
+                # needless complete permutation merely to change run order.
+                sampled = candidates
+            else:
+                sample_count = len(candidates) if args.limit == 0 else min(
+                    len(candidates), args.skip + args.limit
+                )
+                sampled = random.Random(args.seed).sample(candidates, sample_count)
+            for label, ib, ob, gas_limit, relpath in sampled[args.skip:]:
+                if not write_block(label, ib, ob, gas_limit, relpath):
+                    return 1
+            if args.limit and len(candidates) > args.skip + args.limit:
+                print(
+                    f"==> limit {args.limit} reached; sampled blocks uniformly "
+                    f"without replacement from {len(candidates)} candidates",
+                    file=sys.stderr,
+                )
+            print(f"wrote {n} input(s) + manifest {manifest_path}")
+            return 0
+
         for fp in json_files:
             relpath = str(fp.relative_to(fixtures_dir))
             for label, ib, ob, gas_limit in iter_blocks(fp):
@@ -271,74 +372,8 @@ def main() -> int:
                     mf.flush()
                     print(f"wrote {n} input(s) + manifest {manifest_path}")
                     return 0
-                # Make the label unique across fixtures by prefixing a counter.
-                # Truncate the descriptive part so the on-disk filename stays
-                # within the OS limit (255 bytes) -- blob test names with full
-                # parametrization can be 200+ chars. The counter prefix already
-                # guarantees uniqueness; the collision guard handles truncation
-                # clashes.
-                uniq = f"{n:05d}_{label[:96]}"
-                if uniq in used_labels:
-                    uniq = f"{uniq}_{len(used_labels)}"
-                used_labels.add(uniq)
-
-                input_file = out_dir / f"{uniq}.input"
-                packed = pack_ziskemu_input(ib)
-                if args.verify_input_parity or decode_spec_input is not None:
-                    try:
-                        recovered = unpack_ziskemu_input(packed)
-                    except ValueError as exc:
-                        print(
-                            f"  error: ziskemu input packing mismatch for "
-                            f"{relpath} {label}: {exc}",
-                            file=sys.stderr,
-                        )
-                        return 1
-                    if recovered != ib:
-                        print(
-                            f"  error: ziskemu input blob differs from "
-                            f"statelessInputBytes for {relpath} {label}",
-                            file=sys.stderr,
-                        )
-                        return 1
-                if decode_spec_input is not None:
-                    try:
-                        decode_spec_input(ib)
-                    except Exception as exc:
-                        print(
-                            f"  error: execution-specs cannot decode "
-                            f"statelessInputBytes for {relpath} {label}: {exc}",
-                            file=sys.stderr,
-                        )
-                        return 1
-                if run_spec is not None:
-                    spec_output = run_spec(ib)
-                    if spec_output != ob:
-                        print(
-                            f"  error: run_stateless_guest output differs from "
-                            f"statelessOutputBytes for {relpath} {label}",
-                            file=sys.stderr,
-                        )
-                        print(f"    spec:    {spec_output.hex()}", file=sys.stderr)
-                        print(f"    fixture: {ob.hex()}", file=sys.stderr)
-                        return 1
-                input_file.write_bytes(packed)
-                succ_bit = ob[32] if len(ob) > 32 else -1
-                mf.write(
-                    "\t".join(
-                        [
-                            uniq,
-                            str(input_file),
-                            ob.hex(),
-                            str(succ_bit),
-                            str(len(ib)),
-                            str(gas_limit),
-                            relpath,
-                        ]
-                    )
-                    + "\n"
-                )
-                n += 1
+                if not write_block(label, ib, ob, gas_limit, relpath):
+                    return 1
 
     print(f"wrote {n} input(s) + manifest {manifest_path}")
     return 0


### PR DESCRIPTION
## Summary

Make `--random --seed S --limit K` select **K individual stateless blocks**
uniformly without replacement. The old implementation shuffled fixture files;
because each JSON file clusters related blocks, a nominal 200-row screen was
only about 53 independent fixture-family draws and could miss the failure
frontier entirely.

Non-random conversion remains streaming. Random mode deliberately enumerates
and filters the block population **before** sampling, calls
`random.Random(seed).sample`, then converts only the selected rows. `--all
--random` avoids a needless full permutation because every row is selected
already. The harness's former post-selection shuffle is removed because the
selected sample is already random and execution order carries no measurement
information.

## Positive control

On current main `716e2829a`, seed `7702`, limit `200`:

- converter reported 200 blocks sampled without replacement from 26,104;
- 200/200 completed: 195 OK, 5 FR, 0 FA, 0 FAULT/ERROR, 0 BUDGET;
- main's 936/26,104 FR rate predicts about 7.17 FRs in 200 rows, so the
  observed five is ordinary (`P[FR ≤ 5] ≈ 0.28`) and—unlike the old
  file-granular screen—shows that the sampler reaches the known failure
  population;
- the old file-granular random screen observed zero failures, whose probability
  at the same row-level rate is about `0.00077` (roughly one in 1,300);
- this uniform draw spans 108 distinct fixture files, versus 53 for the old
  file-level draw. File-size skew prevents treating the distinct-file count as
  the primary acceptance statistic; the row-level failure count is the control.

The run used immutable ELF
`2f4b15673d940dde68d898ccf901291697d275d3b41fc6ed1c837bdd750f4d2f`.

## Checks

- `python3 -m py_compile scripts/eest-stateless-to-input.py`
- deterministic seed-7702 conversion smoke test (5 selected rows)
- detached Spike positive-control run above, denominator 200
