### PR TITLE
chore: batch-merge #10900 #10901

### DIFF
--- a/EvmAsm/Codegen/Programs/BlockVerdictMtxRuntime.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictMtxRuntime.lean
@@ -228,8 +228,10 @@ def blockVerdictMtxRuntimeLoop : String :=
   -- Execution CodeState is block-lived in the sequential lane. The callable
   -- dispatcher resets transaction-local pending overlays, including
   -- `account_state_pending_count`; it does not preserve that AccountState
-  -- journal across dispatches. Durable state and retained comparator bytes
-  -- survive until this loop finishes.
+  -- journal across dispatches. This reset is the live durability boundary in
+  -- GH #10876: sender effects needed after dispatch must be materialized in
+  -- durable state rather than left in the pending journal. Durable state and
+  -- retained comparator bytes survive until this loop finishes.
   -- CodeState is the sole execution code/existence model for every block,
   -- including the one-transaction case.  The immutable witness is consulted
   -- only after its pending and durable overlays miss.

--- a/EvmAsm/Codegen/Programs/BlockVerdictMtxRuntime.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictMtxRuntime.lean
@@ -225,9 +225,11 @@ def blockVerdictMtxRuntimeLoop : String :=
   "  la a0, nea_sort_b; la t0, bv_eip7702_authority_event_count; ld a1, 0(t0); la a2, bv_eip7702_authority_table; li a3, " ++ toString bvEip7702AuthorityEventCapacity ++ "; la a4, bv_eip7702_authority_count; jal ra, eip7702_authority_state_materialize; bnez a0, .Lbv_sender_nonce_fail\n" ++
   ".Lbv_mtx_state_init:\n" ++
   "  la t0, bv_mtx_i; sd zero, 0(t0)\n" ++
-  -- Execution CodeState is block-lived in the sequential lane.  The callable
-  -- dispatcher resets only its pending overlay; durable state and retained
-  -- comparator bytes survive until this loop finishes.
+  -- Execution CodeState is block-lived in the sequential lane. The callable
+  -- dispatcher resets transaction-local pending overlays, including
+  -- `account_state_pending_count`; it does not preserve that AccountState
+  -- journal across dispatches. Durable state and retained comparator bytes
+  -- survive until this loop finishes.
   -- CodeState is the sole execution code/existence model for every block,
   -- including the one-transaction case.  The immutable witness is consulted
   -- only after its pending and durable overlays miss.

--- a/scripts/eest-bal-replay-report.py
+++ b/scripts/eest-bal-replay-report.py
@@ -474,8 +474,8 @@ def main() -> int:
             parts = line.rstrip("\n").split("\t")
             if len(parts) == 6:
                 label, input_file, expected_hex, _succ_bit, _input_len, relpath = parts
-            elif len(parts) == 7:
-                label, input_file, expected_hex, _succ_bit, _input_len, _gas_limit, relpath = parts
+            elif len(parts) >= 7:
+                label, input_file, expected_hex, _succ_bit, _input_len, _gas_limit, relpath = parts[:7]
             else:
                 raise SystemExit(f"bad manifest row with {len(parts)} columns: {line!r}")
             if args.filter and args.filter not in label and args.filter not in relpath:

