### PR TITLE
chore: batch-merge #10605, #10606

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,6 +27,8 @@ jobs:
         run: scripts/check-unimported.sh
       - name: Round-trip coverage fence (every Instr ctor has a #guard)
         run: scripts/check-roundtrip-coverage.sh
+      - name: EEST sampler span check (negative control on the --random guard)
+        run: scripts/check-eest-sampler-span.py
       # Conventions-as-fitness-functions (Phase 5 / R-D1). Pure source scans,
       # no build needed — kept cheap on the PR push path. See AGENTS.md
       # "Architecture fitness functions".

--- a/scripts/check-eest-sampler-span.py
+++ b/scripts/check-eest-sampler-span.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Regression test for the EEST sampler's corpus-span self-check.
+
+Run: ``scripts/check-eest-sampler-span.py``  (exit 0 = pass)
+
+WHY THIS EXISTS AS A TEST RATHER THAN AS AN ASSERTION ALONE. The sampler's
+span check refuses to emit a manifest when a ``--random`` draw does not span
+the corpus. An assertion nobody has seen fail is not known to work, so this
+drives it with a KNOWN-BAD INPUT whose expected output is the historical
+failure -- a negative control, not a smoke test.
+
+THE KNOWN-BAD INPUT IS THE ACTUAL HISTORICAL DEFECT. Two shipped versions of
+``--random`` selected the FRONT of the manifest rather than a sample of it:
+first because the flag never reached the converter (GH #10596), then because
+it sampled fixture FILES rather than blocks (GH #10597). Both were reported as
+corpus-wide coverage and both passed review. A front-of-corpus draw of 200
+blocks spans ~53 fixture FILES -- that 53 is the signature of the defect, and
+it is pinned below as a fixture value rather than described in a comment.
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+# The corpus size, agreed by THREE separately-derived enumerations: this
+# script's converter, the independent implementation in GH #10603, and an
+# unrelated earlier run's block manifest. A number nobody cross-checked is a
+# number nobody knows; this one has been checked three ways.
+CORPUS_BLOCKS = 26104
+
+# A 200-block draw taken from the FRONT of the corpus spans this many fixture
+# files. This is the file-uniform behaviour's signature, measured on the real
+# corpus, and it is what the check must reject.
+FRONT_DRAW_FILE_SPAN = 53
+DRAW = 200
+
+
+def load_converter():
+    path = Path(__file__).resolve().parent / "eest-stateless-to-input.py"
+    spec = importlib.util.spec_from_file_location("eest_conv", path)
+    mod = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def main() -> int:
+    conv = load_converter()
+    err = conv.selection_span_error
+    failures: list[str] = []
+
+    def expect(name: str, cond: bool, detail: str = "") -> None:
+        print(f"  {'ok  ' if cond else 'FAIL'}  {name}{'  ' + detail if detail else ''}")
+        if not cond:
+            failures.append(name)
+
+    # NEGATIVE CONTROL: the historical defect must be rejected.
+    front = list(range(DRAW))
+    msg = err(front, CORPUS_BLOCKS)
+    expect(
+        "front-of-corpus draw is REJECTED (the GH #10596/#10597 defect)",
+        msg is not None,
+        f"draw={DRAW} corpus={CORPUS_BLOCKS} span={FRONT_DRAW_FILE_SPAN} files",
+    )
+    if msg is not None:
+        expect("rejection message names the highest index", str(DRAW - 1) in msg)
+
+    # A first-half-confined draw is the same defect in weaker form.
+    spread_but_front = list(range(0, CORPUS_BLOCKS // 2 - 1, (CORPUS_BLOCKS // 2) // DRAW))[:DRAW]
+    expect(
+        "draw confined to the first half is REJECTED even when spread",
+        err(spread_but_front, CORPUS_BLOCKS) is not None,
+    )
+
+    # POSITIVE CONTROL: a genuine uniform draw must pass. Fixed seed so this
+    # test cannot flake.
+    import random
+
+    uniform = random.Random(20260726).sample(range(CORPUS_BLOCKS), DRAW)
+    expect(
+        "uniform draw is ACCEPTED",
+        err(uniform, CORPUS_BLOCKS) is None,
+        f"max index {max(uniform)} of {CORPUS_BLOCKS}",
+    )
+
+    # The check must not fire where it cannot carry: a tiny draw can land
+    # anywhere legitimately, and a guard that trips on correct input is worse
+    # than no guard.
+    expect("small draw is EXEMPT (would otherwise false-positive)",
+           err(list(range(5)), CORPUS_BLOCKS) is None)
+    expect("draw comparable to corpus size is EXEMPT",
+           err(list(range(DRAW)), DRAW * 2) is None)
+
+    print()
+    if failures:
+        print(f"check-eest-sampler-span: FAILED ({len(failures)}): {', '.join(failures)}")
+        return 1
+    print("check-eest-sampler-span: OK -- the span check rejects the historical "
+          "defect and accepts a uniform draw.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/eest-stateless-to-input.py
+++ b/scripts/eest-stateless-to-input.py
@@ -97,6 +97,42 @@ def stateless_input_block_gas_limit(blob: bytes) -> int:
     return int.from_bytes(blob[off:end], "little")
 
 
+# A uniform draw must SPAN the corpus. This is asserted in the script rather
+# than described in the help text because the help text has now twice claimed
+# corpus-wide sampling and been wrong -- first when --random never reached the
+# converter at all (GH #10596), then when it sampled fixture FILES rather than
+# blocks (GH #10597). Prose does not hold this contract.
+#
+# Exempted below a threshold because a genuinely small draw can legitimately
+# land anywhere, and a check that fires on correct input is worse than none.
+SPAN_CHECK_MIN_DRAW = 20
+SPAN_CHECK_MIN_CORPUS_RATIO = 4
+
+
+def selection_span_error(picked: list[int], corpus_len: int) -> str | None:
+    """Return an error message if `picked` is not plausibly a uniform draw.
+
+    `picked` are positions into the enumerated corpus. A uniform draw of k
+    from n lands entirely in the first half with probability 2**-k, so for any
+    non-tiny k a wholly front-loaded selection means the sampler is not
+    sampling. Returns None when the selection is acceptable or the draw is too
+    small for the test to carry.
+    """
+    k = len(picked)
+    if k < SPAN_CHECK_MIN_DRAW or corpus_len <= SPAN_CHECK_MIN_CORPUS_RATIO * k:
+        return None
+    hi = max(picked)
+    if hi < corpus_len // 2:
+        return (
+            f"sampler self-check FAILED -- {k} blocks drawn from {corpus_len} "
+            f"but the highest corpus index is {hi}, entirely within the first "
+            f"half. Under uniform sampling that is a 2**-{k} event, so the "
+            f"selection is almost certainly not uniform. Refusing to emit a "
+            f"manifest that would be reported as corpus-wide coverage."
+        )
+    return None
+
+
 def iter_blocks(fixture_path: Path):
     """Yield (label, input_bytes, expected_bytes, block_gas_limit) for each stateless block."""
     try:
@@ -341,7 +377,19 @@ def main() -> int:
                 sample_count = len(candidates) if args.limit == 0 else min(
                     len(candidates), args.skip + args.limit
                 )
-                sampled = random.Random(args.seed).sample(candidates, sample_count)
+                # Sample POSITIONS rather than elements so the selection can
+                # be span-checked. random.sample picks indices independently
+                # of element values, so for a population of the same length
+                # this selects exactly what sample(candidates, k) would --
+                # verified across seeds; existing seeds reproduce unchanged.
+                picked = random.Random(args.seed).sample(
+                    range(len(candidates)), sample_count
+                )
+                span_err = selection_span_error(picked, len(candidates))
+                if span_err is not None:
+                    print(f"error: {span_err}", file=sys.stderr)
+                    return 1
+                sampled = [candidates[i] for i in picked]
             for label, ib, ob, gas_limit, relpath in sampled[args.skip:]:
                 if not write_block(label, ib, ob, gas_limit, relpath):
                     return 1

--- a/scripts/lhkn7-semantic-boundary-v2-analyze.py
+++ b/scripts/lhkn7-semantic-boundary-v2-analyze.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""Analyze semantic-boundary-v2 diagnostic output without raw-delta IDs."""
+
+import argparse
+import csv
+import json
+from collections import Counter, defaultdict
+
+
+def number(row, key):
+    value = row[key]
+    return 0 if value == "" else int(value)
+
+
+def delta_bucket(value):
+    magnitude = abs(value)
+    if magnitude == 0:
+        return "zero"
+    if magnitude <= 1024:
+        return f"small:{magnitude}"
+    if magnitude <= 1_000_000:
+        return "medium"
+    return "large"
+
+
+def relation(row):
+    header = number(row, "u64_120")
+    maximum = number(row, "u64_128")
+    tx_count = number(row, "u64_144")
+    regular = number(row, "u64_152")
+    state = number(row, "u64_160")
+    before = number(row, "u64_168")
+    first_limit = number(row, "u64_176")
+    arena_status = number(row, "u64_184")
+    arena_index = number(row, "u64_192")
+    runtime_count = number(row, "u64_208")
+    eip_status = number(row, "u64_216")
+    eip_index = number(row, "u64_224")
+    auth_success = number(row, "u64_232")
+    rolled_back = number(row, "u64_240")
+    mtx_i = number(row, "u64_248")
+    fail_code = number(row, "u64_112")
+    # Header gas_used is nonzero for this tx-bearing diagnostic population.
+    # A zero header+expected pair therefore means ExactGas never wrote it, not
+    # a computed zero. Undefined fields must not shape root identities.
+    settlement_reached = header != 0 or maximum != 0
+    first_index = f"arena:{arena_index}" if arena_index else (
+        f"eip:{eip_index}" if eip_index else "NONE"
+    )
+    mask = {
+        "tx": "one" if tx_count == 1 else "many",
+        "settlement": "reached" if settlement_reached else f"early:code{fail_code}",
+    }
+    if not settlement_reached:
+        return mask, {"gas": "UNWRITTEN"}, {}
+    mask.update({
+        "H=before": header == before,
+        "H=first_limit": header == first_limit,
+        "H=max": header == maximum,
+        "max=state": maximum == state,
+        "max=regular": maximum == regular,
+        "before=regular+state": before == regular + state,
+        "state_zero": state == 0,
+        "regular_zero": regular == 0,
+        "arena_ok": arena_status == 0,
+        "runtime_complete": runtime_count == tx_count,
+        "eip7778_ok": eip_status == 0,
+        "auth_success_nonzero": auth_success != 0,
+        "rolled_back": rolled_back != 0,
+        "mtx_i_eq_tx_count": mtx_i == tx_count,
+        "first_index": first_index,
+    })
+    raw = {
+        "d_Hmax": header - maximum,
+        "d_before_sum": before - regular - state,
+        "d_limit_header": first_limit - header,
+        "before_minus_state_regular": before - state - regular,
+    }
+    return mask, {name: delta_bucket(value) for name, value in raw.items()}, raw
+
+
+def root_id(mask, buckets):
+    # Exact raw deltas never form identities; cardinality is reported separately.
+    return tuple(mask.items()), tuple(buckets.items())
+
+
+def compact(obj):
+    return json.dumps(obj, sort_keys=True, separators=(",", ":"))
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("tsv")
+    parser.add_argument("--expected-rows", type=int, required=True)
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    with open(args.tsv, newline="") as source:
+        rows = list(csv.DictReader(
+            (line for line in source if not line.startswith("#")), delimiter="\t"))
+    assert len(rows) == args.expected_rows, (
+        f"selected denominator {len(rows)} != {args.expected_rows}")
+    assert len({row["label"] for row in rows}) == len(rows), "labels are not unique"
+    frs = [row for row in rows if row["cat"] == "FR"]
+    print(f"denominator={len(rows)} FR={len(frs)} "
+          f"categories={dict(sorted(Counter(row['cat'] for row in rows).items()))}")
+
+    groups = defaultdict(list)
+    row_relation = {}
+    for row in rows:
+        mask, buckets, raw = relation(row)
+        key = root_id(mask, buckets)
+        if row["cat"] == "FR":
+            groups[key].append((row, mask, buckets, raw))
+        row_relation[row["label"]] = (key, mask, buckets, raw)
+
+    sizes = Counter(map(len, groups.values()))
+    print(f"roots={len(groups)} largest={max(map(len, groups.values()), default=0)} "
+          f"singletons={sizes[1]} size_distribution={dict(sorted(sizes.items()))}")
+    ranked = sorted(groups.items(), key=lambda item: (-len(item[1]), item[1][0][0]["label"]))
+    for ordinal, (_, entries) in enumerate(ranked, 1):
+        rows_here = [entry[0] for entry in entries]
+        cardinalities = {
+            name: len({entry[3][name] for entry in entries}) for name in entries[0][3]
+        }
+        codes = dict(sorted(Counter(number(row, "u64_112") for row in rows_here).items()))
+        reps = ",".join(row["label"] for row in rows_here[:6])
+        print(f"ROOT {ordinal} count={len(entries)} reps={reps} codes={codes} "
+              f"mask={compact(entries[0][1])} buckets={compact(entries[0][2])} "
+              f"raw_cardinality={compact(cardinalities)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/lhkn7-semantic-boundary-v2-sweep.py
+++ b/scripts/lhkn7-semantic-boundary-v2-sweep.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Run a semantic-boundary-v2 diagnostic sweep against an immutable ELF.
+
+The diagnostic schema uses output bytes 112..255.  It is intentionally
+diagnostic-only and must not be used to establish production verdict results.
+Set LHKN7_SELECTOR_MODE to record whether the input ELF uses normal or forced
+routing.  Optional LHKN7_PROVENANCE is copied verbatim into the TSV header.
+"""
+
+import csv
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import threading
+from collections import Counter
+from concurrent.futures import ThreadPoolExecutor
+
+MANIFEST = "/tmp/fc668/in/manifest.tsv"
+SPIKE = "/home/zksecurity/evm-asm4/scripts/spike/spike_run"
+FULL_DENOMINATOR = 26104
+
+
+def fail(message):
+    raise SystemExit(message)
+
+
+if len(sys.argv) not in (3, 4):
+    fail(f"usage: {sys.argv[0]} ELF OUT.tsv [PRIOR_TSV]")
+
+elf, out_tsv = sys.argv[1:3]
+prior_tsv = sys.argv[3] if len(sys.argv) == 4 else None
+labels_file = os.environ.get("LHKN7_LABELS_FILE")
+workers = int(os.environ.get("WORKERS", "30"))
+selector_mode = os.environ.get("LHKN7_SELECTOR_MODE")
+if selector_mode not in {"forced", "normal"}:
+    fail("set LHKN7_SELECTOR_MODE=forced or normal")
+
+with open(MANIFEST) as source:
+    rows = [tuple(line.rstrip("\n").split("\t")[:4]) for line in source
+            if len(line.rstrip("\n").split("\t")) >= 7]
+if len(rows) != FULL_DENOMINATOR:
+    fail(f"manifest denominator mismatch: {len(rows)} != {FULL_DENOMINATOR}")
+
+if prior_tsv and labels_file:
+    fail("use either PRIOR_TSV or LHKN7_LABELS_FILE, not both")
+mode = "full-manifest"
+if labels_file:
+    with open(labels_file) as source:
+        wanted = {line.strip() for line in source if line.strip()}
+    rows = [row for row in rows if row[0] in wanted]
+    if len(rows) != len(wanted):
+        fail(f"selected labels missing from manifest: wanted={len(wanted)} found={len(rows)}")
+    mode = "focused-label-file"
+    print(f"focused mode: {len(rows)} labels selected from {labels_file}", flush=True)
+elif prior_tsv:
+    with open(prior_tsv) as source:
+        prior_meta = [line.rstrip("\n") for line in source if line.startswith("#")]
+    prior_selector = next((line.split("=", 1)[1] for line in prior_meta
+                           if line.startswith("# selector_mode=")), None)
+    if prior_selector != selector_mode:
+        fail(f"selector-mode mismatch: candidate={selector_mode} prior={prior_selector!r}")
+    with open(prior_tsv) as source:
+        prior_rows = list(csv.DictReader(
+            (line for line in source if not line.startswith("#")), delimiter="\t"))
+    if len(prior_rows) != FULL_DENOMINATOR:
+        fail(f"prior denominator mismatch: {len(prior_rows)} != {FULL_DENOMINATOR}")
+    wanted = {row["label"] for row in prior_rows if row["cat"] == "FR"}
+    rows = [row for row in rows if row[0] in wanted]
+    if len(rows) != len(wanted):
+        fail(f"focused labels missing from manifest: wanted={len(wanted)} found={len(rows)}")
+    mode = "focused-prior-FR"
+    print(f"focused mode: {len(rows)} labels selected from {prior_tsv}", flush=True)
+print(f"loaded {len(rows)} rows; elf={elf}; workers={workers}", flush=True)
+
+
+def classify(row):
+    label, inp, expected_hex, oracle_succ = row
+    tmpdir = tempfile.mkdtemp(prefix=f"lhkn7_{threading.get_ident()}_")
+    try:
+        output = os.path.join(tmpdir, "out.bin")
+        try:
+            env = dict(os.environ, SPIKE_OUTPUT_LEN="256")
+            result = subprocess.run([SPIKE, elf, inp, output], env=env,
+                                    stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+                                    timeout=120)
+            rc = result.returncode
+        except subprocess.TimeoutExpired:
+            return (label, oracle_succ, "?", *([""] * 18), False, "TIMEOUT", 0, "FAULT")
+        try:
+            data = open(output, "rb").read()
+        except OSError:
+            data = b""
+        succ = str(data[32]) if len(data) > 32 else "?"
+        words = [int.from_bytes(data[offset:offset + 8], "little")
+                 if len(data) >= offset + 8 else "" for offset in range(112, 256, 8)]
+        match = len(data) >= len(expected_hex) // 2 and data[:len(expected_hex) // 2].hex() == expected_hex
+        fault = rc != 0 or len(data) <= 32
+        cat = "FA" if succ == "1" and oracle_succ == "0" else (
+            "FR" if succ == "0" and oracle_succ == "1" else ("FAULT" if fault else "OK"))
+        return (label, oracle_succ, succ, *words, match, rc, len(data), cat)
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+done = 0
+lock = threading.Lock()
+
+
+def report(row):
+    global done
+    value = classify(row)
+    with lock:
+        done += 1
+        if done % 500 == 0:
+            print(f"  {done}/{len(rows)}", flush=True)
+    return value
+
+
+with ThreadPoolExecutor(max_workers=workers) as executor:
+    results = list(executor.map(report, rows))
+if len(results) != len(rows):
+    fail(f"result denominator mismatch: {len(results)} != {len(rows)}")
+
+with open(out_tsv, "w") as output:
+    fields = ["label", "oracle_succ", "guest_succ"] + [f"u64_{offset}" for offset in range(112, 256, 8)] + ["match", "rc", "len", "cat"]
+    output.write("# schema=semantic-boundary-v2\n")
+    output.write(f"# selector_mode={selector_mode}\n")
+    if provenance := os.environ.get("LHKN7_PROVENANCE"):
+        output.write(f"# provenance={provenance}\n")
+    output.write(f"# selected_rows={len(rows)}; mode={mode}; root-analysis population=FR rows only\n")
+    output.write("\t".join(fields) + "\n")
+    for result in results:
+        output.write("\t".join(map(str, result)) + "\n")
+
+counts = Counter(row[-1] for row in results)
+codes = Counter(row[3] for row in results if row[-1] == "FR")
+print(f"DONE denominator={len(results)} categories={dict(counts)}", flush=True)
+print(f"FR internal-code census={dict(codes)}", flush=True)


### PR DESCRIPTION
## Summary

Batches 2 `merge!`-labeled PRs to amortize CI. Both are pure harness/tooling changes — no guest
codegen, no generated layout files touched:

- #10605 — test(harness): make the EEST sampler's span guard fire, with the historical defect as the fixture
- #10606 — chore(harness): preserve lhkn7 semantic-boundary tools

## Test plan

- [x] Full `lake build` (`LAKE_ARTIFACT_CACHE=false`), 4758/4758 jobs, clean
- [x] All 21 `scripts/check-*.sh` gates pass
- [x] `check-unimported.sh`: 2785/2785 modules reachable, 0 orphans
