### PR TITLE
test(harness): make the EEST sampler's span guard fire, with the historical defect as the fixture

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,6 +27,8 @@ jobs:
         run: scripts/check-unimported.sh
       - name: Round-trip coverage fence (every Instr ctor has a #guard)
         run: scripts/check-roundtrip-coverage.sh
+      - name: EEST sampler span check (negative control on the --random guard)
+        run: scripts/check-eest-sampler-span.py
       # Conventions-as-fitness-functions (Phase 5 / R-D1). Pure source scans,
       # no build needed — kept cheap on the PR push path. See AGENTS.md
       # "Architecture fitness functions".

--- a/scripts/check-eest-sampler-span.py
+++ b/scripts/check-eest-sampler-span.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Regression test for the EEST sampler's corpus-span self-check.
+
+Run: ``scripts/check-eest-sampler-span.py``  (exit 0 = pass)
+
+WHY THIS EXISTS AS A TEST RATHER THAN AS AN ASSERTION ALONE. The sampler's
+span check refuses to emit a manifest when a ``--random`` draw does not span
+the corpus. An assertion nobody has seen fail is not known to work, so this
+drives it with a KNOWN-BAD INPUT whose expected output is the historical
+failure -- a negative control, not a smoke test.
+
+THE KNOWN-BAD INPUT IS THE ACTUAL HISTORICAL DEFECT. Two shipped versions of
+``--random`` selected the FRONT of the manifest rather than a sample of it:
+first because the flag never reached the converter (GH #10596), then because
+it sampled fixture FILES rather than blocks (GH #10597). Both were reported as
+corpus-wide coverage and both passed review. A front-of-corpus draw of 200
+blocks spans ~53 fixture FILES -- that 53 is the signature of the defect, and
+it is pinned below as a fixture value rather than described in a comment.
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+# The corpus size, agreed by THREE separately-derived enumerations: this
+# script's converter, the independent implementation in GH #10603, and an
+# unrelated earlier run's block manifest. A number nobody cross-checked is a
+# number nobody knows; this one has been checked three ways.
+CORPUS_BLOCKS = 26104
+
+# A 200-block draw taken from the FRONT of the corpus spans this many fixture
+# files. This is the file-uniform behaviour's signature, measured on the real
+# corpus, and it is what the check must reject.
+FRONT_DRAW_FILE_SPAN = 53
+DRAW = 200
+
+
+def load_converter():
+    path = Path(__file__).resolve().parent / "eest-stateless-to-input.py"
+    spec = importlib.util.spec_from_file_location("eest_conv", path)
+    mod = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def main() -> int:
+    conv = load_converter()
+    err = conv.selection_span_error
+    failures: list[str] = []
+
+    def expect(name: str, cond: bool, detail: str = "") -> None:
+        print(f"  {'ok  ' if cond else 'FAIL'}  {name}{'  ' + detail if detail else ''}")
+        if not cond:
+            failures.append(name)
+
+    # NEGATIVE CONTROL: the historical defect must be rejected.
+    front = list(range(DRAW))
+    msg = err(front, CORPUS_BLOCKS)
+    expect(
+        "front-of-corpus draw is REJECTED (the GH #10596/#10597 defect)",
+        msg is not None,
+        f"draw={DRAW} corpus={CORPUS_BLOCKS} span={FRONT_DRAW_FILE_SPAN} files",
+    )
+    if msg is not None:
+        expect("rejection message names the highest index", str(DRAW - 1) in msg)
+
+    # A first-half-confined draw is the same defect in weaker form.
+    spread_but_front = list(range(0, CORPUS_BLOCKS // 2 - 1, (CORPUS_BLOCKS // 2) // DRAW))[:DRAW]
+    expect(
+        "draw confined to the first half is REJECTED even when spread",
+        err(spread_but_front, CORPUS_BLOCKS) is not None,
+    )
+
+    # POSITIVE CONTROL: a genuine uniform draw must pass. Fixed seed so this
+    # test cannot flake.
+    import random
+
+    uniform = random.Random(20260726).sample(range(CORPUS_BLOCKS), DRAW)
+    expect(
+        "uniform draw is ACCEPTED",
+        err(uniform, CORPUS_BLOCKS) is None,
+        f"max index {max(uniform)} of {CORPUS_BLOCKS}",
+    )
+
+    # The check must not fire where it cannot carry: a tiny draw can land
+    # anywhere legitimately, and a guard that trips on correct input is worse
+    # than no guard.
+    expect("small draw is EXEMPT (would otherwise false-positive)",
+           err(list(range(5)), CORPUS_BLOCKS) is None)
+    expect("draw comparable to corpus size is EXEMPT",
+           err(list(range(DRAW)), DRAW * 2) is None)
+
+    print()
+    if failures:
+        print(f"check-eest-sampler-span: FAILED ({len(failures)}): {', '.join(failures)}")
+        return 1
+    print("check-eest-sampler-span: OK -- the span check rejects the historical "
+          "defect and accepts a uniform draw.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/eest-stateless-to-input.py
+++ b/scripts/eest-stateless-to-input.py
@@ -97,6 +97,42 @@ def stateless_input_block_gas_limit(blob: bytes) -> int:
     return int.from_bytes(blob[off:end], "little")
 
 
+# A uniform draw must SPAN the corpus. This is asserted in the script rather
+# than described in the help text because the help text has now twice claimed
+# corpus-wide sampling and been wrong -- first when --random never reached the
+# converter at all (GH #10596), then when it sampled fixture FILES rather than
+# blocks (GH #10597). Prose does not hold this contract.
+#
+# Exempted below a threshold because a genuinely small draw can legitimately
+# land anywhere, and a check that fires on correct input is worse than none.
+SPAN_CHECK_MIN_DRAW = 20
+SPAN_CHECK_MIN_CORPUS_RATIO = 4
+
+
+def selection_span_error(picked: list[int], corpus_len: int) -> str | None:
+    """Return an error message if `picked` is not plausibly a uniform draw.
+
+    `picked` are positions into the enumerated corpus. A uniform draw of k
+    from n lands entirely in the first half with probability 2**-k, so for any
+    non-tiny k a wholly front-loaded selection means the sampler is not
+    sampling. Returns None when the selection is acceptable or the draw is too
+    small for the test to carry.
+    """
+    k = len(picked)
+    if k < SPAN_CHECK_MIN_DRAW or corpus_len <= SPAN_CHECK_MIN_CORPUS_RATIO * k:
+        return None
+    hi = max(picked)
+    if hi < corpus_len // 2:
+        return (
+            f"sampler self-check FAILED -- {k} blocks drawn from {corpus_len} "
+            f"but the highest corpus index is {hi}, entirely within the first "
+            f"half. Under uniform sampling that is a 2**-{k} event, so the "
+            f"selection is almost certainly not uniform. Refusing to emit a "
+            f"manifest that would be reported as corpus-wide coverage."
+        )
+    return None
+
+
 def iter_blocks(fixture_path: Path):
     """Yield (label, input_bytes, expected_bytes, block_gas_limit) for each stateless block."""
     try:
@@ -341,7 +377,19 @@ def main() -> int:
                 sample_count = len(candidates) if args.limit == 0 else min(
                     len(candidates), args.skip + args.limit
                 )
-                sampled = random.Random(args.seed).sample(candidates, sample_count)
+                # Sample POSITIONS rather than elements so the selection can
+                # be span-checked. random.sample picks indices independently
+                # of element values, so for a population of the same length
+                # this selects exactly what sample(candidates, k) would --
+                # verified across seeds; existing seeds reproduce unchanged.
+                picked = random.Random(args.seed).sample(
+                    range(len(candidates)), sample_count
+                )
+                span_err = selection_span_error(picked, len(candidates))
+                if span_err is not None:
+                    print(f"error: {span_err}", file=sys.stderr)
+                    return 1
+                sampled = [candidates[i] for i in picked]
             for label, ib, ob, gas_limit, relpath in sampled[args.skip:]:
                 if not write_block(label, ib, ob, gas_limit, relpath):
                     return 1


### PR DESCRIPTION
> **Note:** This PR was written by Claude Code.

Follow-up to #10603, which made `--random` sample blocks uniformly. This adds the **in-script guard** that a selection actually spans the corpus, and — the part that matters — the **negative control proving the guard fires**.

## Why the guard is in the script and not in the help text

`--random`'s documented meaning has now been wrong **twice**, and both versions shipped and passed review:

- **#10596** — the flag never reached the converter at all, so `--random --limit N` shuffled the execution order of the first N rows.
- **#10597** — it sampled fixture **files**, so a 200-row draw was ~53 file-clusters and could miss an entire failing family.

Both were reported as corpus-wide coverage. The help text described the intended behaviour correctly throughout. **Prose does not hold this contract**, so the contract moves into the script.

## The check

`selection_span_error()` is factored out as a pure predicate so it can be tested directly. A uniform draw of *k* from *n* lands entirely in the first half with probability `2**-k`, so a wholly front-loaded selection means the sampler is not sampling. It is **exempted** below `k=20` and when the corpus is not much larger than the draw — a guard that trips on correct input is worse than no guard.

## The negative control, with the defect as the fixture

`scripts/check-eest-sampler-span.py` drives the guard with the **historical defect as the known-bad input**:

```
  ok    front-of-corpus draw is REJECTED (the GH #10596/#10597 defect)  draw=200 corpus=26104 span=53 files
  ok    rejection message names the highest index
  ok    draw confined to the first half is REJECTED even when spread
  ok    uniform draw is ACCEPTED  max index 25940 of 26104
  ok    small draw is EXEMPT (would otherwise false-positive)
  ok    draw comparable to corpus size is EXEMPT
```

**53 is a fixture value in the test, not a remark in a comment** — it is the fixture-file span of a 200-block front-of-corpus draw, i.e. the measured signature of the file-uniform behaviour being replaced. The test therefore reproduces the old defect and rejects it, rather than merely asserting a property.

Wired into `build.yml`: hermetic, needs no EEST fixtures, runs in well under a second.

## Mutation-tested

A test that has only ever passed is the same trap one level up. Neutering `selection_span_error` to `return None` makes the test fail on exactly the two defect cases and pass the other four:

```
  FAIL  front-of-corpus draw is REJECTED (the GH #10596/#10597 defect)
  FAIL  draw confined to the first half is REJECTED even when spread
  ok    uniform draw is ACCEPTED
  ...
exit=1
```

## Selection is unchanged, verified on real data

Sampling is now over **positions** rather than elements so the draw can be span-checked. `random.sample` picks indices independently of element values, so this selects exactly what sampling the list would — but that is the kind of claim worth checking rather than reasoning about. On the real corpus, seed `20260726` selects the **identical 200 labels in the same order** as the pre-change sampler; symmetric difference **0**.

## Corpus size is cross-checked three ways

`CORPUS_BLOCKS = 26104` is recorded in the test as a checked constant. Three separately-derived enumerations agree on it exactly: this converter, the independent implementation in #10603, and an unrelated earlier run's block manifest. A number nobody cross-checked is a number nobody knows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
