### PR TITLE
chore: batch-merge #10987 #10990 #10991

### DIFF
--- a/EvmAsm/Codegen/Programs/BlockVerdictDataSectionTail.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictDataSectionTail.lean
@@ -7,6 +7,7 @@
 
 import EvmAsm.Codegen.Programs.BlockVerdictParams
 import EvmAsm.Codegen.CallFrameLayout
+import EvmAsm.Codegen.Programs.BodyStateSnapshot
 import EvmAsm.Codegen.Programs.NonstorageEffectLog
 import EvmAsm.Codegen.Programs.AccountTupleSequencesConsistent
 import EvmAsm.Codegen.Programs.BalSlotTupleSequence
@@ -488,7 +489,7 @@ def ziskStatelessVerdictV2DataSectionTail : String :=
   -- `Layout.moveZeroDataLines`, preserving fixed `.data` addresses (in
   -- particular bnf_le_a).
   ".balign 8\n" ++
-  "body_state_snapshot_by_depth:\n  .zero 106600\n" ++
+  "body_state_snapshot_by_depth:\n  .zero " ++ toString bodyStateSlabBytes ++ "\n" ++
   -- bmvmx.5.5.2 (umbrella-B1): scratch for the multi-tx per-sender FINAL-nonce check
   -- (BAL sender post nonce == pre + total sender tx count). bv_b1_finals is the 88-byte
   -- bal_account_nonstorage_finals output (separate from c2nsc_finals, which A2a's

--- a/EvmAsm/Codegen/Programs/BodyStateSnapshot.lean
+++ b/EvmAsm/Codegen/Programs/BodyStateSnapshot.lean
@@ -5,6 +5,13 @@
   produce the existing straight-line instructions; they are deliberately not
   guest subroutines, so root and child capture retain their exact instruction
   order and rollback timing.
+
+  GH #10619 also gives the slab's SHAPE a name here.  Its per-depth stride was written
+  nowhere: all eight consumers open-coded `depth * 104` as a shift-add chain, so the field
+  count existed only as the exponents of three `slli`s spread over three files, with the
+  total appearing once more as a bare `.zero 106600`.  Adding a field meant editing nine
+  sites in a form no search for "104" can find, and getting one wrong shifts every deeper
+  frame's snapshot by 8 bytes — a silently wrong rollback, not a build error.
 -/
 
 namespace EvmAsm.Codegen
@@ -26,5 +33,58 @@ def bodyStateCaptureCursorsAsm (sourceSetup sourceEnvReg destinationReg valueReg
     ", 40(" ++ destinationReg ++ "); ld " ++ valueReg ++ ", 464(" ++ sourceEnvReg ++
     "); sd " ++ valueReg ++ ", 48(" ++ destinationReg ++ "); ld " ++ valueReg ++
     ", 472(" ++ sourceEnvReg ++ "); sd " ++ valueReg ++ ", 56(" ++ destinationReg ++ ")\n"
+
+/-- Number of 8-byte fields in one depth's `body_state_snapshot_by_depth` record.
+
+    In offset order: `exec_nonstorage_effect_count`, `exec_nonstorage_effect_overflow`,
+    `exec_code_effect_count`, `exec_code_effect_next`, `exec_code_effect_overflow`, the
+    three `evm_env` cursors, `account_writes_undo_count`, `account_state_pending_count`,
+    `account_state_delete_count`, `account_state_overflow`, `create_nonce_undo_count`. -/
+def bodyStateSlabFields : Nat := 13
+
+/-- Bytes per depth. -/
+def bodyStateSlabStride : Nat := bodyStateSlabFields * 8
+
+/-- Maximum call depth plus one, matching the sibling per-depth arrays
+    (`storage_writes_undo_checkpoint`, `create_frame_flag`). -/
+def bodyStateSlabDepths : Nat := 1025
+
+/-- Total `.bss` allocation of the slab. -/
+def bodyStateSlabBytes : Nat := bodyStateSlabStride * bodyStateSlabDepths
+
+#guard bodyStateSlabStride = 104
+#guard bodyStateSlabBytes = 106600
+
+/-- Emit `acc := depth * bodyStateSlabStride` with shifts and adds only.
+
+    `depth` is read repeatedly and never written; `acc` and `tmp` are clobbered, and `tmp`
+    must differ from `depth`.  The decomposition walks the stride's set bits from high to
+    low, which is exactly what the eight hand-written copies did for 104 (`64 + 32 + 8`).
+
+    Returned WITHOUT leading indentation or a trailing newline, so each call site can splice
+    it into the single emitted line it already occupies.  That is not cosmetic: emitting it
+    as its own line would move `CallFrameDescend`'s `la` from before the chain to after it,
+    which changes the instruction ORDER and therefore the linked bytes even though the
+    computed value is the same. Measured — that mistake changed both hashes. -/
+def bodyStateSlabStrideOps (depth acc tmp : String) : String :=
+  let bits := (List.range 16).reverse.filter (fun i => (bodyStateSlabStride >>> i) % 2 == 1)
+  match bits with
+  | [] => "li " ++ acc ++ ", 0"
+  | hi :: rest =>
+    "slli " ++ acc ++ ", " ++ depth ++ ", " ++ toString hi ++
+      String.join (rest.map (fun i =>
+        "; slli " ++ tmp ++ ", " ++ depth ++ ", " ++ toString i ++
+        "; add " ++ acc ++ ", " ++ acc ++ ", " ++ tmp))
+
+/-- The same chain as its own indented line, for a site that does not splice. -/
+def bodyStateSlabStrideAsm (depth acc tmp : String) : String :=
+  "  " ++ bodyStateSlabStrideOps depth acc tmp ++ "\n"
+
+/- Pin the rendering the eight call sites previously wrote by hand, so a stride change
+   cannot silently alter the instruction sequence.  A `#guard` takes no docstring. -/
+#guard bodyStateSlabStrideOps "t1" "t2" "t3"
+  = "slli t2, t1, 6; slli t3, t1, 5; add t2, t2, t3; slli t3, t1, 3; add t2, t2, t3"
+#guard bodyStateSlabStrideOps "s8" "t2" "t3"
+  = "slli t2, s8, 6; slli t3, s8, 5; add t2, t2, t3; slli t3, s8, 3; add t2, t2, t3"
 
 end EvmAsm.Codegen

--- a/EvmAsm/Codegen/Programs/CallFrameDescend.lean
+++ b/EvmAsm/Codegen/Programs/CallFrameDescend.lean
@@ -510,7 +510,7 @@ def callFrameDescendFunction : String :=
   -- Slot +88 (`account_state_overflow`) is root-only: no child restore existed
   -- before this representation migration, so retaining that child behavior is
   -- deliberate rather than an omitted shared restore.
-  "  la t1, body_state_snapshot_by_depth; slli t2, s8, 6; slli t3, s8, 5; add t2, t2, t3; slli t3, s8, 3; add t2, t2, t3; add t1, t1, t2\n" ++
+  "  la t1, body_state_snapshot_by_depth; " ++ bodyStateSlabStrideOps "s8" "t2" "t3" ++ "; add t1, t1, t2\n" ++
   bodyStateCaptureCursorsAsm "  " "s3" "t1" "t0" ++
   "  la t4, exec_nonstorage_effect_count; ld t0, 0(t4); sd t0, 0(t1)  # nonstorage effect count snapshot\n" ++
   "  la t4, exec_nonstorage_effect_overflow; ld t0, 0(t4); sd t0, 8(t1)  # nonstorage overflow snapshot\n" ++
@@ -524,7 +524,7 @@ def callFrameDescendFunction : String :=
   -- made inside the child, leaving the parent's earlier writes standing.
   "  la t1, storage_writes_undo_count; ld t0, 0(t1)\n" ++
   "  la t1, storage_writes_undo_checkpoint; slli t2, s8, 3; add t1, t1, t2; sd t0, 0(t1)\n" ++
-  "  la t1, body_state_snapshot_by_depth; slli t2, s8, 6; slli t3, s8, 5; add t2, t2, t3; slli t3, s8, 3; add t2, t2, t3; add t1, t1, t2\n" ++
+  "  la t1, body_state_snapshot_by_depth; " ++ bodyStateSlabStrideOps "s8" "t2" "t3" ++ "; add t1, t1, t2\n" ++
   -- Account writes have the same transaction-state rollback rule as storage
   -- writes (but unlike storage reads, which remain evidence of an access).
   bodyStateCaptureScalarAsm "account_writes_undo_count" "t1" 64 "t4" "t0" ++

--- a/EvmAsm/Codegen/Programs/CallFrameReturn.lean
+++ b/EvmAsm/Codegen/Programs/CallFrameReturn.lean
@@ -38,6 +38,7 @@
 
 import EvmAsm.Rv64.Program
 import EvmAsm.Codegen.Layout
+import EvmAsm.Codegen.Programs.BodyStateSnapshot
 import EvmAsm.Codegen.Programs.EvmMemoryGas
 import EvmAsm.Codegen.Programs.CreateCreatorNonce
 
@@ -90,7 +91,7 @@ def frameReturnFunction : String :=
   -- Revert every CREATE nonce-table mutation made since this child frame's
   -- entry checkpoint.  This is a journal replay, not a count truncation: it
   -- restores in-place advances of an existing creator as well as new entries.
-  "  la t0, evm_call_depth; ld t1, 0(t0); slli t2, t1, 6; slli t3, t1, 5; add t2, t2, t3; slli t3, t1, 3; add t2, t2, t3; la t0, body_state_snapshot_by_depth; add t0, t0, t2; ld a0, 96(t0)\n" ++
+  "  la t0, evm_call_depth; ld t1, 0(t0); " ++ bodyStateSlabStrideOps "t1" "t2" "t3" ++ "; la t0, body_state_snapshot_by_depth; add t0, t0, t2; ld a0, 96(t0)\n" ++
   "  jal ra, create_creator_nonce_undo_to\n" ++
   -- r59nm S5a: same replay for the storage write map.  restore_tx_state
   -- (state_tracker.py:809-826) restores the WRITE structures and leaves the
@@ -102,7 +103,7 @@ def frameReturnFunction : String :=
   -- The account-writes mirror is transaction state too: replay its undo journal
   -- on REVERT so a reverted child cannot contribute a balance, nonce, or code
   -- change to the transaction-level BAL source.
-  "  la t0, evm_call_depth; ld t1, 0(t0); slli t2, t1, 6; slli t3, t1, 5; add t2, t2, t3; slli t3, t1, 3; add t2, t2, t3; la t0, body_state_snapshot_by_depth; add t0, t0, t2; ld a0, 64(t0)\n" ++
+  "  la t0, evm_call_depth; ld t1, 0(t0); " ++ bodyStateSlabStrideOps "t1" "t2" "t3" ++ "; la t0, body_state_snapshot_by_depth; add t0, t0, t2; ld a0, 64(t0)\n" ++
   "  jal ra, account_writes_restore_frame\n" ++
   -- On child error, execution-specs `refill_frame_state_gas` returns the
   -- child state-gas allocation in LIFO order: the portion that spilled into
@@ -197,7 +198,7 @@ def frameReturnFunction : String :=
   -- i3djw/reverted-CREATE rollback: truncate global effect logs to the
   -- pre-child snapshots captured by call_frame_descend. Successful child frames
   -- keep their CREATE/CALL value effects; reverted child frames discard them.
-  "  la t0, evm_call_depth; ld t2, 0(t0); slli t1, t2, 6; slli t3, t2, 5; add t1, t1, t3; slli t3, t2, 3; add t1, t1, t3; la t0, body_state_snapshot_by_depth; add t0, t0, t1\n" ++
+  "  la t0, evm_call_depth; ld t2, 0(t0); " ++ bodyStateSlabStrideOps "t2" "t1" "t3" ++ "; la t0, body_state_snapshot_by_depth; add t0, t0, t1\n" ++
   "  ld t2, 0(t0); la t1, exec_nonstorage_effect_count; sd t2, 0(t1)\n" ++
   "  ld t2, 8(t0); la t1, exec_nonstorage_effect_overflow; sd t2, 0(t1)\n" ++
   "  ld t2, 16(t0); la t1, exec_code_effect_count; sd t2, 0(t1)\n" ++
@@ -205,9 +206,9 @@ def frameReturnFunction : String :=
   "  ld t2, 32(t0); la t1, exec_code_effect_overflow; sd t2, 0(t1)\n" ++
   -- Restore this child's CodeState high-water marks on REVERT/exceptional
   -- return.  The current depth still names the child at this point.
-  "  la t0, evm_call_depth; ld t2, 0(t0); slli t1, t2, 6; slli t3, t2, 5; add t1, t1, t3; slli t3, t2, 3; add t1, t1, t3; la t0, body_state_snapshot_by_depth; add t0, t0, t1\n" ++
+  "  la t0, evm_call_depth; ld t2, 0(t0); " ++ bodyStateSlabStrideOps "t2" "t1" "t3" ++ "; la t0, body_state_snapshot_by_depth; add t0, t0, t1\n" ++
   "  ld t3, 72(t0); la t1, account_state_pending_count; sd t3, 0(t1)\n" ++
-  "  la t0, evm_call_depth; ld t2, 0(t0); slli t1, t2, 6; slli t3, t2, 5; add t1, t1, t3; slli t3, t2, 3; add t1, t1, t3; la t0, body_state_snapshot_by_depth; add t0, t0, t1; ld t3, 80(t0); la t1, account_state_delete_count; sd t3, 0(t1)\n" ++
+  "  la t0, evm_call_depth; ld t2, 0(t0); " ++ bodyStateSlabStrideOps "t2" "t1" "t3" ++ "; la t0, body_state_snapshot_by_depth; add t0, t0, t1; ld t3, 80(t0); la t1, account_state_delete_count; sd t3, 0(t1)\n" ++
   "  la t0, evm_call_depth; ld t2, 0(t0); slli t2, t2, 3\n" ++
   "  la t0, evm_selfdestruct_seen_count_by_depth; add t0, t0, t2; ld t3, 0(t0); la t1, evm_selfdestruct_seen_count; sd t3, 0(t1)\n" ++
   "  la t0, evm_selfdestruct_seen_overflow_by_depth; add t0, t0, t2; ld t3, 0(t0); la t1, evm_selfdestruct_seen_overflow; sd t3, 0(t1)\n" ++

--- a/EvmAsm/Codegen/Programs/ChildFrameCreateTail.lean
+++ b/EvmAsm/Codegen/Programs/ChildFrameCreateTail.lean
@@ -9,6 +9,7 @@
 import EvmAsm.Codegen.Programs.EvmAccessGas
 import EvmAsm.Codegen.Programs.EvmMemoryGas
 import EvmAsm.Codegen.Programs.CreateRuntime
+import EvmAsm.Codegen.Programs.EIP7708Logs
 import EvmAsm.Codegen.Programs.CreateSameTxCollision
 import EvmAsm.Codegen.Programs.AmsterdamSystemTx
 import EvmAsm.Rv64.Program
@@ -486,24 +487,15 @@ def createUnsupportedTail (netPopBytes : Nat) (hasSalt : Bool) : String :=
     "  ld t3, 584(x20)\n  beqz t3, .Lcr_tl_done_" ++ (if hasSalt then "f5" else "f0") ++ "\n" ++
     "  la t0, create_value_be\n  ld t1, 0(t0); ld t2, 8(t0); or t1, t1, t2; ld t2, 16(t0); or t1, t1, t2; ld t2, 24(t0); or t1, t1, t2\n" ++
     "  beqz t1, .Lcr_tl_done_" ++ (if hasSalt then "f5" else "f0") ++ "\n" ++   -- value == 0: no log
-    "  addi sp, sp, -128\n  sd x10, 96(sp)\n  sd x12, 104(sp)\n  sd x13, 112(sp)\n" ++
-    -- from_sw = [reverse(create_sender_be) low 20][12 zero] (sp+0)
-    "  sd zero, 0(sp); sd zero, 8(sp); sd zero, 16(sp); sd zero, 24(sp)\n" ++
-    "  la t0, create_sender_be; addi t0, t0, 19; addi t1, sp, 0; li t2, 20\n" ++
-    ".Lcr_tl_from_" ++ (if hasSalt then "f5" else "f0") ++ ":\n" ++
-    "  lbu t3, 0(t0); sb t3, 0(t1); addi t0, t0, -1; addi t1, t1, 1; addi t2, t2, -1; bnez t2, .Lcr_tl_from_" ++ (if hasSalt then "f5" else "f0") ++ "\n" ++
-    -- to_sw = [reverse(create_address_be) low 20][12 zero] (sp+32)
-    "  sd zero, 32(sp); sd zero, 40(sp); sd zero, 48(sp); sd zero, 56(sp)\n" ++
-    "  la t0, create_address_be; addi t0, t0, 19; addi t1, sp, 32; li t2, 20\n" ++
-    ".Lcr_tl_to_" ++ (if hasSalt then "f5" else "f0") ++ ":\n" ++
-    "  lbu t3, 0(t0); sb t3, 0(t1); addi t0, t0, -1; addi t1, t1, 1; addi t2, t2, -1; bnez t2, .Lcr_tl_to_" ++ (if hasSalt then "f5" else "f0") ++ "\n" ++
-    -- val_sw = reverse(create_value_be) = LE 32 bytes (sp+64)
-    "  la t0, create_value_be; addi t0, t0, 31; addi t1, sp, 64; li t2, 32\n" ++
-    ".Lcr_tl_val_" ++ (if hasSalt then "f5" else "f0") ++ ":\n" ++
-    "  lbu t3, 0(t0); sb t3, 0(t1); addi t0, t0, -1; addi t1, t1, 1; addi t2, t2, -1; bnez t2, .Lcr_tl_val_" ++ (if hasSalt then "f5" else "f0") ++ "\n" ++
-    "  addi a0, sp, 0\n  addi a1, sp, 32\n  addi a2, sp, 64\n" ++   -- from = from_sw, to = to_sw, amount = val_sw
-    "  jal ra, eip7708_append_transfer_log\n" ++
-    "  ld x10, 96(sp)\n  ld x12, 104(sp)\n  ld x13, 112(sp)\n  addi sp, sp, 128\n" ++
+    -- GH #10938 cut 4: the operand staging is the shared `eip7708TransferLogStageAsm`,
+    -- which the value-CALL frame-entry site also uses.  from_sw is
+    -- [reverse(create_sender_be) low 20][12 zero] at sp+0, to_sw the same for
+    -- create_address_be at sp+32, val_sw = reverse(create_value_be) (LE 32B) at sp+64.
+    -- The ctx gate and the value != 0 test above stay here: they are this site's guard.
+    eip7708TransferLogStageAsm "create_sender_be" "create_address_be" "create_value_be"
+      (".Lcr_tl_from_" ++ (if hasSalt then "f5" else "f0"))
+      (".Lcr_tl_to_" ++ (if hasSalt then "f5" else "f0"))
+      (".Lcr_tl_val_" ++ (if hasSalt then "f5" else "f0")) ++
     ".Lcr_tl_done_" ++ (if hasSalt then "f5" else "f0") ++ ":\n" ++
     -- The shared producer above is this CREATE frame's sole balance-transfer
     -- recorder.  Keep the independent EIP-161 nonce transition here, but give

--- a/EvmAsm/Codegen/Programs/ChildFrameHandlers.lean
+++ b/EvmAsm/Codegen/Programs/ChildFrameHandlers.lean
@@ -210,22 +210,13 @@ def callDescendFallThrough
     -- build from_sw/to_sw/val_sw on the stack from the canonical-BE globals (mirrors the
     -- CREATE-endowment emit in ChildFrameHandlerTails): a stack word holds the address in
     -- the LOW 20 bytes (the synthetic-log materializer reverses the WHOLE 32B slot to BE).
-    "  addi sp, sp, -128\n  sd x10, 96(sp)\n  sd x12, 104(sp)\n  sd x13, 112(sp)\n" ++
-    "  sd zero, 0(sp); sd zero, 8(sp); sd zero, 16(sp); sd zero, 24(sp)\n" ++
-    "  la t0, cd_caller_be; addi t0, t0, 19; addi t1, sp, 0; li t2, 20\n" ++
-    ".Lcd_xlog_from_" ++ site ++ tag ++ ":\n" ++
-    "  lbu t3, 0(t0); sb t3, 0(t1); addi t0, t0, -1; addi t1, t1, 1; addi t2, t2, -1; bnez t2, .Lcd_xlog_from_" ++ site ++ tag ++ "\n" ++
-    "  sd zero, 32(sp); sd zero, 40(sp); sd zero, 48(sp); sd zero, 56(sp)\n" ++
-    "  la t0, cd_callee_be; addi t0, t0, 19; addi t1, sp, 32; li t2, 20\n" ++
-    ".Lcd_xlog_to_" ++ site ++ tag ++ ":\n" ++
-    "  lbu t3, 0(t0); sb t3, 0(t1); addi t0, t0, -1; addi t1, t1, 1; addi t2, t2, -1; bnez t2, .Lcd_xlog_to_" ++ site ++ tag ++ "\n" ++
-    "  la t0, cd_value_be; addi t0, t0, 31; addi t1, sp, 64; li t2, 32\n" ++
-    ".Lcd_xlog_val_" ++ site ++ tag ++ ":\n" ++
-    "  lbu t3, 0(t0); sb t3, 0(t1); addi t0, t0, -1; addi t1, t1, 1; addi t2, t2, -1; bnez t2, .Lcd_xlog_val_" ++ site ++ tag ++ "\n" ++
-    "  addi a0, sp, 0\n  addi a1, sp, 32\n  addi a2, sp, 64\n" ++
-    "  jal ra, eip7708_append_transfer_log\n" ++
-    ".Lcd_xlog_restore_" ++ site ++ tag ++ ":\n" ++
-    "  ld x10, 96(sp)\n  ld x12, 104(sp)\n  ld x13, 112(sp)\n  addi sp, sp, 128\n" ++
+    -- GH #10938 cut 4: the operand staging is now the shared
+    -- `eip7708TransferLogStageAsm`, which the CREATE-endowment site also uses.  Only the
+    -- one-shot pending-flag guard above and below is CALL-specific.
+    eip7708TransferLogStageAsm "cd_caller_be" "cd_callee_be" "cd_value_be"
+      (".Lcd_xlog_from_" ++ site ++ tag) (".Lcd_xlog_to_" ++ site ++ tag)
+      (".Lcd_xlog_val_" ++ site ++ tag)
+      (restoreLabel := ".Lcd_xlog_restore_" ++ site ++ tag) ++
     ".Lcd_xlog_skip_" ++ site ++ tag ++ ":\n"
   let refundNewAccountStateGas : String → String := fun site =>
     -- execution-specs `credit_state_gas_refund(NEW_ACCOUNT)`: refund in LIFO

--- a/EvmAsm/Codegen/Programs/EIP7708Logs.lean
+++ b/EvmAsm/Codegen/Programs/EIP7708Logs.lean
@@ -11,6 +11,60 @@ namespace EvmAsm.Codegen
 
 open EvmAsm.Rv64
 
+/-- Stage the three `eip7708_append_transfer_log` operands from canonical big-endian
+    globals into a 128-byte stack frame, call the appender, and restore the live runtime
+    cursors.  GH #10938 cut 4.
+
+    ## Why this exists
+
+    execution-specs has **one** `emit_transfer_log` call, at `vm/interpreter.py:391-397`
+    inside `process_message`, shared by every message-call frame entry at every depth.
+    The guest had two byte-identical copies of the operand staging: the value-CALL frame
+    entry (`Programs.ChildFrameHandlers`, emitted eight times — two sites in each of four
+    closures) and the CREATE endowment (`Programs.ChildFrameCreateTail`, emitted twice for
+    the salt/no-salt forms).
+
+    **Measured, not assumed:** extracting the two blocks from
+    `gen-out/regionmap/stateless_guest.s` and renaming the three source globals makes them
+    diff to **one line** — a label the CALL side emits and the CREATE side does not, which
+    contributes zero bytes.  That is why this is an extraction and not a rewrite, and it is
+    the discriminator cut 1 lacked: there the two blocks' *control flow* differed (opposite
+    branch senses, two labels versus three), so no shared emitter could reproduce both.
+
+    ## What is deliberately NOT shared
+
+    Each caller keeps its own **guard**, because the guards are genuinely different
+    predicates over different state: the CALL side is a one-shot `cd_xfer_log_pending`
+    flag cleared before the emit, the CREATE side is an account-witness context gate plus
+    `value != 0`.  Folding those together would repeat cut 1's mistake in the other
+    direction — a shared capture must never imply a shared disposition.
+
+    Operands are 32-byte stack words, matching what the appender expects: an address in the
+    **low 20 bytes** (the synthetic-log materializer reverses the whole 32-byte slot back to
+    big-endian), and the value byte-reversed to little-endian.
+
+    `labFrom`/`labTo`/`labVal` are complete label names including the leading `.L`;
+    `restoreLabel`, when non-empty, emits a branch target immediately after the call for a
+    caller that needs to jump straight to the register restore. -/
+def eip7708TransferLogStageAsm (fromSym toSym valSym labFrom labTo labVal : String)
+    (restoreLabel : String := "") : String :=
+  "  addi sp, sp, -128\n  sd x10, 96(sp)\n  sd x12, 104(sp)\n  sd x13, 112(sp)\n" ++
+  "  sd zero, 0(sp); sd zero, 8(sp); sd zero, 16(sp); sd zero, 24(sp)\n" ++
+  "  la t0, " ++ fromSym ++ "; addi t0, t0, 19; addi t1, sp, 0; li t2, 20\n" ++
+  labFrom ++ ":\n" ++
+  "  lbu t3, 0(t0); sb t3, 0(t1); addi t0, t0, -1; addi t1, t1, 1; addi t2, t2, -1; bnez t2, " ++ labFrom ++ "\n" ++
+  "  sd zero, 32(sp); sd zero, 40(sp); sd zero, 48(sp); sd zero, 56(sp)\n" ++
+  "  la t0, " ++ toSym ++ "; addi t0, t0, 19; addi t1, sp, 32; li t2, 20\n" ++
+  labTo ++ ":\n" ++
+  "  lbu t3, 0(t0); sb t3, 0(t1); addi t0, t0, -1; addi t1, t1, 1; addi t2, t2, -1; bnez t2, " ++ labTo ++ "\n" ++
+  "  la t0, " ++ valSym ++ "; addi t0, t0, 31; addi t1, sp, 64; li t2, 32\n" ++
+  labVal ++ ":\n" ++
+  "  lbu t3, 0(t0); sb t3, 0(t1); addi t0, t0, -1; addi t1, t1, 1; addi t2, t2, -1; bnez t2, " ++ labVal ++ "\n" ++
+  "  addi a0, sp, 0\n  addi a1, sp, 32\n  addi a2, sp, 64\n" ++
+  "  jal ra, eip7708_append_transfer_log\n" ++
+  (if restoreLabel.isEmpty then "" else restoreLabel ++ ":\n") ++
+  "  ld x10, 96(sp)\n  ld x12, 104(sp)\n  ld x13, 112(sp)\n  addi sp, sp, 128\n"
+
 private def copyWordAsm (src : String) (dstOff : Nat) : String :=
   "  ld t3, 0(" ++ src ++ ")\n" ++
   "  sd t3, " ++ toString dstOff ++ "(t2)\n" ++

--- a/PLAN.md
+++ b/PLAN.md
@@ -4744,7 +4744,7 @@ through ECALL bridges (extending `EvmAsm/EL/Keccak*EcallBridge.lean`).
   deferred sibling in #10973's same in-place/high-water-mark cell, requiring
   separate read/write lifetimes rather than a truncation patch.
 
-  **Creation-route unification, measured 2026-07-31.** #10784 cut 2 (PR #10985)
+  **Creation-route unification, measured 2026-07-31.** #10938 cut 2 (PR #10985)
   moves `mark_account_created` for the **top-level** creation route to the
   spec's pre-body position (`vm/interpreter.py:208`, before `process_message`
   at `:212`), matching what `create_frame_descend` already did for nested
