### PR TITLE
refactor(codegen): parameterise U256GasPricing over GuestLayout (GH #10753)

### DIFF
--- a/EvmAsm/Codegen/GuestLayout.lean
+++ b/EvmAsm/Codegen/GuestLayout.lean
@@ -51,6 +51,11 @@ structure GuestLayout where
   -- U256 (u256_mul_u64_be: accumulator window and entry).
   u256m_acc : Nat
   u256_mul_u64_be : Nat
+  -- U256GasPricing (priority_fee_per_gas_eip1559: own entry and the two
+  -- helpers it calls).
+  priority_fee_per_gas_eip1559 : Nat
+  u256_sub_be : Nat
+  u256_min : Nat
 
 /-- The all-zero layout: emission/guard view, never linked against. -/
 def GuestLayout.zero : GuestLayout :=
@@ -65,6 +70,9 @@ def GuestLayout.zero : GuestLayout :=
     bav_hash := 0
     bloom_add_value := 0
     u256m_acc := 0
-    u256_mul_u64_be := 0 }
+    u256_mul_u64_be := 0
+    priority_fee_per_gas_eip1559 := 0
+    u256_sub_be := 0
+    u256_min := 0 }
 
 end EvmAsm.Codegen

--- a/EvmAsm/Codegen/GuestLayoutInstance.lean
+++ b/EvmAsm/Codegen/GuestLayoutInstance.lean
@@ -33,6 +33,9 @@ def guestLayout : GuestLayout :=
     bav_hash := GuestAddrs.bav_hash
     bloom_add_value := GuestAddrs.bloom_add_value
     u256m_acc := GuestAddrs.u256m_acc
-    u256_mul_u64_be := GuestAddrs.u256_mul_u64_be }
+    u256_mul_u64_be := GuestAddrs.u256_mul_u64_be
+    priority_fee_per_gas_eip1559 := GuestAddrs.priority_fee_per_gas_eip1559
+    u256_sub_be := GuestAddrs.u256_sub_be
+    u256_min := GuestAddrs.u256_min }
 
 end EvmAsm.Codegen

--- a/EvmAsm/Codegen/Programs/U256GasPricing.lean
+++ b/EvmAsm/Codegen/Programs/U256GasPricing.lean
@@ -4,98 +4,22 @@
   EIP-1559 gas-pricing composites over the U256-BE arithmetic helpers.
 -/
 
-import EvmAsm.Rv64.Program
 import EvmAsm.Codegen.Layout
-import EvmAsm.Codegen.Emit
-import EvmAsm.Codegen.GuestAddrs
-import EvmAsm.Codegen.AsmReloc
 import EvmAsm.Codegen.Programs.U256
+import EvmAsm.Codegen.Programs.U256GasPricingProg
+import EvmAsm.Codegen.GuestLayoutInstance
 
 namespace EvmAsm.Codegen
 
 open EvmAsm.Rv64
 
-/-! ## priority_fee_per_gas_eip1559 -- PR-K62
+/-- The concrete `priority_fee_per_gas_eip1559` program at the linked guest
+    layout.  Name and type are required by the concrete-render gate
+    (`emitProgram priorityFeePerGasEip1559_prog`) and by consumers; the
+    parameterised program lives in `U256GasPricingProg`. -/
+def priorityFeePerGasEip1559_prog : Program := priorityFeePerGasEip1559_prog_of guestLayout
 
-    Compute the effective priority fee per gas for a post-EIP-1559
-    transaction. Mirrors Python's
-    `transaction_priority_fee_per_gas` from
-    `forks/amsterdam/transaction_helpers.py`:
 
