### PR TITLE
docs(codegen): clarify legacy creation stager scope

### DIFF
--- a/EvmAsm/Codegen/Programs/BlockVerdictCreationStage.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictCreationStage.lean
@@ -21,10 +21,10 @@ open EvmAsm.Rv64
     charged as transaction data but executed as frame code.
 
     This slice supports only one-byte STOP initcode. That is the narrow shape
-    whose execution does not observe ADDRESS/CALLER/ORIGIN/CALLVALUE, so the
-    later integration can run it before the created-address/creator-env
-    substrate exists. Broader constructors must stay gated until those fields
-    are staged soundly.
+    whose execution does not observe ADDRESS/CALLER/ORIGIN/CALLVALUE. These
+    constraints apply only to this legacy probe: they do not gate production
+    creation. `blockVerdictCreationRuntimeFunction` below stages the created
+    address and creator environment before dispatching arbitrary initcode.
 
     Calling convention:
       a0 = context record ptr (192-byte simple_transfer/multi_tx_nth_context


### PR DESCRIPTION
Fixes #10932.

`stage_creation_runtime_payload` is a legacy probe-only, one-byte STOP helper. Its previous documentation said broader constructors must remain gated pending later integration, which misdirected readers toward a non-live path.

The comment now states that the limitation applies only to the legacy probe and directs production readers to `blockVerdictCreationRuntimeFunction`, which stages created address and creator environment before dispatching arbitrary initcode through `stage_runtime_payload_code`.

Validation: `lake build EvmAsm.Codegen.Programs.BlockVerdictCreationStage` (17 jobs).

Docs only: no emitted guest code or layout artifact changes.