### PR TITLE
chore: batch-merge #11002 #11005

### DIFF
--- a/EvmAsm/Codegen/Programs/ChildFrameCreateTail.lean
+++ b/EvmAsm/Codegen/Programs/ChildFrameCreateTail.lean
@@ -463,10 +463,10 @@ def createUnsupportedTail (netPopBytes : Nat) (hasSalt : Bool) : String :=
     -- the child target's staged pre-state balance.  Record the shared
     -- move_ether pair after the child snapshot, so frame_return discards it
     -- with a reverting initcode.  Log scheduling remains below at this caller.
-    "  addi sp, sp, -32\n  sd x10, 0(sp)\n  sd x12, 8(sp)\n  sd x13, 16(sp)\n" ++
-    "  la a0, create_sender_be\n  la a1, create_address_be\n  la a2, create_value_be\n  ld a3, 584(x20)\n  la a4, message_value_transfer_sender_pre\n  la a5, nse_create_pre_bal\n" ++
-    "  jal ra, record_message_value_transfer\n" ++
-    "  ld x10, 0(sp)\n  ld x12, 8(sp)\n  ld x13, 16(sp)\n  addi sp, sp, 32\n" ++
+    -- GH #10938: shared setup with the value-CALL descend site — one `move_ether` in the
+    -- spec, because `process_create_message` delegates to `process_message` (`:212`).
+    recordMessageValueTransferAsm "create_sender_be" "create_address_be" "create_value_be"
+      "ld a3, 584(x20)" "message_value_transfer_sender_pre" "nse_create_pre_bal" ++
     -- coc3g.6 CAUSE 3: EIP-7708 transfer log for the CREATE endowment value move. Spec
     -- interpreter.py:307-316 emits Transfer(caller, current_target, value) at EVERY message-call
     -- frame entry with should_transfer_value and value!=0 and caller!=current_target, AFTER the

--- a/EvmAsm/Codegen/Programs/ChildFrameHandlers.lean
+++ b/EvmAsm/Codegen/Programs/ChildFrameHandlers.lean
@@ -987,10 +987,11 @@ def callDescendFallThrough
   -- reused by nested calls, so they are valid only in this post-descend,
   -- pre-dispatch window.
   (if mode != 0 then "" else
-    "  addi sp, sp, -32\n  sd x10, 0(sp)\n  sd x12, 8(sp)\n  sd x13, 16(sp)\n" ++
-    "  la a0, cd_caller_be\n  la a1, nse_callee_be\n  la a2, cd_value_be\n  li a3, 1\n  la a4, cd_balance_be\n  la a5, nse_acct\n  addi a5, a5, 8\n" ++
-    "  jal ra, record_message_value_transfer\n" ++
-    "  ld x10, 0(sp)\n  ld x12, 8(sp)\n  ld x13, 16(sp)\n  addi sp, sp, 32\n") ++
+    -- GH #10938: the setup is the shared `recordMessageValueTransferAsm`, which the
+    -- CREATE-endowment site also uses.  The spec has ONE `move_ether` for both, since
+    -- `process_create_message` delegates to `process_message` (`interpreter.py:212`).
+    recordMessageValueTransferAsm "cd_caller_be" "nse_callee_be" "cd_value_be" "li a3, 1"
+      "cd_balance_be" "nse_acct" (recipientPreAdjust := "addi a5, a5, 8")) ++
   -- fva3w: x20 now = CHILD env (call_frame_descend repointed it; eventLogCheckpoint@480 is
   -- set to the current count). Emit the deferred EIP-7708 value-CALL transfer log HERE so it
   -- lands in the child frame's logs: frame_return rolls it back on a child REVERT/exceptional

