### PR TITLE
docs(codegen): warn that single_tx_creation_runtime is called from the MULTI-tx path

### DIFF
--- a/EvmAsm/Codegen/Programs/BlockVerdictCreationStage.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictCreationStage.lean
@@ -265,6 +265,28 @@ def ziskStageCreationRuntimePayloadProbeUnit : BuildUnit := {
 
     Returns:
       a0 = 0 when runtime windows were filled; nonzero staging status otherwise.
+
+    ⚠️ **The `single_tx` in this name is misleading — the MULTI-tx path calls it too.**
+    There are eight call sites (GH #10663):
+
+    | site | |
+    |---|---|
+    | `BlockVerdictCreateCollision.lean:114`  | single-tx creation dispatch |
+    | `BlockVerdictMtxRuntime.lean:521`       | **multi-tx mirror** (`:507` carries the parallel
+                                                `.Lbv_mtx_creation_access_field` structure) |
+    | `EvmDispatchUnits.lean:118,138,145,152,159,165` | six |
+
+    So **"this routine ran" is NOT evidence that the single-tx path ran.** Measured for
+    `create_oog_from_eoa_refunds`: dispatch comes from `MtxRuntime:521` (24/24), never from
+    `CreateCollision:114` (0/24). During GH #10614 this name made a false premise plausible
+    enough to file as an issue (#10662, since closed), and then made two *true* results —
+    "these blocks are on the multi-tx path" and "the creation runtime is entered" — look
+    mutually contradictory. Hours went into reconciling a conflict only the name created.
+
+    Sibling trap: `dispatch_tx_runtime_code` (`BlockVerdictFunction:847`) is a **different**
+    routine, and creation transactions never reach it — they divert at `BlockVerdictFunction:299`
+    into `BlockVerdictCreateCollision:23`, which is also why the single-tx check region at
+    `:1122` is never entered for them. One diversion explains both non-arrivals.
 -/
 def blockVerdictSingleTxCreationRuntimeFunction : String :=
   "block_verdict_single_tx_creation_runtime:\n" ++


### PR DESCRIPTION
Closes the documentation half of #10663. **Comment-only** — one Lean docstring, no code, no emitted-guest change.

## The problem

`block_verdict_single_tx_creation_runtime` has **eight** call sites, and the multi-tx path is one of them:

| site | |
|---|---|
| `BlockVerdictCreateCollision.lean:114` | single-tx creation dispatch |
| **`BlockVerdictMtxRuntime.lean:521`** | **multi-tx mirror** |
| `EvmDispatchUnits.lean:118,138,145,152,159,165` | six |

So the `single_tx` in the name is wrong, and the docstring now says so with the consequence spelled out: **"this routine ran" is not evidence that the single-tx path ran.**

## The measured cost

During #10614 this name did two distinct kinds of damage:

1. **It made a false premise plausible enough to file.** The reading *"dispatched by the single-tx path, verified by the multi-tx path"* was filed as an issue **with that claim in its title** (#10662), and later retracted.
2. **It made two true results look contradictory.** "These blocks are on the multi-tx path" and "the creation runtime is entered" are both correct; only the name suggested otherwise. Hours went into reconciling a conflict that did not exist.

Measured for `create_oog_from_eoa_refunds`: dispatch comes from `MtxRuntime:521` (24/24), never `CreateCollision:114` (0/24).

The docstring also records the sibling trap — `dispatch_tx_runtime_code` (`BlockVerdictFunction:847`) is a *different* routine that creation transactions never reach, because they divert at `:299`. One diversion explains both that non-arrival and the unentered single-tx check region at `:1122`.

## Why documentation and not a rename

A rename touches the symbol, `GuestAddrs`, and all eight call sites — semantics-adjacent, and not what #10663 asks for. If a rename is wanted it should be its own PR with the byte-identity gate exercised.

## Gates

`lake build EvmAsm.Codegen.Programs.BlockVerdictCreationStage` ✔ (17 jobs). `check-forbidden-tactics.sh`, `check-file-size.sh`, `check-naming.sh` all pass. Not run: the ziskemu/EEST sweeps — a docstring above a `def` cannot change the emitted `String`, so they are unexercised rather than passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
