### PR TITLE
fix(regionmap): restore three dropped storage-writes regions, and gate the invariant that let them vanish

### DIFF
--- a/EvmAsm/Codegen/RegionMap.lean
+++ b/EvmAsm/Codegen/RegionMap.lean
@@ -198,7 +198,28 @@ def schemeAAnchors : List GuestRegion :=
     { name := "tx_account_reads_area",  base := 0xa1ea0000, size := 0x80000,   mode := .rw, zone := .ram,
       evidence := "MemoryLayout TX_ACCOUNT_READS_AREA; per-tx account_reads" },
     { name := "tx_code_reads_area",     base := 0xa1f20000, size := 0x80000,   mode := .rw, zone := .ram,
-      evidence := "MemoryLayout TX_CODE_READS_AREA; per-tx code_reads" } ]
+      evidence := "MemoryLayout TX_CODE_READS_AREA; per-tx code_reads" },
+    -- r59nm S2: the WRITE side of the same two levels.  BlockState.storage_writes
+    -- (state_tracker.py:74) and TransactionState.storage_writes (:101).  ONE map per
+    -- level, not one per source: the spec has no system-specific write container --
+    -- process_unchecked_system_transaction (fork.py:782) builds an ordinary
+    -- TransactionState and incorporates at :858, regular txs at :1204, withdrawals
+    -- at :1226.  These replace bv_system_storage_log and bv_user_storage_log, whose
+    -- two-arena split mirrors nothing.
+    { name := "storage_writes_area",    base := 0xa1fa0000, size := 0x200000,  mode := .rw, zone := .ram,
+      evidence := "MemoryLayout STORAGE_WRITES_AREA; 2 MiB = 16384x128 "
+        ++ "(addrHash++slotKey++value, 96 B used of the shared bvStorageLogRowBytes stride); "
+        ++ "block level, filled only by write_sets_incorporate_tx" },
+    { name := "tx_storage_writes_area", base := 0xa21a0000, size := 0x200000,  mode := .rw, zone := .ram,
+      evidence := "MemoryLayout TX_STORAGE_WRITES_AREA; per-tx storage_writes, "
+        ++ "target of storage_write_record (mirrors set_storage, state_tracker.py:489)" },
+    -- r59nm S5a: undo journal standing in for take_snapshot's dict copy
+    -- (state_tracker.py:800-806) under the no-dynamic-allocation constraint --
+    -- a per-frame copy would cost capacity x call depth.  Bounded by the SSTORE
+    -- handler's own 16384-row cap, so it needs no overflow path.
+    { name := "storage_writes_undo_area", base := 0xa23a0000, size := 0x100000, mode := .rw, zone := .ram,
+      evidence := "MemoryLayout STORAGE_WRITES_UNDO_AREA; 1 MiB = 16384x64 "
+        ++ "(entryIndex, wasAbsent, prevValue); reverse-replayed by write_sets_restore_frame" } ]
 
 /-! ## Section / I/O extents (ELF ground truth, `readelf -S`).
 
@@ -584,7 +605,12 @@ theorem schemeA_matches_layout :
         (EvmAsm.Stateless.CODE_READS_AREA).toNat,
         (EvmAsm.Stateless.TX_STORAGE_READS_AREA).toNat,
         (EvmAsm.Stateless.TX_ACCOUNT_READS_AREA).toNat,
-        (EvmAsm.Stateless.TX_CODE_READS_AREA).toNat ] := by decide
+        (EvmAsm.Stateless.TX_CODE_READS_AREA).toNat,
+        -- r59nm: the write side of the same two levels (state_tracker.py:74 block,
+        -- :101 transaction) plus S5a's undo journal.
+        (EvmAsm.Stateless.STORAGE_WRITES_AREA).toNat,
+        (EvmAsm.Stateless.TX_STORAGE_WRITES_AREA).toNat,
+        (EvmAsm.Stateless.STORAGE_WRITES_UNDO_AREA).toNat ] := by decide
 
 /-! ## Within-`.bss` aliasing inventory (the `call_frame_arena` union).
 
