### PR TITLE
docs(proofs): delete stale address ranges from docstrings (GH #10790 remaining half)

### DIFF
--- a/EvmAsm/Codegen/Programs/AccountAccessorTopSpec.lean
+++ b/EvmAsm/Codegen/Programs/AccountAccessorTopSpec.lean
@@ -45,12 +45,16 @@
   The four verified helper bodies sit at their linked guest addresses
   (`EvmAsm/Codegen/GuestAddrs.lean`), pinned here as `Word` constants with
   `rfl` guards. The layout is contiguous:
-    rlp_walk_init  0x800049fc (53 instrs) … ends at 0x80004ad0
-    rlp_walk_next  0x80004ad0 (103)       … ends at 0x80004c64
-    rlp_content_to_u64  0x80004c64 (22)   … ends at 0x80004cc4
-    rlp_content_to_u256_be 0x80004cc4 (26)… ends at 0x80004d2c
-    account_extract_balance 0x8001c5c8 (35) … ends at 0x8001c654
-    account_extract_nonce   0x8001c654 (23) … ends at 0x8001c6b0
+    rlp_walk_init  (53 instrs)
+    rlp_walk_next  (103)
+    rlp_content_to_u64  (22)
+    rlp_content_to_u256_be (26)
+    account_extract_balance (35)
+    account_extract_nonce   (23)
+
+  Address ranges are deliberately not restated here: they regenerate from
+  `GuestAddrs`, and restating literals recreates the drift condition
+  (GH #10790).
 
   No `sorry`/`admit`/`native_decide`/`bv_decide`; classical-3 axioms only.
 -/

--- a/EvmAsm/Codegen/Programs/RlpItemSpanSpec.lean
+++ b/EvmAsm/Codegen/Programs/RlpItemSpanSpec.lean
@@ -157,8 +157,9 @@ theorem rlpItemSpan_prog_length : rlpItemSpan_prog.length = 53 := by decide
 theorem rlpItemSize_prog_length : rlpItemSize_prog.length = 35 := by decide
 
 /-- Full deployed layout: `rlp_item_span` plus its callee `rlp_item_size`
-    at their linked guest addresses (contiguous: size `0x80004a30..0x80004abc`,
-    span `0x80004abc..0x80004b90`). -/
+    at their linked guest addresses (contiguous).  Address ranges are
+    deliberately not restated here: they regenerate from `GuestAddrs`, and
+    restating literals recreates the drift condition (GH #10790). -/
 abbrev rlpItemSpanFullCode : CodeReq :=
   rlpItemSpanCode.union rlpItemSizeCode
 


### PR DESCRIPTION
Second half of #10790 (the pin theorems were deleted in #10813): the stale ADDRESS PROSE in docstrings.

- `RlpItemSpanSpec.lean`: the `rlpItemSpanFullCode` docstring claimed `size 0x80004a30..0x80004abc, span 0x80004abc..0x80004b90` — stale (current linked addresses are rlp_item_size 0x80004d34, rlp_item_span 0x80004dc0). Range **deleted, not refreshed**: refreshed literals recreate the drift condition (#10790's whole point); a note says the ranges regenerate from GuestAddrs.
- `AccountAccessorTopSpec.lean`: the code-layout table carried six address literals (coord counted four; the table had six — rlp_walk_init/next, rlp_content_to_u64/u256_be, account_extract_balance/nonce). All deleted; rows keep name + instruction count; same note.

Docstring-only; no code, no generated artifacts, no regen (zero layout impact).

## Gate status (stated plainly, per project guidance)

`scripts/check-build-parallel.sh` was run in this artifact-cache checkout (LAKE_ARTIFACT_CACHE mode, 695 oleans / 2060 .olean.hash sidecars). Three gates **cannot run in this mode** and failed for that reason alone — none are reachable by a docstring diff:

1. guarded-handler-bytes: `lake env lean --run` cannot resolve cache-fetched modules (#10537 family).
2. asm-to-program lean_render: its `lake build <mods>` step returned 1 on the same module closure the codegen step had just built successfully (env/materialize path, not a source error).
3. check-axioms: the witness module was cache-FETCHED, and a fetch does not replay `#print axioms` messages — the completeness interlock correctly refused to pass with 0 reports (designed behavior; a non-cache checkout builds the module and reports parse, as CI does).

The gates that can run in this mode all **PASS**: codegen build (4288 jobs), check-region-map (TSV matches ELF: text 0x673f4, data 0x5370, bss 0x1c139580), MemoryLayout anchors (23), region coverage. CI runs the full driver in a non-cache environment.