### PR TITLE
codegen: share the EIP-7708 transfer-log operand staging (GH #10938 cut 4)

### DIFF
--- a/EvmAsm/Codegen/Programs/ChildFrameCreateTail.lean
+++ b/EvmAsm/Codegen/Programs/ChildFrameCreateTail.lean
@@ -9,6 +9,7 @@
 import EvmAsm.Codegen.Programs.EvmAccessGas
 import EvmAsm.Codegen.Programs.EvmMemoryGas
 import EvmAsm.Codegen.Programs.CreateRuntime
+import EvmAsm.Codegen.Programs.EIP7708Logs
 import EvmAsm.Codegen.Programs.CreateSameTxCollision
 import EvmAsm.Codegen.Programs.AmsterdamSystemTx
 import EvmAsm.Rv64.Program
@@ -486,24 +487,15 @@ def createUnsupportedTail (netPopBytes : Nat) (hasSalt : Bool) : String :=
     "  ld t3, 584(x20)\n  beqz t3, .Lcr_tl_done_" ++ (if hasSalt then "f5" else "f0") ++ "\n" ++
     "  la t0, create_value_be\n  ld t1, 0(t0); ld t2, 8(t0); or t1, t1, t2; ld t2, 16(t0); or t1, t1, t2; ld t2, 24(t0); or t1, t1, t2\n" ++
     "  beqz t1, .Lcr_tl_done_" ++ (if hasSalt then "f5" else "f0") ++ "\n" ++   -- value == 0: no log
-    "  addi sp, sp, -128\n  sd x10, 96(sp)\n  sd x12, 104(sp)\n  sd x13, 112(sp)\n" ++
-    -- from_sw = [reverse(create_sender_be) low 20][12 zero] (sp+0)
-    "  sd zero, 0(sp); sd zero, 8(sp); sd zero, 16(sp); sd zero, 24(sp)\n" ++
-    "  la t0, create_sender_be; addi t0, t0, 19; addi t1, sp, 0; li t2, 20\n" ++
-    ".Lcr_tl_from_" ++ (if hasSalt then "f5" else "f0") ++ ":\n" ++
-    "  lbu t3, 0(t0); sb t3, 0(t1); addi t0, t0, -1; addi t1, t1, 1; addi t2, t2, -1; bnez t2, .Lcr_tl_from_" ++ (if hasSalt then "f5" else "f0") ++ "\n" ++
-    -- to_sw = [reverse(create_address_be) low 20][12 zero] (sp+32)
-    "  sd zero, 32(sp); sd zero, 40(sp); sd zero, 48(sp); sd zero, 56(sp)\n" ++
-    "  la t0, create_address_be; addi t0, t0, 19; addi t1, sp, 32; li t2, 20\n" ++
-    ".Lcr_tl_to_" ++ (if hasSalt then "f5" else "f0") ++ ":\n" ++
-    "  lbu t3, 0(t0); sb t3, 0(t1); addi t0, t0, -1; addi t1, t1, 1; addi t2, t2, -1; bnez t2, .Lcr_tl_to_" ++ (if hasSalt then "f5" else "f0") ++ "\n" ++
-    -- val_sw = reverse(create_value_be) = LE 32 bytes (sp+64)
-    "  la t0, create_value_be; addi t0, t0, 31; addi t1, sp, 64; li t2, 32\n" ++
-    ".Lcr_tl_val_" ++ (if hasSalt then "f5" else "f0") ++ ":\n" ++
-    "  lbu t3, 0(t0); sb t3, 0(t1); addi t0, t0, -1; addi t1, t1, 1; addi t2, t2, -1; bnez t2, .Lcr_tl_val_" ++ (if hasSalt then "f5" else "f0") ++ "\n" ++
-    "  addi a0, sp, 0\n  addi a1, sp, 32\n  addi a2, sp, 64\n" ++   -- from = from_sw, to = to_sw, amount = val_sw
-    "  jal ra, eip7708_append_transfer_log\n" ++
-    "  ld x10, 96(sp)\n  ld x12, 104(sp)\n  ld x13, 112(sp)\n  addi sp, sp, 128\n" ++
+    -- GH #10938 cut 4: the operand staging is the shared `eip7708TransferLogStageAsm`,
+    -- which the value-CALL frame-entry site also uses.  from_sw is
+    -- [reverse(create_sender_be) low 20][12 zero] at sp+0, to_sw the same for
+    -- create_address_be at sp+32, val_sw = reverse(create_value_be) (LE 32B) at sp+64.
+    -- The ctx gate and the value != 0 test above stay here: they are this site's guard.
+    eip7708TransferLogStageAsm "create_sender_be" "create_address_be" "create_value_be"
+      (".Lcr_tl_from_" ++ (if hasSalt then "f5" else "f0"))
+      (".Lcr_tl_to_" ++ (if hasSalt then "f5" else "f0"))
+      (".Lcr_tl_val_" ++ (if hasSalt then "f5" else "f0")) ++
     ".Lcr_tl_done_" ++ (if hasSalt then "f5" else "f0") ++ ":\n" ++
     -- The shared producer above is this CREATE frame's sole balance-transfer
     -- recorder.  Keep the independent EIP-161 nonce transition here, but give

--- a/EvmAsm/Codegen/Programs/ChildFrameHandlers.lean
+++ b/EvmAsm/Codegen/Programs/ChildFrameHandlers.lean
@@ -210,22 +210,13 @@ def callDescendFallThrough
     -- build from_sw/to_sw/val_sw on the stack from the canonical-BE globals (mirrors the
     -- CREATE-endowment emit in ChildFrameHandlerTails): a stack word holds the address in
     -- the LOW 20 bytes (the synthetic-log materializer reverses the WHOLE 32B slot to BE).
-    "  addi sp, sp, -128\n  sd x10, 96(sp)\n  sd x12, 104(sp)\n  sd x13, 112(sp)\n" ++
-    "  sd zero, 0(sp); sd zero, 8(sp); sd zero, 16(sp); sd zero, 24(sp)\n" ++
-    "  la t0, cd_caller_be; addi t0, t0, 19; addi t1, sp, 0; li t2, 20\n" ++
-    ".Lcd_xlog_from_" ++ site ++ tag ++ ":\n" ++
-    "  lbu t3, 0(t0); sb t3, 0(t1); addi t0, t0, -1; addi t1, t1, 1; addi t2, t2, -1; bnez t2, .Lcd_xlog_from_" ++ site ++ tag ++ "\n" ++
-    "  sd zero, 32(sp); sd zero, 40(sp); sd zero, 48(sp); sd zero, 56(sp)\n" ++
-    "  la t0, cd_callee_be; addi t0, t0, 19; addi t1, sp, 32; li t2, 20\n" ++
-    ".Lcd_xlog_to_" ++ site ++ tag ++ ":\n" ++
-    "  lbu t3, 0(t0); sb t3, 0(t1); addi t0, t0, -1; addi t1, t1, 1; addi t2, t2, -1; bnez t2, .Lcd_xlog_to_" ++ site ++ tag ++ "\n" ++
-    "  la t0, cd_value_be; addi t0, t0, 31; addi t1, sp, 64; li t2, 32\n" ++
-    ".Lcd_xlog_val_" ++ site ++ tag ++ ":\n" ++
-    "  lbu t3, 0(t0); sb t3, 0(t1); addi t0, t0, -1; addi t1, t1, 1; addi t2, t2, -1; bnez t2, .Lcd_xlog_val_" ++ site ++ tag ++ "\n" ++
-    "  addi a0, sp, 0\n  addi a1, sp, 32\n  addi a2, sp, 64\n" ++
-    "  jal ra, eip7708_append_transfer_log\n" ++
-    ".Lcd_xlog_restore_" ++ site ++ tag ++ ":\n" ++
-    "  ld x10, 96(sp)\n  ld x12, 104(sp)\n  ld x13, 112(sp)\n  addi sp, sp, 128\n" ++
+    -- GH #10938 cut 4: the operand staging is now the shared
+    -- `eip7708TransferLogStageAsm`, which the CREATE-endowment site also uses.  Only the
+    -- one-shot pending-flag guard above and below is CALL-specific.
+    eip7708TransferLogStageAsm "cd_caller_be" "cd_callee_be" "cd_value_be"
+      (".Lcd_xlog_from_" ++ site ++ tag) (".Lcd_xlog_to_" ++ site ++ tag)
+      (".Lcd_xlog_val_" ++ site ++ tag)
+      (restoreLabel := ".Lcd_xlog_restore_" ++ site ++ tag) ++
     ".Lcd_xlog_skip_" ++ site ++ tag ++ ":\n"
   let refundNewAccountStateGas : String → String := fun site =>
     -- execution-specs `credit_state_gas_refund(NEW_ACCOUNT)`: refund in LIFO

--- a/EvmAsm/Codegen/Programs/EIP7708Logs.lean
+++ b/EvmAsm/Codegen/Programs/EIP7708Logs.lean
@@ -11,6 +11,60 @@ namespace EvmAsm.Codegen
 
 open EvmAsm.Rv64
 
+/-- Stage the three `eip7708_append_transfer_log` operands from canonical big-endian
+    globals into a 128-byte stack frame, call the appender, and restore the live runtime
+    cursors.  GH #10938 cut 4.
+
+    ## Why this exists
+
+    execution-specs has **one** `emit_transfer_log` call, at `vm/interpreter.py:391-397`
+    inside `process_message`, shared by every message-call frame entry at every depth.
+    The guest had two byte-identical copies of the operand staging: the value-CALL frame
+    entry (`Programs.ChildFrameHandlers`, emitted eight times — two sites in each of four
+    closures) and the CREATE endowment (`Programs.ChildFrameCreateTail`, emitted twice for
+    the salt/no-salt forms).
+
+    **Measured, not assumed:** extracting the two blocks from
+    `gen-out/regionmap/stateless_guest.s` and renaming the three source globals makes them
+    diff to **one line** — a label the CALL side emits and the CREATE side does not, which
+    contributes zero bytes.  That is why this is an extraction and not a rewrite, and it is
+    the discriminator cut 1 lacked: there the two blocks' *control flow* differed (opposite
+    branch senses, two labels versus three), so no shared emitter could reproduce both.
+
+    ## What is deliberately NOT shared
+
+    Each caller keeps its own **guard**, because the guards are genuinely different
+    predicates over different state: the CALL side is a one-shot `cd_xfer_log_pending`
+    flag cleared before the emit, the CREATE side is an account-witness context gate plus
+    `value != 0`.  Folding those together would repeat cut 1's mistake in the other
+    direction — a shared capture must never imply a shared disposition.
+
+    Operands are 32-byte stack words, matching what the appender expects: an address in the
+    **low 20 bytes** (the synthetic-log materializer reverses the whole 32-byte slot back to
+    big-endian), and the value byte-reversed to little-endian.
+
+    `labFrom`/`labTo`/`labVal` are complete label names including the leading `.L`;
+    `restoreLabel`, when non-empty, emits a branch target immediately after the call for a
+    caller that needs to jump straight to the register restore. -/
+def eip7708TransferLogStageAsm (fromSym toSym valSym labFrom labTo labVal : String)
+    (restoreLabel : String := "") : String :=
+  "  addi sp, sp, -128\n  sd x10, 96(sp)\n  sd x12, 104(sp)\n  sd x13, 112(sp)\n" ++
+  "  sd zero, 0(sp); sd zero, 8(sp); sd zero, 16(sp); sd zero, 24(sp)\n" ++
+  "  la t0, " ++ fromSym ++ "; addi t0, t0, 19; addi t1, sp, 0; li t2, 20\n" ++
+  labFrom ++ ":\n" ++
+  "  lbu t3, 0(t0); sb t3, 0(t1); addi t0, t0, -1; addi t1, t1, 1; addi t2, t2, -1; bnez t2, " ++ labFrom ++ "\n" ++
+  "  sd zero, 32(sp); sd zero, 40(sp); sd zero, 48(sp); sd zero, 56(sp)\n" ++
+  "  la t0, " ++ toSym ++ "; addi t0, t0, 19; addi t1, sp, 32; li t2, 20\n" ++
+  labTo ++ ":\n" ++
+  "  lbu t3, 0(t0); sb t3, 0(t1); addi t0, t0, -1; addi t1, t1, 1; addi t2, t2, -1; bnez t2, " ++ labTo ++ "\n" ++
+  "  la t0, " ++ valSym ++ "; addi t0, t0, 31; addi t1, sp, 64; li t2, 32\n" ++
+  labVal ++ ":\n" ++
+  "  lbu t3, 0(t0); sb t3, 0(t1); addi t0, t0, -1; addi t1, t1, 1; addi t2, t2, -1; bnez t2, " ++ labVal ++ "\n" ++
+  "  addi a0, sp, 0\n  addi a1, sp, 32\n  addi a2, sp, 64\n" ++
+  "  jal ra, eip7708_append_transfer_log\n" ++
+  (if restoreLabel.isEmpty then "" else restoreLabel ++ ":\n") ++
+  "  ld x10, 96(sp)\n  ld x12, 104(sp)\n  ld x13, 112(sp)\n  addi sp, sp, 128\n"
+
 private def copyWordAsm (src : String) (dstOff : Nat) : String :=
   "  ld t3, 0(" ++ src ++ ")\n" ++
   "  sd t3, " ++ toString dstOff ++ "(t2)\n" ++