--- a/scripts/eest-gas-parity-report.py
+++ b/scripts/eest-gas-parity-report.py
@@ -95,9 +95,10 @@ def iter_manifest(path: Path) -> Iterable[tuple[str, Path, str, str, int, int, s
     for raw in path.read_text().splitlines():
         if not raw:
             continue
-        label, input_file, expected_hex, succ_bit, input_len, gas_limit, relpath = raw.split(
-            "\t", 6
-        )
+        fields = raw.split("\t")
+        if len(fields) < 7:
+            raise ValueError(f"bad manifest row with {len(fields)} columns: {raw!r}")
+        label, input_file, expected_hex, succ_bit, input_len, gas_limit, relpath = fields[:7]
         yield (
             label,
             Path(input_file),

--- a/scripts/eest-precompile-frontier-report.py
+++ b/scripts/eest-precompile-frontier-report.py
@@ -205,8 +205,8 @@ def read_manifest(path: Path) -> Iterable[tuple[str, str, str]]:
             parts = line.rstrip("\n").split("\t")
             if len(parts) == 6:
                 label, _input_file, expected_hex, _succ_bit, _input_len, relpath = parts
-            elif len(parts) == 7:
-                label, _input_file, expected_hex, _succ_bit, _input_len, _gas_limit, relpath = parts
+            elif len(parts) >= 7:
+                label, _input_file, expected_hex, _succ_bit, _input_len, _gas_limit, relpath = parts[:7]
             else:
                 raise SystemExit(f"bad manifest row with {len(parts)} columns: {line!r}")
             rows.append((label, expected_hex, relpath))

--- a/scripts/eest-receipt-log-frontier-report.py
+++ b/scripts/eest-receipt-log-frontier-report.py
@@ -47,11 +47,14 @@ def read_manifest(path: Path, strict: bool) -> list[ManifestRow]:
         if not line.strip():
             continue
         fields = line.split("\t")
-        if len(fields) != 6:
+        if len(fields) == 6:
+            label, input_path, expected_hex, succ_bit, input_len, relpath = fields
+        elif len(fields) >= 7:
+            label, input_path, expected_hex, succ_bit, input_len, _gas_limit, relpath = fields[:7]
+        else:
             if strict:
-                raise SystemExit(f"{path}:{line_no}: expected 6 TSV fields, got {len(fields)}")
+                raise SystemExit(f"{path}:{line_no}: expected at least 6 TSV fields, got {len(fields)}")
             continue
-        label, input_path, expected_hex, succ_bit, input_len, relpath = fields
         rows.append(
             ManifestRow(
                 label=label,

--- a/scripts/eest-stateless-to-input.py
+++ b/scripts/eest-stateless-to-input.py
@@ -23,7 +23,12 @@ Manifest fields derived below are for launch/reporting only and must not become
 a second authoritative guest input schema.
 
 Manifest columns (tab-separated, one row per guest invocation):
-  label  input_file  expected_hex  succ_bit  input_len  block_gas_limit  fixture_relpath
+  label input_file expected_hex succ_bit input_len block_gas_limit fixture_relpath case_id
+
+``case_id`` is a SHA-256 identity for the fixture-relative path, complete EEST
+test name, block index, and input bytes. It preserves scenario identity when
+the display label and input filename must be truncated to fit the host
+filesystem name limit.
 
 Usage:
   eest-stateless-to-input.py --fixtures-dir DIR --out-dir DIR
@@ -53,6 +58,7 @@ generated from the same execution-specs checkout.
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import os
 import struct
@@ -133,8 +139,8 @@ def selection_span_error(picked: list[int], corpus_len: int) -> str | None:
     return None
 
 
-def iter_blocks(fixture_path: Path):
-    """Yield (label, input_bytes, expected_bytes, block_gas_limit) for each stateless block."""
+def iter_blocks(fixture_path: Path, fixture_relpath: str):
+    """Yield (label, case_id, input_bytes, expected_bytes, gas_limit) per block."""
     try:
         doc = json.loads(fixture_path.read_text())
     except (json.JSONDecodeError, OSError) as exc:  # corrupt / unreadable
@@ -166,7 +172,17 @@ def iter_blocks(fixture_path: Path):
                 # `run_stateless_guest` returns a failed sentinel for them.
                 gas_limit = 0
             label = sanitize(f"{short}#b{bi}")
-            yield label, ib, ob, gas_limit
+            identity = (
+                fixture_relpath.encode("utf-8")
+                + b"\0"
+                + test_name.encode("utf-8")
+                + b"\0"
+                + str(bi).encode("ascii")
+                + b"\0"
+                + ib
+            )
+            case_id = hashlib.sha256(identity).hexdigest()
+            yield label, case_id, ib, ob, gas_limit
 
 
 def load_execution_specs_input_decoder():
@@ -280,6 +296,7 @@ def main() -> int:
     with manifest_path.open("w") as mf:
         def write_block(
             label: str,
+            case_id: str,
             ib: bytes,
             ob: bytes,
             gas_limit: int,
@@ -349,6 +366,7 @@ def main() -> int:
                         str(len(ib)),
                         str(gas_limit),
                         relpath,
+                        case_id,
                     ]
                 )
                 + "\n"
@@ -364,10 +382,10 @@ def main() -> int:
             candidates = []
             for fp in json_files:
                 relpath = str(fp.relative_to(fixtures_dir))
-                for label, ib, ob, gas_limit in iter_blocks(fp):
+                for label, case_id, ib, ob, gas_limit in iter_blocks(fp, relpath):
                     if args.filter and args.filter not in relpath and args.filter not in label:
                         continue
-                    candidates.append((label, ib, ob, gas_limit, relpath))
+                    candidates.append((label, case_id, ib, ob, gas_limit, relpath))
 
             if args.limit == 0 and args.skip == 0:
                 # `--all --random` selects every row already; avoid creating a
@@ -390,8 +408,8 @@ def main() -> int:
                     print(f"error: {span_err}", file=sys.stderr)
                     return 1
                 sampled = [candidates[i] for i in picked]
-            for label, ib, ob, gas_limit, relpath in sampled[args.skip:]:
-                if not write_block(label, ib, ob, gas_limit, relpath):
+            for label, case_id, ib, ob, gas_limit, relpath in sampled[args.skip:]:
+                if not write_block(label, case_id, ib, ob, gas_limit, relpath):
                     return 1
             if args.limit and len(candidates) > args.skip + args.limit:
                 print(
@@ -404,7 +422,7 @@ def main() -> int:
 
         for fp in json_files:
             relpath = str(fp.relative_to(fixtures_dir))
-            for label, ib, ob, gas_limit in iter_blocks(fp):
+            for label, case_id, ib, ob, gas_limit in iter_blocks(fp, relpath):
                 if args.filter and args.filter not in relpath and args.filter not in label:
                     continue
                 if selected < args.skip:
@@ -420,7 +438,7 @@ def main() -> int:
                     mf.flush()
                     print(f"wrote {n} input(s) + manifest {manifest_path}")
                     return 0
-                if not write_block(label, ib, ob, gas_limit, relpath):
+                if not write_block(label, case_id, ib, ob, gas_limit, relpath):
                     return 1
 
     print(f"wrote {n} input(s) + manifest {manifest_path}")

--- a/scripts/eest-succ-mismatch-report.py
+++ b/scripts/eest-succ-mismatch-report.py
@@ -260,7 +260,7 @@ def main() -> int:
             fields = line.rstrip("\n").split("\t")
             if len(fields) == 6:
                 label, input_file, expected_hex, _succ_bit, _input_len, relpath = fields
-            elif len(fields) == 7:
+            elif len(fields) >= 7:
                 (
                     label,
                     input_file,
@@ -269,7 +269,7 @@ def main() -> int:
                     _input_len,
                     _gas_limit,
                     relpath,
-                ) = fields
+                ) = fields[:7]
             else:
                 raise ValueError(f"unexpected manifest column count: {len(fields)}")
             input_path = Path(input_file)


### PR DESCRIPTION
Batch-merge of #10900 #10901 (all author pirapira). Verified locally: `lake build` + all `check-*.sh` green.

Both constituents went `BEHIND` when #10896 landed, so batching collapses two CI cycles into one.

- **#10900** docs: describe dispatcher reset of account phase state
- **#10901** tooling: preserve full EEST case identity in the manifest

Verification on this exact merge result: real merge commits (`--no-ff`), no conflicts in either merge; regen **fixpoint on round 1** with all three step exit codes 0 and no drift; `lake build` exit 0 (4791 jobs); **25/25 `check-*.sh` green on the first pass**. Pins unchanged at `.text 0x067410` / `.data 0x5370` / `.bss 0x1c139580`.