@@ -4770,6 +4770,49 @@ through ECALL bridges (extending `EvmAsm/EL/Keccak*EcallBridge.lean`).
     `Codegen/ArenaCapacities.lean` for the same reason — neither marking site
     imports `CreateCodeEffectLog`, which is why the descent site carried a
     bare `8192`.
+
+  **Computation-level deduplication is essentially DONE; the residue is caller
+  adapters (measured 2026-07-31).** A sweep of the emitted stream for computations
+  duplicated across both depths found almost none left — most are already behind a
+  `jal`, shared at seven, four and four call sites, plus the MPT builder, frame
+  descend, `tx_gas_settle` and the capture/restore pair. *(Those call-site counts come
+  from that sweep and are recorded as relayed; the two-remaining-computations claim
+  below is the part independently corroborated — cut 1 was withdrawn on exactly the
+  deploy-charge branch-shape finding.)* **Exactly two single
+  computations remain inline at both depths, and neither is unifiable:**
+  - the **deploy-charge arithmetic** — same constants and same spec ordering
+    (`vm/interpreter.py:222-231`), but incompatible branch shapes: the top level
+    bails conservatively to `.Lbvcr_ret` while the nested site OOG-fails the CREATE
+    via `.Lrr_crinv_<kind>`, with opposite branch senses and a different number of
+    labels. This is what made #10938 cut 1 unviable and it is a mechanical
+    consequence of the addressing model, not a divergence.
+  - the **CREATE collision consequence**, which **the spec itself requires to
+    differ**: terminal at `vm/interpreter.py:126` versus recoverable at
+    `vm/system.py:117-123`. The *predicate* is already shared; only the consequence
+    diverges, so unifying it would be wrong.
+
+  ⭐ **Two independent lines of work converged on the same conclusion from opposite
+  directions, neither aware of the other.** The boundary analysis traced the creation
+  boundary and concluded there is **no safe physical seam**, because the divergence
+  lives in the payload and frame adapters rather than in the computations; the
+  emitted-stream sweep looked for duplicated computations and found the residue is
+  **caller-side machinery**. Same answer, opposite starting points. That convergence
+  is the reason to believe it, and it is why the remaining #10938 cuts are scoped as
+  per-field moves and shared-emitter extractions rather than as a single unification
+  of the two creation processors.
+
+  - **#10938 cut 4 landed as PR #10990**, byte-identity measured on the `.s` **and**
+    the `.elf`. It is a **deduplication, not a placement move**: the nested transfer
+    record and log already sat after `create_frame_descend` and before the initcode,
+    and `record_message_value_transfer` was already the shared producer — what was
+    duplicated was the EIP-7708 **log operand staging**, present as one already-shared
+    emitter on the value-CALL side (8 emissions) and a second copy on the CREATE side
+    (2 emissions). Cut 1's lesson was applied as a gate first: normalising labels and
+    renaming the three source globals in `stateless_guest.s` made the two bodies differ
+    by **one zero-byte label line**, which is exactly the check the deploy charges fail.
+    `ChildFrameHandlerTailHelpers.lean:165-182` is deliberately excluded — it passes raw
+    stack-word pointers and does no staging, so it is not a copy but the site that does
+    not need the helper. Each caller keeps its own guard.
 
 - 🔶 **Contract-recipient gas-measurement accuracy (beads `nxio8`, `tpdo1`; 2026-06)**: the runtime
   dispatcher meters CONTRACT execution with STATIC base opcode gas only (`Dispatch.lean:338-345`),