### PR DESCRIPTION
## Summary

GH #10938 **cut 4** — the nested post-descend block. Extracts the EIP-7708
`emit_transfer_log` operand staging into one emitter,
`eip7708TransferLogStageAsm` in `Programs/EIP7708Logs.lean`, shared by the value-CALL
frame entry and the CREATE endowment.

**Representation only, and byte-identity is MEASURED on both artefacts — including the
`.s` text.** Base `a714079a3`:

| artifact | before | after |
|---|---|---|
| `stateless_guest.s` | `4f690273e75b3644333f9a12c5934cdc8704ca70a516f6422034f554887ed0ae` | **identical** |
| `stateless_guest.elf` | `acd31bd5afb1149370990b8358c42c6a8a22d62dfab45b092d2d0ea991291a2d` | **identical** |

`.s` identity is the strong form here: it covers **all ten** emissions of the block at
once (eight CALL, two CREATE), not a spot check. No generated file changes, so no layout
regen — `scripts/check-region-map.sh` passes unchanged.

## The spec position

`execution-specs` at pinned `e5a8caf1b`, `vm/interpreter.py:391-397` — **one**
`emit_transfer_log`, inside `process_message`, after the `copy_tx_state` snapshot
(`:380`) and paired with the unguarded `move_ether` above it:

