### PR TITLE
fix(codegen): source CREATE/CREATE2 static gas from SpecRef CREATE_ACCESS (part of #10569)

### DIFF
--- a/EvmAsm/Codegen/Dispatch.lean
+++ b/EvmAsm/Codegen/Dispatch.lean
@@ -586,7 +586,7 @@ def staticGasCost (op : Nat) : Nat :=
     | 0x5c => OPCODE_TLOAD      | 0x5d => OPCODE_TSTORE
     | 0x5e => OPCODE_MCOPY_BASE
     -- child frames (base; dynamic call/create costs charged elsewhere)
-    | 0xf0 => 11000 | 0xf5 => 11000                      -- CREATE, CREATE2: no SpecRef symbol
+    | 0xf0 => CREATE_ACCESS | 0xf5 => CREATE_ACCESS      -- CREATE, CREATE2 (system.py:193,247)
     | 0xf1 => WARM_ACCESS       -- CALL         (warm floor)
     | 0xf2 => WARM_ACCESS       -- CALLCODE
     | 0xf4 => WARM_ACCESS       -- DELEGATECALL


### PR DESCRIPTION
> **Note:** This PR was written by Claude Code.

Part of #10569.

The 256-entry static gas table annotated CREATE and CREATE2 as **"no SpecRef symbol"** and carried a bare `11000` at both entries. **That annotation is wrong.**

```
CREATE_ACCESS = ACCOUNT_WRITE + COLD_STORAGE_ACCESS = 8000 + 3000 = 11000
```

`SpecRef/Gas.lean:77` defines it, and execution-specs charges **that exact symbol** as the static component of both opcodes — `GasCosts.CREATE_ACCESS` at `vm/instructions/system.py:193` (CREATE) and `:247` (CREATE2).

## The symbol was checked, not just the value

Deriving `8000 + 3000 = 11000` and finding `11000` in the table only proves two transcriptions agree. I opened the spec's CREATE and CREATE2 handlers to confirm they charge `CREATE_ACCESS` itself. That distinction is exactly what made the SELFBALANCE substitution wrong earlier in this family — right value, wrong symbol, and byte-identity passed anyway because `LOW` and `FAST_STEP` are both 5.

Interpolating the symbol means a future change to `ACCOUNT_WRITE` or `COLD_STORAGE_ACCESS` propagates, instead of the table silently diverging from the spec.

## Byte-identical

```
before  47595661818fbb3d98c4deb2c66571feee0070c18e89f6fef780f8adac4fb76c
after   47595661818fbb3d98c4deb2c66571feee0070c18e89f6fef780f8adac4fb76c
```

Both legs emitted under the **same output name**, since the linker embeds the object filename and differing `-o` names produce a spurious ELF difference (the trap from #10579).

## What is left in #10569

`SELFDESTRUCT`'s `5000` stays a literal — there is no corresponding symbol in the pinned spec's `gas.py`, so there is nothing to interpolate. Its "no SpecRef symbol" annotation is now the only accurate one of the three. After this, the table's only bare results are that `5000` and a `0`.

**Gates:** full `lake build` green; `check-forbidden-tactics` OK; `check-region-map` matches the linked ELF; `check-asm-to-program` CLEAN (389 converted defs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
