### PR TITLE
fix(codegen): MPT inline/hash routing threshold 27 -> 32 per merkle_patricia_trie.py:223-225 (GH #10924)

### DIFF
--- a/EvmAsm/Codegen/Programs/MptIndexedTrieRoot.lean
+++ b/EvmAsm/Codegen/Programs/MptIndexedTrieRoot.lean
@@ -185,7 +185,7 @@ def mptIndexedStreamLeafHashFunction : String :=
   "mpt_indexed_stream_leaf_hash:\n" ++
   "  addi sp, sp, -176\n" ++
   "  sd ra, 0(sp); sd s0, 8(sp); sd s1, 16(sp); sd s2, 24(sp); sd s3, 32(sp); sd s4, 40(sp); sd s5, 48(sp); sd s6, 56(sp); sd s7, 64(sp); sd s8, 72(sp); sd s9, 80(sp)\n" ++
-  "  mv s1, a0; mv s2, a1; mv s3, a2; mv s4, a3; mv s5, a4; li t0, 6; bgtu s2, t0, .Lmislh_fail; li t0, 27; bltu s4, t0, .Lmislh_fail\n" ++
+  "  mv s1, a0; mv s2, a1; mv s3, a2; mv s4, a3; mv s5, a4; li t0, 6; bgtu s2, t0, .Lmislh_fail; li t0, 32; bltu s4, t0, .Lmislh_fail\n" ++
   "  mv a0, s1; mv a1, s2; li a2, 1; addi a3, sp, 88; jal ra, hp_encode_nibbles; mv s7, a0\n" ++
   "  addi a0, sp, 88; mv a1, s7; addi a2, sp, 96; addi a3, sp, 144; jal ra, rlp_encode_bytes; ld s7, 144(sp)\n" ++
   "  li t0, 1; bne s4, t0, .Lmislh_value_prefix; lbu t1, 0(s3); li t2, 128; bgeu t1, t2, .Lmislh_value_prefix; li s8, 0; j .Lmislh_value_ready\n" ++
@@ -259,13 +259,18 @@ def mptIndexedSortChangesFunction : String :=
 
 /-! Construct one canonical raw child reference for an indexed-trie leaf.
     Small values use the regular encoder into a fixed 1 KiB structural scratch;
-    every value at least 27 bytes uses the streaming helper, so no transaction
-    or receipt payload is copied into an MPT buffer. -/
+    every value at least 32 bytes uses the streaming helper, so no transaction
+    or receipt payload is copied into an MPT buffer.  The threshold is 32, not
+    27: the MPT embeds any leaf node whose serialization is under 32 bytes
+    (execution-specs merkle_patricia_trie.py:223-225), and a 27-31 byte value
+    can still encode to a <32 node, so routing it to the direct-hash stream
+    was wrong (GH #10924).  The inline path below re-checks the encoded node
+    length and hashes at >=32, so only values guaranteed >=32 go to stream. -/
 def mptIndexedLeafRefFunction : String :=
   "mpt_indexed_leaf_ref:\n" ++
   "  addi sp, sp, -64\n" ++
   "  sd ra, 0(sp); sd s0, 8(sp); sd s1, 16(sp); sd s2, 24(sp); sd s3, 32(sp); sd s4, 40(sp); sd s5, 48(sp)\n" ++
-  "  mv s0, a0; mv s1, a1; mv s2, a2; mv s3, a3; mv s4, a4; mv s5, a5; sd zero, 0(s5); li t0, " ++ toString itrIndexedKeyMaxNibbles ++ "; bgtu s1, t0, .Lmilr_fail; li t0, 27; bgeu s3, t0, .Lmilr_stream\n" ++
+  "  mv s0, a0; mv s1, a1; mv s2, a2; mv s3, a3; mv s4, a4; mv s5, a5; sd zero, 0(s5); li t0, " ++ toString itrIndexedKeyMaxNibbles ++ "; bgtu s1, t0, .Lmilr_fail; li t0, 32; bgeu s3, t0, .Lmilr_stream\n" ++
   "  mv a0, s0; mv a1, s1; mv a2, s2; mv a3, s3; la a4, itr_builder_node; la a5, itr_builder_node_len; jal ra, mpt_leaf_node_encode_from_nibbles; bnez a0, .Lmilr_fail; la t0, itr_builder_node_len; ld t1, 0(t0); li t2, 32; bgeu t1, t2, .Lmilr_small_hash; la t0, itr_builder_node; mv t2, s4\n" ++
   ".Lmilr_copy:\n" ++
   "  beqz t1, .Lmilr_inline_ok; lbu t3, 0(t0); sb t3, 0(t2); addi t0, t0, 1; addi t2, t2, 1; addi t1, t1, -1; j .Lmilr_copy\n" ++


### PR DESCRIPTION
## The defect

The bounded MPT trie builder inline-versus-stream routing threshold was 27 where the MPT rule requires 32. merkle_patricia_trie.py:223-225: when a node serialization is at least 32 bytes it is hashed; under 32 it is returned unhashed and embedded into the parent. The routing decision in MptIndexedTrieRoot.lean (li t0, 27; bgeu s3, t0, .Lmilr_stream) admitted values of 27-31 bytes into the direct-hash stream — a five-byte hole. The stream routine own guard (bltu s4, 27, .Lmislh_fail) also admitted 27-31 despite its docstring stating callers must prove the encoded leaf is at least 32 bytes (unenforced precondition — a defect generator, same class as #10932).

A withdrawal RLP value is 26 bytes when its index is one RLP byte (255 or less) and 27 when it needs two (256 or more). So any block whose withdrawal indices cross 255 routes every withdrawal leaf down the hash path where MPT semantics require inline embedding — and the guest rejects the block. Measured live on HEAD cf888605b (stateless_guest, spike): the multi-withdrawal family (manifest ids 25117-25135, all succ_bit=1 valid blocks) passes 17/20 and fails exactly b16/b17/b18, whose withdrawal indices are 256-271/272-287/288-303. The flip is at index 256 exactly; the +16 block-RLP delta at the flip is fully accounted by the 16 indices each gaining one byte. Live-guest fail code 31 (byte 112 of the failure output), reachable arm .Lbv_withdrawals_root_fail (BlockVerdictStateRoot.lean:521). The value encoder is exonerated: rlp_encode_uint_be is a general minimal-integer encoder, correct for its u64 inputs.

## The fix (derived, not fitted)

The routing threshold uses 32, the MPT embedding boundary — not widened to fit the failing fixtures, and nothing else changes. Encoded node = list header + hp path + value header + value, roughly value + 3-4 bytes, so value >= 32 implies node >= 35 >= 32 and the direct-hash stream is safe; values 27-31 now take the inline path, which re-checks the encoded node length and inlines under 32 or hashes at 32 or more — correct in both directions. The stream guard is tightened to 32 as well so its stated precondition is enforced rather than assumed.

Change is immediate-only (li t0, 27 -> li t0, 32, same instruction count): no layout repin needed (textSizeBytes, GuestAddrs, symbol-addresses.tsv unchanged).

## Verification (HEAD cf888605b, spike)

- The three previously-failing fixtures fail -> pass: 25133, 25134, 25135 (succ=1).
- All 17 previously-passing family members still pass (00560 + 25117-25132) — 20/20 for the family.
- Artifact identity verified before running: emitted .s contains li t0, 32 at both edited sites (the remaining li t0, 27 at .s:18683 is a different constant — a fail-code write, legitimate).

Fixes #10924.