### PR TITLE
HOLD - docs(soundness): 8-byte padding precondition (central claim is wrong, see comment)

### DIFF
--- a/docs/SOUNDNESS.md
+++ b/docs/SOUNDNESS.md
@@ -1,0 +1,57 @@
+# Soundness preconditions on the guest's inputs
+
+This document records **assumptions the guest is entitled to make about its inputs**. They are not
+implementation details: a caller that violates one is outside the specified interface, and the
+guest's behaviour on such an input carries no soundness guarantee.
+
+Each entry states the assumption, why the guest needs it, and what happens if it is broken.
+
+---
+
+## 1. The input blob's length must be padded to an 8-byte (dword) multiple
+
+**Assumption.** The byte length of the input region supplied to the guest is a multiple of 8.
+
+**Why the guest needs it.** The guest's memory logic operates at **8-byte (dword) granularity**.
+Its loads, its scans and its bounds arithmetic are all expressed in dword units — RISC-V `ld`/`sd`
+against 8-aligned addresses, scans that advance by 8, and lengths reasoned about as dword counts.
+A guest built on that granularity cannot express a read that stops mid-dword, so it treats the
+input as a sequence of dwords and expects the final dword to be whole.
+
+**Consequence if broken.** A trailing partial dword makes the guest's final read extend past the
+end of the supplied input. Whether that is observable depends entirely on the environment
+underneath:
+
+- **ziskemu** creates the input section sized to the actual input and therefore **panics**:
+  `Mem::read() section not found for addr: … with width: 1`. The row terminates abnormally and
+  produces **no verdict at all** — neither an accept nor a reject.
+- **spike** does not report it. The same read is satisfied silently from its mapping, and the run
+  completes normally.
+
+So an unpadded input yields **an abnormal termination on one backend and a silent read of
+unspecified bytes on another**. The silent case is the dangerous one, because it is the side that
+produces a verdict.
+
+**Note that nothing in the ELF constrains this.** `readelf -lW` on the guest shows no LOAD segment
+covering the input region at all — the region is created entirely by the emulator from the input
+file it is handed. `RegionMap`'s `INPUT` extent is a **guest-side constant describing what the
+guest believes it may read**, and it is never expressed as an ELF declaration. There is therefore
+no linker or loader check that can catch an unpadded input; the padding is part of the **trusted
+interface**, not something the toolchain enforces.
+
+**Obligations this places on callers.**
+
+- **Producers of real inputs** must emit a dword-aligned blob length.
+- **Test and fixture harnesses** must pad each input to an 8-byte multiple before handing it to
+  the guest. An unpadded fixture measures nothing: on ziskemu it is an unscored row, and on spike
+  it is a verdict computed partly from bytes the fixture never specified.
+
+**Do not "fix" this by widening the guest's bounds.** The guest reasoning in dword units is
+deliberate and pervasive; making a single consumer byte-exact would leave the granularity
+assumption in place everywhere else while removing the one place it was visible.
+
+---
+
+*Written by **Claude Code** (coord agent) at the maintainer's direction. Placed in `docs/` to match
+the existing convention (`docs/agents/…`, `docs/4ch8f-…`) rather than creating a second top-level
+documentation directory.*


### PR DESCRIPTION
Records an **assumption the guest is entitled to make about its inputs**, at the maintainer's direction: the input blob's byte length must be a multiple of 8.

## Why this is a soundness document rather than a bug report

**The guest's memory logic operates at 8-byte (dword) granularity throughout** — `ld`/`sd` against 8-aligned addresses, scans that advance by 8, lengths reasoned about as dword counts. A guest built that way **cannot express a read that stops mid-dword**, so it treats the input as a sequence of dwords and expects the final one to be whole. A trailing partial dword pushes the last read past the supplied input.

**The consequence is environment-dependent, and that is the point:**

- **ziskemu** sizes the input section to the actual input, so the read **panics** — `Mem::read() section not found … with width: 1` — and the row produces **no verdict at all**.
- **spike** satisfies the same read silently from its mapping and completes normally.

So an unpadded input gives **an abnormal termination on one backend and a silent read of unspecified bytes on the other. The silent side is the one that produces a verdict.**

## And nothing in the toolchain can catch it

`readelf -lW` on a current guest shows LOAD segments at `0x7ffff000`, `0xa2000000`, `0xa3000000`, `0xa4000000` and `0xbf980000` — **no segment covers the input region at all.** That region is created entirely by the emulator from the `-i` file. `RegionMap`'s `INPUT [0x40000000, 0x40002000)` is a **guest-side constant describing what the guest believes it may read**, never expressed as an ELF declaration, so the two are unlinked. **There is no linker or loader check that can reject an unpadded input** — the padding is part of the trusted interface.

## Measured basis

This is what #10658's twelve unscored rows are. On fixture 00159: file 4928 bytes, leading u64 of 4916, 4 bytes of tail padding; the panic address `0x40001348` is the first byte past the mapped input. Across five fixtures the faulting address is always the mapping end — the *"align to 8"* appearance is an artefact of the host padding the mapping to a dword boundary, not align-up arithmetic in the guest. A search of `Programs` for `add 7` / `and -8` rounding confirmed there is no such arithmetic to find.

## Obligations, and one explicit do-not

Producers of real inputs emit a dword-aligned blob length. **Test and fixture harnesses must pad each input to a multiple of 8** — an unpadded fixture measures nothing: unscored on ziskemu, and on spike a verdict computed partly from bytes the fixture never specified. Harness change tracked separately.

**Do not fix this by widening the guest's bounds.** The dword granularity is deliberate and pervasive; making one consumer byte-exact would leave the assumption in place everywhere else while removing the one place it was visible.

## Notes for review

- Placed in `docs/` to match the existing convention (`docs/agents/…`, `docs/4ch8f-…`) rather than creating a second top-level documentation directory one letter apart. Retarget if `doc/` is preferred.
- Documentation only; no Lean, no codegen, no generated artefacts. The Lean build and the ziskemu/EEST gates are therefore **unexercised rather than passing**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