@@ -803,6 +829,10 @@ def stableGuestBases : List (String × Nat) :=
 
 -- 20 -> 23: the three read-container anchors added for GH #10619.
 -- 23 -> 26: the three per-transaction read containers (GH #10619 gate 3).
-theorem stableGuestBases_length : stableGuestBases.length = 26 := by decide
+-- 26 -> 29: the two storage_writes levels and S5a's undo journal (r59nm).
+--            Lost in a merge resolution of #10679 and restored here; the
+--            constants and the guest's use of the addresses were never removed,
+--            so three in-use regions had no disjointness or fit proof.
+theorem stableGuestBases_length : stableGuestBases.length = 29 := by decide
 
 end EvmAsm.Codegen.RegionMap

--- a/scripts/check-build-parallel.sh
+++ b/scripts/check-build-parallel.sh
@@ -24,6 +24,11 @@ codegen_checks() {
   # guest handlers can reference an undefined symbol with every gate green.
   scripts/check-build-units-link.sh
   scripts/check-region-map.sh
+  # check-region-map compares the DECLARED map against the ELF, so a region that
+  # is not declared is not checked. Three in-use anchors were dropped from
+  # RegionMap by a merge resolution with every gate green; this asserts the
+  # missing invariant (declared anchor => has a region entry). Pure grep, instant.
+  scripts/check-memorylayout-region-coverage.sh
   scripts/check-guarded-handler-bytes.sh
 }
 

--- a/scripts/check-memorylayout-region-coverage.sh
+++ b/scripts/check-memorylayout-region-coverage.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Every working-RAM anchor declared in MemoryLayout must have a corresponding
+# entry in RegionMap's schemeAAnchors base list.
+#
+# Why this exists: three anchors (STORAGE_WRITES_AREA, TX_STORAGE_WRITES_AREA,
+# STORAGE_WRITES_UNDO_AREA) were silently dropped from RegionMap by a merge
+# resolution while their constants and the guest's use of the addresses remained.
+# The result was three in-use RAM regions with no pairwise-disjointness and no
+# zone-fit proof, and NOTHING objected: check-region-map.sh compares the
+# DECLARED map against the ELF, so a region that is not declared is not checked.
+# This script asserts the missing invariant -- declaration implies coverage.
+set -uo pipefail
+cd "$(dirname "$0")/.."
+
+LAYOUT=EvmAsm/Stateless/MemoryLayout.lean
+REGIONS=EvmAsm/Codegen/RegionMap.lean
+[[ -f $LAYOUT && -f $REGIONS ]] || { echo "missing $LAYOUT or $REGIONS" >&2; exit 2; }
+
+# Anchors are `def NAME : Word := 0x...` in MemoryLayout. STATELESS_WORK_BASE is a
+# base reference rather than a region, and the SSZ scratch pair is covered by its
+# own dedicated theorem (sszScratch_matches_layout), so both are exempt.
+mapfile -t anchors < <(
+  grep -oE '^def [A-Z][A-Z0-9_]*[[:space:]]*:[[:space:]]*Word' "$LAYOUT" \
+    | awk '{print $2}' \
+    | grep -vE '^(STATELESS_WORK_BASE|SSZ_SCRATCH_BASE|SSZ_SCRATCH_SIZE)$' \
+    | sort -u
+)
+
+(( ${#anchors[@]} > 0 )) || { echo "no anchors parsed from $LAYOUT -- selector is stale" >&2; exit 2; }
+
+missing=()
+for a in "${anchors[@]}"; do
+  grep -qE "EvmAsm\.Stateless\.$a\b" "$REGIONS" || missing+=("$a")
+done
+
+echo "MemoryLayout anchors checked: ${#anchors[@]}"
+if (( ${#missing[@]} )); then
+  echo "MISSING from RegionMap (declared, but no region entry -> no disjointness/fit proof):" >&2
+  for m in "${missing[@]}"; do echo "  $m" >&2; done
+  echo "check-memorylayout-region-coverage: FAIL (${#missing[@]} uncovered)" >&2
+  exit 1
+fi
+echo "check-memorylayout-region-coverage: every anchor has a RegionMap entry"


### PR DESCRIPTION
Three RAM regions were in use by the guest with **no `guestRegionMap` entry** — so no pairwise-disjointness proof and no zone-fit proof covered them.

| | on main before this PR |
|---|---|
| `MemoryLayout` constants (`STORAGE_WRITES_AREA`, `TX_STORAGE_WRITES_AREA`, `STORAGE_WRITES_UNDO_AREA`) | **present** |
| `StorageWriteMap` references to those addresses | **6** |
| `RegionMap` region entries | **0** |
| `schemeAAnchors` bases | **0** |
| `stableGuestBases_length` | **26** (S2 raised it to 28, S5a to 29) |

## Where it was lost

Traced over the **full** ancestry (a first-parent-only walk misattributes this — see the correction comment):

| commit | entries | |
|---|---|---|
| `6b670c745` | **1** | Merge PR #10672 (S2) |
| `2c8c3c201` | **0** | Merge PR #10670 into batch — already lost |
| `54eebb21a` | **1** | S5a re-adds the third region |
| `5374a05a1` | **0** | Merge PR #10676 into batch — dropped again |
| `a8d298499` | 0 | Merge PR #10679 — inherited, both parents already 0 |

**Two successive batch-merge resolutions dropped them**: the #10670 batch lost S2's entries, the #10676 batch lost S5a's re-addition. #10679 and #10689 merely carried an already-broken file. The cause is the **batch-merge layout regeneration** treating `RegionMap.lean` as a generated artifact — which is why it happened twice in a row on the same batch.

## And nothing objected — which is the more important half

`check-region-map.sh` compares the **declared** map against the linked ELF. A region that is not declared is simply **not checked**, so the existing gate is structurally blind to this class of loss.

`RegionMap.lean` is also a **mixed** file: generated pins (`textSizeBytes`, `bssSizeBytes`) alongside **hand-written** region entries. The standing rule "regenerate generated layout files rather than pick a side" restores the pins and **silently discards the hand-written half** — which is exactly how #10689 propagated this.

## What this PR does

1. **Restores** the three region entries, the three `schemeAAnchors` bases, and the count at **29**.
2. **Adds `scripts/check-memorylayout-region-coverage.sh`**, asserting the invariant that was violated: every `MemoryLayout` anchor must have a `RegionMap` entry.
3. **Wires it into `check-build-parallel.sh`'s `codegen_checks`** — the CI run step at `.github/workflows/build.yml:99`. An ungated guard is indistinguishable from a passing one.

### The guard was validated in both directions

```
on this tree      : MemoryLayout anchors checked: 20
                    every anchor has a RegionMap entry            exit 0
on main's RegionMap: MISSING from RegionMap
                      STORAGE_WRITES_AREA
                      STORAGE_WRITES_UNDO_AREA
                      TX_STORAGE_WRITES_AREA
                    FAIL (3 uncovered)                            exit 1
```

It fires on the actual regression and names exactly the three lost regions. `STATELESS_WORK_BASE` and the SSZ scratch pair are exempted with reasons in the script — the latter has its own dedicated theorem.

## Gate

**No emitted-code change.** The addresses, the constants and every routine using them are untouched; only the region *declarations* and the anchor count change. `check-region-map.sh` passes on all five pins, the `decide`-backed disjointness and fit theorems build with the three regions restored, and `check-forbidden-tactics` / `check-layering` / `check-naming` pass.

Refs #10679, #10689, #10672, #10676.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
