### PR TITLE
fix(tactics): normalize GuestLayout program bridges in runBlock

### DIFF
--- a/EvmAsm.lean
+++ b/EvmAsm.lean
@@ -43,3 +43,4 @@ import EvmAsm.Tests.ArithDiffCheck
 import EvmAsm.Tests.Div128V5RandomCheck
 import EvmAsm.Tests.RlpDiffCheck
 import EvmAsm.Tests.SpecRefEestCheck
+import EvmAsm.Tests.RunBlockLayoutBridge

--- a/EvmAsm/Rv64/Tactics/RunBlock.lean
+++ b/EvmAsm/Rv64/Tactics/RunBlock.lean
@@ -1066,6 +1066,42 @@ private partial def extractCrEntriesPure (cr : Expr) : List (Expr × Expr) :=
     extractCrEntriesPure args[0]! ++ extractCrEntriesPure args[1]!
   else []
 
+/-- Return the program argument of the first `CodeReq.ofProg` in a CodeReq tree. -/
+private partial def ofProgArg? (cr : Expr) : Option Expr :=
+  if cr.isAppOfArity ``EvmAsm.Rv64.CodeReq.union 2 then
+    let args := cr.getAppArgs
+    (ofProgArg? args[0]!).orElse fun _ => ofProgArg? args[1]!
+  else if cr.isAppOfArity ``EvmAsm.Rv64.CodeReq.ofProg 2 then
+    some cr.getAppArgs[1]!
+  else none
+
+private def isConcreteGuestLayout (e : Expr) : Bool :=
+  match e.getAppFn with
+  | .const name _ => name.toString == "EvmAsm.Codegen.guestLayout"
+  | _ => false
+
+/-- Recognize exactly the two-step Codegen bridge shape
+    `foo_prog := foo_prog_of guestLayout` and its applied `_prog_of` target.
+    Unrelated opaque `CodeReq.ofProg` arguments deliberately remain opaque. -/
+private def layoutProgramHeadDef? (prog : Expr) : MetaM (Option Name) := do
+  match prog.getAppFn with
+  | .const name _ =>
+    let args := prog.getAppArgs
+    if name.toString.endsWith "_prog_of" then
+      if args.any isConcreteGuestLayout then return some name else return none
+    if name.toString.endsWith "_prog" then
+      match (← getEnv).find? name with
+      | some (.defnInfo info) =>
+        let body := info.value
+        match body.getAppFn with
+        | .const bodyName _ =>
+          if bodyName.toString.endsWith "_prog_of" && body.getAppArgs.any isConcreteGuestLayout
+          then return some name else return none
+        | _ => return none
+      | _ => return none
+    return none
+  | _ => return none
+
 /-- Walk a concrete `List Instr` (whnf'd) and emit `(base + 4*k, instr)` entries. -/
 private partial def extractProgEntries (base : Expr) (progList : Expr) (off : Nat := 0) :
     MetaM (List (Expr × Expr)) := do
@@ -1298,11 +1334,15 @@ elab "runBlock" specs:ident* : tactic => withMainContext do
     -- in the actual goal so all proof terms share the same expression.
     let mvarGoal ← do
       let crEntries := extractCrEntriesPure goalCr
+      let layoutOfProgHead? ← match ofProgArg? goalCr with
+        | some prog => layoutProgramHeadDef? prog
+        | none => Pure.pure none
       if crEntries.isEmpty then
         match goalCr.getAppFn with
         | .const name _ =>
           if name == ``EvmAsm.Rv64.CodeReq.singleton || name == ``EvmAsm.Rv64.CodeReq.union ||
-             name == ``EvmAsm.Rv64.CodeReq.empty then
+             name == ``EvmAsm.Rv64.CodeReq.empty ||
+             (name == ``EvmAsm.Rv64.CodeReq.ofProg && layoutOfProgHead?.isSome) then
             Pure.pure mvarGoal
           else
             trace[runBlock] "deltaTarget: unfolding CodeReq abbrev {name}"
@@ -1310,6 +1350,38 @@ elab "runBlock" specs:ident* : tactic => withMainContext do
             catch _ => Pure.pure mvarGoal
         | _ => Pure.pure mvarGoal
       else Pure.pure mvarGoal
+    -- A layout-parameterised program often reaches the goal as
+    -- `CodeReq.ofProg base (foo_prog_of guestLayout)`.  Unlike a literal list,
+    -- its bridge and parameterised definition need target-level delta unfolding
+    -- before `CodeReq.ofProg` can expose the singleton chain used for framing.
+    -- Keep this bounded and recognize only the concrete GuestLayout bridge shape:
+    -- unrelated opaque program arguments remain on the old path.
+    let mvarGoal ← do
+      let mut workingGoal := mvarGoal
+      let mut keepUnfolding := true
+      for _ in [:4] do
+        if keepUnfolding then
+          let ty := inlineLets (← instantiateMVars (← workingGoal.getType))
+          match ← parseCpsTripleWithin? ty with
+          | some (_, _, _, cr, _, _) =>
+            match ofProgArg? cr with
+            | some prog =>
+              match ← layoutProgramHeadDef? prog with
+              | some name =>
+                trace[runBlock] "deltaTarget: unfolding CodeReq.ofProg head {name}"
+                try workingGoal ← workingGoal.deltaTarget (· == name)
+                catch _ => keepUnfolding := false
+              | none => keepUnfolding := false
+            | none => keepUnfolding := false
+          | none => keepUnfolding := false
+      if keepUnfolding then
+        let ty := inlineLets (← instantiateMVars (← workingGoal.getType))
+        if let some (_, _, _, cr, _, _) ← parseCpsTripleWithin? ty then
+          if let some prog := ofProgArg? cr then
+            if let some name ← layoutProgramHeadDef? prog then
+              throwError "runBlock: layout CodeReq.ofProg normalization exhausted 4 steps at {name}; \
+                add an explicit bridge theorem or increase the tactic fuel deliberately."
+      Pure.pure workingGoal
     -- Re-parse goal after potential delta-unfolding
     let goalType := inlineLets (← instantiateMVars (← mvarGoal.getType))
     -- Normalize addresses in goal type (signExtend12, e+0, address flattening)

--- a/EvmAsm/Tests/RunBlockLayoutBridge.lean
+++ b/EvmAsm/Tests/RunBlockLayoutBridge.lean
@@ -1,0 +1,56 @@
+import EvmAsm.Rv64.SyscallSpecs
+import EvmAsm.Rv64.Program
+import EvmAsm.Rv64.Tactics.RunBlock
+import EvmAsm.Codegen.GuestLayoutInstance
+
+namespace EvmAsm.Tests.RunBlockLayoutBridge
+
+open EvmAsm.Rv64
+open EvmAsm.Rv64.Tactics
+open EvmAsm.Codegen
+
+def layoutLi_prog_of (_ : GuestLayout) : Program := by
+  exact (show List Instr from [ Instr.LI .x5 (0 : Word) ])
+def layoutLi_prog : Program := layoutLi_prog_of guestLayout
+
+example (base v : Word) :
+    cpsTripleWithin 1 base (base + 4) (CodeReq.ofProg base layoutLi_prog)
+      (.x5 ↦ᵣ v) (.x5 ↦ᵣ 0) := by
+  have h := li_spec_gen_within .x5 v (0 : Word) base (by nofun)
+  runBlock h
+
+opaque opaqueProgram : Program := by
+  exact (show List Instr from [ Instr.LI .x5 (0 : Word) ])
+
+/--
+error: don't know how to synthesize placeholder
+context:
+base v : Word
+h : cpsTripleWithin 1 base (base + 4) (CodeReq.singleton base (Instr.LI Reg.x5 0)) (Reg.x5 ↦ᵣ v) (Reg.x5 ↦ᵣ 0)
+⊢ cpsTripleWithin 1 base (base + 4) (CodeReq.ofProg base opaqueProgram) (Reg.x5 ↦ᵣ v) (Reg.x5 ↦ᵣ 0)
+-/
+#guard_msgs in
+example (base v : Word) :
+    cpsTripleWithin 1 base (base + 4) (CodeReq.ofProg base opaqueProgram)
+      (.x5 ↦ᵣ v) (.x5 ↦ᵣ 0) := by
+  have h := li_spec_gen_within .x5 v (0 : Word) base (by nofun)
+  runBlock h
+
+def tooDeep4_prog_of (_ : GuestLayout) : Program := by
+  exact (show List Instr from [ Instr.LI .x5 (0 : Word) ])
+def tooDeep3_prog_of (L : GuestLayout) : Program := tooDeep4_prog_of L
+def tooDeep2_prog_of (L : GuestLayout) : Program := tooDeep3_prog_of L
+def tooDeep1_prog_of (L : GuestLayout) : Program := tooDeep2_prog_of L
+def tooDeep0_prog_of (L : GuestLayout) : Program := tooDeep1_prog_of L
+
+/--
+error: runBlock: layout CodeReq.ofProg normalization exhausted 4 steps at EvmAsm.Tests.RunBlockLayoutBridge.tooDeep4_prog_of; add an explicit bridge theorem or increase the tactic fuel deliberately.
+-/
+#guard_msgs in
+example (base v : Word) :
+    cpsTripleWithin 1 base (base + 4) (CodeReq.ofProg base (tooDeep0_prog_of guestLayout))
+      (.x5 ↦ᵣ v) (.x5 ↦ᵣ 0) := by
+  have h := li_spec_gen_within .x5 v (0 : Word) base (by nofun)
+  runBlock h
+
+end EvmAsm.Tests.RunBlockLayoutBridge


### PR DESCRIPTION
## Summary

`runBlock` now recognizes the narrow layout bridge shape `foo_prog := foo_prog_of guestLayout` beneath `CodeReq.ofProg`. It unfolds only that bridge and its concrete `_prog_of` application, then uses the existing singleton-chain composition path.

All ordinary `CodeReq.ofProg` users retain the pre-existing generic-delta route unchanged. The special path is entered only after inspecting the bridge definition body; arbitrary opaque programs remain opaque.

The bounded normalizer has fuel 4. Exhaustion reports `runBlock: layout CodeReq.ofProg normalization exhausted 4 steps at <name>` with action guidance, rather than surfacing later as a framing placeholder.

## Evidence

- Exact conversion reproduction: `U256IsZeroSpec` builds on the layout-conversion branch after removing its documented manual `simp` workaround. The special route performs exactly two deltas: `u256IsZero_prog`, then `u256IsZero_prog_of`.
- Permanent main test module `EvmAsm.Tests.RunBlockLayoutBridge` covers the bridge success case, a `#guard_msgs` opaque non-Codegen rejection, and a `#guard_msgs` five-hop fuel-exhaustion diagnostic naming `tooDeep4_prog_of`.
- Current-main checks: `RunBlock`, `U256IsZeroSpec`, and `CallReturn` build.
- Profiled legacy U256 path at base `d47ccc767`: median 53.005 ms, range 43.989--70.871 ms. Candidate: median 44.055 ms, range 43.611--84.188 ms. No regression is detectable at this sample size because noise exceeds the median difference.
- Additional ordinary-user sanity check: `RLP/WalkNext` has 48 `runBlock` calls; its slowest profiled call was 279.199 ms, below the 800 ms ceiling.
- The converted U256 route is approximately 188 ms inside `runBlock`, below the same 800 ms ceiling. This cost applies only to layout bridges and retires the hand-written workaround.

No heartbeat, recursion-depth, or tactic-bound changes; no `native_decide` or `bv_decide`.
