### PR TITLE
docs(verdict): say at the flag what bv_block_hash_check_enabled actually gates (#10770)

### DIFF
--- a/EvmAsm/Codegen/Programs/BlockVerdictDataSection.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictDataSection.lean
@@ -54,6 +54,23 @@ def ziskStatelessVerdictV2DataSection : String :=
   ".balign 32\n" ++
   "bv_block_hash:\n  .zero 32\n" ++
   ".balign 8\n" ++
+  -- ON TODAY: `.dword 1` with NO WRITER anywhere in the guest, so only a source edit
+  -- turns it off. What it gates is larger than its name suggests.
+  --
+  -- It guards the block-hash comparison at `BlockVerdictFunction.lean:70`. That
+  -- comparison is ALSO the only thing binding the supplied block-access-list bytes to
+  -- the header: the guest never reads a header BAL-hash field, it CONSTRUCTS one --
+  -- `svf_bal_hash` (keccak over the supplied BAL bytes) is passed as a7 to
+  -- `block_header_ssz_to_rlp` (`BlockHeaderSszToRlp.lean:77`, a7 = block_access_list_hash
+  -- ptr) and embedded while the header RLP is rebuilt. `block_hash_from_header` then
+  -- hashes that RLP and compares it byte-by-byte against the payload's block hash.
+  --
+  -- So with this flag at zero, NOTHING binds the supplied BAL to the header, and a
+  -- rebuild-and-compare check over that BAL becomes self-referential -- verifying its
+  -- own input against itself. That consequence is invisible from here and from the
+  -- comparison site; the dependency runs from this declaration, through an argument
+  -- register, into a routine two levels away, and neither end mentioned the other.
+  -- See GH #10770.
   "bv_block_hash_check_enabled:\n  .dword 1\n" ++
   ".balign 8\n" ++
   "svf_tx_count:\n  .zero 8\n" ++


### PR DESCRIPTION
`.dword 1` with no writer, so it is on today and only a source edit changes it. The
name says block-hash check. What it also gates is the ONLY binding between the
supplied block-access-list bytes and the header.

The guest never reads a header BAL-hash field -- it CONSTRUCTS one. `svf_bal_hash`,
keccak over the supplied BAL bytes, is passed as a7 to `block_header_ssz_to_rlp`
(`BlockHeaderSszToRlp.lean:77`: a7 = block_access_list_hash ptr) and embedded while
the header RLP is rebuilt; `block_hash_from_header` then hashes that RLP and compares
it byte-by-byte against the payload's block hash.

So with this flag at zero, nothing binds the supplied BAL to the header, and #10680's
rebuild-and-compare becomes SELF-REFERENTIAL -- verifying its own input against
itself. That is a much larger consequence than "the block hash is not checked", which
is how the flag reads where it is declared.

The dependency ran from this declaration, through an argument register, into a routine
two levels away, and NEITHER END MENTIONED THE OTHER. Four greps to establish and
invisible from either site. A comment is the whole fix; this is it.

Comment-only: the emitted guest is byte-identical before and after, verified with cmp
rather than assumed, since a comment in an asm-string file is exactly the edit that can
accidentally land inside a string literal.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

Byte-identity verified against **main** (80979 lines each, cmp-identical) — my first check used a baseline from another branch and warned; the corrected comparison is in the thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)