### PR TITLE
fix: stop BAL oracle echo during callee seeding

### DIFF
--- a/EvmAsm/Codegen/Programs/BlockVerdictDispatchTx.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictDispatchTx.lean
@@ -129,7 +129,7 @@ def seedCalleeStorageFunction : String :=
   "  la t0, callee_balance_count; ld t1, 0(t0); li t2, 512; bgeu t1, t2, .Lscs_bal_done\n" ++
   "  la t0, svf_parent_rlp; ld a0, 0(t0); la t0, svf_parent_rlp_len; ld a1, 0(t0)\n" ++
   "  la t0, csce_addrp; ld a2, 0(t0); li a3, 20; mv a4, s0; mv a5, s1; la a6, csce_bal_struct\n" ++
-  "  jal ra, account_at_header_state_root_tracked\n" ++
+  "  jal ra, account_at_header_state_root\n" ++
   "  bnez a0, .Lscs_bal_done\n" ++                  -- absent/error -> skip (descend default 0)
   "  la t0, callee_balance_count; ld t1, 0(t0); slli t2, t1, 6; la t3, callee_balance_table; add t3, t3, t2\n" ++
   -- addr (canonical BE, csce_addrp) -> entry+0..19, zero-pad +20..31


### PR DESCRIPTION
## Summary

Stops `seed_callee_storage` from using the tracked account accessor while it
walks the supplied Block Access List. The seeding lookup is a raw witness-state
lookup; it is not execution-level account access and must not feed the BAL
builder's account-read set.

This is deliberately isolated from the held EXTCODE recording experiment.

## Causal KAT: b35

The parent ELF `635fee6d1f16948f995454962a4ee8d10af9c46c1738c66bbac0fa1f6296bab7`
and candidate ELF `7375b58e51ed03399bf0681a448dbfcfbe766ea391542f23133673d89d3a5a3b`
ran with the same runner
`c03f2f7b3072042b954c3d0b0bf4b71c582b3a96fc7a1e22b9dd5816c46b71f3`.

For `13567 ... EXTCODEHASH-debug__b35`, parent diagnostic fields at OUTPUT
offsets 120/128/136 were `shadow_status=0`, `rebuilt_len=492`,
`supplied_len=492`. The candidate was `1`, `465`, `492`.

The pre-registered 27-byte decrease is exactly one all-empty BAL entry: the
supplied entry for `c8873dbccb5d26a2ca2557552325fcb953fb4a3a` is no longer
re-emitted. Thus the removed tracked read was causally supplying an oracle
entry to the rebuilt BAL.

The change is instruction-size neutral: both artifacts link at `.text`
`0x67228`, `.data` `0x5370`, `.bss` `0x1b85cae0`.

## Paired cost measurement

Captured selection seed: `8213940673021854146`; 200 shared manifest rows;
same runner and immutable ELF snapshots above.

| Transition | Rows |
| --- | ---: |
| FR -> FR | 73 |
| OK -> OK | 55 |
| OK -> FR | 72 |
| FA / FAULT | 0 |

Parent: FA=0, FR=73, OK=127, FAULT=0. Candidate: FA=0, FR=145, OK=55,
FAULT=0. All 72 changed rows changed `shadow_status` from 0 to 1. Their
state-root and tail bytes were unchanged; their verdict/full-match changed
from accepted to rejected.

72 of the parent's 127 passing blocks (56.7%) were passing because the oracle
echo supplied account existence. On this sample, the honest producer-coverage
baseline is 55/200 (27.5%), not the previously observed 110/200 (55.0%). This
is not a behavioural regression to minimise: it is the corrected baseline after
removing an oracle echo that had inflated apparent account-existence coverage.

FA remained zero on both legs. The echo is an FA mechanism because it can hide
a missing touched-account producer, but this valid-only corpus cannot measure
the reject side of that acceptance-widening mechanism. Its absence of observed
FAs is therefore **unverified by measurement**, not a claim that the mechanism
was clean.

## Scope finding and controls

`seed_callee_storage` calls the tracked accessor for every parsable BAL item
whose first field is a 20-byte address, before recipient skipping and before
storage-key enumeration. The tracked wrapper records before its raw lookup.
There is no tx-recipient or storage-presence filter at this ingress. The echo
is nevertheless empirically partial. Whether that is due to dispatch reachability,
the 512-entry cap, or another path condition remains open and is recorded in
#10843, so neither presence nor absence alone should be read as producer coverage.

The following full-label controls were rerun parent/candidate and were unchanged:
`00070_test_value_move_to_precompiles_fork_Amsterdam-precompile_0x0000000000000000000000000000000000000`,
`00079_test_value_move_to_precompiles_fork_Amsterdam-precompile_0x0000000000000000000000000000000000000`,
and `00165_test_top_frame_charges_delegation_in_access_list_fork_Amsterdam-blockchain_test_from_state_test-`.
They are not scoper's selector-relative `valid_tx_invalid_chain` natural-experiment
fixture. In particular, this PR's `00070` was already a shadow mismatch on the
current parent artifact (`status=1, rebuilt=310, supplied=337`).