```python
if message.should_transfer_value and message.value != 0:
    move_ether(tx_state, message.caller, message.current_target, message.value)
    if message.caller != message.current_target:
        emit_transfer_log(evm, message.caller, message.current_target, message.value)
```

`process_create_message` has no counterpart of its own — it calls `process_message`
(`:212`), so the CREATE endowment log is *the same call site* in the spec. Two guest
copies of the staging is exactly the shape #10938 is about.

## The population, measured rather than inferred

`jal ra, eip7708_append_transfer_log` occurs **14** times in
`gen-out/regionmap/stateless_guest.s`. Clustering the 23 lines preceding each call and
normalising label names gives **six** distinct shapes, of which two are the duplicated
staging:

| shape | emissions | producer |
|---|---|---|
| `cd_xfer_log_pending` guard + staging | **8** | `ChildFrameHandlers.emitPendingXferLog` (2 sites × 4 closures) |
| ctx gate + `value != 0` + staging | **2** | `ChildFrameCreateTail` (salt / no-salt) |
| 4 others | 1 each | `BlockVerdictFunction`, `EIP7708Logs` (burn), `ChildFrameHandlerTailHelpers`, `Selfdestruct` |

**The CALL side was already factored** into one emitter; the CREATE side was a second
copy of it. So cut 4 is one deduplication, not eight.

