### PR TITLE
chore: batch-merge #10664, #10665

### DIFF
--- a/EvmAsm/Codegen/Programs/BlockVerdictCreationStage.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictCreationStage.lean
@@ -265,6 +265,28 @@ def ziskStageCreationRuntimePayloadProbeUnit : BuildUnit := {
 
     Returns:
       a0 = 0 when runtime windows were filled; nonzero staging status otherwise.
+
+    ⚠️ **The `single_tx` in this name is misleading — the MULTI-tx path calls it too.**
+    There are eight call sites (GH #10663):
+
+    | site | |
+    |---|---|
+    | `BlockVerdictCreateCollision.lean:114`  | single-tx creation dispatch |
+    | `BlockVerdictMtxRuntime.lean:521`       | **multi-tx mirror** (`:507` carries the parallel
+                                                `.Lbv_mtx_creation_access_field` structure) |
+    | `EvmDispatchUnits.lean:118,138,145,152,159,165` | six |
+
+    So **"this routine ran" is NOT evidence that the single-tx path ran.** Measured for
+    `create_oog_from_eoa_refunds`: dispatch comes from `MtxRuntime:521` (24/24), never from
+    `CreateCollision:114` (0/24). During GH #10614 this name made a false premise plausible
+    enough to file as an issue (#10662, since closed), and then made two *true* results —
+    "these blocks are on the multi-tx path" and "the creation runtime is entered" — look
+    mutually contradictory. Hours went into reconciling a conflict only the name created.
+
+    Sibling trap: `dispatch_tx_runtime_code` (`BlockVerdictFunction:847`) is a **different**
+    routine, and creation transactions never reach it — they divert at `BlockVerdictFunction:299`
+    into `BlockVerdictCreateCollision:23`, which is also why the single-tx check region at
+    `:1122` is never entered for them. One diversion explains both non-arrivals.
 -/
 def blockVerdictSingleTxCreationRuntimeFunction : String :=
   "block_verdict_single_tx_creation_runtime:\n" ++

--- a/PLAN.md
+++ b/PLAN.md
@@ -4476,6 +4476,26 @@ through ECALL bridges (extending `EvmAsm/EL/Keccak*EcallBridge.lean`).
     `bal_storage_covers_exec_log` / `bal_storage_reads_in_exec_log` over the append-per-write
     storage exec-log, wrapped all-accounts by `bal_all_accounts_storage_consistent` (callee key
     via `bal_addr_to_exec_log_key`, recipient checked in `block_verdict`).
+    - ⚠️ **Known false-reject, diagnosed not fixed (GH #10614, 2026-07-27)**: two
+      `create_oog_from_eoa_refunds` cases reject with `bv_fail=37`. Chain, each link measured:
+      a top-level creation's initcode makes a **zero-value CALL** to a *pre-existing* contract
+      that `SSTORE`s a net change; the outer CREATE OOGs and the spec rolls back, but the
+      exec-log row is already **committed**, so the reverse arm demands a BAL `storage_change`
+      the builder never emits. `bal_storage_covers_exec_log`'s *"Legacy evidence-based fallback
+      for failed CREATE/CREATE2 initcode"* would give the **spec-correct** answer — forcing it
+      turns `succ 22/24` into **full match 24/24** — but it is declined because no
+      nonstorage-effect record exists for a zero-value callee (`ChildFrameHandlers`:
+      `beqz t3, … -- value == 0: no debit`, a *correct* guard: such records are balance/nonce
+      effects and feed `bal_all_accounts_nonstorage_consistent`).
+      **Not a comparator or frame-discipline bug**: `frame_return` merges cursors only on
+      success and `MtxTail:243` passes the committed cursor. **Fix shape is "snapshot earlier"**
+      — `MtxRuntime:519` snapshots *after* the initcode has already appended. **Blocked on a
+      semantics decision** (should creation rollback be separate from the tx-status mechanism
+      it is fused to at `:531`?), with a measured constraint: two sibling cases *depend* on the
+      current snapshot position and broke when it was disturbed.
+      The fixture family supplies its own control — `sstore_callcode` / `sstore_delegatecall`
+      run the callee's code in the **caller's** storage context, so they write the *created*
+      account, which **does** get a record, and the demotion works for them.
   - **Non-storage** (balance/nonce/code, `i3djw`): per-account `bal_account_nonstorage_finals`
     → `bal_account_nonstorage_consistent` (balance+nonce forward+reverse) +
     `bal_account_code_consistent` (deployed-code bytes); wrapped all-accounts forward
@@ -4489,6 +4509,15 @@ through ECALL bridges (extending `EvmAsm/EL/Keccak*EcallBridge.lean`).
     `exec_log_slot_tuples` (exec side: group-by-txindex, last-write-per-tx, net-zero filtered) +
     `slot_tuple_sequences_match`, composed per-account (`account_tuple_sequences_consistent`)
     and all-accounts (`bal_all_accounts_tuple_sequences_consistent`).
+  - ⚠️ **Those probes are almost all ungated (GH #10642, measured 2026-07-27)**: of **778**
+    `scripts/codegen-*-check.sh`, exactly **1** is reachable from CI (`check-build-parallel.sh`
+    → `codegen-stateless-link-check.sh`); 727 are referenced by nothing at all, and 35 more
+    only via one glob aggregator (`codegen-zisk-mpt-bounded-full-check.sh`) that is itself
+    ungated. An ungated check is indistinguishable from a passing one — the #10642 probe was
+    red for months and surfaced only when run by hand. Cost of a "which are red?" sweep is a
+    **lower bound per category**: ≥703 invoke ziskemu (serial-only), 73 delegate to the shared
+    EEST runner (spike-capable, the cheap tranche); text-based categorisation understates it
+    because wrappers and aggregators delegate.
   - Each ships a ziskemu probe cross-checked against `execution-specs` amsterdam
     `block_access_lists.py` / `fork.py`. **Wiring** of the non-storage/code/tuple checks into
     `block_verdict` lands as execution emits the per-account effect records + the per-tx


### PR DESCRIPTION
## Summary

Batches 2 `merge!`-labeled PRs to amortize CI. Both are documentation-only — no emitted-byte
changes, no generated layout files touched:

- #10664 — docs(plan): PLAN.md status update for #10614-#10642
- #10665 — docs: docstring hazard note above `blockVerdictSingleTxCreationRuntimeFunction` (#10663)

#10665's docstring insertion sits entirely between the `/--` and `-/` doc-comment markers; the
`def blockVerdictSingleTxCreationRuntimeFunction : String := ...` body is byte-for-byte unchanged
(confirmed by diff inspection).

## Test plan

- [x] Full `lake build` (`LAKE_ARTIFACT_CACHE=false`), 4762/4762 jobs, clean
- [x] All 21 `scripts/check-*.sh` gates pass
- [x] `check-unimported.sh`: 2789/2789 modules reachable, 0 orphans
