### PR TITLE
harness: --guest-elf flag, GUEST_ELF env removed, guest sha in every run header (#10617)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,6 +29,8 @@ jobs:
         run: scripts/check-roundtrip-coverage.sh
       - name: EEST sampler span check (negative control on the --random guard)
         run: scripts/check-eest-sampler-span.py
+      - name: Guest-ELF override guard (negative control: an ignored override ran the default guest, #10617)
+        run: scripts/check-guest-elf-override.sh
       # Conventions-as-fitness-functions (Phase 5 / R-D1). Pure source scans,
       # no build needed — kept cheap on the PR push path. See AGENTS.md
       # "Architecture fitness functions".

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
         run: scripts/check-roundtrip-coverage.sh
       - name: EEST sampler span check (negative control on the --random guard)
         run: scripts/check-eest-sampler-span.py
-      - name: Guest-ELF override guard (negative control: an ignored override ran the default guest, #10617)
+      - name: "Guest-ELF override guard (negative control; an ignored override ran the default guest, #10617)"
         run: scripts/check-guest-elf-override.sh
       # Conventions-as-fitness-functions (Phase 5 / R-D1). Pure source scans,
       # no build needed — kept cheap on the PR push path. See AGENTS.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -319,6 +319,31 @@ Verified `Program`s are emitted to RV64 ELFs and run on `ziskemu` — roadmap in
 line) is the build-time gate for `emitInstr` drift. The conformance harness for
 guest changes is `scripts/codegen-eest-stateless-check.sh` (EEST A/B).
 
+#### Choosing the guest ELF, and knowing which one you ran (GH #10617)
+
+Override the guest with the **flag** `--guest-elf <path>`; it implies
+`--no-build`. There is no environment override: `GUEST_ELF` (and its internal
+twin `USER_GUEST_ELF`) now make the script **fail** and point at the flag.
+The variable used to be read as `USER_GUEST_ELF="${GUEST_ELF:-…}"`, so exporting
+the internal name was silently ignored — three consecutive sweeps reported clean
+passes on the default guest, and a 120-row false-reject population was declared
+fixed on that evidence. A misspelled argument fails loudly; a misspelled
+variable is indistinguishable from an unset one.
+
+Every run now echoes the resolved guest path and its **sha256** before running
+anything, and records both (plus `repo_head`, `repo_dirty`, backend and fixture
+tag) in `$RUN_DIR/run-provenance.tsv`; the sha is also in
+`eest-baseline.txt`. `scripts/eest-ab-compare.py` reads that file, so
+self-check 0 (“the two legs are distinct artifacts”) now runs even when a leg's
+guest came from outside the run dir instead of being skipped. The same
+`# guest_elf` / `# guest_elf_sha256` header is written by
+`scripts/lhkn7-semantic-boundary-v2-sweep.py`, and `scripts/spike/parity-check.sh`
+takes `--guest-elf` on the same terms.
+
+**Before believing any result that depends on an override, read back the sha the
+run printed.** An artifact that is not what it says it is has been the shape of
+every measurement failure on this harness so far.
+
 ## Architecture fitness functions (`scripts/check-*.sh`)
 
 The `scripts/check-*.sh` suite **is** a set of *architecture fitness

--- a/docs/sasm-howto.md
+++ b/docs/sasm-howto.md
@@ -595,10 +595,16 @@ The pattern of `ChainIdSAsm.lean` / `ActiveForkSAsm.lean`:
    - baseline ELF: `git stash -u`, then
      `lake exe codegen --program stateless_guest --halt linux93 -o gen-out/<base>`,
      `git stash pop`; candidate ELF likewise from the branch;
-   - per leg: `GUEST_ELF=<elf> EEST_RUN_DIR=<dir>
-     scripts/codegen-eest-stateless-check.sh --no-build --backend spike
+   - per leg: `EEST_RUN_DIR=<dir>
+     scripts/codegen-eest-stateless-check.sh --guest-elf <elf> --backend spike
      --random --seed 4242 --limit 200 --jobs 8 --quiet-passes`
-     (note: `--all` bypasses `--limit`);
+     (note: `--all` bypasses `--limit`; `--guest-elf` implies `--no-build`.
+     The guest is chosen with the **flag** — the old `GUEST_ELF` environment
+     variable is removed and setting it is now an error, because in one of its
+     two spellings it was silently ignored and ran the default guest, GH #10617.
+     Each leg echoes its resolved guest path and sha256 and records both in
+     `<dir>/run-provenance.tsv`; **check that the two legs' shas differ** before
+     believing any delta);
    - diff the per-case `PASS/FAIL/ERROR/BUDGET` labels between legs —
      **failures are acceptable only if identical on both legs**; also
      sanity-diff the two `.s` files (only the expected expansion).

--- a/scripts/check-guest-elf-override.sh
+++ b/scripts/check-guest-elf-override.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# check-guest-elf-override.sh -- negative control on the guest-ELF override guard.
+#
+# GH #10617. The harness used to resolve its guest as
+# `USER_GUEST_ELF="${GUEST_ELF:-…}"`, where `USER_GUEST_ELF` was the *internal*
+# variable. Exporting the internal name was therefore silently ignored: three
+# consecutive sweeps ran the DEFAULT guest, reported clean passes, and a 120-row
+# false-reject population was declared fixed on that evidence.
+#
+# The override is now a flag and the environment names are rejected. This script
+# is the mechanism that keeps it that way, because the review of the fix found the
+# same failure one layer up: the guard was written with `-n` (a NON-EMPTY test),
+# the change was verified by exporting a *path*, and so the one case that
+# distinguishes `-n` from a presence test -- an EMPTY export -- was the case never
+# exercised. A claim about the empty case needs the empty case run. That is what
+# this file does, on every push, instead of asking anyone to remember.
+#
+# Each assertion below is a case where a WRONG implementation still looks right:
+#   * `-n` instead of `${var+x}`  -> an empty export sails through (case 1)
+#   * honouring the flag but not rejecting a stale export -> ambiguous intent
+#     resolved silently by precedence (case 3)
+#   * falling back to the default guest when the flag names a missing file ->
+#     the original incident, one layer down (case 5)
+set -uo pipefail
+cd "$(dirname "$0")/.."
+
+HARNESS=scripts/codegen-eest-stateless-check.sh
+PARITY=scripts/spike/parity-check.sh
+rc=0
+
+fail() { echo "FAIL: $*" >&2; rc=1; }
+ok()   { echo "  ok: $*"; }
+
+# Every case must exit non-zero AND name the flag, so the operator is told what
+# to do rather than only what not to do. An exit code alone would pass even if
+# the script died for an unrelated reason.
+expect_rejected() {
+  local what="$1"; shift
+  local out status
+  out="$("$@" 2>&1)"; status=$?
+  if [[ "$status" -eq 0 ]]; then
+    fail "$what was ACCEPTED (exit 0) -- a silent override is the incident this guard exists to prevent"
+    return
+  fi
+  if ! grep -q -- '--guest-elf' <<<"$out"; then
+    fail "$what was rejected but the message never names --guest-elf: $out"
+    return
+  fi
+  ok "$what rejected, message names the flag"
+}
+
+echo "==> guest-ELF override guard ($HARNESS)"
+
+# 1. PRESENCE, not a non-empty value. The likeliest source of an empty export is
+#    a wrapper or profile that computed a path and got the empty string -- which
+#    is exactly the case where a silent fallback misleads most.
+expect_rejected "empty GUEST_ELF export" \
+  env GUEST_ELF= "$HARNESS" --limit 1 --backend spike
+
+# 2. The non-empty form of the same variable.
+expect_rejected "GUEST_ELF=<path> export" \
+  env GUEST_ELF=/nonexistent/guest.elf "$HARNESS" --limit 1 --backend spike
+
+# 3. Presence is rejected even beside a CORRECT flag: a stale export next to a
+#    correct flag is ambiguous about intent, and precedence rules are not.
+expect_rejected "GUEST_ELF export alongside a correct --guest-elf" \
+  env GUEST_ELF=/nonexistent/guest.elf "$HARNESS" --limit 1 --backend spike --guest-elf /bin/sh
+
+# 4. The internal spelling -- the one actually exported in the incident.
+expect_rejected "empty USER_GUEST_ELF export" \
+  env USER_GUEST_ELF= "$HARNESS" --limit 1 --backend spike
+
+# 5. A flag naming a path that does not exist must NOT fall back to the default
+#    guest. That fallback is the incident itself, one layer down.
+expect_rejected "--guest-elf pointing at a missing file" \
+  "$HARNESS" --limit 1 --backend spike --guest-elf /nonexistent/guest.elf
+
+echo "==> the rejected names and the used names are disjoint"
+# The guard rejects GUEST_ELF / USER_GUEST_ELF. If the script also USES a variable
+# of that name, an inherited child environment or a future export would make the
+# harness trip its own guard. Disjointness makes that impossible by construction
+# rather than by nobody happening to export it.
+for f in "$HARNESS" "$PARITY"; do
+  if grep -nE '^[[:space:]]*(GUEST_ELF|USER_GUEST_ELF)=' "$f"; then
+    fail "$f assigns to a variable named GUEST_ELF/USER_GUEST_ELF (the names the guard rejects); rename the internal one"
+  else
+    ok "$f: no assignment to a rejected name"
+  fi
+done
+
+echo "==> $PARITY rejects the same names"
+expect_rejected "empty GUEST_ELF export (parity-check)" \
+  env GUEST_ELF= "$PARITY"
+
+if [[ "$rc" -eq 0 ]]; then
+  echo "guest-ELF override guard: all cases rejected as required"
+fi
+exit "$rc"

--- a/scripts/codegen-eest-stateless-check.sh
+++ b/scripts/codegen-eest-stateless-check.sh
@@ -114,8 +114,9 @@
 #   and recorded in $RUN_DIR/run-provenance.tsv, so a result can never be
 #   silently about a different artifact than the one that was chosen.
 #
-#   The former `GUEST_ELF` environment override is REMOVED and setting it is now
-#   a hard error. It read `USER_GUEST_ELF="${GUEST_ELF:-...}"`, where
+#   The former `GUEST_ELF` environment override is REMOVED: having it PRESENT in
+#   the environment -- even empty, even alongside a correct `--guest-elf` -- is a
+#   hard error. It read `USER_GUEST_ELF="${GUEST_ELF:-...}"`, where
 #   USER_GUEST_ELF is the script's *internal* name -- so exporting the internal
 #   name was silently ignored and ran the default guest with no error and no
 #   warning. Three consecutive sweeps reported clean passes on an artifact
@@ -210,12 +211,21 @@ NO_BUILD="${EEST_NO_BUILD:-0}"
 # the old public name and the old internal name are rejected loudly here rather
 # than honoured or ignored -- an ignored override is the most persuasive wrong
 # answer available, because its output is exactly what a working setup produces.
+#
+# Three deliberate choices:
+#  * PRESENCE, not a non-empty value (`${var+x}`, not `-n`): an empty export is
+#    still someone attempting an override, and deserves the same complaint.
+#  * unconditional, even when --guest-elf is also given: a lingering export beside
+#    a correct flag is ambiguous about intent, and a stale export in a shell
+#    profile or a wrapper is exactly how someone comes to believe a run used an
+#    artifact it did not. Failing on presence is unambiguous; precedence is not.
+#  * before argument parsing, so no run can begin under an ambiguous guest.
 for stale_var in GUEST_ELF USER_GUEST_ELF; do
-  if [[ -n "${!stale_var:-}" ]]; then
-    echo "error: the $stale_var environment override was removed (GH #10617)." >&2
-    echo "  use: --guest-elf ${!stale_var}" >&2
-    echo "  (the old variable was silently ignored in one of its two spellings," >&2
-    echo "   which reported clean passes on the default guest; the flag fails loudly.)" >&2
+  if [[ -n "${!stale_var+x}" ]]; then
+    echo "error: $stale_var is no longer supported; pass --guest-elf <path> instead (GH #10617)." >&2
+    echo "  unset $stale_var and put the path in the flag${!stale_var:+, e.g.: --guest-elf ${!stale_var}}" >&2
+    echo "  (the variable was silently ignored in one of its two spellings, which" >&2
+    echo "   reported clean passes on the default guest; the flag fails loudly.)" >&2
     exit 1
   fi
 done

--- a/scripts/codegen-eest-stateless-check.sh
+++ b/scripts/codegen-eest-stateless-check.sh
@@ -105,6 +105,24 @@
 #                        first-N selection without shuffling. Applied after
 #                        --random when both are given (reverses the shuffle).
 #     --tag TAG          EEST fixture tag (default $EEST_FIXTURE_TAG or scripts/eest-fixture-tag.txt)
+#     --guest-elf PATH   run PATH instead of building a guest. This is the ONLY
+#                        supported way to override the guest, and it implies
+#                        --no-build. See "Guest identity" below.
+#
+# Guest identity (GH #10617):
+#   The resolved guest path and its sha256 are echoed at the start of every run
+#   and recorded in $RUN_DIR/run-provenance.tsv, so a result can never be
+#   silently about a different artifact than the one that was chosen.
+#
+#   The former `GUEST_ELF` environment override is REMOVED and setting it is now
+#   a hard error. It read `USER_GUEST_ELF="${GUEST_ELF:-...}"`, where
+#   USER_GUEST_ELF is the script's *internal* name -- so exporting the internal
+#   name was silently ignored and ran the default guest with no error and no
+#   warning. Three consecutive sweeps reported clean passes on an artifact
+#   nobody had chosen, and a 120-row false-reject population was wrongly
+#   declared fixed on that evidence. A misspelled *argument* fails loudly; a
+#   misspelled *variable* is indistinguishable from not setting one. Removing
+#   the mechanism beats promising to remember it.
 #
 # Environment:
 #   EEST_RUN_DIR         explicit conversion/result directory. When unset, each
@@ -118,6 +136,11 @@
 #   1 -- build/convert failure, no fixtures, or a --min-{succ,full,root} regression
 set -euo pipefail
 
+# The directory the caller invoked us from, captured BEFORE the cd below so a
+# relative `--guest-elf` path resolves against the caller's cwd rather than
+# silently against the repo root (GH #10617: a path that resolves somewhere
+# unexpected is the same class of bug as an override that is not read at all).
+INVOCATION_CWD="$PWD"
 cd "$(dirname "$0")/.."
 REPO_ROOT="$(pwd)"
 
@@ -183,7 +206,20 @@ DEFAULT_TAG="$(tr -d '[:space:]' < scripts/eest-fixture-tag.txt 2>/dev/null || t
 DEFAULT_TAG="${DEFAULT_TAG:-$(cat scripts/eest-fixture-tag.txt)}"
 TAG="${EEST_FIXTURE_TAG:-$DEFAULT_TAG}"
 NO_BUILD="${EEST_NO_BUILD:-0}"
-USER_GUEST_ELF="${GUEST_ELF:-}"
+# GH #10617: the guest override is a FLAG, never an environment variable.  Both
+# the old public name and the old internal name are rejected loudly here rather
+# than honoured or ignored -- an ignored override is the most persuasive wrong
+# answer available, because its output is exactly what a working setup produces.
+for stale_var in GUEST_ELF USER_GUEST_ELF; do
+  if [[ -n "${!stale_var:-}" ]]; then
+    echo "error: the $stale_var environment override was removed (GH #10617)." >&2
+    echo "  use: --guest-elf ${!stale_var}" >&2
+    echo "  (the old variable was silently ignored in one of its two spellings," >&2
+    echo "   which reported clean passes on the default guest; the flag fails loudly.)" >&2
+    exit 1
+  fi
+done
+GUEST_ELF_OVERRIDE=""
 VERDICT_DEBUG="${EEST_VERDICT_DEBUG:-1}"
 VERDICT_DEBUG_ELF=""
 VERIFY_INPUT_PARITY="${EEST_VERIFY_INPUT_PARITY:-1}"
@@ -232,6 +268,11 @@ Options:
                            classify verdict differences as false-accept/reject
   --tag TAG                EEST fixture tag (default $EEST_FIXTURE_TAG or scripts/eest-fixture-tag.txt)
   --no-build               skip lake build + ELF emit (reuse existing gen-out/stateless_guest.elf)
+  --guest-elf PATH         run PATH instead of building a guest (implies --no-build).
+                           The ONLY supported guest override; the GUEST_ELF
+                           environment variable is removed and is now an error.
+                           The resolved path and its sha256 are echoed and
+                           recorded in the run's run-provenance.tsv.
   --no-verdict-debug       do not rerun fixed-size verdict probe on succ mismatches
   --random                 after --filter, sample individual stateless blocks
                            uniformly WITHOUT replacement BEFORE --limit
@@ -282,6 +323,7 @@ while [[ $# -gt 0 ]]; do
     --tag) require_arg "$1" "${2:-}"; TAG="$2"; shift 2 ;;
     --run-dir) require_arg "$1" "${2:-}"; RUN_DIR_OVERRIDE="$2"; shift 2 ;;
     --no-build) NO_BUILD=1; shift ;;
+    --guest-elf) require_arg "$1" "${2:-}"; GUEST_ELF_OVERRIDE="$2"; shift 2 ;;
     --no-verdict-debug) VERDICT_DEBUG=0; shift ;;
     --random) RANDOM_ORDER=1; shift ;;
     --seed) require_arg "$1" "${2:-}"; RANDOM_SEED="$2"; shift 2 ;;
@@ -350,6 +392,29 @@ case "$BACKEND" in
   ziskemu|spike) ;;
   *) echo "--backend/EEST_BACKEND must be ziskemu or spike (got: $BACKEND)" >&2; exit 1 ;;
 esac
+
+if [[ -n "$GUEST_ELF_OVERRIDE" ]]; then
+  # Resolve against the CALLER's cwd and fail if it is not a readable file.  An
+  # override that names a nonexistent path must not fall back to the default
+  # guest -- that fallback is the incident this flag replaces.
+  [[ "$GUEST_ELF_OVERRIDE" == /* ]] || GUEST_ELF_OVERRIDE="$INVOCATION_CWD/$GUEST_ELF_OVERRIDE"
+  if [[ ! -f "$GUEST_ELF_OVERRIDE" ]]; then
+    echo "--guest-elf: not a readable file: $GUEST_ELF_OVERRIDE" >&2
+    exit 1
+  fi
+  GUEST_ELF_OVERRIDE="$(cd "$(dirname "$GUEST_ELF_OVERRIDE")" && pwd)/$(basename "$GUEST_ELF_OVERRIDE")"
+  # An override supplies the artifact, so building one would either overwrite it
+  # or (worse) run a different guest than the one named.
+  if [[ "$NO_BUILD" -eq 0 ]]; then
+    echo "==> --guest-elf implies --no-build (using the supplied artifact, not building one)"
+    NO_BUILD=1
+  fi
+  if [[ -n "$BSR_WITNESS_CAP" || -n "$BSR_BAL_CAP" ]]; then
+    echo "--guest-elf cannot be combined with --bsr-witness-cap/--bsr-bal-cap:" >&2
+    echo "  those patch the emitted assembly and relink, which requires a build." >&2
+    exit 1
+  fi
+fi
 
 if ! [[ "$SKIP" =~ ^[0-9]+$ ]]; then
   echo "--skip must be a nonnegative integer (got: $SKIP)" >&2
@@ -736,13 +801,43 @@ if [[ "$NO_BUILD" -eq 0 ]]; then
   fi
 else
   echo "==> skipping build (--no-build)"
-  GUEST_ELF="${USER_GUEST_ELF:-$REPO_ROOT/gen-out/stateless_guest.elf}"
+  GUEST_ELF="${GUEST_ELF_OVERRIDE:-$REPO_ROOT/gen-out/stateless_guest.elf}"
   if [[ ! -f "$GUEST_ELF" ]]; then
     echo "--no-build requested, but stateless_guest ELF does not exist: $GUEST_ELF" >&2
-    echo "set GUEST_ELF=/path/to/stateless_guest.elf or run without --no-build" >&2
+    echo "pass --guest-elf /path/to/stateless_guest.elf, or run without --no-build" >&2
     exit 1
   fi
 fi
+
+# GH #10617: state the artifact's identity before it is used, and record it in
+# the run dir.  This is the property that makes a result self-describing: no
+# comparison can silently be about a different guest than the one printed here,
+# whatever mechanism supplied it.
+GUEST_ELF_SHA256="$(sha256sum "$GUEST_ELF" | cut -d' ' -f1)"
+if [[ -n "$GUEST_ELF_OVERRIDE" ]]; then
+  GUEST_ELF_SOURCE="--guest-elf"
+elif [[ "$NO_BUILD" -eq 1 ]]; then
+  GUEST_ELF_SOURCE="no-build-default"
+else
+  GUEST_ELF_SOURCE="built"
+fi
+echo "==> guest ELF: $GUEST_ELF"
+echo "    sha256:    $GUEST_ELF_SHA256  (source: $GUEST_ELF_SOURCE)"
+GUEST_PROVENANCE="$RUN_DIR/run-provenance.tsv"
+{
+  printf '# schema=run-provenance-v1\n'
+  printf 'field\tvalue\n'
+  printf 'guest_elf\t%s\n' "$GUEST_ELF"
+  printf 'guest_elf_sha256\t%s\n' "$GUEST_ELF_SHA256"
+  printf 'guest_elf_source\t%s\n' "$GUEST_ELF_SOURCE"
+  printf 'guest_elf_bytes\t%s\n' "$(stat -c %s "$GUEST_ELF")"
+  printf 'backend\t%s\n' "$BACKEND"
+  printf 'fixture_tag\t%s\n' "$TAG"
+  printf 'repo_head\t%s\n' "$(git -C "$REPO_ROOT" rev-parse HEAD 2>/dev/null || echo unknown)"
+  printf 'repo_dirty\t%s\n' "$([[ -n "$(git -C "$REPO_ROOT" status --porcelain 2>/dev/null)" ]] && echo 1 || echo 0)"
+  printf 'generated\t%s\n' "$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+} > "$GUEST_PROVENANCE"
+echo "    provenance: $GUEST_PROVENANCE"
 
 
 run_guest_elf() {
@@ -1546,6 +1641,8 @@ BASELINE="$RUN_DIR/eest-baseline.txt"
   echo "  generated:   $(date -u '+%Y-%m-%dT%H:%M:%SZ')"
   echo "  fixture tag: $TAG"
   echo "  selection:   $selection"
+  echo "  guest elf:   $GUEST_ELF ($GUEST_ELF_SOURCE)"
+  echo "  guest sha256:$GUEST_ELF_SHA256"
   echo "  backend:     $BACKEND"
   if [[ "$BACKEND" == "ziskemu" ]]; then
     echo "  ziskemu:     $ZISKEMU (steps=$STEPS, budget_retry_steps=$BUDGET_RETRY_STEPS, budget_retry_min_gas=$BUDGET_RETRY_MIN_GAS)"

--- a/scripts/codegen-eest-stateless-check.sh
+++ b/scripts/codegen-eest-stateless-check.sh
@@ -730,7 +730,7 @@ fi
 rm -rf "$RUN_DIR"
 mkdir -p "$RUN_DIR"
 GUEST_PREFIX="$RUN_DIR/stateless_guest"
-GUEST_ELF="$GUEST_PREFIX.elf"
+RESOLVED_GUEST_ELF="$GUEST_PREFIX.elf"
 
 resolve_riscv_tool() {
   local env_var="$1"; shift
@@ -778,7 +778,7 @@ PYPATCH
 patch_bsr_caps_and_relink() {
   local asm="$GUEST_PREFIX.s"
   local obj="$GUEST_PREFIX.o"
-  local elf="$GUEST_ELF"
+  local elf="$RESOLVED_GUEST_ELF"
   local as_tool ld_tool
 
   patch_bsr_caps_asm "$asm"
@@ -811,9 +811,9 @@ if [[ "$NO_BUILD" -eq 0 ]]; then
   fi
 else
   echo "==> skipping build (--no-build)"
-  GUEST_ELF="${GUEST_ELF_OVERRIDE:-$REPO_ROOT/gen-out/stateless_guest.elf}"
-  if [[ ! -f "$GUEST_ELF" ]]; then
-    echo "--no-build requested, but stateless_guest ELF does not exist: $GUEST_ELF" >&2
+  RESOLVED_GUEST_ELF="${GUEST_ELF_OVERRIDE:-$REPO_ROOT/gen-out/stateless_guest.elf}"
+  if [[ ! -f "$RESOLVED_GUEST_ELF" ]]; then
+    echo "--no-build requested, but stateless_guest ELF does not exist: $RESOLVED_GUEST_ELF" >&2
     echo "pass --guest-elf /path/to/stateless_guest.elf, or run without --no-build" >&2
     exit 1
   fi
@@ -823,7 +823,7 @@ fi
 # the run dir.  This is the property that makes a result self-describing: no
 # comparison can silently be about a different guest than the one printed here,
 # whatever mechanism supplied it.
-GUEST_ELF_SHA256="$(sha256sum "$GUEST_ELF" | cut -d' ' -f1)"
+GUEST_ELF_SHA256="$(sha256sum "$RESOLVED_GUEST_ELF" | cut -d' ' -f1)"
 if [[ -n "$GUEST_ELF_OVERRIDE" ]]; then
   GUEST_ELF_SOURCE="--guest-elf"
 elif [[ "$NO_BUILD" -eq 1 ]]; then
@@ -831,16 +831,16 @@ elif [[ "$NO_BUILD" -eq 1 ]]; then
 else
   GUEST_ELF_SOURCE="built"
 fi
-echo "==> guest ELF: $GUEST_ELF"
+echo "==> guest ELF: $RESOLVED_GUEST_ELF"
 echo "    sha256:    $GUEST_ELF_SHA256  (source: $GUEST_ELF_SOURCE)"
 GUEST_PROVENANCE="$RUN_DIR/run-provenance.tsv"
 {
   printf '# schema=run-provenance-v1\n'
   printf 'field\tvalue\n'
-  printf 'guest_elf\t%s\n' "$GUEST_ELF"
+  printf 'guest_elf\t%s\n' "$RESOLVED_GUEST_ELF"
   printf 'guest_elf_sha256\t%s\n' "$GUEST_ELF_SHA256"
   printf 'guest_elf_source\t%s\n' "$GUEST_ELF_SOURCE"
-  printf 'guest_elf_bytes\t%s\n' "$(stat -c %s "$GUEST_ELF")"
+  printf 'guest_elf_bytes\t%s\n' "$(stat -c %s "$RESOLVED_GUEST_ELF")"
   printf 'backend\t%s\n' "$BACKEND"
   printf 'fixture_tag\t%s\n' "$TAG"
   printf 'repo_head\t%s\n' "$(git -C "$REPO_ROOT" rev-parse HEAD 2>/dev/null || echo unknown)"
@@ -1305,7 +1305,7 @@ run_case() {
   run_emulator_case() {
     local steps="$1"
     local run_log="$2"
-    run_guest_elf "$GUEST_ELF" "$input" "$out" "$run_log" "$steps"
+    run_guest_elf "$RESOLVED_GUEST_ELF" "$input" "$out" "$run_log" "$steps"
   }
 
   retry_budget_case() {
@@ -1651,7 +1651,7 @@ BASELINE="$RUN_DIR/eest-baseline.txt"
   echo "  generated:   $(date -u '+%Y-%m-%dT%H:%M:%SZ')"
   echo "  fixture tag: $TAG"
   echo "  selection:   $selection"
-  echo "  guest elf:   $GUEST_ELF ($GUEST_ELF_SOURCE)"
+  echo "  guest elf:   $RESOLVED_GUEST_ELF ($GUEST_ELF_SOURCE)"
   echo "  guest sha256:$GUEST_ELF_SHA256"
   echo "  backend:     $BACKEND"
   if [[ "$BACKEND" == "ziskemu" ]]; then

--- a/scripts/eest-ab-compare.py
+++ b/scripts/eest-ab-compare.py
@@ -127,13 +127,38 @@ def read_manifest(run_dir: str) -> dict[str, tuple[str, str, str]]:
     return rows
 
 
-def guest_elf_digest(run_dir: str) -> str | None:
-    """sha256 of the run dir's own `stateless_guest.elf`, or None if absent.
+def provenance_guest_sha(run_dir: str) -> str | None:
+    """`guest_elf_sha256` from the run's run-provenance.tsv, or None.
 
-    Absent when the run used `--no-build` with a `GUEST_ELF` override pointing
-    outside the run dir; in that case self-check 0 cannot run and says so
-    rather than passing silently.
+    Written by codegen-eest-stateless-check.sh for EVERY run (GH #10617),
+    including runs that supplied the guest with `--guest-elf` from outside the
+    run dir.  Reading it is what lets self-check 0 run on an overridden leg
+    instead of being skipped -- and a skipped identity check is exactly how two
+    legs of the same artifact got compared as though they were different.
     """
+    path = os.path.join(run_dir, "run-provenance.tsv")
+    try:
+        with open(path) as handle:
+            for line in handle:
+                if line.startswith("guest_elf_sha256\t"):
+                    return line.rstrip("\n").split("\t", 1)[1].strip() or None
+    except OSError:
+        return None
+    return None
+
+
+def guest_elf_digest(run_dir: str) -> str | None:
+    """sha256 of the run's guest ELF, or None if it cannot be established.
+
+    Prefers the recorded provenance (present for every run, and correct when the
+    guest came from `--guest-elf` outside the run dir), and falls back to
+    hashing the run dir's own `stateless_guest.elf` for runs predating the
+    provenance file.  None only when neither is available; in that case
+    self-check 0 says it did not run rather than passing silently.
+    """
+    recorded = provenance_guest_sha(run_dir)
+    if recorded is not None:
+        return recorded
     path = os.path.join(run_dir, "stateless_guest.elf")
     try:
         with open(path, "rb") as handle:
@@ -242,8 +267,9 @@ def main() -> int:
     base_elf, cand_elf = guest_elf_digest(base_dir), guest_elf_digest(cand_dir)
     if base_elf is None or cand_elf is None:
         missing = [n for n, d in (("base", base_elf), ("candidate", cand_elf)) if d is None]
-        print(f"note: self-check 0 NOT RUN -- no stateless_guest.elf in {', '.join(missing)} "
-              "run dir (GUEST_ELF override?); cannot confirm the two legs are distinct builds")
+        print(f"note: self-check 0 NOT RUN -- no run-provenance.tsv and no stateless_guest.elf "
+              f"in {', '.join(missing)} run dir (a run predating GH #10617?); "
+              "cannot confirm the two legs are distinct builds")
     elif base_elf == cand_elf:
         print(f"!! BOTH LEGS ARE THE SAME BUILD: sha256 {base_elf[:16]}... "
               "-- this comparison is vacuous. Build each leg from a COMMITTED ref "

--- a/scripts/gen-port-kit.py
+++ b/scripts/gen-port-kit.py
@@ -168,9 +168,11 @@ def main():
        git stash -u && lake exe codegen --program stateless_guest \\
          --halt linux93 -o gen-out/base && git stash pop
        lake exe codegen --program stateless_guest --halt linux93 -o gen-out/cand
-       GUEST_ELF=<elf> EEST_RUN_DIR=<dir> \\
-         scripts/codegen-eest-stateless-check.sh --no-build --backend spike \\
+       EEST_RUN_DIR=<dir> scripts/codegen-eest-stateless-check.sh \\
+         --guest-elf <elf> --backend spike \\
          --random --seed 4242 --limit 200 --jobs 8 --quiet-passes
+       (--guest-elf implies --no-build and echoes the resolved path + sha256;
+        the GUEST_ELF env var is removed and is now an error, GH #10617)
   3. PLAN.md + docs/agents/top-theorem-ledger.md updated; bead closed only
      after the PR lands on main.
 -/

--- a/scripts/lhkn7-semantic-boundary-v2-sweep.py
+++ b/scripts/lhkn7-semantic-boundary-v2-sweep.py
@@ -5,9 +5,14 @@ The diagnostic schema uses output bytes 112..255.  It is intentionally
 diagnostic-only and must not be used to establish production verdict results.
 Set LHKN7_SELECTOR_MODE to record whether the input ELF uses normal or forced
 routing.  Optional LHKN7_PROVENANCE is copied verbatim into the TSV header.
+
+The resolved ELF path and its sha256 are printed at startup and written to the
+TSV header as `# guest_elf` / `# guest_elf_sha256` (GH #10617), so a sweep is
+self-describing about which artifact produced it.
 """
 
 import csv
+import hashlib
 import os
 import shutil
 import subprocess
@@ -72,7 +77,19 @@ elif prior_tsv:
         fail(f"focused labels missing from manifest: wanted={len(wanted)} found={len(rows)}")
     mode = "focused-prior-FR"
     print(f"focused mode: {len(rows)} labels selected from {prior_tsv}", flush=True)
-print(f"loaded {len(rows)} rows; elf={elf}; workers={workers}", flush=True)
+
+# GH #10617: state the artifact's identity before using it, and record it in the
+# header.  A sweep whose ELF sha is written down cannot later be mistaken for a
+# sweep of a different build -- which is how a superseded forced-routing ELF made
+# a whole failure surface look phantom.
+try:
+    with open(elf, "rb") as handle:
+        elf_sha = hashlib.sha256(handle.read()).hexdigest()
+except OSError as exc:
+    fail(f"cannot read ELF {elf}: {exc}")
+elf_abs = os.path.abspath(elf)
+print(f"loaded {len(rows)} rows; elf={elf_abs}; workers={workers}", flush=True)
+print(f"  elf sha256={elf_sha}", flush=True)
 
 
 def classify(row):
@@ -127,6 +144,8 @@ with open(out_tsv, "w") as output:
     fields = ["label", "oracle_succ", "guest_succ"] + [f"u64_{offset}" for offset in range(112, 256, 8)] + ["match", "rc", "len", "cat"]
     output.write("# schema=semantic-boundary-v2\n")
     output.write(f"# selector_mode={selector_mode}\n")
+    output.write(f"# guest_elf={elf_abs}\n")
+    output.write(f"# guest_elf_sha256={elf_sha}\n")
     if provenance := os.environ.get("LHKN7_PROVENANCE"):
         output.write(f"# provenance={provenance}\n")
     output.write(f"# selected_rows={len(rows)}; mode={mode}; root-analysis population=FR rows only\n")

--- a/scripts/spike/parity-check.sh
+++ b/scripts/spike/parity-check.sh
@@ -1,20 +1,42 @@
 #!/usr/bin/env bash
-# parity-check.sh [N] [SEED]
+# parity-check.sh [--guest-elf PATH] [N] [SEED]
 # Sample N blocks from the full manifest, run each on BOTH ziskemu and spike_run,
 # and diff the 256-byte outputs. Byte-parity is the correctness gate for the
 # SPIKE backend. Also prints per-backend wall time. Blocks that hit an
 # unimplemented accelerator CSR (precompiles) are reported separately (expected
 # to diverge until those CSRs land).
+#
+# The guest is overridden with --guest-elf PATH, never with an environment
+# variable (GH #10617): a mistyped variable is indistinguishable from an unset
+# one, and running the default guest under a name you chose yourself is the most
+# persuasive wrong answer available. GUEST_ELF in the environment is an error.
 set -uo pipefail
+INVOCATION_CWD="$PWD"
 cd "$(dirname "$0")/../.."   # worktree root
+if [[ -n "${GUEST_ELF:-}" || -n "${USER_GUEST_ELF:-}" ]]; then
+  echo "error: the GUEST_ELF environment override was removed (GH #10617)." >&2
+  echo "  use: $0 --guest-elf ${GUEST_ELF:-${USER_GUEST_ELF:-}} [N] [SEED]" >&2
+  exit 1
+fi
+ELF_OVERRIDE=""
+if [[ "${1:-}" == "--guest-elf" ]]; then
+  [[ -n "${2:-}" ]] || { echo "--guest-elf requires an argument" >&2; exit 1; }
+  ELF_OVERRIDE="$2"
+  [[ "$ELF_OVERRIDE" == /* ]] || ELF_OVERRIDE="$INVOCATION_CWD/$ELF_OVERRIDE"
+  [[ -f "$ELF_OVERRIDE" ]] || { echo "--guest-elf: not a readable file: $ELF_OVERRIDE" >&2; exit 1; }
+  shift 2
+fi
 N="${1:-8}"; SEED="${2:-1}"
-ELF="${GUEST_ELF:-$PWD/gen-out/stateless_guest_clzfix.elf}"
+ELF="${ELF_OVERRIDE:-$PWD/gen-out/stateless_guest_clzfix.elf}"
 MAN="${MANIFEST:-$PWD/gen-out/loop/full/manifest.tsv}"
 ZISKEMU="${ZISKEMU:-$HOME/.zisk/bin/ziskemu}"
 SPIKE_RUN="$PWD/scripts/spike/spike_run"
 STEPS="${EEST_STEPS:-5000000000}"
 OUT="$PWD/gen-out/spike-parity"; mkdir -p "$OUT"
 [[ -x "$SPIKE_RUN" ]] || { echo "build spike_run first (scripts/spike/build.sh)" >&2; exit 1; }
+[[ -f "$ELF" ]] || { echo "guest ELF does not exist: $ELF (pass --guest-elf PATH)" >&2; exit 1; }
+echo "==> guest ELF: $ELF"
+echo "    sha256:    $(sha256sum "$ELF" | cut -d' ' -f1)  (source: ${ELF_OVERRIDE:+--guest-elf}${ELF_OVERRIDE:-default})"
 
 mapfile -t rows < <(python3 -c "
 import random,sys

--- a/scripts/spike/parity-check.sh
+++ b/scripts/spike/parity-check.sh
@@ -13,11 +13,16 @@
 set -uo pipefail
 INVOCATION_CWD="$PWD"
 cd "$(dirname "$0")/../.."   # worktree root
-if [[ -n "${GUEST_ELF:-}" || -n "${USER_GUEST_ELF:-}" ]]; then
-  echo "error: the GUEST_ELF environment override was removed (GH #10617)." >&2
-  echo "  use: $0 --guest-elf ${GUEST_ELF:-${USER_GUEST_ELF:-}} [N] [SEED]" >&2
-  exit 1
-fi
+# Presence, not a non-empty value, and unconditional: an empty export is still an
+# attempted override, and a stale export beside a correct flag is ambiguous about
+# intent (GH #10617).
+for stale_var in GUEST_ELF USER_GUEST_ELF; do
+  if [[ -n "${!stale_var+x}" ]]; then
+    echo "error: $stale_var is no longer supported; pass --guest-elf <path> instead (GH #10617)." >&2
+    echo "  usage: $0 [--guest-elf PATH] [N] [SEED]" >&2
+    exit 1
+  fi
+done
 ELF_OVERRIDE=""
 if [[ "${1:-}" == "--guest-elf" ]]; then
   [[ -n "${2:-}" ]] || { echo "--guest-elf requires an argument" >&2; exit 1; }


### PR DESCRIPTION
Closes #10617.

## The bug, exactly

`scripts/codegen-eest-stateless-check.sh` resolved the guest as
`USER_GUEST_ELF="${GUEST_ELF:-…}"`. `USER_GUEST_ELF` is the script's **internal**
variable; `GUEST_ELF` was the environment name. Exporting the internal name was
therefore read as empty and **silently ignored** — three consecutive sweeps ran
the *default* guest and reported clean passes, and a 120-row false-reject
population was declared fixed on that evidence. A misspelled *argument* fails
loudly; a misspelled *variable* is indistinguishable from an unset one.

## Interface

- **`--guest-elf PATH`** is now the only supported override. It implies
  `--no-build`; resolves relative paths against the **caller's** cwd (the script
  `cd`s to the repo root before parsing, so a relative path would otherwise
  resolve somewhere the caller did not name — the same class of bug); **rejects a
  nonexistent path** rather than falling back to the default guest; and conflicts
  explicitly with `--bsr-witness-cap`/`--bsr-bal-cap`, which need a build.
- **`GUEST_ELF` and `USER_GUEST_ELF` in the environment are a hard error**
  pointing at the flag. Per the maintainer comment on the issue, plain removal
  would leave an old export as a silent no-op — the precise failure the issue
  exists to prevent.

## Identity — the part that closes the gap for *every* future mechanism

- Every run **echoes the resolved guest path and its sha256** before doing
  anything, labelled with how it was chosen (`--guest-elf` / `no-build-default` /
  `built`).
- Both go into **`$RUN_DIR/run-provenance.tsv`** (`schema=run-provenance-v1`)
  next to `guest_elf_bytes`, `backend`, `fixture_tag`, `repo_head`, `repo_dirty`,
  `generated`; the sha is also in `eest-baseline.txt`.
- **`eest-ab-compare.py` reads it**, so self-check 0 — *the two legs are distinct
  artifacts* — now **runs** on legs whose guest came from outside the run dir,
  where it previously printed `NOT RUN` and skipped. That is the mechanical form
  of the rule, as requested: a comparator that can refuse to join two runs whose
  guest shas disagree. Hashing the run dir's own ELF stays as the fallback for
  run dirs predating this change.
- `lhkn7-semantic-boundary-v2-sweep.py` writes `# guest_elf` /
  `# guest_elf_sha256` into its TSV header (its analyzer skips `#` lines, so no
  consumer changes).
- `spike/parity-check.sh` takes `--guest-elf` on the same terms and rejects the
  env vars — the name is gone from the repo rather than deprecated in one script
  and live in another.

## Verification

| Check | Result |
|---|---|
| `GUEST_ELF=… <script>` | exit 1, points at `--guest-elf` |
| `USER_GUEST_ELF=… <script>` | exit 1, same |
| `--guest-elf /nonexistent` | exit 1, **no fallback to the default guest** |
| `--guest-elf X --bsr-bal-cap 5` | exit 1 |
| override **honoured** | run with `--guest-elf /var/tmp/evm-asm/early44-parent-normal.elf` echoed `edfdcf8453c8c443…` = that file's sha, **not** the default's `c2f3bb3a54f85531…`; `run-provenance.tsv` agrees |
| two overridden legs | `guest ELF: base edfdcf84… != candidate c2f3bb3a… (distinct builds)` — previously skipped |
| same-build guard intact | `!! BOTH LEGS ARE THE SAME BUILD … vacuous` |
| syntax | `bash -n` on both shell scripts; `ast.parse` on all three Python scripts |

The override was proven live the way the incident should have been caught: by
reading back a sha that could only come from the artifact I named, plus the
`/nonexistent` case to show a bad override cannot pass silently.

## Gate

**Non-emitting.** No file under `EvmAsm/` is touched — the diff is 5 scripts and
2 docs — so the guest ELF sha is **unchanged by construction**
(`gen-out/stateless_guest.elf` = `c2f3bb3a54f85531a39c7c7fa8fb4f00907d5d4a4d7aaeaa9ec7e8985533be24`,
identical before and after). No A/B sweep is owed for a change that cannot move a
byte of the guest.

**Not run:** `check-axioms.sh` — it cannot run in cache mode (#10537), so CI's to
run; no Lean proof is touched either way. Spec pin unchanged
(`execution-specs` `e5a8caf1b`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