`ChildFrameHandlerTailHelpers.lean:165-182` deliberately stays out: the value-bearing
precompile tail passes **raw stack-word pointers** (`x20`, `x12+32`, `x12+valueOff`)
straight to the appender and does no staging at all, because its operands are already
stack words. It is not a copy — it is the site that does not need the helper.

## The discriminator cut 1 lacked

Cut 1 was withdrawn because comparing the two deploy-charge blocks at three levels found
something new each time: same constants, four differences in form, and then **different
control flow** (opposite branch senses, two labels versus three), so no shared emitter
could reproduce both sites without changing one site's instructions.

I ran that comparison first here, on the **emitted stream** rather than the Lean source.
Extracting both bodies from `stateless_guest.s`, normalising labels, and renaming the
three source globals (`cd_caller_be`/`cd_callee_be`/`cd_value_be` →
`create_sender_be`/`create_address_be`/`create_value_be`) makes them differ by **exactly
one line**: a label the CALL side emits and the CREATE side does not, which contributes
**zero bytes**. That is what made the extraction viable and is why the emitter takes an
optional `restoreLabel` rather than always emitting one.

## What is deliberately NOT shared

Each caller keeps its **own guard**, because the two are different predicates over
different state:

* CALL — a one-shot `cd_xfer_log_pending` flag, cleared *before* the emit.
* CREATE — an account-witness context gate (`584(x20)`) plus `value != 0`; the caller
  is a freshly derived address so the spec's `caller != current_target` test is
  statically true and needs no emission.

