### PR TITLE
chore(harness): preserve lhkn7 semantic-boundary tools

### DIFF
--- a/scripts/lhkn7-semantic-boundary-v2-analyze.py
+++ b/scripts/lhkn7-semantic-boundary-v2-analyze.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""Analyze semantic-boundary-v2 diagnostic output without raw-delta IDs."""
+
+import argparse
+import csv
+import json
+from collections import Counter, defaultdict
+
+
+def number(row, key):
+    value = row[key]
+    return 0 if value == "" else int(value)
+
+
+def delta_bucket(value):
+    magnitude = abs(value)
+    if magnitude == 0:
+        return "zero"
+    if magnitude <= 1024:
+        return f"small:{magnitude}"
+    if magnitude <= 1_000_000:
+        return "medium"
+    return "large"
+
+
+def relation(row):
+    header = number(row, "u64_120")
+    maximum = number(row, "u64_128")
+    tx_count = number(row, "u64_144")
+    regular = number(row, "u64_152")
+    state = number(row, "u64_160")
+    before = number(row, "u64_168")
+    first_limit = number(row, "u64_176")
+    arena_status = number(row, "u64_184")
+    arena_index = number(row, "u64_192")
+    runtime_count = number(row, "u64_208")
+    eip_status = number(row, "u64_216")
+    eip_index = number(row, "u64_224")
+    auth_success = number(row, "u64_232")
+    rolled_back = number(row, "u64_240")
+    mtx_i = number(row, "u64_248")
+    fail_code = number(row, "u64_112")
+    # Header gas_used is nonzero for this tx-bearing diagnostic population.
+    # A zero header+expected pair therefore means ExactGas never wrote it, not
+    # a computed zero. Undefined fields must not shape root identities.
+    settlement_reached = header != 0 or maximum != 0
+    first_index = f"arena:{arena_index}" if arena_index else (
+        f"eip:{eip_index}" if eip_index else "NONE"
+    )
+    mask = {
+        "tx": "one" if tx_count == 1 else "many",
+        "settlement": "reached" if settlement_reached else f"early:code{fail_code}",
+    }
+    if not settlement_reached:
+        return mask, {"gas": "UNWRITTEN"}, {}
+    mask.update({
+        "H=before": header == before,
+        "H=first_limit": header == first_limit,
+        "H=max": header == maximum,
+        "max=state": maximum == state,
+        "max=regular": maximum == regular,
+        "before=regular+state": before == regular + state,
+        "state_zero": state == 0,
+        "regular_zero": regular == 0,
+        "arena_ok": arena_status == 0,
+        "runtime_complete": runtime_count == tx_count,
+        "eip7778_ok": eip_status == 0,
+        "auth_success_nonzero": auth_success != 0,
+        "rolled_back": rolled_back != 0,
+        "mtx_i_eq_tx_count": mtx_i == tx_count,
+        "first_index": first_index,
+    })
+    raw = {
+        "d_Hmax": header - maximum,
+        "d_before_sum": before - regular - state,
+        "d_limit_header": first_limit - header,
+        "before_minus_state_regular": before - state - regular,
+    }
+    return mask, {name: delta_bucket(value) for name, value in raw.items()}, raw
+
+
+def root_id(mask, buckets):
+    # Exact raw deltas never form identities; cardinality is reported separately.
+    return tuple(mask.items()), tuple(buckets.items())
+
+
+def compact(obj):
+    return json.dumps(obj, sort_keys=True, separators=(",", ":"))
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("tsv")
+    parser.add_argument("--expected-rows", type=int, required=True)
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    with open(args.tsv, newline="") as source:
+        rows = list(csv.DictReader(
+            (line for line in source if not line.startswith("#")), delimiter="\t"))
+    assert len(rows) == args.expected_rows, (
+        f"selected denominator {len(rows)} != {args.expected_rows}")
+    assert len({row["label"] for row in rows}) == len(rows), "labels are not unique"
+    frs = [row for row in rows if row["cat"] == "FR"]
+    print(f"denominator={len(rows)} FR={len(frs)} "
+          f"categories={dict(sorted(Counter(row['cat'] for row in rows).items()))}")
+
+    groups = defaultdict(list)
+    row_relation = {}
+    for row in rows:
+        mask, buckets, raw = relation(row)
+        key = root_id(mask, buckets)
+        if row["cat"] == "FR":
+            groups[key].append((row, mask, buckets, raw))
+        row_relation[row["label"]] = (key, mask, buckets, raw)
+
+    sizes = Counter(map(len, groups.values()))
+    print(f"roots={len(groups)} largest={max(map(len, groups.values()), default=0)} "
+          f"singletons={sizes[1]} size_distribution={dict(sorted(sizes.items()))}")
+    ranked = sorted(groups.items(), key=lambda item: (-len(item[1]), item[1][0][0]["label"]))
+    for ordinal, (_, entries) in enumerate(ranked, 1):
+        rows_here = [entry[0] for entry in entries]
+        cardinalities = {
+            name: len({entry[3][name] for entry in entries}) for name in entries[0][3]
+        }
+        codes = dict(sorted(Counter(number(row, "u64_112") for row in rows_here).items()))
+        reps = ",".join(row["label"] for row in rows_here[:6])
+        print(f"ROOT {ordinal} count={len(entries)} reps={reps} codes={codes} "
+              f"mask={compact(entries[0][1])} buckets={compact(entries[0][2])} "
+              f"raw_cardinality={compact(cardinalities)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/lhkn7-semantic-boundary-v2-sweep.py
+++ b/scripts/lhkn7-semantic-boundary-v2-sweep.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Run a semantic-boundary-v2 diagnostic sweep against an immutable ELF.
+
+The diagnostic schema uses output bytes 112..255.  It is intentionally
+diagnostic-only and must not be used to establish production verdict results.
+Set LHKN7_SELECTOR_MODE to record whether the input ELF uses normal or forced
+routing.  Optional LHKN7_PROVENANCE is copied verbatim into the TSV header.
+"""
+
+import csv
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import threading
+from collections import Counter
+from concurrent.futures import ThreadPoolExecutor
+
+MANIFEST = "/tmp/fc668/in/manifest.tsv"
+SPIKE = "/home/zksecurity/evm-asm4/scripts/spike/spike_run"
+FULL_DENOMINATOR = 26104
+
+
+def fail(message):
+    raise SystemExit(message)
+
+
+if len(sys.argv) not in (3, 4):
+    fail(f"usage: {sys.argv[0]} ELF OUT.tsv [PRIOR_TSV]")
+
+elf, out_tsv = sys.argv[1:3]
+prior_tsv = sys.argv[3] if len(sys.argv) == 4 else None
+labels_file = os.environ.get("LHKN7_LABELS_FILE")
+workers = int(os.environ.get("WORKERS", "30"))
+selector_mode = os.environ.get("LHKN7_SELECTOR_MODE")
+if selector_mode not in {"forced", "normal"}:
+    fail("set LHKN7_SELECTOR_MODE=forced or normal")
+
+with open(MANIFEST) as source:
+    rows = [tuple(line.rstrip("\n").split("\t")[:4]) for line in source
+            if len(line.rstrip("\n").split("\t")) >= 7]
+if len(rows) != FULL_DENOMINATOR:
+    fail(f"manifest denominator mismatch: {len(rows)} != {FULL_DENOMINATOR}")
+
+if prior_tsv and labels_file:
+    fail("use either PRIOR_TSV or LHKN7_LABELS_FILE, not both")
+mode = "full-manifest"
+if labels_file:
+    with open(labels_file) as source:
+        wanted = {line.strip() for line in source if line.strip()}
+    rows = [row for row in rows if row[0] in wanted]
+    if len(rows) != len(wanted):
+        fail(f"selected labels missing from manifest: wanted={len(wanted)} found={len(rows)}")
+    mode = "focused-label-file"
+    print(f"focused mode: {len(rows)} labels selected from {labels_file}", flush=True)
+elif prior_tsv:
+    with open(prior_tsv) as source:
+        prior_meta = [line.rstrip("\n") for line in source if line.startswith("#")]
+    prior_selector = next((line.split("=", 1)[1] for line in prior_meta
+                           if line.startswith("# selector_mode=")), None)
+    if prior_selector != selector_mode:
+        fail(f"selector-mode mismatch: candidate={selector_mode} prior={prior_selector!r}")
+    with open(prior_tsv) as source:
+        prior_rows = list(csv.DictReader(
+            (line for line in source if not line.startswith("#")), delimiter="\t"))
+    if len(prior_rows) != FULL_DENOMINATOR:
+        fail(f"prior denominator mismatch: {len(prior_rows)} != {FULL_DENOMINATOR}")
+    wanted = {row["label"] for row in prior_rows if row["cat"] == "FR"}
+    rows = [row for row in rows if row[0] in wanted]
+    if len(rows) != len(wanted):
+        fail(f"focused labels missing from manifest: wanted={len(wanted)} found={len(rows)}")
+    mode = "focused-prior-FR"
+    print(f"focused mode: {len(rows)} labels selected from {prior_tsv}", flush=True)
+print(f"loaded {len(rows)} rows; elf={elf}; workers={workers}", flush=True)
+
+
+def classify(row):
+    label, inp, expected_hex, oracle_succ = row
+    tmpdir = tempfile.mkdtemp(prefix=f"lhkn7_{threading.get_ident()}_")
+    try:
+        output = os.path.join(tmpdir, "out.bin")
+        try:
+            env = dict(os.environ, SPIKE_OUTPUT_LEN="256")
+            result = subprocess.run([SPIKE, elf, inp, output], env=env,
+                                    stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+                                    timeout=120)
+            rc = result.returncode
+        except subprocess.TimeoutExpired:
+            return (label, oracle_succ, "?", *([""] * 18), False, "TIMEOUT", 0, "FAULT")
+        try:
+            data = open(output, "rb").read()
+        except OSError:
+            data = b""
+        succ = str(data[32]) if len(data) > 32 else "?"
+        words = [int.from_bytes(data[offset:offset + 8], "little")
+                 if len(data) >= offset + 8 else "" for offset in range(112, 256, 8)]
+        match = len(data) >= len(expected_hex) // 2 and data[:len(expected_hex) // 2].hex() == expected_hex
+        fault = rc != 0 or len(data) <= 32
+        cat = "FA" if succ == "1" and oracle_succ == "0" else (
+            "FR" if succ == "0" and oracle_succ == "1" else ("FAULT" if fault else "OK"))
+        return (label, oracle_succ, succ, *words, match, rc, len(data), cat)
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+done = 0
+lock = threading.Lock()
+
+
+def report(row):
+    global done
+    value = classify(row)
+    with lock:
+        done += 1
+        if done % 500 == 0:
+            print(f"  {done}/{len(rows)}", flush=True)
+    return value
+
+
+with ThreadPoolExecutor(max_workers=workers) as executor:
+    results = list(executor.map(report, rows))
+if len(results) != len(rows):
+    fail(f"result denominator mismatch: {len(results)} != {len(rows)}")
+
+with open(out_tsv, "w") as output:
+    fields = ["label", "oracle_succ", "guest_succ"] + [f"u64_{offset}" for offset in range(112, 256, 8)] + ["match", "rc", "len", "cat"]
+    output.write("# schema=semantic-boundary-v2\n")
+    output.write(f"# selector_mode={selector_mode}\n")
+    if provenance := os.environ.get("LHKN7_PROVENANCE"):
+        output.write(f"# provenance={provenance}\n")
+    output.write(f"# selected_rows={len(rows)}; mode={mode}; root-analysis population=FR rows only\n")
+    output.write("\t".join(fields) + "\n")
+    for result in results:
+        output.write("\t".join(map(str, result)) + "\n")
+
+counts = Counter(row[-1] for row in results)
+codes = Counter(row[3] for row in results if row[-1] == "FR")
+print(f"DONE denominator={len(results)} categories={dict(counts)}", flush=True)
+print(f"FR internal-code census={dict(codes)}", flush=True)


### PR DESCRIPTION
Preserves the diagnostic-only semantic-boundary-v2 sweep and analyzer that were previously untracked in the lhkn7 phase1 worktree. The tools explicitly record selector mode, assert manifest denominators, and keep raw deltas out of root identities. No emitted Lean sources or generated artifacts change.