### PR DESCRIPTION
Batch-merge of #10987 #10990 #10991 (all author pirapira). Verified locally: `lake build` + all `check-*.sh` green.

All three were BEHIND `main` after #10989 landed; merged serially they would cost **three** CI cycles. Batched it is one.

### ⚠️ #10987 was only *partly* landed by #10989 — this carries its remainder

#10989 batched an earlier commit of #10987, but the author pushed `bc2e2ed85` (*"correct the cut citation to #10938 and record the deduplication result"*) **after** that batch was assembled. GitHub therefore left #10987 open while the other four constituents auto-closed as MERGED — its head was no longer an ancestor of `main`.

That is worth stating plainly because the mechanical post-batch step is "close any constituent GitHub didn't auto-close", and doing that here would have **discarded an unlanded commit**. The head-not-an-ancestor signal is exactly what distinguishes "GitHub missed it" from "there is still work on this branch". This batch carries that remaining commit.

### Layout: verified byte-neutral, not assumed

All three merged without conflict and the pins are unchanged from `main` — which for two codegen PRs warrants checking rather than accepting. A full regen reproduced the TSV, `GuestAddrs.lean` and `GuestImageEntries.lean` **byte-identically** (tree clean, nothing to repin), and the ELF re-reported `main`'s sizes, confirming the constant-naming and the transfer-log operand-staging factoring are genuinely emission-neutral.

The seed equalled the relinked value, which alone proves nothing since `textSizeBytes` is an input to emission as well as an output, so it was re-seeded deliberately wrong with `0x066c34` and relinked: the ELF still returned `0x066be8`.

```
textSizeBytes = 0x066be8   (unchanged)
dataSizeBytes = 0x5370     (unchanged)
bssSizeBytes  = 0x1c0fafe0 (unchanged)
bnf_le_a      = 0xa3000ee0 (unchanged)
```

`GuestImage.lean` untouched and checked, not assumed: both bounds stay `0xbf20afe0`, equal to the freshly regenerated TSV's `__BSS_END__` and `_end`.

### Constituents

- **#10987** docs: record the 2026-07-31 creation-route unification and gas-constant naming — *includes `bc2e2ed85`, not in `main`*
- **#10990** codegen: share the EIP-7708 transfer-log operand staging (GH #10938 cut 4)
- **#10991** codegen: name the body-state slab's stride and size (GH #10619 prerequisite)

### Gates

`lake build` green and all `check-*.sh` pass on this run.