Folding those together would repeat cut 1's error in the other direction. The
plan's prohibition stands: **a shared capture must never imply a shared disposition.**
Nothing about placement moves either — both blocks already sat where the spec puts the
log, after the child snapshot and before the body, and both are still rolled back by
`frame_return` on a reverting child. Byte identity is the proof that no ordering changed.

## Home, and reachability

`Programs/EIP7708Logs.lean`, which already owns `eip7708_append_transfer_log` — the
staging helper for its arguments belongs beside it. It imports only `Rv64.Program` and
`Codegen.Layout`, both already in `ChildFrameCreateTail`'s cone, so the one added import
edge pulls in nothing new; `ChildFrameHandlers` reaches it transitively because it
already imports `ChildFrameCreateTail` (`:34`). No file approaches the 1500-line
`Programs` cap (`EIP7708Logs` 527, `ChildFrameHandlers` 1001, `ChildFrameCreateTail`
567).

## Verification

* Byte-identity measured on `.s` **and** `.elf` (table above).
* `lake build` — clean.
* `scripts/check-region-map.sh` — OK on all five lines; no generated file changed.
* `scripts/check-forbidden-tactics.sh` — OK.
* `scripts/check-guarded-handler-bytes.sh` — fails, and **fails identically on the
  unmodified tree**: a local build cache holds `Callable.olean.hash` without
  `Callable.olean`. Pre-existing and environmental; the script is not referenced from
  `.github/workflows`. Same note as #10985.

## Note on issue numbering

Cuts 1–4 are defined on **#10938**. PR #10985 (cut 2) mistakenly cites #10784 in its
title, body, and three source comments; corrections are recorded as author comments on
#10985 and #10987, and a follow-up will fix the source text once those merge. This PR
cites #10938 throughout.
