### PR TITLE
codegen: share the record_message_value_transfer call setup between CALL and CREATE (GH #10938)

### DIFF
--- a/EvmAsm/Codegen/Programs/ChildFrameCreateTail.lean
+++ b/EvmAsm/Codegen/Programs/ChildFrameCreateTail.lean
@@ -463,10 +463,10 @@ def createUnsupportedTail (netPopBytes : Nat) (hasSalt : Bool) : String :=
     -- the child target's staged pre-state balance.  Record the shared
     -- move_ether pair after the child snapshot, so frame_return discards it
     -- with a reverting initcode.  Log scheduling remains below at this caller.
-    "  addi sp, sp, -32\n  sd x10, 0(sp)\n  sd x12, 8(sp)\n  sd x13, 16(sp)\n" ++
-    "  la a0, create_sender_be\n  la a1, create_address_be\n  la a2, create_value_be\n  ld a3, 584(x20)\n  la a4, message_value_transfer_sender_pre\n  la a5, nse_create_pre_bal\n" ++
-    "  jal ra, record_message_value_transfer\n" ++
-    "  ld x10, 0(sp)\n  ld x12, 8(sp)\n  ld x13, 16(sp)\n  addi sp, sp, 32\n" ++
+    -- GH #10938: shared setup with the value-CALL descend site — one `move_ether` in the
+    -- spec, because `process_create_message` delegates to `process_message` (`:212`).
+    recordMessageValueTransferAsm "create_sender_be" "create_address_be" "create_value_be"
+      "ld a3, 584(x20)" "message_value_transfer_sender_pre" "nse_create_pre_bal" ++
     -- coc3g.6 CAUSE 3: EIP-7708 transfer log for the CREATE endowment value move. Spec
     -- interpreter.py:307-316 emits Transfer(caller, current_target, value) at EVERY message-call
     -- frame entry with should_transfer_value and value!=0 and caller!=current_target, AFTER the

--- a/EvmAsm/Codegen/Programs/ChildFrameHandlers.lean
+++ b/EvmAsm/Codegen/Programs/ChildFrameHandlers.lean
@@ -987,10 +987,11 @@ def callDescendFallThrough
   -- reused by nested calls, so they are valid only in this post-descend,
   -- pre-dispatch window.
   (if mode != 0 then "" else
-    "  addi sp, sp, -32\n  sd x10, 0(sp)\n  sd x12, 8(sp)\n  sd x13, 16(sp)\n" ++
-    "  la a0, cd_caller_be\n  la a1, nse_callee_be\n  la a2, cd_value_be\n  li a3, 1\n  la a4, cd_balance_be\n  la a5, nse_acct\n  addi a5, a5, 8\n" ++
-    "  jal ra, record_message_value_transfer\n" ++
-    "  ld x10, 0(sp)\n  ld x12, 8(sp)\n  ld x13, 16(sp)\n  addi sp, sp, 32\n") ++
+    -- GH #10938: the setup is the shared `recordMessageValueTransferAsm`, which the
+    -- CREATE-endowment site also uses.  The spec has ONE `move_ether` for both, since
+    -- `process_create_message` delegates to `process_message` (`interpreter.py:212`).
+    recordMessageValueTransferAsm "cd_caller_be" "nse_callee_be" "cd_value_be" "li a3, 1"
+      "cd_balance_be" "nse_acct" (recipientPreAdjust := "addi a5, a5, 8")) ++
   -- fva3w: x20 now = CHILD env (call_frame_descend repointed it; eventLogCheckpoint@480 is
   -- set to the current count). Emit the deferred EIP-7708 value-CALL transfer log HERE so it
   -- lands in the child frame's logs: frame_return rolls it back on a child REVERT/exceptional

--- a/EvmAsm/Codegen/Programs/EIP7708Logs.lean
+++ b/EvmAsm/Codegen/Programs/EIP7708Logs.lean
@@ -340,6 +340,43 @@ def eip7708SyntheticLogFunctions : String :=
   "  addi sp, sp, 144\n" ++
   "  ret\n"
 
