### PR TITLE
fix(harness): sample uniformly over BLOCKS, not fixture files (follow-up to #10597)

### DIFF
--- a/scripts/eest-stateless-to-input.py
+++ b/scripts/eest-stateless-to-input.py
@@ -36,6 +36,12 @@ Usage:
 per-block EEST test label contains the given substring.  ``--skip`` drops the
 first N selected stateless blocks after filtering, then ``--limit`` caps the
 number of guest invocations emitted.
+``--random`` (with ``--seed``) makes ``--limit`` a uniform random sample over
+BLOCKS rather than a truncation: every fixture is parsed to enumerate its
+blocks, ``--limit`` identities are drawn without replacement from that full
+list, and only those blocks are converted.  Enumeration is a parse, not a
+conversion, so the conversion budget is unchanged.  Without ``--random``,
+``--limit`` keeps its cheap truncate-first behaviour for smoke runs.
 ``--verify-input-parity`` unpacks each emitted ziskemu input and checks that
 the guest-visible blob is byte-for-byte the fixture's ``statelessInputBytes``.
 ``--verify-execution-spec-input`` additionally decodes that same blob through
@@ -93,7 +99,7 @@ def stateless_input_block_gas_limit(blob: bytes) -> int:
 
 
 def iter_blocks(fixture_path: Path):
-    """Yield (label, input_bytes, expected_bytes, block_gas_limit) for each stateless block."""
+    """Yield (label, input_bytes, expected_bytes, gas_limit, test_name, bi) per stateless block."""
     try:
         doc = json.loads(fixture_path.read_text())
     except (json.JSONDecodeError, OSError) as exc:  # corrupt / unreadable
@@ -125,7 +131,35 @@ def iter_blocks(fixture_path: Path):
                 # `run_stateless_guest` returns a failed sentinel for them.
                 gas_limit = 0
             label = sanitize(f"{short}#b{bi}")
-            yield label, ib, ob, gas_limit
+            yield label, ib, ob, gas_limit, test_name, bi
+
+
+def iter_block_ids(fixture_path: Path):
+    """Yield (test_name, block_index, label) for each stateless block.
+
+    Enumeration only: this parses the fixture and reads the two stateless keys
+    for presence, but does NOT hex-decode them or compute the gas limit. That
+    is the whole point -- parsing to enumerate is not converting to SSZ, and
+    the conversion is the expensive half. Keep this in step with
+    ``iter_blocks``: a block is enumerable exactly when that function would
+    yield it, or the sampler will pick identities the converter then skips.
+    """
+    try:
+        doc = json.loads(fixture_path.read_text())
+    except (json.JSONDecodeError, OSError) as exc:
+        print(f"  warn: cannot parse {fixture_path}: {exc}", file=sys.stderr)
+        return
+    for test_name, tc in doc.items():
+        blocks = tc.get("blocks") if isinstance(tc, dict) else None
+        if not isinstance(blocks, list):
+            continue
+        short = test_name.split("::")[-1] if "::" in test_name else test_name
+        for bi, blk in enumerate(blocks):
+            if not isinstance(blk, dict):
+                continue
+            if not blk.get("statelessInputBytes") or not blk.get("statelessOutputBytes"):
+                continue  # block opted out of stateless validation
+            yield test_name, bi, sanitize(f"{short}#b{bi}")
 
 
 def load_execution_specs_input_decoder():
@@ -174,9 +208,12 @@ def main() -> int:
     ap.add_argument(
         "--random",
         action="store_true",
-        help="shuffle the fixture FILE list before applying --skip/--limit, so "
-             "the cap selects a spread across the corpus rather than its front "
-             "(GH #10596). Requires --seed.",
+        help="sample --limit BLOCKS uniformly at random from the whole "
+             "enumerated corpus -- block-uniform, not file-uniform. Every "
+             "fixture is parsed to enumerate its blocks, then k identities "
+             "are drawn without replacement and only those are converted. "
+             "Selections are NOT nested across different --limit values. "
+             "Requires --seed. (GH #10596, #10597)",
     )
     ap.add_argument(
         "--seed", type=int, default=None,
@@ -240,14 +277,69 @@ def main() -> int:
     # manifest order tracks fixture family, so the result was a clustered sample
     # presented as a spread one.
     #
-    # The shuffle is over the FILE list, not the block list: blocks are streamed
-    # out of each file by `iter_blocks`, so sampling at block granularity would
-    # mean parsing all ~6.3k fixtures up front, which is most of the conversion
-    # cost the cap exists to avoid. At ~4.1 blocks per file the residual is that
-    # a selected file contributes its handful of blocks together; the
-    # family-level clustering that made the old behaviour misleading is gone.
-    if args.random:
-        random.Random(args.seed).shuffle(json_files)
+    # The sampling unit is the BLOCK, not the fixture file. File-uniform
+    # sampling was the first fix's compromise and it did not hold: 200 rows is
+    # ~53 files of ~3.1k, and failing rows CLUSTER BY FILE because a fixture's
+    # blocks all exercise one scenario, so a file-granular draw can miss a
+    # whole failing family and still report clean. It did exactly that -- a
+    # 200-row draw against a ~3%-failing baseline returned ZERO failing rows,
+    # which is a one-in-three outcome under file sampling and ~3-in-1000 under
+    # block sampling.
+    #
+    # The cost argument that motivated file granularity conflated two things:
+    # PARSING TO ENUMERATE IS NOT CONVERTING TO SSZ. `iter_block_ids` parses
+    # each fixture and lists its blocks without hex-decoding the (large)
+    # stateless payloads, then only the sampled blocks are converted. The
+    # conversion budget is unchanged; the selection is genuinely uniform.
+    selected_ids: set[tuple[str, str, int]] | None = None
+    if args.random and args.limit:
+        corpus: list[tuple[str, str, int]] = []
+        for fp in json_files:
+            relpath = str(fp.relative_to(fixtures_dir))
+            for test_name, bi, label in iter_block_ids(fp):
+                if args.filter and args.filter not in relpath and args.filter not in label:
+                    continue
+                corpus.append((relpath, test_name, bi))
+        if not corpus:
+            print("error: --random enumerated 0 blocks; nothing to sample",
+                  file=sys.stderr)
+            return 1
+        want = min(args.limit, len(corpus))
+        # random.sample is exactly pick-one-then-pick-from-the-rest: k draws
+        # rather than a full 26k-element permutation, same uniform
+        # distribution over k-subsets. SEED SEMANTICS: selections are NOT
+        # nested -- the same seed at --limit 500 is not a superset of the
+        # --limit 200 selection. Nothing here relies on nesting; use a
+        # shuffle-then-slice if you ever need it.
+        picked = random.Random(args.seed).sample(range(len(corpus)), want)
+        selected_ids = {corpus[i] for i in picked}
+
+        # POSITIVE CONTROL ON THE SAMPLER ITSELF, in the script rather than in
+        # prose: the help text already claimed corpus-wide sampling twice and
+        # was wrong both times, so this is asserted rather than documented. A
+        # uniform draw must SPAN the corpus; a selection confined to the front
+        # is the exact defect this replaces.
+        lo, hi = min(picked), max(picked)
+        nfiles = len({c[0] for c in selected_ids})
+        print(f"==> --random: sampled {want} block(s) uniformly from "
+              f"{len(corpus)} across {nfiles} fixture file(s); "
+              f"corpus indices {lo}..{hi}", file=sys.stderr)
+        if want >= 20 and len(corpus) > 4 * want and hi < len(corpus) // 2:
+            print(
+                f"error: sampler self-check FAILED -- {want} blocks drawn from "
+                f"{len(corpus)} but the highest index is {hi}, entirely within "
+                f"the first half of the corpus. Under uniform sampling that is "
+                f"a 2^-{want} event, so the selection is almost certainly not "
+                f"uniform. Refusing to emit a manifest that would be reported "
+                f"as corpus-wide coverage.",
+                file=sys.stderr,
+            )
+            return 1
+    elif args.random:
+        # --random with no --limit selects everything anyway; the flag only
+        # affects WHICH blocks are chosen, and there is nothing to choose.
+        print("==> --random with no --limit: whole corpus selected, "
+              "sampling is a no-op", file=sys.stderr)
 
     selected = 0
     n = 0
@@ -255,8 +347,10 @@ def main() -> int:
     with manifest_path.open("w") as mf:
         for fp in json_files:
             relpath = str(fp.relative_to(fixtures_dir))
-            for label, ib, ob, gas_limit in iter_blocks(fp):
+            for label, ib, ob, gas_limit, test_name, bi in iter_blocks(fp):
                 if args.filter and args.filter not in relpath and args.filter not in label:
+                    continue
+                if selected_ids is not None and (relpath, test_name, bi) not in selected_ids:
                     continue
                 if selected < args.skip:
                     selected += 1


### PR DESCRIPTION
> **Note:** This PR was written by Claude Code.

Follow-up to #10597. That PR fixed the real defect — `--random` never reached the converter — but made the sampling unit the **fixture file**. This makes it the **block**.

## Why file granularity does not hold

200 rows is about **53 files of ~3.1k**, and failing rows **cluster by file**: a fixture's blocks all exercise one scenario. So a file-granular draw can miss an entire failing family and still report clean — which is what happened. A 200-row draw against a ~3%-failing baseline returned **zero** failing rows. That is roughly a one-in-three outcome under file sampling and ~3-in-1000 under block sampling. A regression screen that cannot see regressions is worse than no screen, because its clean result is reported as coverage.

## The cost argument conflated two operations

#10597's rationale was that block sampling means parsing all ~6.3k fixtures up front, "most of the conversion cost the cap exists to avoid". **Parsing to enumerate is not converting to SSZ.** The new `iter_block_ids` parses each fixture and lists its blocks *without* hex-decoding the large stateless payloads or computing gas limits. `--limit` identities are drawn from the full list, and only those blocks are converted — same conversion budget, genuinely uniform selection.

Measured rather than assumed:

| run | result | wall |
|---|---|---|
| `--random --seed 1 --limit 200` | 26104 blocks enumerated, 200 drawn across **118** files | **35.4s** |
| `--limit 200` (no `--random`) | cheap truncate-first preserved | **0.26s** |

Enumeration costs ~35s and is paid **only** when `--random` is passed, so smoke runs are unaffected.

The enumerated **26104** independently matches the row count of a pre-existing block-level manifest produced by an unrelated earlier run — an external check that the enumerator agrees with a separately-derived enumeration to the row.

`random.sample` is used rather than shuffle-then-slice: k draws instead of 26,104 swaps to use 200 of them, with the same uniform distribution over 200-subsets.

## Controls

| control | result |
|---|---|
| **span** | corpus indices `51..25844` of 26104, across **118** files (vs ~53 under file-uniform) |
| **cheap path preserved** | `--limit` without `--random` still truncates, 0.26s |
| **reproducibility** | same seed → byte-identical selection |
| **independence** | seed 1 vs seed 2 overlap **2 of 200** (expected ~1.5 by chance) |
| **negative control on the self-check** | with `random.sample` rigged to return the corpus front, the run **refuses and exits 1**, writing 0 inputs |

That last row is the one I would not have had otherwise. An assertion nobody has seen fail is not known to work, so I forced the failure it exists to catch. Notably the rigged front-of-corpus draw spanned exactly **53 files** — the same figure that characterises the file-uniform behaviour this replaces.

## The self-check is in the script, not in the prose

The help text claimed corpus-wide sampling **twice** and was wrong both times. Prose does not hold a contract. A `--random` run now asserts its selection spans the corpus and **refuses to emit a manifest** that would be reported as corpus-wide coverage.

**Seed semantics**, stated in `--help` because someone will eventually assume otherwise: selections are **not nested** across different `--limit` values, since `random.sample` is used rather than shuffle-then-slice. Nothing in the harness relies on nesting.

## Not done here

The acceptance test — a uniform 200-row draw against main's `FR=936` baseline should contain **≈7 failing rows** (`936/26104 × 200 = 7.2`), where zero would mean the sampler still is not sampling — requires a guest sweep and is pending ELF approval. It will be posted as a comment. The controls above verify the *selection*; that test verifies the *screen*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
