### PR TITLE
docs: explain lenient BAL slot payload binding

### DIFF
--- a/EvmAsm/Codegen/Programs/BalStorageChangeValues.lean
+++ b/EvmAsm/Codegen/Programs/BalStorageChangeValues.lean
@@ -15,6 +15,21 @@
   writes superseded within the block.
 
   Both keys and values are emitted as 32-byte big-endian, left-padded.
+
+  ## Deliberately lenient slot payloads
+
+  Slot keys and post values here accept any RLP payload of length at most 32 and
+  zero-left-pad it; this reader deliberately does not require a shortest scalar
+  encoding or call `rlp_content_to_u256_be`.  The local normalization is safe
+  only because the supplied BAL bytes are committed into the rebuilt header via
+  its BAL hash, and `block_hash_from_header` compares that header commitment
+  with the payload block hash.  A non-canonical supplied payload therefore
+  cannot survive the block-hash binding even when it normalizes to the same
+  32-byte key/value as a canonical payload.
+
+  This is a cross-file dependency, not a property of this reader.  The binding
+  is conditional on `bv_block_hash_check_enabled`; see #10771 and #10777.
+  Do not tighten or rely on this acceptance without re-auditing that gate.
 -/
 
 import EvmAsm.Rv64.Program


### PR DESCRIPTION
## Summary

Documents why `bal_storage_change_values` deliberately accepts RLP slot/value
payloads of length at most 32 and zero-left-pads them instead of requiring a
canonical scalar encoding.

The comment records the cross-file safety condition: supplied BAL bytes are
committed through the rebuilt header's BAL hash and checked by
`block_hash_from_header` against the payload block hash. It also records the
conditional gate, `bv_block_hash_check_enabled`, and references #10771 and
#10777.

No emitted assembly or behavior changes.

## Validation

- `git diff --check`
