### PR TITLE
codegen: document the same-transaction delete-cancellation no-op instead of deleting it (GH #10976)

### DIFF
--- a/EvmAsm/Codegen/Programs/CreateCodeEffectLog.lean
+++ b/EvmAsm/Codegen/Programs/CreateCodeEffectLog.lean
@@ -844,8 +844,31 @@ def createRecordCodeEffectFunction : String :=
   -- `gen-out/regionmap/stateless_guest.s` (the self-test call sites at the bottom of
   -- this file are not emitted).  A successful deposit is still an AccountState code
   -- event, which is the `account_state_record_code` call above and is unchanged.
-  -- A successful later CREATE at the same address is the latest transaction
-  -- state and cancels an earlier same-transaction EIP-6780 delete request.
+  -- ⚠️ GH #10976: THIS CALL IS A NO-OP TODAY AND IS KEPT DELIBERATELY.  It runs on every
+  -- successful deposit and its miss return is ignored, so it will never show up as
+  -- unexecuted in a coverage or reachability analysis — only the precondition finds it.
+  --
+  -- Its stated purpose is that a successful later CREATE at the same address is the latest
+  -- transaction state and cancels an earlier same-transaction EIP-6780 delete request.
+  -- **That CREATE cannot succeed.**  `account_deployable` requires nonce 0 and empty code;
+  -- SELFDESTRUCT clears neither mid-transaction (the clearing is at `fork.py:1201`, after
+  -- execution); and the `modify_state` destroy-cascade that might otherwise have rescued it
+  -- needs nonce 0 too (`account_exists_and_is_empty`).  So there is never a delete row here
+  -- to cancel, and the flag-clear always misses.
+  --
+  -- WHY IT STAYS RATHER THAN BEING DELETED.  The delete set is an IN-PLACE editor whose
+  -- rollback is a HIGH-WATER MARK, which is the one cell of the append-versus-in-place ×
+  -- mark-versus-journal grid that is actually unsound (GH #10966).  This call is the only
+  -- barrier between a future reachability change and that combination: if anything ever makes
+  -- a same-transaction re-CREATE at a destroyed address succeed, the cancel must already be
+  -- here or a stale delete request survives into commit.  One instruction on the
+  -- successful-deposit path is a fair price for that, and unlike a dead SYMBOL a no-op CALL
+  -- does not pollute any allocation census.
+  --
+  -- WHAT WOULD MAKE IT LIVE: any change that lets `account_deployable` admit an address with a
+  -- pending same-transaction delete — e.g. clearing nonce/code at SELFDESTRUCT time rather than
+  -- at `fork.py:1201`, or a destroy-cascade that no longer requires nonce 0.  If you are
+  -- editing either, this line is load-bearing and its miss return should start being checked.
   "  mv a0, s0; la a1, account_state_delete; la a2, account_state_delete_count; li a3, " ++ toString accountStateDeleteCapacity ++ "; li a4, 0; jal ra, code_state_address_set_flag\n" ++
   -- CREATE writes code, existence, and nonce=1 into the transaction-local map.
   -- Balance remains absent here: value flow owns its own nonstorage record.


### PR DESCRIPTION
## Summary

GH #10976: the same-transaction delete-cancellation call in `create_record_code_effect` **can never
find a row to cancel**. This PR **keeps the call** and documents why it is a no-op, what would make
it live, and why deleting it would be the wrong repair.

**Comment-only. Byte-identity measured on both artefacts.** Base `7b5f41255`:

| artifact | before | after |
|---|---|---|
| `stateless_guest.s` | `f136a84f842d39d73a0e…` | **identical** |
| `stateless_guest.elf` | `7df7e822d803caafb253…` | **identical** |

## Why it is a no-op

`git show 7b5f41255:EvmAsm/Codegen/Programs/CreateCodeEffectLog.lean` — the call clears the delete
flag for `s0`, on the stated grounds that a successful later CREATE at the same address cancels an
earlier same-transaction EIP-6780 delete request. **That CREATE cannot succeed**, at pinned
`e5a8caf1b`:

* `account_deployable` requires **nonce 0 and empty code**;
* SELFDESTRUCT clears **neither** mid-transaction — the clearing is at `fork.py:1201`, *after*
  execution;
* the `modify_state` destroy-cascade that might otherwise have rescued it needs nonce 0 too
  (`account_exists_and_is_empty`).

So the flag-clear always misses.

⚠️ **It will never appear as unexecuted in a coverage or reachability analysis.** The instruction
runs on every successful deposit and the helper's miss return is ignored — only reasoning about the
*precondition* finds it. That is why no tool flagged it and why this is a comment rather than a
deletion.

## Why deleting it would be the wrong repair

The delete set is an **in-place editor** whose rollback is a **high-water mark** — the one cell of
the append-versus-in-place × mark-versus-journal grid (GH #10966) that is actually **unsound**. This
call is the only barrier between a future reachability change and that combination: if anything ever
lets a same-transaction re-CREATE at a destroyed address succeed, the cancel has to already be here
or a stale delete request survives into commit.

And the cleanup rationale that motivated the surrounding sweep — unused code and data poison `grep`
results — **does not reach this case**: it is a **call, not a symbol**, so it pollutes no allocation
census. One instruction on the successful-deposit path is a fair price for the barrier.

## What the comment adds

* the precondition argument, with its three spec anchors, so the next reader does not re-derive it;
* an explicit **"what would make it live"** clause — any change letting `account_deployable` admit an
  address with a pending same-transaction delete, e.g. clearing nonce/code at SELFDESTRUCT time
  rather than at `fork.py:1201`, or a destroy-cascade no longer requiring nonce 0. If you are editing
  either, this line becomes load-bearing and its miss return should start being checked.

This converts an invisible no-op into a **documented invariant**, which is strictly better than
either deleting it or leaving it unexplained.

## Disclosure

I argued for keeping this barrier earlier in the same session while analysing GH #10964/#10966, so
this PR is consistent with that rather than a fresh judgement — worth stating, since the task that
surfaced #10976 asked for deletions and I am declining one.

Suggest closing **#10976** as *wontfix-with-rationale* when this lands.
