### PR TITLE
codegen: name the body-state slab's stride and size (GH #10619 prerequisite)

### DIFF
--- a/EvmAsm/Codegen/Programs/BlockVerdictDataSectionTail.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictDataSectionTail.lean
@@ -7,6 +7,7 @@
 
 import EvmAsm.Codegen.Programs.BlockVerdictParams
 import EvmAsm.Codegen.CallFrameLayout
+import EvmAsm.Codegen.Programs.BodyStateSnapshot
 import EvmAsm.Codegen.Programs.NonstorageEffectLog
 import EvmAsm.Codegen.Programs.AccountTupleSequencesConsistent
 import EvmAsm.Codegen.Programs.BalSlotTupleSequence
@@ -488,7 +489,7 @@ def ziskStatelessVerdictV2DataSectionTail : String :=
   -- `Layout.moveZeroDataLines`, preserving fixed `.data` addresses (in
   -- particular bnf_le_a).
   ".balign 8\n" ++
-  "body_state_snapshot_by_depth:\n  .zero 106600\n" ++
+  "body_state_snapshot_by_depth:\n  .zero " ++ toString bodyStateSlabBytes ++ "\n" ++
   -- bmvmx.5.5.2 (umbrella-B1): scratch for the multi-tx per-sender FINAL-nonce check
   -- (BAL sender post nonce == pre + total sender tx count). bv_b1_finals is the 88-byte
   -- bal_account_nonstorage_finals output (separate from c2nsc_finals, which A2a's

--- a/EvmAsm/Codegen/Programs/BodyStateSnapshot.lean
+++ b/EvmAsm/Codegen/Programs/BodyStateSnapshot.lean
@@ -5,6 +5,13 @@
   produce the existing straight-line instructions; they are deliberately not
   guest subroutines, so root and child capture retain their exact instruction
   order and rollback timing.
+
+  GH #10619 also gives the slab's SHAPE a name here.  Its per-depth stride was written
+  nowhere: all eight consumers open-coded `depth * 104` as a shift-add chain, so the field
+  count existed only as the exponents of three `slli`s spread over three files, with the
+  total appearing once more as a bare `.zero 106600`.  Adding a field meant editing nine
+  sites in a form no search for "104" can find, and getting one wrong shifts every deeper
+  frame's snapshot by 8 bytes — a silently wrong rollback, not a build error.
 -/
 
 namespace EvmAsm.Codegen
@@ -26,5 +33,58 @@ def bodyStateCaptureCursorsAsm (sourceSetup sourceEnvReg destinationReg valueReg
     ", 40(" ++ destinationReg ++ "); ld " ++ valueReg ++ ", 464(" ++ sourceEnvReg ++
     "); sd " ++ valueReg ++ ", 48(" ++ destinationReg ++ "); ld " ++ valueReg ++
     ", 472(" ++ sourceEnvReg ++ "); sd " ++ valueReg ++ ", 56(" ++ destinationReg ++ ")\n"
+
+/-- Number of 8-byte fields in one depth's `body_state_snapshot_by_depth` record.
+
+    In offset order: `exec_nonstorage_effect_count`, `exec_nonstorage_effect_overflow`,
+    `exec_code_effect_count`, `exec_code_effect_next`, `exec_code_effect_overflow`, the
+    three `evm_env` cursors, `account_writes_undo_count`, `account_state_pending_count`,
+    `account_state_delete_count`, `account_state_overflow`, `create_nonce_undo_count`. -/
+def bodyStateSlabFields : Nat := 13
+
+/-- Bytes per depth. -/
+def bodyStateSlabStride : Nat := bodyStateSlabFields * 8
+
+/-- Maximum call depth plus one, matching the sibling per-depth arrays
+    (`storage_writes_undo_checkpoint`, `create_frame_flag`). -/
+def bodyStateSlabDepths : Nat := 1025
+
+/-- Total `.bss` allocation of the slab. -/
+def bodyStateSlabBytes : Nat := bodyStateSlabStride * bodyStateSlabDepths
+
+#guard bodyStateSlabStride = 104
+#guard bodyStateSlabBytes = 106600
+
+/-- Emit `acc := depth * bodyStateSlabStride` with shifts and adds only.
+
+    `depth` is read repeatedly and never written; `acc` and `tmp` are clobbered, and `tmp`
+    must differ from `depth`.  The decomposition walks the stride's set bits from high to
+    low, which is exactly what the eight hand-written copies did for 104 (`64 + 32 + 8`).
+
+    Returned WITHOUT leading indentation or a trailing newline, so each call site can splice
+    it into the single emitted line it already occupies.  That is not cosmetic: emitting it
+    as its own line would move `CallFrameDescend`'s `la` from before the chain to after it,
+    which changes the instruction ORDER and therefore the linked bytes even though the
+    computed value is the same. Measured — that mistake changed both hashes. -/
+def bodyStateSlabStrideOps (depth acc tmp : String) : String :=
+  let bits := (List.range 16).reverse.filter (fun i => (bodyStateSlabStride >>> i) % 2 == 1)
+  match bits with
+  | [] => "li " ++ acc ++ ", 0"
+  | hi :: rest =>
+    "slli " ++ acc ++ ", " ++ depth ++ ", " ++ toString hi ++
+      String.join (rest.map (fun i =>
+        "; slli " ++ tmp ++ ", " ++ depth ++ ", " ++ toString i ++
+        "; add " ++ acc ++ ", " ++ acc ++ ", " ++ tmp))
+
+/-- The same chain as its own indented line, for a site that does not splice. -/
+def bodyStateSlabStrideAsm (depth acc tmp : String) : String :=
+  "  " ++ bodyStateSlabStrideOps depth acc tmp ++ "\n"
+
+/- Pin the rendering the eight call sites previously wrote by hand, so a stride change
+   cannot silently alter the instruction sequence.  A `#guard` takes no docstring. -/
+#guard bodyStateSlabStrideOps "t1" "t2" "t3"
+  = "slli t2, t1, 6; slli t3, t1, 5; add t2, t2, t3; slli t3, t1, 3; add t2, t2, t3"
+#guard bodyStateSlabStrideOps "s8" "t2" "t3"
+  = "slli t2, s8, 6; slli t3, s8, 5; add t2, t2, t3; slli t3, s8, 3; add t2, t2, t3"
 
 end EvmAsm.Codegen

--- a/EvmAsm/Codegen/Programs/CallFrameDescend.lean
+++ b/EvmAsm/Codegen/Programs/CallFrameDescend.lean
@@ -510,7 +510,7 @@ def callFrameDescendFunction : String :=
   -- Slot +88 (`account_state_overflow`) is root-only: no child restore existed
   -- before this representation migration, so retaining that child behavior is
   -- deliberate rather than an omitted shared restore.
-  "  la t1, body_state_snapshot_by_depth; slli t2, s8, 6; slli t3, s8, 5; add t2, t2, t3; slli t3, s8, 3; add t2, t2, t3; add t1, t1, t2\n" ++
+  "  la t1, body_state_snapshot_by_depth; " ++ bodyStateSlabStrideOps "s8" "t2" "t3" ++ "; add t1, t1, t2\n" ++
   bodyStateCaptureCursorsAsm "  " "s3" "t1" "t0" ++
   "  la t4, exec_nonstorage_effect_count; ld t0, 0(t4); sd t0, 0(t1)  # nonstorage effect count snapshot\n" ++
   "  la t4, exec_nonstorage_effect_overflow; ld t0, 0(t4); sd t0, 8(t1)  # nonstorage overflow snapshot\n" ++
@@ -524,7 +524,7 @@ def callFrameDescendFunction : String :=
   -- made inside the child, leaving the parent's earlier writes standing.
   "  la t1, storage_writes_undo_count; ld t0, 0(t1)\n" ++
   "  la t1, storage_writes_undo_checkpoint; slli t2, s8, 3; add t1, t1, t2; sd t0, 0(t1)\n" ++
-  "  la t1, body_state_snapshot_by_depth; slli t2, s8, 6; slli t3, s8, 5; add t2, t2, t3; slli t3, s8, 3; add t2, t2, t3; add t1, t1, t2\n" ++
+  "  la t1, body_state_snapshot_by_depth; " ++ bodyStateSlabStrideOps "s8" "t2" "t3" ++ "; add t1, t1, t2\n" ++
   -- Account writes have the same transaction-state rollback rule as storage
   -- writes (but unlike storage reads, which remain evidence of an access).
   bodyStateCaptureScalarAsm "account_writes_undo_count" "t1" 64 "t4" "t0" ++

--- a/EvmAsm/Codegen/Programs/CallFrameReturn.lean
+++ b/EvmAsm/Codegen/Programs/CallFrameReturn.lean
@@ -38,6 +38,7 @@
 
 import EvmAsm.Rv64.Program
 import EvmAsm.Codegen.Layout
+import EvmAsm.Codegen.Programs.BodyStateSnapshot
 import EvmAsm.Codegen.Programs.EvmMemoryGas
 import EvmAsm.Codegen.Programs.CreateCreatorNonce
 
@@ -90,7 +91,7 @@ def frameReturnFunction : String :=
   -- Revert every CREATE nonce-table mutation made since this child frame's
   -- entry checkpoint.  This is a journal replay, not a count truncation: it
   -- restores in-place advances of an existing creator as well as new entries.
-  "  la t0, evm_call_depth; ld t1, 0(t0); slli t2, t1, 6; slli t3, t1, 5; add t2, t2, t3; slli t3, t1, 3; add t2, t2, t3; la t0, body_state_snapshot_by_depth; add t0, t0, t2; ld a0, 96(t0)\n" ++
+  "  la t0, evm_call_depth; ld t1, 0(t0); " ++ bodyStateSlabStrideOps "t1" "t2" "t3" ++ "; la t0, body_state_snapshot_by_depth; add t0, t0, t2; ld a0, 96(t0)\n" ++
   "  jal ra, create_creator_nonce_undo_to\n" ++
   -- r59nm S5a: same replay for the storage write map.  restore_tx_state
   -- (state_tracker.py:809-826) restores the WRITE structures and leaves the
@@ -102,7 +103,7 @@ def frameReturnFunction : String :=
   -- The account-writes mirror is transaction state too: replay its undo journal
   -- on REVERT so a reverted child cannot contribute a balance, nonce, or code
   -- change to the transaction-level BAL source.
-  "  la t0, evm_call_depth; ld t1, 0(t0); slli t2, t1, 6; slli t3, t1, 5; add t2, t2, t3; slli t3, t1, 3; add t2, t2, t3; la t0, body_state_snapshot_by_depth; add t0, t0, t2; ld a0, 64(t0)\n" ++
+  "  la t0, evm_call_depth; ld t1, 0(t0); " ++ bodyStateSlabStrideOps "t1" "t2" "t3" ++ "; la t0, body_state_snapshot_by_depth; add t0, t0, t2; ld a0, 64(t0)\n" ++
   "  jal ra, account_writes_restore_frame\n" ++
   -- On child error, execution-specs `refill_frame_state_gas` returns the
   -- child state-gas allocation in LIFO order: the portion that spilled into
@@ -197,7 +198,7 @@ def frameReturnFunction : String :=
   -- i3djw/reverted-CREATE rollback: truncate global effect logs to the
   -- pre-child snapshots captured by call_frame_descend. Successful child frames
   -- keep their CREATE/CALL value effects; reverted child frames discard them.
-  "  la t0, evm_call_depth; ld t2, 0(t0); slli t1, t2, 6; slli t3, t2, 5; add t1, t1, t3; slli t3, t2, 3; add t1, t1, t3; la t0, body_state_snapshot_by_depth; add t0, t0, t1\n" ++
+  "  la t0, evm_call_depth; ld t2, 0(t0); " ++ bodyStateSlabStrideOps "t2" "t1" "t3" ++ "; la t0, body_state_snapshot_by_depth; add t0, t0, t1\n" ++
   "  ld t2, 0(t0); la t1, exec_nonstorage_effect_count; sd t2, 0(t1)\n" ++
   "  ld t2, 8(t0); la t1, exec_nonstorage_effect_overflow; sd t2, 0(t1)\n" ++
   "  ld t2, 16(t0); la t1, exec_code_effect_count; sd t2, 0(t1)\n" ++
@@ -205,9 +206,9 @@ def frameReturnFunction : String :=
   "  ld t2, 32(t0); la t1, exec_code_effect_overflow; sd t2, 0(t1)\n" ++
   -- Restore this child's CodeState high-water marks on REVERT/exceptional
   -- return.  The current depth still names the child at this point.
-  "  la t0, evm_call_depth; ld t2, 0(t0); slli t1, t2, 6; slli t3, t2, 5; add t1, t1, t3; slli t3, t2, 3; add t1, t1, t3; la t0, body_state_snapshot_by_depth; add t0, t0, t1\n" ++
+  "  la t0, evm_call_depth; ld t2, 0(t0); " ++ bodyStateSlabStrideOps "t2" "t1" "t3" ++ "; la t0, body_state_snapshot_by_depth; add t0, t0, t1\n" ++
   "  ld t3, 72(t0); la t1, account_state_pending_count; sd t3, 0(t1)\n" ++
-  "  la t0, evm_call_depth; ld t2, 0(t0); slli t1, t2, 6; slli t3, t2, 5; add t1, t1, t3; slli t3, t2, 3; add t1, t1, t3; la t0, body_state_snapshot_by_depth; add t0, t0, t1; ld t3, 80(t0); la t1, account_state_delete_count; sd t3, 0(t1)\n" ++
+  "  la t0, evm_call_depth; ld t2, 0(t0); " ++ bodyStateSlabStrideOps "t2" "t1" "t3" ++ "; la t0, body_state_snapshot_by_depth; add t0, t0, t1; ld t3, 80(t0); la t1, account_state_delete_count; sd t3, 0(t1)\n" ++
   "  la t0, evm_call_depth; ld t2, 0(t0); slli t2, t2, 3\n" ++
   "  la t0, evm_selfdestruct_seen_count_by_depth; add t0, t0, t2; ld t3, 0(t0); la t1, evm_selfdestruct_seen_count; sd t3, 0(t1)\n" ++
   "  la t0, evm_selfdestruct_seen_overflow_by_depth; add t0, t0, t2; ld t3, 0(t0); la t1, evm_selfdestruct_seen_overflow; sd t3, 0(t1)\n" ++


### PR DESCRIPTION
## Summary

Prerequisite for GH #10619's one-field slab extension: give
`body_state_snapshot_by_depth` a **named** stride and size, so the field addition is an
edit to one number rather than to nine hand-written sites.

**Representation only. Byte-identity MEASURED on both artefacts.** Base `a714079a3`:

| artifact | before | after |
|---|---|---|
| `stateless_guest.s` | `4f690273e75b3644333f9a12c5934cdc8704ca70a516f6422034f554887ed0ae` | **identical** |
| `stateless_guest.elf` | `acd31bd5afb1149370990b8358c42c6a8a22d62dfab45b092d2d0ea991291a2d` | **identical** |

No generated file changes, so no layout regen and no interaction with the
one-regenerating-PR-at-a-time rule. `scripts/check-region-map.sh` passes unchanged.

## What was unnamed

The slab is the guest's analogue of `copy_tx_state` — one `process_message` body
checkpoint per frame depth. Its per-depth stride of 104 bytes **appeared nowhere as a
number.** All eight consumers open-coded `depth * 104` as

```
slli acc, depth, 6 ; slli tmp, depth, 5 ; add acc, acc, tmp ; slli tmp, depth, 3 ; add acc, acc, tmp
```

so the thirteen-field count existed **only as the exponents of three `slli`s**, spread
over three files, with the total appearing once more as a bare `.zero 106600` in a
fourth. Sites: `CallFrameReturn.lean` ×5, `CallFrameDescend.lean` ×2,
`BlockVerdictDataSectionTail.lean` ×1 (the allocation).

**Why that is a tripwire-absence rather than untidiness:** adding a fourteenth field
means changing all nine, in a form that no search for `104`, for the slab's name, or for
"stride" can enumerate. Miss one and every *deeper* frame's snapshot shifts by 8 bytes —
a **silently wrong rollback**, not a build error, and one that only shows up at depth ≥ 1
in whichever field happens to land on the seam.

## What this adds

In the existing import-free `Programs/BodyStateSnapshot.lean`, which already owns
`bodyStateCaptureScalarAsm`/`bodyStateCaptureCursorsAsm` — so this is the module's own
subject, and the two files that needed the import (`CallFrameReturn`,
`BlockVerdictDataSectionTail`) gain an edge into a module that imports nothing.

* `bodyStateSlabFields = 13`, with the field list in offset order in the docstring
* `bodyStateSlabStride = fields * 8`, `bodyStateSlabDepths = 1025`,
  `bodyStateSlabBytes = stride * depths`
* `bodyStateSlabStrideOps depth acc tmp` — the shift-add chain, derived from the set bits
  of `bodyStateSlabStride` rather than hardcoded
* `#guard`s pinning `stride = 104`, `bytes = 106600`, and **the rendered text for both
  register conventions** in use

## ⛔ The part that was measured rather than assumed

My first attempt had the emitter return its own indented line. That is **not**
byte-neutral, and both hashes changed:

```
- la t1, body_state_snapshot_by_depth; slli t2, s8, 6; … ; add t1, t1, t2
+ slli t2, s8, 6; … ; add t2, t2, t3
+ la t1, body_state_snapshot_by_depth; add t1, t1, t2
```

Diffing the two emitted streams showed **every difference was a line split** — same
mnemonics, same operands, same order *within* each site — except that at
`CallFrameDescend`'s two sites the original line **begins** with the `la`, so hoisting the
chain onto its own line moved the `la` from before the chain to after it. The computed
address is identical; the **instruction order** is not, and the linked bytes follow the
order.

Hence `bodyStateSlabStrideOps` returns no indentation and no trailing newline, and each
site splices it into the line it already occupies. That preserves the `.s` **text**, which
is why the identity above is exact rather than ELF-only.

The general form, worth stating because it is easy to get wrong in the other direction: an
extraction that changes only *line structure* can still change instruction order whenever
the original line **starts** with an instruction the extracted block must follow. `.s`
identity catches it; an ELF-only check would have caught it here too, but a
"same instructions, different formatting" argument would not have.

## Verification

* Byte-identity measured on `.s` and `.elf` (table above).
* `scripts/check-region-map.sh` — OK on all five lines, no generated file changed.
* `scripts/check-forbidden-tactics.sh` — OK.
* `#guard`s cover the stride, the total, and both rendered register conventions.

## Next

GH #10619 itself — capture `storage_writes_undo_count` at slot 104 and replay it in
`dispatcher_restore_body_state` — follows as a separate PR on top of this one. That one
is behavioural and grows `.bss`, so per the review split it is held for review rather
than landed on the representation-only clause. It must land **before** #10784.
