### PR TITLE
fix(codegen): source EXTCODECOPY's warm-access charge from SpecRef (completes #10572)

### DIFF
--- a/EvmAsm/Codegen/Programs/EvmExtcodecopy.lean
+++ b/EvmAsm/Codegen/Programs/EvmExtcodecopy.lean
@@ -132,7 +132,7 @@ private def extcodecopyWitnessTail : HandlerTail :=
 " ++
     "  ld t0, 568(x20)
 " ++
-    "  li t1, 100
+    s!"  li t1, {EvmAsm.Stateless.SpecRef.GasCosts.WARM_ACCESS}
 " ++
     "  bltu t0, t1, .exit_outofgas
 " ++


### PR DESCRIPTION
> **Note:** This PR was written by Claude Code.

Completes #10572.

The flat `WARM_ACCESS` charge was substituted across the gas surface earlier, but **`EvmExtcodecopy.lean:135` was missed** — it still emitted a bare `li t1, 100`.

## It is a genuine charge, not a false positive

The surrounding construct is the gas-charge idiom, not one of the look-alikes:

```
  ld t0, 568(x20)
  li t1, 100
  bltu t0, t1, .exit_outofgas
  sub t0, t0, t1
```

## The site list was re-derived, not inherited

My classification on the issue is from midday and the tree has moved a lot since, so I re-ran it rather than trusting my own number. A bounded scan for `li <reg>, 100` — **not** matching `1000`/`10000`/`100000`, and allowing the semicolon-joined forms a `^\s*li` anchor would miss — finds **10** sites:

| classification | count | sites |
|---|---|---|
| **WARM_ACCESS (this PR)** | **1** | `EvmExtcodecopy.lean:135` |
| status-code decade remap | 5 | `Block`, `Tx`, `TxTotalBlobGas`, `Withdrawal`, `WithdrawalBlockSummary` |
| multiplier | 1 | `ReceiptRecords.lean:151` |
| probe fixture / seed | 3 | `CallFrameDescend`, `CallFrameReturn`, `B3CoinbaseFee` |

The other nine are correctly untouched. All eight sites from the original classification are already substituted — `GasCosts.WARM_ACCESS` now appears in 10 places under `EvmAsm/Codegen/`.

## Byte-identical

```
before  47595661818fbb3d98c4deb2c66571feee0070c18e89f6fef780f8adac4fb76c
after   47595661818fbb3d98c4deb2c66571feee0070c18e89f6fef780f8adac4fb76c
```

Both legs emitted under the **same output name** (the linker embeds the object filename — the #10579 trap).

## The `.s` was checked directly, not just the build

An over-escaped newline **in this exact edit** once produced a literal `\n` that fused two instructions — and it passed the build and every source gate. So:

- `li t1, 100` lines still emitted: **17** (unchanged)
- literal `\n` sequences in the emitted `.s`: **0**

**Gates:** full `lake build` green; `check-forbidden-tactics` OK; `check-region-map` matches the linked ELF; `check-asm-to-program` CLEAN (389 converted defs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