+/-- Emit the `record_message_value_transfer` call: save the live runtime cursors, load the
+    six operands, call the producer, restore.  GH #10938.
+
+    ## Why this is shared
+
+    execution-specs has **one** `move_ether` (`vm/interpreter.py:385-390`) serving calls and
+    creations alike, because `process_create_message` **delegates** to `process_message`
+    (`:212`) rather than transferring value itself.  The guest had the same twelve-instruction
+    setup written out at the value-CALL descend site and again at the CREATE-endowment site.
+
+    **Measured, not assumed:** extracting both from `gen-out/regionmap/stateless_guest.s` and
+    renaming the five operand globals leaves **two** differences — `li a3, 1` versus
+    `ld a3, 584(x20)`, and one `addi a5, a5, 8`.  Both are **operand locations**, which
+    parameterise; the **control shape is identical** (same save set, same six operands, same
+    `jal`, same restore).  That is the check GH #10938's cut 1 failed, where the two candidate
+    bodies had opposite branch senses.
+
+    `a3Setup` is the caller's full instruction for `a3` — the value-CALL site passes a constant
+    `should_transfer_value`, the CREATE site passes the account-witness context word.
+    `recipientPreAdjust`, when non-empty, is appended after the `a5` load for a site whose
+    recipient-pre pointer needs an offset.
+
+    ⚠️ **Deliberately does NOT serve the value-bearing precompile tail**
+    (`Programs.ChildFrameHandlerTailHelpers`).  That site emits the identical instructions but
+    as a **single `;`-separated line**, so routing it through this emitter would change the `.s`
+    line structure.  That is not cosmetic: line structure has already been shown to change
+    instruction ORDER when the original line begins with an instruction the block must follow
+    (GH #10619's prerequisite). It stays out until it can be moved without disturbing text. -/
+def recordMessageValueTransferAsm (fromSym toSym valSym a3Setup senderPre recipientPre : String)
+    (recipientPreAdjust : String := "") : String :=
+  "  addi sp, sp, -32\n  sd x10, 0(sp)\n  sd x12, 8(sp)\n  sd x13, 16(sp)\n" ++
+  "  la a0, " ++ fromSym ++ "\n  la a1, " ++ toSym ++ "\n  la a2, " ++ valSym ++ "\n  " ++
+    a3Setup ++ "\n  la a4, " ++ senderPre ++ "\n  la a5, " ++ recipientPre ++ "\n" ++
+    (if recipientPreAdjust.isEmpty then "" else "  " ++ recipientPreAdjust ++ "\n") ++
+  "  jal ra, record_message_value_transfer\n" ++
+  "  ld x10, 0(sp)\n  ld x12, 8(sp)\n  ld x13, 16(sp)\n  addi sp, sp, 32\n"
+
 /-- Frame-generic `move_ether` recorder.
 
     The caller supplies the two authenticated/live pre-balances because the guest


### PR DESCRIPTION
## Summary

GH #10938: share the `record_message_value_transfer` call setup between the **value-CALL descend
site** and the **CREATE-endowment site**. Extraction only — nothing moves relative to the child
snapshot.

**Byte-identity MEASURED on both artefacts, including the `.s` text.** Base `7b5f41255`:

| artifact | before | after |
|---|---|---|
| `stateless_guest.s` | `f136a84f842d39d73a0e0aa1…` | **identical** |
| `stateless_guest.elf` | `7df7e822d803caafb2533ea1…` | **identical** |

`.s` identity covers all **three** emissions at once (value-CALL, and the CREATE salt/no-salt
forms). No generated file changes, so no layout regen; `check-region-map.sh` passes unchanged.

## Why the spec wants these shared

`execution-specs` at pinned `e5a8caf1b` has **one** `move_ether`
(`vm/interpreter.py:385-390`) serving calls and creations alike, because
**`process_create_message` delegates to `process_message` at `:212`** rather than transferring
value itself. Creation does not have its own transfer — it uses the one the CALL path uses. Two
guest copies of that setup is duplication the spec forbids, not merely duplication we dislike.

## The extraction gate, run before committing to a shape

Both bodies pulled from `gen-out/regionmap/stateless_guest.s`, labels normalised, the five operand
globals renamed:

```
 CALL (.s:61068)            CREATE (.s:57132)
 addi sp, sp, -32           addi sp, sp, -32
 sd x10/x12/x13             sd x10/x12/x13
 la a0/a1/a2  FROM/TO/VAL   la a0/a1/a2  FROM/TO/VAL
 li a3, 1                   ld a3, 584(x20)      <-- differs
 la a4, SPRE                la a4, SPRE
 la a5, RPRE                la a5, RPRE
 addi a5, a5, 8             —                    <-- differs
 jal record_message_value_transfer   (same)
```

**Twelve lines against eleven, differing in exactly two places, and both are operand
locations** — which parameterise. **The control shape is identical**: same save set, same six
operands, same `jal`, same restore. No opposite branch senses, no label-count mismatch.

That is the check **cut 1 failed** — there the two candidate bodies had different control flow
(opposite branch senses, two labels versus three), so no shared emitter could reproduce both
without changing one site's instructions. Running the gate first is why this one is byte-identical
rather than withdrawn.

## Scope: what this deliberately does not do

* **Nothing crosses the child snapshot.** Both call sites keep their current position, which for
  both is already **after** the descent — the placement each site's comment claims and which
  matches `process_message`'s snapshot→`move_ether` order.
* **The value-bearing precompile tail is excluded** (`Programs.ChildFrameHandlerTailHelpers`). It
  emits the identical instructions as a **single `;`-separated line**, so routing it through this
  emitter would change `.s` line structure. That is not cosmetic — line structure has already been
  shown to change instruction **order** when the original line begins with an instruction the
  extracted block must follow (the GH #10619 prerequisite). It stays out until it can move without
  disturbing text.
* **The caller-side debit and the callee pre-balance staging are NOT touched.** Those are the two
  halves of `move_ether` and they sit on the wrong side of the snapshot; that is filed separately
  as GH #11001, and the repair is blocked on parent-env addressing because `call_frame_descend`
  repoints `x20` (`.s:46172` saves the parent env, `.s:46343` installs the child).

## Verification

* Byte-identity measured on `.s` **and** `.elf` (table above).
* Emitted call sites of the producer unchanged: **5** — `.s:39201`, `57132`, `58006`, `61068`,
  `67505`.
* `lake build` — clean.
* `scripts/check-region-map.sh` — OK, no generated file changed.
* `scripts/check-forbidden-tactics.sh` — OK.
* **Fixture legs deliberately not claimed as evidence.** The ELF hash is *identical*, so a fixture
  run would execute the same binary and could not distinguish anything — it would be a tautology,
  not a check. (Pre-edit controls were measured green regardless: `bal_account_access_target` 8/8,
  `call_to_self_no_log` 2/2, guest `7df7e822…`.)
