### PR TITLE
refactor(codegen): generalise six U256 SAsm modules over GuestLayout (GH #10753)

### DIFF
--- a/EvmAsm/Codegen/Programs/U256AddBeSAsm.lean
+++ b/EvmAsm/Codegen/Programs/U256AddBeSAsm.lean
@@ -10,7 +10,8 @@
   writable window, so this theorem covers the non-overlapping ownership shape.
 -/
 
-import EvmAsm.Codegen.Programs.U256
+import EvmAsm.Codegen.GuestLayout
+import EvmAsm.Codegen.Programs.U256Prog
 import EvmAsm.Rv64.SAsm.Tactic
 
 namespace EvmAsm.Codegen
@@ -146,8 +147,12 @@ def u256AddBeFn (aPtr bPtr outPtr : Word)
   post := u256AddBePost aPtr bPtr outPtr aBytes bBytes orig
   body := u256AddBeBody aPtr bPtr outPtr aBytes bBytes orig
 
-#guard (u256AddBeBody 0 0 0 [] [] []).flatten 0 ++ [Instr.JALR .x0 .x1 (0 : BitVec 12)]
-  = u256AddBe_prog
+/-- The flattened body is layout-independent: `u256AddBeBody` never
+    references a `GuestLayout` field, so `rfl` closes this with `L`
+    free (it would fail if the body ever baked a layout value in). -/
+theorem u256AddBeBody_flatten (L : GuestLayout) :
+    (u256AddBeBody 0 0 0 [] [] []).flatten 0 ++ [Instr.JALR .x0 .x1 (0 : BitVec 12)]
+      = u256AddBe_prog_of L := rfl
 
 #guard (u256AddBeBody 0 0 0 [] [] []).flatten 0 =
   (u256AddBeBody 0 0 0 [] [] []).flatten 0x80000000
@@ -758,8 +763,11 @@ def u256AddBeInPlaceFn (aPtr bPtr : Word)
     ws = u256AddBeBytes aBytes bBytes aBytes ∧ A = bytesRegion bPtr bBytes
   body := u256AddBeInPlaceBody aPtr bPtr aBytes bBytes
 
-#guard (u256AddBeInPlaceBody 0 0 [] []).flatten 0 ++
-  [Instr.JALR .x0 .x1 (0 : BitVec 12)] = u256AddBe_prog
+/-- Layout-independence of the in-place body: it flattens to the same
+    program as `u256AddBeBody` (see `u256AddBeBody_flatten`). -/
+theorem u256AddBeInPlaceBody_flatten (L : GuestLayout) :
+    (u256AddBeInPlaceBody 0 0 [] []).flatten 0 ++
+      [Instr.JALR .x0 .x1 (0 : BitVec 12)] = u256AddBe_prog_of L := rfl
 
 private theorem execBlock_lbu_rw_current (aPtr : Word) (rf : RegFile)
     (ws aBytes bBytes : List (BitVec 8)) (i : Nat) (hi : i ≤ 31)

--- a/EvmAsm/Codegen/Programs/U256DivU64BeSAsm.lean
+++ b/EvmAsm/Codegen/Programs/U256DivU64BeSAsm.lean
@@ -10,7 +10,8 @@
   consumer of `Stmt.whileHeader`.
 -/
 
-import EvmAsm.Codegen.Programs.U256
+import EvmAsm.Codegen.GuestLayout
+import EvmAsm.Codegen.Programs.U256Prog
 import EvmAsm.Rv64.SAsm.Tactic
 
 namespace EvmAsm.Codegen
@@ -144,8 +145,12 @@ def u256DivU64BeFn (srcPtr outPtr b : Word)
   post := u256DivU64BePost srcPtr outPtr b srcBytes orig
   body := u256DivU64BeBody srcPtr outPtr b srcBytes orig
 
-#guard (u256DivU64BeBody 0 0 1 [] []).flatten 0 ++ [Instr.JALR .x0 .x1 (0 : BitVec 12)]
-  = u256DivU64Be_prog
+/-- Layout-independence interlock: the body flattens to `u256DivU64Be_prog_of
+    L` for an ARBITRARY layout `L`, so the body cannot reference the layout.
+    (`rfl` closes it; a future layout reference would make it fail.) -/
+theorem u256DivU64BeBody_flatten (L : GuestLayout) :
+    (u256DivU64BeBody 0 0 1 [] []).flatten 0 ++ [Instr.JALR .x0 .x1 (0 : BitVec 12)]
+      = u256DivU64Be_prog_of L := rfl
 
 #guard (u256DivU64BeBody 0 0 1 [] []).flatten 0 =
   (u256DivU64BeBody 0 0 1 [] []).flatten 0x80000000

--- a/EvmAsm/Codegen/Programs/U256EqSAsm.lean
+++ b/EvmAsm/Codegen/Programs/U256EqSAsm.lean
@@ -8,7 +8,8 @@
   legacy single-exit `Fn.Spec` epilogue path.
 -/
 
-import EvmAsm.Codegen.Programs.U256
+import EvmAsm.Codegen.GuestLayout
+import EvmAsm.Codegen.Programs.U256Prog
 import EvmAsm.Codegen.Programs.Bn254Field
 import EvmAsm.Rv64.SAsm.Tactic
 
@@ -434,8 +435,11 @@ theorem u256Eq_spec (ptr1 ptr2 base ret : Word) (bs1 bs2 : List (BitVec 8))
     (sepConj_mono_right (asrtM_mono (u256Eq_sp_post ptr1 ptr2 bs1 bs2))) hsound
 
 
--- Byte-identity to the existing emitted `u256_eq` program.
-#guard (u256EqBody 0 0 [] []).flatten 0 = u256Eq_prog
+-- Byte-identity to the emitted `u256_eq` program, for an ARBITRARY layout:
+-- the body cannot reference the layout (`rfl`; a future layout reference
+-- would make this fail).
+theorem u256EqBody_flatten (L : GuestLayout) :
+    (u256EqBody 0 0 [] []).flatten 0 = u256Eq_prog_of L := rfl
 #guard (u256EqBody 0 0 [] []).retOffsetsOk
 #guard !(u256EqBody 0 0 [] []).offsetsOk
 

--- a/EvmAsm/Codegen/Programs/U256FromU64BeSAsm.lean
+++ b/EvmAsm/Codegen/Programs/U256FromU64BeSAsm.lean
@@ -12,7 +12,8 @@
   `u256FromU64BeBody.flatten 0 ++ [ret] = u256FromU64Be_prog`.
 -/
 
-import EvmAsm.Codegen.Programs.U256
+import EvmAsm.Codegen.GuestLayout
+import EvmAsm.Codegen.Programs.U256Prog
 import EvmAsm.Rv64.SAsm.MultiDword
 import EvmAsm.Rv64.SAsm.Tactic
 
@@ -108,8 +109,12 @@ def u256FromU64Be_verified : Program :=
 #guard u256FromU64BeBody.flatten 0 = u256FromU64BeInstrs
 #guard (u256FromU64Be_verified : List Instr).length = 18
 #guard u256FromU64BeBody.flatten 0 = u256FromU64BeBody.flatten 0x80000000
-#guard u256FromU64BeBody.flatten 0 ++ [Instr.JALR .x0 .x1 (0 : BitVec 12)]
-  = u256FromU64Be_prog
+/-- Layout-independence interlock: the body flattens to `u256FromU64Be_prog_of
+    L` for an ARBITRARY layout `L`, so the body cannot reference the layout.
+    (`rfl` closes it; a future layout reference would make it fail.) -/
+theorem u256FromU64BeBody_flatten (L : GuestLayout) :
+    u256FromU64BeBody.flatten 0 ++ [Instr.JALR .x0 .x1 (0 : BitVec 12)]
+      = u256FromU64Be_prog_of L := rfl
 
 
 

--- a/EvmAsm/Codegen/Programs/U256IsZeroSAsm.lean
+++ b/EvmAsm/Codegen/Programs/U256IsZeroSAsm.lean
@@ -25,7 +25,8 @@
   Spec-only module (no emitted-code change) — no EEST A/B required.
 -/
 
-import EvmAsm.Codegen.Programs.U256
+import EvmAsm.Codegen.GuestLayout
+import EvmAsm.Codegen.Programs.U256Prog
 import EvmAsm.Rv64.SAsm.Tactic
 
 namespace EvmAsm.Codegen
@@ -64,9 +65,12 @@ def u256IsZero_verified : Program :=
 #guard u256IsZeroBody.flatten 0 = u256IsZeroBody.flatten 0x80000000
 
 -- Byte-identity to the emitted routine: the 8 body instructions plus the
--- calling-convention `ret` epilogue reproduce `u256IsZero_prog` exactly.
-#guard u256IsZeroBody.flatten 0 ++ [Instr.JALR .x0 .x1 (0 : BitVec 12)]
-  = u256IsZero_prog
+-- calling-convention `ret` epilogue reproduce `u256IsZero_prog_of L` for an
+-- ARBITRARY layout `L` — the body cannot reference the layout (`rfl`; a
+-- future layout reference would make this fail).
+theorem u256IsZeroBody_flatten (L : GuestLayout) :
+    u256IsZeroBody.flatten 0 ++ [Instr.JALR .x0 .x1 (0 : BitVec 12)]
+      = u256IsZero_prog_of L := rfl
 
 private theorem se12_0 : signExtend12 (0#12 : BitVec 12) = (0 : Word) := by decide
 private theorem se12_8 : signExtend12 (8#12 : BitVec 12) = (8 : Word) := by decide

--- a/EvmAsm/Codegen/Programs/U256SubBeSAsm.lean
+++ b/EvmAsm/Codegen/Programs/U256SubBeSAsm.lean
@@ -10,7 +10,8 @@
   writable window, so this theorem covers the non-overlapping ownership shape.
 -/
 
-import EvmAsm.Codegen.Programs.U256
+import EvmAsm.Codegen.GuestLayout
+import EvmAsm.Codegen.Programs.U256Prog
 import EvmAsm.Rv64.SAsm.Tactic
 
 namespace EvmAsm.Codegen
@@ -146,8 +147,12 @@ def u256SubBeFn (aPtr bPtr outPtr : Word)
   post := u256SubBePost aPtr bPtr outPtr aBytes bBytes orig
   body := u256SubBeBody aPtr bPtr outPtr aBytes bBytes orig
 
-#guard (u256SubBeBody 0 0 0 [] [] []).flatten 0 ++ [Instr.JALR .x0 .x1 (0 : BitVec 12)]
-  = u256SubBe_prog
+/-- Layout-independence interlock: the body flattens to `u256SubBe_prog_of L`
+    for an ARBITRARY layout `L`, so the body cannot reference the layout.
+    (`rfl` closes it; a future layout reference would make it fail.) -/
+theorem u256SubBeBody_flatten (L : GuestLayout) :
+    (u256SubBeBody 0 0 0 [] [] []).flatten 0 ++ [Instr.JALR .x0 .x1 (0 : BitVec 12)]
+      = u256SubBe_prog_of L := rfl
 
 #guard (u256SubBeBody 0 0 0 [] [] []).flatten 0 =
   (u256SubBeBody 0 0 0 [] [] []).flatten 0x80000000


### PR DESCRIPTION
Behaviour-neutral with byte-identical emission, verified not asserted (numbers below).

Second conversion on the GH #10753 theme, following the pattern of #10842 (the U256 leaf/bridge split). Six U256 SAsm modules — AddBeSAsm, SubBeSAsm, EqSAsm, IsZeroSAsm, DivU64BeSAsm, FromU64BeSAsm — each touched in exactly two places: the import re-points from the concrete bridge `Programs.U256` to `GuestLayout` + `Programs.U256Prog` (the abstract leaf), and each concrete-program `#guard` becomes a **theorem over an arbitrary layout `L` closed by `rfl`** — proving the body cannot reference the layout, rather than checking a single instantiation. No `GuestLayout`/`GuestLayoutInstance` field edits: none of these bodies reference a layout symbol.

## Footprint payoff (issue 10751), before/after

Before: each module was inside the 362-module transitive import set of `GuestLayoutInstance` via the `Programs.U256` bridge edge. After: out of it — e.g. U256AddBeSAsm's transitive import closure is 43 modules, none reaching the instance. Instance rebuilds will no longer touch these six.

## Emission: byte-identical vs base 8fd59deec (post-10842 main)

| instrument | base | branch | verdict |
|---|---|---|---|
| emitted `.s` sha256 | c75bb6fe…098991b | c75bb6fe…098991b | identical |
| stripped ELF sha256 | af37d83a…0281a95 | af37d83a…0281a95 | identical |
| text / data / bss | 422524 / 21360 / 482058976 | 422524 / 21360 / 482058976 | identical |

Raw ELF shas differ between any two emissions by the embedded object filename — that comparison is a trap; the emitted `.s` and the stripped ELF are the right instruments. text = 0x6727c and data = 0x5370 match the independently-derived main pins.

## Checks

- `lake build codegen` clean (4280 jobs)
- Every file under the 1500-line cap: AddBeSAsm 1095, SubBeSAsm 680, EqSAsm 447, IsZeroSAsm 431, DivU64BeSAsm 610, FromU64BeSAsm 297
- Diff vs main is exactly these six files (+52/−21)

The four field-needing modules (U256LtBeSAsm, U256MinSAsm, U256GasPricing, U256MulU64Be) are deliberately NOT in this PR — one at a time after, GasPricing first; MulU64Be's layout-independence theorem cannot close (its body genuinely references the layout) and needs a different, weaker check.

**Generated artifacts:** none were regenerated — emission is byte-identical, so there is nothing to regenerate. Stated as a positive: the diff contains no shared-file edits and no generated artifacts by construction, not by omission.

### Section table (bss accounting, from `readelf -SW` on the emitted ELF)

| Section | Type | Size |
|---|---|---|
| `.bss` | NOBITS | 0x1b85cae0 (461,753,056) |
| `.committed_storage` | NOBITS | 0xcdd800 (13,490,176) |
| `.sszscratch` | NOBITS | 0x680000 (6,815,744) |

The pin 0x1b85cae0 measures `.bss` alone; GNU `size`'s bss column sums ALL NOBITS sections (+0x10000 accounting slack) = 0x1cbba2e0 (482,058,976). Different quantities, both consistent; total reserved NOBITS ≈ 482MB.