### PR TITLE
docs(plan): CALL-family route classification and dominance results

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -4814,6 +4814,77 @@ through ECALL bridges (extending `EvmAsm/EL/Keccak*EcallBridge.lean`).
     stack-word pointers and does no staging, so it is not a copy but the site that does
     not need the helper. Each caller keeps its own guard.
 
+  **CALL-route convergence status, all figures measured at base `7d21882a9` unless
+  marked otherwise.** ⚠️ Every number here is a measurement with a base commit; a figure
+  without its commit has misled readers of this file before.
+
+  - **Executor tail unification is 4-of-4, complete at this base.** PR #10992 routed
+    ordinary CALL (mode 0) through the shared child entry, PR #10997 added DELEGATECALL
+    (mode 3) and STATICCALL (mode 1), and **PR #10999 landed CALLCODE (mode 2)** — the
+    four child-entry jumps now sit at `.s:61103 / 64150 / 66995 / 70692`, exactly one per
+    mode. All four modes already shared
+    `jal call_frame_descend` before any of these cuts — **what the cuts unified is the
+    POST-DESCENT TAIL**, not the descent. The ingress census bounded this at exactly four
+    routes, so this **closes** rather than merely advances.
+  - **The CALL-route caller adapters are classified on #10938** with the same three-way
+    scheme used for the creation route: **18 items — 8 spec-caller-side (staying), 4
+    spec-processor-side (all four movable), 3 guest-only-necessary, 3
+    needs-justification.** The four movable items are the caller-side value debit, the
+    callee pre-balance staging, `record_message_value_transfer` and the EIP-7708 transfer
+    log — i.e. half of `move_ether`, its other operand, its BAL record, and
+    `emit_transfer_log`, all inside `process_message` in the spec
+    (`interpreter.py:384-397`).
+  - ⭐ **The number that scopes the next phase: `.Lcd_*` label counts per mode are CALL
+    67, CALLCODE 29, DELEGATECALL 19, STATICCALL 19.** The residual duplication is **not**
+    four copies of one thing — it is one big adapter and three small ones, and the entire
+    delta is the **value machinery** (CALLCODE sits between because it gates on value
+    without transferring). That reframes the remaining work from *unify four things* to
+    **move the value payload inward**.
+  - ⛔ **So the routing cut is NOT near the end of the alignment work.** That answers the
+    planning question in the negative, which is more useful than a yes: there is a
+    coherent bounded next step rather than a finished phase.
+  - **`.Lcd_empty` (the empty-target short-circuit) is equivalent on two tested axes and
+    remains classified needs-justification, not necessary.** The depth gate dominates it
+    on all four modes (gate `.s:60359` before the earliest edge `.s:60711` for CALL, and
+    likewise `63817/63905`, `66784/66802`, `70481/70499`), and the target's access record
+    — `account_read_record` on `evm_access_seed_addr`, straight-line immediately after
+    `.Lcallmem_precompile_<mode>_target_done` — also dominates it. Both were established
+    by enumerating **every** edge plus a bypass test, not by source order. Two cleared
+    axes are **not** a general equivalence claim: the short-circuit still skips whatever
+    else `process_message` does for an empty-code target, and that is unenumerated.
+    *(Both dominance results were re-derived at this base rather than carried: the four
+    `.s` pointers past `h_CALLCODE` each shifted by −1 when #10999 landed, while the
+    instructions they name are unchanged and each still has a unique match. The bypass
+    tests were re-run — band labels 57/15/7/7 with zero references from above the gate, and
+    zero numeric labels, indirect jumps or foreign globals; access record at +3 from
+    `.Lcallmem_precompile_<mode>_done` with no intervening branch and zero references from
+    before it.)*
+  - **Computation-level dedup was already essentially done**; the caller-adapter
+    classification above is the refinement of that earlier finding, and both converge with
+    the boundary analysis from the opposite direction — payload and frame adapters there,
+    the **value** payload here.
+
+  **#10698 is diagnosed three layers deep, and the repair order is forced.** The BAL
+  sender row's value-correctness depends on: (1) `dispatcher_seed_pending_value_transfer`,
+  the only top-level `move_ether` recorder, having **one** call site (`.s:36120`) against
+  the upfront publisher's **two** (`.s:22353`, `.s:36117`); (2) that one site being doubly
+  gated, with the `account_state_latest_balance` miss traced as the live bail; and (3)
+  `blockVerdictMtxRecordSenderRefund` reconstructing the row as `pre + refund` with **no
+  value operand**, as the **later** writer, while `balance_changes` is last-write per
+  address and BAI.
+  - ⛔ **Layer 3 masks layers 1 and 2**, so making the reconstruction value-aware or
+    fail-closed must come **first**; only then do the bailing guard (#10698) and the
+    structurally absent call site (#10944) become verifiable. **Anyone who fixes the guard,
+    measures no change, and concludes the guard was innocent will be wrong.**
+  - ⚠️ **1 wei does not discriminate value-blind from off-by-one.** A `+1` patch would pass
+    the witnessing fixture and be wrong; the structural argument (no value operand in the
+    producer) is the evidence, and it does not depend on the magnitude.
+  - **#10996** records a three-route `-3` BAL shortfall, evidence-only at this base.
+  - **#10998** files `cd_xfer_log_pending` as a deferred one-shot flag with **eight**
+    consumer sites across the four modes against **one** `emit_transfer_log` in the spec,
+    where the one-shot discipline rests on a *stated* per-CALL reset rather than a
+    fail-closed mechanism — the #10925 single-buffer shape. Not a demonstrated defect.
+
 - 🔶 **Contract-recipient gas-measurement accuracy (beads `nxio8`, `tpdo1`; 2026-06)**: the runtime
   dispatcher meters CONTRACT execution with STATIC base opcode gas only (`Dispatch.lean:338-345`),
   dropping the dynamic components — so a contract recipient measured by `dispatch_tx_runtime_code`


### PR DESCRIPTION
Docs-only: `PLAN.md` +71, one file, one hunk. Authored by scoper; opened by merge-bot so it can go through normal review.

## Why this is opened unlabelled

I am **not** adding `merge!` and **not** enabling auto-merge. This needs human review like any other PR — see the note at the bottom.

## Verification performed

The added prose cites eleven emitted-stream line numbers. These were re-derived against `7d21882a9` (post-#10999) and every one resolves to the expected instruction:

| citation | instruction |
|---|---|
| 22353, 36117 | `jal ra, dispatcher_seed_pending_upfront_sender_balance` |
| 36120 | `jal ra, dispatcher_seed_pending_value_transfer` |
| 60359 / 60711 | CALL depth gate / `.Lcd_empty` edge |
| 63817 / 63905 | CALLCODE |
| 66784 / 66802 | DELEGATECALL |
| 70481 / 70499 | STATICCALL |

Four moved by −1 relative to the pre-#10999 text (`66785→66784`, `66803→66802`, `70482→70481`, `70500→70499`); the other seven are unchanged. Derived by searching for the instruction text rather than by adjusting offsets, and each named instruction still has its expected match count (each depth gate unique, the upfront publisher exactly 2, the transfer publisher exactly 1, each `.Lcd_empty` exactly 5 edges) — so no citation became ambiguous.

The 4-of-4 executor-tail-unification claim is now unconditional: #10992 (CALL), #10997 (DELEGATECALL/STATICCALL), #10999 (CALLCODE), with child-entry jumps at `.s` 61103 / 64150 / 66995 / 70692.

## Note for the reviewer

Docs-only, so no build risk, but the line numbers are pointers into a generated stream and **will rot on the next layout-moving cut**. They are correct as of `7d21882a9`.