### PR TITLE
refactor(codegen): remove stale GuestAddrs decide pins (GH #10790)

### DIFF
--- a/EvmAsm/Codegen/Programs/RlpItemSpanSpec.lean
+++ b/EvmAsm/Codegen/Programs/RlpItemSpanSpec.lean
@@ -149,8 +149,6 @@ theorem cursor_lt_length (items : List RLPItem) (k : Nat) (hk : k < items.length
 /-- Guest entry of `rlp_item_span`. -/
 def rlpItemSpanBase : Word := BitVec.ofNat 64 GuestAddrs.rlp_item_span
 
-theorem rlpItemSpanBase_eq : rlpItemSpanBase = (0x80004abc : Word) := by decide
-
 /-- The `rlp_item_span` body at its linked guest address. -/
 abbrev rlpItemSpanCode : CodeReq :=
   CodeReq.ofProg rlpItemSpanBase rlpItemSpan_prog

--- a/EvmAsm/Codegen/Programs/RlpSpliceHelperSpec.lean
+++ b/EvmAsm/Codegen/Programs/RlpSpliceHelperSpec.lean
@@ -694,8 +694,6 @@ theorem rlp_item_size_form_own_spec_within (base ptr raVal : Word)
 /-- Guest entry of `rlp_item_size`. -/
 def rlpItemSizeBase : Word := BitVec.ofNat 64 GuestAddrs.rlp_item_size
 
-theorem rlpItemSizeBase_eq : rlpItemSizeBase = (0x80004a30 : Word) := by decide
-
 /-- The `rlp_item_size` body at its linked guest address. -/
 abbrev rlpItemSizeCode : CodeReq :=
   CodeReq.ofProg rlpItemSizeBase rlpItemSize_prog


### PR DESCRIPTION
Deletes two unused theorem declarations that pin concrete linked addresses — the bootstrap-cycle hazard of GH #10790:

- `rlpItemSpanBase_eq` (`EvmAsm/Codegen/Programs/RlpItemSpanSpec.lean`, pinning 0x80004abc)
- `rlpItemSizeBase_eq` (`EvmAsm/Codegen/Programs/RlpSpliceHelperSpec.lean`, pinning 0x80004a30)

Both are referenced nowhere (grep over `EvmAsm/`: only the declaration lines match). The underlying defs are already symbol-based (`BitVec.ofNat 64 GuestAddrs.rlp_item_span` / `.rlp_item_size`), so nothing goes stale after this; the bootstrap cycle (stale pin fails `codegen` which builds the Spec modules) disappears.

**Lookalikes checked and deliberately excluded**: `accBase_toNat` (`EvmAsm/Codegen/Programs/U256MulU64Be/OuterLoop.lean:77`) is CONSUMED by `rw` at lines 83/103 (data/.bss region class), and `EVM_MEMORY_AREA_toNat` (`EvmAsm/Evm64/StateAssertions.lean:342`) is consumed at 353/375/395 (region base, rfl-closed) — both are live and are left alone.

**Acceptance**
- `lake build codegen` clean.
- Emitted guest byte-identity vs main: emitted `.s` byte-identical (sha 53e59f26... both); stripped ELFs identical (sha 781f02fb... both); full-ELF diff is only the embedded object filename. Section layouts unchanged.
- `scripts/check-axioms.sh`: OK — 95 witnesses, only classical axioms (propext, Classical.choice, Quot.sound), 0 grandfathered forbidden-tactic owners. (Note: needed one `LAKE_ARTIFACT_CACHE=false lake build EvmAsm.Progress` first — the artifact-cache mode incompatibility from AGENTS.md, not a gate failure.)