--- a/EvmAsm/Codegen/Programs/CreateCodeEffectLog.lean
+++ b/EvmAsm/Codegen/Programs/CreateCodeEffectLog.lean
@@ -844,8 +844,31 @@ def createRecordCodeEffectFunction : String :=
   -- `gen-out/regionmap/stateless_guest.s` (the self-test call sites at the bottom of
   -- this file are not emitted).  A successful deposit is still an AccountState code
   -- event, which is the `account_state_record_code` call above and is unchanged.
-  -- A successful later CREATE at the same address is the latest transaction
-  -- state and cancels an earlier same-transaction EIP-6780 delete request.
+  -- ⚠️ GH #10976: THIS CALL IS A NO-OP TODAY AND IS KEPT DELIBERATELY.  It runs on every
+  -- successful deposit and its miss return is ignored, so it will never show up as
+  -- unexecuted in a coverage or reachability analysis — only the precondition finds it.
+  --
+  -- Its stated purpose is that a successful later CREATE at the same address is the latest
+  -- transaction state and cancels an earlier same-transaction EIP-6780 delete request.
+  -- **That CREATE cannot succeed.**  `account_deployable` requires nonce 0 and empty code;
+  -- SELFDESTRUCT clears neither mid-transaction (the clearing is at `fork.py:1201`, after
+  -- execution); and the `modify_state` destroy-cascade that might otherwise have rescued it
+  -- needs nonce 0 too (`account_exists_and_is_empty`).  So there is never a delete row here
+  -- to cancel, and the flag-clear always misses.
+  --
+  -- WHY IT STAYS RATHER THAN BEING DELETED.  The delete set is an IN-PLACE editor whose
+  -- rollback is a HIGH-WATER MARK, which is the one cell of the append-versus-in-place ×
+  -- mark-versus-journal grid that is actually unsound (GH #10966).  This call is the only
+  -- barrier between a future reachability change and that combination: if anything ever makes
+  -- a same-transaction re-CREATE at a destroyed address succeed, the cancel must already be
+  -- here or a stale delete request survives into commit.  One instruction on the
+  -- successful-deposit path is a fair price for that, and unlike a dead SYMBOL a no-op CALL
+  -- does not pollute any allocation census.
+  --
+  -- WHAT WOULD MAKE IT LIVE: any change that lets `account_deployable` admit an address with a
+  -- pending same-transaction delete — e.g. clearing nonce/code at SELFDESTRUCT time rather than
+  -- at `fork.py:1201`, or a destroy-cascade that no longer requires nonce 0.  If you are
+  -- editing either, this line is load-bearing and its miss return should start being checked.
   "  mv a0, s0; la a1, account_state_delete; la a2, account_state_delete_count; li a3, " ++ toString accountStateDeleteCapacity ++ "; li a4, 0; jal ra, code_state_address_set_flag\n" ++
   -- CREATE writes code, existence, and nonce=1 into the transaction-local map.
   -- Balance remains absent here: value flow owns its own nonstorage record.

--- a/EvmAsm/Codegen/Programs/EIP7708Logs.lean
+++ b/EvmAsm/Codegen/Programs/EIP7708Logs.lean
@@ -340,6 +340,43 @@ def eip7708SyntheticLogFunctions : String :=
   "  addi sp, sp, 144\n" ++
   "  ret\n"
 
+/-- Emit the `record_message_value_transfer` call: save the live runtime cursors, load the
+    six operands, call the producer, restore.  GH #10938.
+
+    ## Why this is shared
+
+    execution-specs has **one** `move_ether` (`vm/interpreter.py:385-390`) serving calls and
+    creations alike, because `process_create_message` **delegates** to `process_message`
+    (`:212`) rather than transferring value itself.  The guest had the same twelve-instruction
+    setup written out at the value-CALL descend site and again at the CREATE-endowment site.
+
+    **Measured, not assumed:** extracting both from `gen-out/regionmap/stateless_guest.s` and
+    renaming the five operand globals leaves **two** differences — `li a3, 1` versus
+    `ld a3, 584(x20)`, and one `addi a5, a5, 8`.  Both are **operand locations**, which
+    parameterise; the **control shape is identical** (same save set, same six operands, same
+    `jal`, same restore).  That is the check GH #10938's cut 1 failed, where the two candidate
+    bodies had opposite branch senses.
+
+    `a3Setup` is the caller's full instruction for `a3` — the value-CALL site passes a constant
+    `should_transfer_value`, the CREATE site passes the account-witness context word.
+    `recipientPreAdjust`, when non-empty, is appended after the `a5` load for a site whose
+    recipient-pre pointer needs an offset.
+
+    ⚠️ **Deliberately does NOT serve the value-bearing precompile tail**
+    (`Programs.ChildFrameHandlerTailHelpers`).  That site emits the identical instructions but
+    as a **single `;`-separated line**, so routing it through this emitter would change the `.s`
+    line structure.  That is not cosmetic: line structure has already been shown to change
+    instruction ORDER when the original line begins with an instruction the block must follow
+    (GH #10619's prerequisite). It stays out until it can be moved without disturbing text. -/
+def recordMessageValueTransferAsm (fromSym toSym valSym a3Setup senderPre recipientPre : String)
+    (recipientPreAdjust : String := "") : String :=
+  "  addi sp, sp, -32\n  sd x10, 0(sp)\n  sd x12, 8(sp)\n  sd x13, 16(sp)\n" ++
+  "  la a0, " ++ fromSym ++ "\n  la a1, " ++ toSym ++ "\n  la a2, " ++ valSym ++ "\n  " ++
+    a3Setup ++ "\n  la a4, " ++ senderPre ++ "\n  la a5, " ++ recipientPre ++ "\n" ++
+    (if recipientPreAdjust.isEmpty then "" else "  " ++ recipientPreAdjust ++ "\n") ++
+  "  jal ra, record_message_value_transfer\n" ++
+  "  ld x10, 0(sp)\n  ld x12, 8(sp)\n  ld x13, 16(sp)\n  addi sp, sp, 32\n"
+
 /-- Frame-generic `move_ether` recorder.
 
     The caller supplies the two authenticated/live pre-balances because the guest


### PR DESCRIPTION
Batch-merge of #11002 and #11005 (both author pirapira, both carrying `merge!` applied by a human). Real `--no-ff` merge commits, so both constituents close by ancestry.

## Verified locally

- `lake build` green (4794 jobs, 0 errors)
- Full regen pipeline to a fixpoint — **zero diff** on all generated artefacts
- All 25 `check-*.sh` pass

## Layout: byte-identical, and pre-registered as such

Both PRs are emission-neutral. The regenerated artefacts are byte-for-byte identical to `7b5f41255`:

| artefact | sha256 (first 24) |
|---|---|
| `stateless_guest.s` | `f136a84f842d39d73a0e0aa1` |
| `stateless_guest.elf` | `7df7e822d803caafb2533ea1` |

Pins therefore unchanged: `textSizeBytes 0x066be8`, `dataSizeBytes 0x5370`, `bssSizeBytes 0x1c0fcfe0`.

These two hashes were **predicted before this batch was built** and sent directly to the merger, so they functioned as a pre-registered gate rather than after-the-fact corroboration. Confirmed the artefacts were genuinely rewritten this run (mtimes 20s before the check) rather than left stale — a byte-identical artefact is otherwise indistinguishable from one that was never regenerated.

## Note on the gate run

Four driver-based gates (`check-axioms`, `check-guarded-handler-bytes`, `check-opcode-tables`, `check-build-parallel`) initially failed under artifact-cache mode, which supplies `.c.o` files instead of the `.olean`s those drivers need — `check-axioms` reported `parsed 0 axiom report(s) for 95 registry witness(es)`. Rebuilding with `LAKE_ARTIFACT_CACHE=false` fixed all four; the improvement is explained rather than unexplained. This is the documented mode incompatibility, not a defect in either PR.