-      surplus = tx.max_fee_per_gas - block.base_fee_per_gas
-      priority_fee = min(tx.max_priority_fee_per_gas, surplus)
-
-    Where `surplus = max_fee - base_fee` would underflow
-    (`max_fee < base_fee`), the tx is invalid; this helper
-    returns `1` so the caller can reject without inspecting the
-    output. Otherwise returns `0` and the 32-byte priority fee
-    is written to `*out` in big-endian.
-
-    First higher-level helper composed on the K-stack's u256
-    toolkit: PR-K52 `u256_sub_be` + PR-K59 `u256_min`. Both are
-    inlined into the probe BuildUnit so this PR doesn't require
-    any new external symbols.
-
-    BE storage convention: byte 0 = MSB, byte 31 = LSB.
-
-    Calling convention:
-      a0 (input)  : max_priority_fee_per_gas ptr (32 B BE)
-      a1 (input)  : max_fee_per_gas ptr (32 B BE)
-      a2 (input)  : base_fee_per_gas ptr (32 B BE)
-      a3 (input)  : output ptr (32 B BE; receives priority fee)
-      ra (input)  : return
-      a0 (output) : 0 success / 1 max_fee < base_fee (reject tx). -/
-def priorityFeePerGasEip1559_prog : Program :=
-  [ .ADDI .x2 .x2 (-48 : BitVec 12),
-    .SD .x2 .x1 (0 : BitVec 12),
-    .SD .x2 .x8 (8 : BitVec 12),
-    .SD .x2 .x9 (16 : BitVec 12),
-    .SD .x2 .x18 (24 : BitVec 12),
-    .SD .x2 .x19 (32 : BitVec 12),
-    .MV .x8 .x10,
-    .MV .x9 .x11,
-    .MV .x18 .x12,
-    .MV .x19 .x13,
-    .MV .x10 .x9,
-    .MV .x11 .x18,
-    .MV .x12 .x19,
-    .JAL .x1 (jalOff GuestAddrs.u256_sub_be (GuestAddrs.priority_fee_per_gas_eip1559 + 52)),
-    .BNE .x10 .x0 (28 : BitVec 13),
-    .MV .x10 .x8,
-    .MV .x11 .x19,
-    .MV .x12 .x19,
-    .JAL .x1 (jalOff GuestAddrs.u256_min (GuestAddrs.priority_fee_per_gas_eip1559 + 72)),
-    .LI .x10 (0 : Word),
-    .JAL .x0 (8 : BitVec 21),
-    .LI .x10 (1 : Word),
-    .LD .x1 .x2 (0 : BitVec 12),
-    .LD .x8 .x2 (8 : BitVec 12),
-    .LD .x9 .x2 (16 : BitVec 12),
-    .LD .x18 .x2 (24 : BitVec 12),
-    .LD .x19 .x2 (32 : BitVec 12),
-    .ADDI .x2 .x2 (48 : BitVec 12),
-    .JALR .x0 .x1 (0 : BitVec 12) ]
-
-/-- Reloc side-table for `priorityFeePerGasEip1559_prog`: the `la`/cross-`jal` instruction indices
-    kept SYMBOLIC in the emitted image text (`emitProgramR`), while the Program
-    above carries the concrete guest-linked immediates for verification. -/
-def priorityFeePerGasEip1559_relocs : RelocTable :=
-  [ (13, .jal .x1 "u256_sub_be"),
-    (18, .jal .x1 "u256_min") ]
-
-def priorityFeePerGasEip1559Function : String :=
-  "priority_fee_per_gas_eip1559:\n" ++ emitProgramR priorityFeePerGasEip1559_prog priorityFeePerGasEip1559_relocs
-
-/-- Kernel-checked drift guard: the emitted (image-agnostic, symbolic) Codegen
-    string is exactly `priorityFeePerGasEip1559_prog` rendered under its label with the `la`/`jal`
-    relocs kept symbolic (bead evm-asm-4ch8f.9.3, mechanical conversion by
-    `scripts/asm_to_program.py`). Guest binary byte-identity + guest-linked
-    consistency of the concrete Program verified offline by assemble/link+cmp. -/
-theorem priorityFeePerGasEip1559Function_eq_prog :
-    priorityFeePerGasEip1559Function = "priority_fee_per_gas_eip1559:\n" ++ emitProgramR priorityFeePerGasEip1559_prog priorityFeePerGasEip1559_relocs := rfl
-
-#guard priorityFeePerGasEip1559Function.startsWith "priority_fee_per_gas_eip1559:\n"
-#guard priorityFeePerGasEip1559_prog.length = 29
 /-- `zisk_priority_fee_per_gas_eip1559`: probe BuildUnit. Reads
     (32B max_priority, 32B max_fee, 32B base_fee) from host
     input, writes (status, 32B priority fee BE) to OUTPUT (40

--- a/EvmAsm/Codegen/Programs/U256GasPricingProg.lean
+++ b/EvmAsm/Codegen/Programs/U256GasPricingProg.lean
@@ -1,0 +1,106 @@
+/-
+Copyright (c) 2025 zkSecurity. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: zkSecurity
+-/
+import EvmAsm.Codegen.Emit
+import EvmAsm.Codegen.AsmReloc
+import EvmAsm.Codegen.GuestLayout
+
+/-! Abstract (GuestLayout-parameterised) U256 gas-pricing program.
+
+    GH #10753 leaf: the program is parameterised over `GuestLayout`; the
+    concrete instance lives in the bridge `U256GasPricing.lean`, which
+    re-exposes the original names and types. -/
+
+namespace EvmAsm.Codegen
+
+open EvmAsm.Rv64
+
+/-! ## priority_fee_per_gas_eip1559 -- PR-K62
+
+    Compute the effective priority fee per gas for a post-EIP-1559
+    transaction. Mirrors Python's
+    `transaction_priority_fee_per_gas` from
+    `forks/amsterdam/transaction_helpers.py`:
+
+      surplus = tx.max_fee_per_gas - block.base_fee_per_gas
+      priority_fee = min(tx.max_priority_fee_per_gas, surplus)
+
+    Where `surplus = max_fee - base_fee` would underflow
+    (`max_fee < base_fee`), the tx is invalid; this helper
+    returns `1` so the caller can reject without inspecting the
+    output. Otherwise returns `0` and the 32-byte priority fee
+    is written to `*out` in big-endian.
+
+    First higher-level helper composed on the K-stack's u256
+    toolkit: PR-K52 `u256_sub_be` + PR-K59 `u256_min`. Both are
+    inlined into the probe BuildUnit so this PR doesn't require
+    any new external symbols.
+
+    BE storage convention: byte 0 = MSB, byte 31 = LSB.
+
+    Calling convention:
+      a0 (input)  : max_priority_fee_per_gas ptr (32 B BE)
+      a1 (input)  : max_fee_per_gas ptr (32 B BE)
+      a2 (input)  : base_fee_per_gas ptr (32 B BE)
+      a3 (input)  : output ptr (32 B BE; receives priority fee)
+      ra (input)  : return
+      a0 (output) : 0 success / 1 max_fee < base_fee (reject tx). -/
+
+def priorityFeePerGasEip1559_prog_of (L : GuestLayout) : Program :=
+  [ .ADDI .x2 .x2 (-48 : BitVec 12),
+    .SD .x2 .x1 (0 : BitVec 12),
+    .SD .x2 .x8 (8 : BitVec 12),
+    .SD .x2 .x9 (16 : BitVec 12),
+    .SD .x2 .x18 (24 : BitVec 12),
+    .SD .x2 .x19 (32 : BitVec 12),
+    .MV .x8 .x10,
+    .MV .x9 .x11,
+    .MV .x18 .x12,
+    .MV .x19 .x13,
+    .MV .x10 .x9,
+    .MV .x11 .x18,
+    .MV .x12 .x19,
+    .JAL .x1 (jalOff L.u256_sub_be (L.priority_fee_per_gas_eip1559 + 52)),
+    .BNE .x10 .x0 (28 : BitVec 13),
+    .MV .x10 .x8,
+    .MV .x11 .x19,
+    .MV .x12 .x19,
+    .JAL .x1 (jalOff L.u256_min (L.priority_fee_per_gas_eip1559 + 72)),
+    .LI .x10 (0 : Word),
+    .JAL .x0 (8 : BitVec 21),
+    .LI .x10 (1 : Word),
+    .LD .x1 .x2 (0 : BitVec 12),
+    .LD .x8 .x2 (8 : BitVec 12),
+    .LD .x9 .x2 (16 : BitVec 12),
+    .LD .x18 .x2 (24 : BitVec 12),
+    .LD .x19 .x2 (32 : BitVec 12),
+    .ADDI .x2 .x2 (48 : BitVec 12),
+    .JALR .x0 .x1 (0 : BitVec 12) ]
+
+/-- Reloc side-table for `priorityFeePerGasEip1559_prog_of`: the `la`/cross-`jal` instruction
+    indices kept SYMBOLIC in the emitted image text (`emitProgramR`), while
+    the Program above carries the layout-parameterised immediates
+    (`laHi`/`laLo`/`jalOff L.…`) for verification. -/
+def priorityFeePerGasEip1559_relocs : RelocTable :=
+  [ (13, .jal .x1 "u256_sub_be"),
+    (18, .jal .x1 "u256_min") ]
+
+def priorityFeePerGasEip1559Function : String :=
+  "priority_fee_per_gas_eip1559:\n" ++ emitProgramR (priorityFeePerGasEip1559_prog_of .zero) priorityFeePerGasEip1559_relocs
+
+/-- Kernel-checked drift guard: the emitted (image-agnostic, symbolic) Codegen
+    string is exactly `priorityFeePerGasEip1559_prog_of .zero` rendered under its label with the
+    `la`/`jal` relocs kept symbolic (layout-parameterised per GH #10753;
+    emission is layout-independent, mechanical conversion by
+    `scripts/asm_to_program.py`). Guest binary byte-identity + guest-linked
+    consistency of the concrete Program verified offline by assemble/link+cmp
+    over the bridge's `priorityFeePerGasEip1559_prog` (`_of guestLayout`). -/
+theorem priorityFeePerGasEip1559Function_eq_prog :
+    priorityFeePerGasEip1559Function = "priority_fee_per_gas_eip1559:\n" ++ emitProgramR (priorityFeePerGasEip1559_prog_of .zero) priorityFeePerGasEip1559_relocs := rfl
+
+#guard priorityFeePerGasEip1559Function.startsWith "priority_fee_per_gas_eip1559:\n"
+#guard (priorityFeePerGasEip1559_prog_of .zero).length = 29
+
+end EvmAsm.Codegen


### PR DESCRIPTION
GH #10753 conversion (seventh module overall; first needing NEW GuestLayout fields since the six-module SAsm batch #10850). Pattern: abstract leaf + applied bridge, as established in #10842.

## Diff

- `EvmAsm/Codegen/Programs/U256GasPricingProg.lean` (NEW, 106 lines): abstract leaf — `priorityFeePerGasEip1559_prog_of (L : GuestLayout)`, relocs, `priorityFeePerGasEip1559Function` at `(_of .zero)`, eq_prog, guards. No `GuestAddrs` import.
- `EvmAsm/Codegen/Programs/U256GasPricing.lean` (bridge, 157 lines): module name unchanged; `priorityFeePerGasEip1559_prog := priorityFeePerGasEip1559_prog_of guestLayout` (name+type required by the concrete-render gate); probe BuildUnits unchanged.
- `GuestLayout.lean`: +3 fields (`priority_fee_per_gas_eip1559`, `u256_sub_be`, `u256_min`) — 12 → 15 total.
- `GuestLayoutInstance.lean`: +3 bindings.

## Verification (measured on this branch, base = main 7a2b91701)

| Instrument | base | head |
|---|---|---|
| emitted `.s` sha256 | 913ce745… | 913ce745… (identical) |
| stripped ELF sha256 | 535ab3f2… | 535ab3f2… (identical) |
| text / data / bss | 422608 / 21360 / 482058976 | identical |

Behaviour-neutral with byte-identical emission, **verified** not asserted. Raw ELF shas are not compared: they differ by the embedded object filename.

- `check-file --funcs priorityFeePerGasEip1559Function`: CLEAN (1 def, generator-produced leaf block matches drift gate).
- Byte-identity oracle RE-RUN on this branch: `scripts/guest_image_coverage.py --emit-lean` regenerates `GuestImageEntries.lean` byte-identical (364 entries / 142 imports).
- `lake build codegen` clean (4286 jobs). Line counts 106 / 157 (1500 cap).
- No generated artifacts were regenerated: emission is byte-identical, so there was nothing to regenerate — that is the verification, not an omission.