### PR TITLE
codegen: name the two code-deposit gas multipliers (GH #10980)

### DIFF
--- a/EvmAsm/Codegen/GasConstants.lean
+++ b/EvmAsm/Codegen/GasConstants.lean
@@ -1,0 +1,79 @@
+/-
+  EvmAsm.Codegen.GasConstants
+
+  GH #10980 — gas constants that reach the emitted stream as *runtime multipliers*,
+  in a **leaf module with no imports** (same rationale as `EvmAsm.Codegen.ArenaCapacities`).
+
+  ## Why these two constants needed a home of their own
+
+  Every other state-gas charge in the emitter has a compile-time byte count, so it
+  goes through `liStateGasRuntime`, which does the multiply in Lean and emits a single
+  `li` of the product.  The **code-deposit** charges cannot: the byte count is
+  `len(contract_code)`, known only at run time, so the emitter has to put the
+  *multiplier itself* into the instruction stream:
+
+  ```
+    li t1, 1530 ; mul t0, t0, t1      -- code_deposit_state_gas
+    li t1, 6    ; mul t0, t0, t1      -- code_hash_gas
+  ```
+
+  That is the whole population, and it is exactly the population that
+  `liStateGasRuntime`'s existence hides: a reader who checks that state-gas
+  multipliers are named will find every *other* site parameterised and conclude the
+  emitter has no bare literals.  The four that remain are the two deploy sites
+  (nested CREATE in `Programs.NoopHalt`, top-level creation in
+  `Programs.BlockVerdictCreationStage`) × the two dimensions (STATE and REGULAR).
+
+  ## Why a leaf importing nothing
+
+  `amsterdamCostPerStateByte` lived in `Programs.AmsterdamSystemTx`, which has many
+  importers.  Moving it **down** into a module with no imports keeps the value
+  reachable from the two deploy-site files at zero reachability cost — an import edge
+  into a leaf pulls in nothing, so the CI build does not grow.  `AmsterdamSystemTx`
+  now imports this module, so every existing user of the name still resolves it
+  transitively and no other file needed touching.
+
+  The obvious stronger alternative — define these as references to
+  `EvmAsm.Stateless.SpecRef.StateGasCosts.COST_PER_STATE_BYTE` and a new
+  `GasCosts.OPCODE_KECCAK256_PER_WORD`, the way `Codegen.MemoryBudgetGuard` ties
+  `memoryPerWord` to `SpecRef.GasCosts.MEMORY_PER_WORD` — was **deliberately not
+  taken**: it would put `SpecRef.Gas` in the reachable set of every importer of
+  `AmsterdamSystemTx`.  The spec mirror is cited from each docstring instead, and
+  since it holds the same numbers independently it already functions as the
+  cross-check a shared definition would have given.
+-/
+
+namespace EvmAsm.Codegen
+
+/-- execution-specs Amsterdam `StateGasCosts.COST_PER_STATE_BYTE` (`vm/gas.py:40`).
+
+    The v0.4.0 conformance target (`tests-zkevm@v0.4.0`) uses a **constant** 1530.  A
+    later eip-8037 draft scales it with the block gas limit; the v0.4.0 fixtures do
+    **not** — `header.gas_used` there is independent of `gas_limit`.  A refactor
+    (drj99.1.2) once made this a runtime `evm_state_gas_per_byte` load, which regressed
+    every state-gas charge; see `liStateGasRuntime` for that history.
+
+    Mirrored independently at `EvmAsm/Stateless/SpecRef/Gas.lean:49`, and note the spec
+    marks the enclosing class *"may be patched at runtime by a future gas repricing
+    utility"* (`vm/gas.py:30-31`) — which is the argument for one name rather than five
+    literals. -/
+def amsterdamCostPerStateByte : Nat := 1530
+
+/-- execution-specs Amsterdam `GasCosts.OPCODE_KECCAK256_PER_WORD` (`vm/gas.py:229`).
+
+    Reaches the emitted stream only via `code_hash_gas` at the two deploy sites
+    (`vm/interpreter.py:222-226`: `OPCODE_KECCAK256_PER_WORD * ceil32(ulen(code)) // 32`),
+    charged against the **REGULAR** gas pool — the sibling `code_deposit_state_gas`
+    immediately below it goes to the **STATE** pool.  The two literals sit two lines
+    apart at each site and are charged to different pools, which is the other reason to
+    name them: a reader cannot tell them apart by position. -/
+def amsterdamKeccak256PerWord : Nat := 6
+
+/- Tripwires.  These are the point of the module: the two bare literals had no guard of
+   any kind, so a repricing that edited one deploy site and missed the other would have
+   produced a *silently* asymmetric emitter.  `#guard` fails the build.
+   (A `/-- -/` docstring is not accepted on `#guard`, hence the plain comment.) -/
+#guard amsterdamCostPerStateByte = 1530
+#guard amsterdamKeccak256PerWord = 6
+
+end EvmAsm.Codegen

--- a/EvmAsm/Codegen/Programs/AmsterdamSystemTx.lean
+++ b/EvmAsm/Codegen/Programs/AmsterdamSystemTx.lean
@@ -8,17 +8,23 @@
   16 storage-set writes.  The concrete system-contract children (EIP-4788,
   EIP-2935, EIP-7002, EIP-7251) should import this module instead of
   open-coding these numbers.
+
+  `COST_PER_STATE_BYTE` itself moved **down** to the import-free
+  `EvmAsm.Codegen.GasConstants` (GH #10980) so the two code-deposit sites, which need
+  the multiplier as a runtime operand rather than a folded product, can name it without
+  importing this module.  Every user of `amsterdamCostPerStateByte` still resolves it
+  through the import below.
 -/
+
+import EvmAsm.Codegen.GasConstants
 
 namespace EvmAsm.Codegen
 
 /-- execution-specs Amsterdam `SYSTEM_TRANSACTION_GAS`. -/
 def amsterdamSystemTransactionGas : Nat := 30000000
 
-/-- execution-specs Amsterdam `COST_PER_STATE_BYTE` — the v0.4.0 conformance target uses a CONSTANT 1530
-    (vm/gas.py:29). (A later eip-8037 draft scales it with the block gas limit; the v0.4.0 fixtures do NOT —
-    header.gas_used is independent of gas_limit. See memory project_v04_state_gas_constant_not_scaling.) -/
-def amsterdamCostPerStateByte : Nat := 1530
+/- `amsterdamCostPerStateByte` now lives in `EvmAsm.Codegen.GasConstants` (imported above);
+   it is unchanged at 1530 and is still referenced by name throughout this module. -/
 
 /-- `STATE_BYTES_PER_NEW_ACCOUNT` for the v0.4.0 conformance target = 120 (vm/gas.py:31). -/
 def amsterdamStateBytesPerNewAccountV2 : Nat := 120

--- a/EvmAsm/Codegen/Programs/BlockVerdictCreationStage.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictCreationStage.lean
@@ -9,6 +9,7 @@ import EvmAsm.Codegen.Layout
 import EvmAsm.Codegen.Programs.BlockVerdictContractStage
 import EvmAsm.Codegen.Programs.BlockVerdictParams
 import EvmAsm.Codegen.ArenaCapacities
+import EvmAsm.Codegen.GasConstants
 
 namespace EvmAsm.Codegen
 
@@ -469,12 +470,12 @@ def blockVerdictCreationRuntimeFunction : String :=
   ".Lbvcr_deposit_validate:\n" ++
   "  la a0, top_level_creation_returndata; la t0, top_level_creation_returndata_len; ld a1, 0(t0); jal ra, create_deployed_code_valid; bnez a0, .Lbvcr_deposit_exception\n" ++
   -- Hash gas = 6 * ceil32(code_len)/32, charged against the top-level frame.
-  "  la t0, top_level_creation_returndata_len; ld t0, 0(t0); addi t0, t0, 31; srli t0, t0, 5; li t1, 6; mul t0, t0, t1\n" ++
+  "  la t0, top_level_creation_returndata_len; ld t0, 0(t0); addi t0, t0, 31; srli t0, t0, 5; li t1, " ++ toString amsterdamKeccak256PerWord ++ "; mul t0, t0, t1\n" ++
   "  la t1, evm_env; ld t2, 568(t1); bltu t2, t0, .Lbvcr_ret; sub t2, t2, t0; sd t2, 568(t1)\n" ++
   -- Code-deposit state gas = 1530 * code_len.  This is the same reservoir /
   -- spill fold used by the nested CREATE RETURN tail, with the top-level env
   -- as the regular-gas source.
-  "  la t1, top_level_creation_returndata_len; ld t0, 0(t1); li t1, 1530; mul t0, t0, t1\n" ++
+  "  la t1, top_level_creation_returndata_len; ld t0, 0(t1); li t1, " ++ toString amsterdamCostPerStateByte ++ "; mul t0, t0, t1\n" ++
   "  la t1, evm_state_gas_left; ld t2, 0(t1); bgeu t2, t0, .Lbvcr_csg_res\n" ++
   "  sub t3, t0, t2; la t4, evm_env; ld t5, 568(t4); bltu t5, t3, .Lbvcr_ret\n" ++
   "  sd zero, 0(t1); sub t5, t5, t3; sd t5, 568(t4); la t1, evm_state_gas_spilled; ld t2, 0(t1); add t2, t2, t3; sd t2, 0(t1); j .Lbvcr_csg_used\n" ++

--- a/EvmAsm/Codegen/Programs/NoopHalt.lean
+++ b/EvmAsm/Codegen/Programs/NoopHalt.lean
@@ -13,6 +13,7 @@ import EvmAsm.Codegen.Programs.StaticContext
 import EvmAsm.Rv64.Program
 import EvmAsm.Stateless.SpecRef.Gas
 import EvmAsm.Codegen.ArenaCapacities
+import EvmAsm.Codegen.GasConstants
 
 namespace EvmAsm.Codegen
 
@@ -131,7 +132,7 @@ private def returnRevertTail (kind : Nat) (rollbackAsm : String := "")
       -- (no reservoir/spill): drain the child frame gas_left (568(x20)); OOG-fail the CREATE
       -- (-> .Lrr_crinv) if short. A valid block never OOGs at deposit -> no false-reject. x15 preserved.
       "  addi t0, x15, 31\n  srli t0, t0, 5\n" ++                  -- words = ceil32(len)/32
-      "  li t1, 6\n  mul t0, t0, t1\n" ++                          -- code_hash_gas = 6 * words
+      "  li t1, " ++ toString amsterdamKeccak256PerWord ++ "\n  mul t0, t0, t1\n" ++   -- code_hash_gas = 6 * words
       "  ld t1, 568(x20)\n  bltu t1, t0, .Lrr_crinv_" ++ toString kind ++ "\n" ++   -- gas_left < code_hash_gas -> OOG, CREATE fails
       "  sub t1, t1, t0\n  sd t1, 568(x20)\n" ++                   -- gas_left -= code_hash_gas
       -- nxio8.6: charge code-deposit STATE gas = deployed_code_len(x15) * COST_PER_STATE_BYTE(1530)
@@ -146,7 +147,7 @@ private def returnRevertTail (kind : Nat) (rollbackAsm : String := "")
       -- creation blocks); this makes the exec state gas (bvgr_tx_exec_state_gas) spec-accurate.
       -- x13/x14/x15 preserved by create_deployed_code_valid (#8629) and untouched here (only t0-t3 +
       -- the child gas_left). x15 <= MAX_CODE_SIZE (0x10000) so x15*1530 cannot overflow u64.
-      "  li t0, 1530\n  mul t0, x15, t0\n" ++  -- code-deposit state gas = code_len * COST_PER_STATE_BYTE (v0.4.0 constant 1530)
+      "  li t0, " ++ toString amsterdamCostPerStateByte ++ "\n  mul t0, x15, t0\n" ++  -- code-deposit state gas = code_len * COST_PER_STATE_BYTE
       "  la t1, evm_state_gas_left\n  ld t2, 0(t1)\n" ++
       "  bgeu t2, t0, .Lrr_csg_res_" ++ toString kind ++ "\n" ++
       "  sub t3, t0, t2\n" ++                                             -- reservoir short: spill = charge - reservoir


### PR DESCRIPTION
## Summary

Closes the substantive half of GH #10980: the **four** gas literals that reach the
emitted instruction stream unnamed. Adds the import-free leaf
`EvmAsm/Codegen/GasConstants.lean`, moves `amsterdamCostPerStateByte` down into it,
adds `amsterdamKeccak256PerWord`, and replaces the literals at the two code-deposit
sites.

**BEHAVIOUR-NEUTRAL, and byte-identity is MEASURED rather than inferred.** Base
`f1a342e6d`. Built clean, recorded, applied the change, rebuilt with
`lake exe codegen --program stateless_guest --halt linux93`:

| artifact | before | after |
|---|---|---|
| `stateless_guest.s` | `d372c326b5cce457b5e6bc64d7af45c8fff855345939e12011e50fd01df68d94` | **identical** |
| `stateless_guest.elf` | `fa5ee778249b524e7f73ecf9e9e0d0c3814ef576a5eaba6dfcfc86ae9288432c` | **identical** |

Emission is `toString` of the same `Nat`, so this is expected — it is measured anyway
because "expected" is what a wrong `toString` insertion also looks like.
`scripts/check-region-map.sh` passes against the rebuilt ELF (`.text = 66c34`,
`.bss = 1c105000`, `symbol-addresses.tsv` matches), so no layout regen was needed and
none was performed.

## Why exactly these four, and why the population is not obvious

Every *other* state-gas charge in the emitter goes through `liStateGasRuntime`, which
takes a compile-time byte count, does the multiply in Lean, and emits one `li` of the
product. The code-deposit charges **cannot**: the byte count is `len(contract_code)`,
known only at run time, so the emitter has to put the multiplier itself into the
stream as a `li` + `mul` pair.

That is the whole population — the two deploy sites × the two gas dimensions:

| site | dimension | was | now |
|---|---|---|---|
| `Programs/NoopHalt.lean:135` (nested CREATE) | REGULAR | `li t1, 6` | `amsterdamKeccak256PerWord` |
| `Programs/NoopHalt.lean:150` (nested CREATE) | STATE | `li t0, 1530` | `amsterdamCostPerStateByte` |
| `Programs/BlockVerdictCreationStage.lean:473` (top-level) | REGULAR | `li t1, 6` | `amsterdamKeccak256PerWord` |
| `Programs/BlockVerdictCreationStage.lean:478` (top-level) | STATE | `li t1, 1530` | `amsterdamCostPerStateByte` |

**`liStateGasRuntime`'s existence is what hid them.** A reader auditing whether
state-gas multipliers are named finds every other site parameterised and reasonably
concludes the emitter has none bare. The four survivors are precisely the ones the
helper cannot serve. This is the same shape as GH #10971's delete bound, where four
of six sites were bare literals invisible to a search for the constant's name.

The two literals at each site sit **two lines apart and are charged to different
pools** — `code_hash_gas` to REGULAR, `code_deposit_state_gas` to STATE. Position does
not distinguish them; only the names do.

## Spec citations, at pinned commit `e5a8caf1b`

`src/ethereum/forks/amsterdam/vm/interpreter.py:222-231`:

```python
code_hash_gas = (
    GasCosts.OPCODE_KECCAK256_PER_WORD * ceil32(ulen(contract_code)) // Uint(32)
)
charge_gas(evm, code_hash_gas)
code_deposit_state_gas = (
    ulen(contract_code) * StateGasCosts.COST_PER_STATE_BYTE
)
charge_state_gas(evm, code_deposit_state_gas)
```

* `vm/gas.py:40` — `COST_PER_STATE_BYTE: Final[StateGasPerByte] = StateGasPerByte(Uint(1530))`
* `vm/gas.py:229` — `OPCODE_KECCAK256_PER_WORD: Final[Uint] = Uint(6)`

Values unchanged; both are pinned by `#guard` in the new leaf. That is the point of
the change rather than a side effect — **neither literal had a guard of any kind**, so
a repricing that edited one deploy site and missed the other would have produced a
silently asymmetric emitter, with a wrong `header.gas_used` rather than a build error.

The spec also marks the enclosing class *"may be patched at runtime by a future gas
repricing utility to fast-iterate on state-byte costs"* (`vm/gas.py:30-31`), which is
the upstream's own statement that this number is expected to move.

## Design: why a leaf, and the stronger option deliberately declined

`amsterdamCostPerStateByte` lived in `Programs/AmsterdamSystemTx.lean`, which has many
importers, so the deploy-site files could not simply import it — and
`BlockVerdictCreationStage` does not use any other name from that module. Moving the
constant **down** into a module that imports nothing keeps it reachable at zero cost:
an import edge into a leaf pulls in nothing. `AmsterdamSystemTx` now imports the leaf,
so every existing user of the name resolves it transitively and **no other file needed
touching** (same rationale as `EvmAsm/Codegen/ArenaCapacities.lean`, GH #10971).

The stronger alternative — define these as references to
`SpecRef.StateGasCosts.COST_PER_STATE_BYTE` and a new `GasCosts.OPCODE_KECCAK256_PER_WORD`,
the way `Codegen/MemoryBudgetGuard.lean:114-116` ties `memoryPerWord` to
`SpecRef.GasCosts.MEMORY_PER_WORD` with a `by decide` tripwire — was **declined**, and
the reason is recorded in the module docstring: it would put `SpecRef.Gas` in the
reachable set of every importer of `AmsterdamSystemTx`, which is a measurable CI build
cost for a cross-check we already have. `EvmAsm/Stateless/SpecRef/Gas.lean:49` holds
`COST_PER_STATE_BYTE = 1530` independently, so the mirror already functions as the
second witness; it is cited from the docstring instead. If someone later wants the
shared definition, the leaf is the right place to make that edit once.

## Scope

* Does **not** touch `PR #10983` (the `liAmsterdamNewAccountStateGas` docstring). That
  PR edits `AmsterdamSystemTx.lean:75-77`; this one edits the header and `:18-21`. They
  are independent hunks of the same file, so whichever lands second may need a trivial
  rebase — no semantic interaction.
* Does **not** add a `SpecRef` constant, per the above.
* Noted but **not** fixed here, to keep this file's diff to one hunk: two surviving
  citations in `AmsterdamSystemTx.lean` are stale by ten lines against the current pin
  (`vm/gas.py:29` and `:31`, now `:40` and `:41`) — the file gained ten lines upstream.
  The new leaf uses the correct current lines.
