### PR TITLE
refactor(codegen): concatenate appended string literals in Modexp/ModexpBackend

### DIFF
--- a/EvmAsm/Codegen/Programs/Modexp.lean
+++ b/EvmAsm/Codegen/Programs/Modexp.lean
@@ -15,8 +15,9 @@ private def modexpReadLengthAsm (suffix : String) (fieldOff : Nat) (dstReg : Str
   "  beq x29, x31, .Lmodexp_len_done_" ++ suffix ++ "_" ++ toString fieldOff ++ "\n" ++
   "  addi x31, x29, " ++ toString fieldOff ++ "\n" ++
   "  bgeu x31, x17, .Lmodexp_len_missing_" ++ suffix ++ "_" ++ toString fieldOff ++ "\n" ++
-  "  add x31, x18, x31\n" ++
-  "  lbu x16, 0(x31)\n" ++
+  "  add x31, x18, x31
+  lbu x16, 0(x31)
+" ++
   "  j .Lmodexp_len_have_byte_" ++ suffix ++ "_" ++ toString fieldOff ++ "\n" ++
   ".Lmodexp_len_missing_" ++ suffix ++ "_" ++ toString fieldOff ++ ":\n" ++
   "  li x16, 0\n" ++
@@ -81,8 +82,9 @@ private def modexpReadSmallComponentAsm
   "  beq x29, " ++ lenReg ++ ", .Lmodexp_read_" ++ name ++ "_done_" ++ suffix ++ "\n" ++
   "  add x31, " ++ startReg ++ ", x29\n" ++
   "  bgeu x31, x17, .Lmodexp_read_" ++ name ++ "_missing_" ++ suffix ++ "\n" ++
-  "  add x31, x18, x31\n" ++
-  "  lbu x16, 0(x31)\n" ++
+  "  add x31, x18, x31
+  lbu x16, 0(x31)
+" ++
   "  j .Lmodexp_read_" ++ name ++ "_have_" ++ suffix ++ "\n" ++
   ".Lmodexp_read_" ++ name ++ "_missing_" ++ suffix ++ ":\n" ++
   "  li x16, 0\n" ++
@@ -101,15 +103,17 @@ private def modexpStageComponentAsm
   "  beq x29, " ++ lenReg ++ ", .Lmodexp_stage_" ++ name ++ "_done_" ++ suffix ++ "\n" ++
   "  add x31, " ++ startReg ++ ", x29\n" ++
   "  bgeu x31, x17, .Lmodexp_stage_" ++ name ++ "_missing_" ++ suffix ++ "\n" ++
-  "  add x31, x18, x31\n" ++
-  "  lbu x16, 0(x31)\n" ++
+  "  add x31, x18, x31
+  lbu x16, 0(x31)
+" ++
   "  j .Lmodexp_stage_" ++ name ++ "_have_" ++ suffix ++ "\n" ++
   ".Lmodexp_stage_" ++ name ++ "_missing_" ++ suffix ++ ":\n" ++
   "  li x16, 0\n" ++
   ".Lmodexp_stage_" ++ name ++ "_have_" ++ suffix ++ ":\n" ++
-  "  sb x16, 0(x28)\n" ++
-  "  addi x28, x28, 1\n" ++
-  "  addi x29, x29, 1\n" ++
+  "  sb x16, 0(x28)
+  addi x28, x28, 1
+  addi x29, x29, 1
+" ++
   "  j .Lmodexp_stage_" ++ name ++ "_loop_" ++ suffix ++ "\n" ++
   ".Lmodexp_stage_" ++ name ++ "_done_" ++ suffix ++ ":\n"
 
@@ -117,10 +121,11 @@ def modexpPrecompileGasAsm
     (chargePrecompileGasAsm : String → String → String)
     (suffix : String)
     (inOffsetOff inSizeOff outOffsetOff outSizeOff : Nat) : String :=
-  "  la x15, evm_precompile_frame\n" ++
-  "  li x16, 1\n" ++
-  "  sd x16, 0(x15)\n" ++
-  "  sd x0, 8(x15)\n" ++
+  "  la x15, evm_precompile_frame
+  li x16, 1
+  sd x16, 0(x15)
+  sd x0, 8(x15)
+" ++
   "  ld x17, " ++ toString inSizeOff ++ "(x12)\n" ++
   "  ld x18, " ++ toString inOffsetOff ++ "(x12)\n" ++
   "  add x18, x13, x18\n" ++
@@ -131,31 +136,36 @@ def modexpPrecompileGasAsm
   "  bgeu x24, x23, .Lmodexp_max_done_" ++ suffix ++ "\n" ++
   "  mv x24, x23\n" ++
   ".Lmodexp_max_done_" ++ suffix ++ ":\n" ++
-  "  addi x25, x24, 7\n" ++
-  "  srli x25, x25, 3\n" ++
-  "  li x31, 32\n" ++
+  "  addi x25, x24, 7
+  srli x25, x25, 3
+  li x31, 32
+" ++
   "  bltu x31, x24, .Lmodexp_complex_large_" ++ suffix ++ "\n" ++
   "  li x26, 16\n" ++
   "  j .Lmodexp_complex_done_" ++ suffix ++ "\n" ++
   ".Lmodexp_complex_large_" ++ suffix ++ ":\n" ++
-  "  mul x26, x25, x25\n" ++
-  "  slli x26, x26, 1\n" ++
+  "  mul x26, x25, x25
+  slli x26, x26, 1
+" ++
   ".Lmodexp_complex_done_" ++ suffix ++ ":\n" ++
-  "  li x27, 0\n" ++
-  "  li x30, 0\n" ++
-  "  mv x28, x22\n" ++
-  "  li x31, 32\n" ++
+  "  li x27, 0
+  li x30, 0
+  mv x28, x22
+  li x31, 32
+" ++
   "  bgeu x31, x28, .Lmodexp_head_len_done_" ++ suffix ++ "\n" ++
   "  mv x28, x31\n" ++
   ".Lmodexp_head_len_done_" ++ suffix ++ ":\n" ++
   "  li x29, 0\n" ++
   ".Lmodexp_head_loop_" ++ suffix ++ ":\n" ++
   "  beq x29, x28, .Lmodexp_head_done_zero_" ++ suffix ++ "\n" ++
-  "  addi x31, x5, 96\n" ++
-  "  add x31, x31, x29\n" ++
+  "  addi x31, x5, 96
+  add x31, x31, x29
+" ++
   "  bgeu x31, x17, .Lmodexp_head_missing_" ++ suffix ++ "\n" ++
-  "  add x31, x18, x31\n" ++
-  "  lbu x16, 0(x31)\n" ++
+  "  add x31, x18, x31
+  lbu x16, 0(x31)
+" ++
   "  j .Lmodexp_head_have_byte_" ++ suffix ++ "\n" ++
   ".Lmodexp_head_missing_" ++ suffix ++ ":\n" ++
   "  li x16, 0\n" ++
@@ -164,10 +174,11 @@ def modexpPrecompileGasAsm
   "  addi x29, x29, 1\n" ++
   "  j .Lmodexp_head_loop_" ++ suffix ++ "\n" ++
   ".Lmodexp_head_nonzero_" ++ suffix ++ ":\n" ++
-  "  li x30, 1\n" ++
-  "  sub x27, x28, x29\n" ++
-  "  addi x27, x27, -1\n" ++
-  "  slli x27, x27, 3\n" ++
+  "  li x30, 1
+  sub x27, x28, x29
+  addi x27, x27, -1
+  slli x27, x27, 3
+" ++
   modexpByteLog2Asm suffix ++
   ".Lmodexp_head_done_zero_" ++ suffix ++ ":\n" ++
   ".Lmodexp_log_done_" ++ suffix ++ ":\n" ++
@@ -177,9 +188,10 @@ def modexpPrecompileGasAsm
   "  mv x28, x27\n" ++
   "  j .Lmodexp_iter_max_" ++ suffix ++ "\n" ++
   ".Lmodexp_iter_large_exp_" ++ suffix ++ ":\n" ++
-  "  addi x28, x22, -32\n" ++
-  "  slli x28, x28, 4\n" ++
-  "  add x28, x28, x27\n" ++
+  "  addi x28, x22, -32
+  slli x28, x28, 4
+  add x28, x28, x27
+" ++
   "  j .Lmodexp_iter_max_" ++ suffix ++ "\n" ++
   ".Lmodexp_iter_zero_head_" ++ suffix ++ ":\n" ++
   "  li x28, 0\n" ++
@@ -187,16 +199,18 @@ def modexpPrecompileGasAsm
   "  bnez x28, .Lmodexp_iter_done_" ++ suffix ++ "\n" ++
   "  li x28, 1\n" ++
   ".Lmodexp_iter_done_" ++ suffix ++ ":\n" ++
-  "  mul x16, x26, x28\n" ++
-  "  li x31, 500\n" ++
+  "  mul x16, x26, x28
+  li x31, 500
+" ++
   "  bgeu x16, x31, .Lmodexp_cost_done_" ++ suffix ++ "\n" ++
   "  mv x16, x31\n" ++
   ".Lmodexp_cost_done_" ++ suffix ++ ":\n" ++
   chargePrecompileGasAsm "x16" "x31" ++
-  "  or x24, x5, x23\n" ++
-  "  beqz x24, 7b\n" ++
-  "  beqz x23, 7b\n" ++
-  "  li x31, 4\n" ++
+  "  or x24, x5, x23
+  beqz x24, 7b
+  beqz x23, 7b
+  li x31, 4
+" ++
   "  bltu x31, x5, .Lmodexp_backend_" ++ suffix ++ "\n" ++
   "  bltu x31, x22, .Lmodexp_backend_" ++ suffix ++ "\n" ++
   "  bltu x31, x23, .Lmodexp_backend_" ++ suffix ++ "\n" ++
@@ -208,36 +222,41 @@ def modexpPrecompileGasAsm
   modexpReadSmallComponentAsm suffix "mod" "x30" "x23" "x26" ++
   "  li x27, 0\n" ++
   "  beqz x26, .Lmodexp_result_ready_" ++ suffix ++ "\n" ++
-  "  remu x24, x24, x26\n" ++
-  "  li x27, 1\n" ++
-  "  remu x27, x27, x26\n" ++
-  "  mv x28, x25\n" ++
+  "  remu x24, x24, x26
+  li x27, 1
+  remu x27, x27, x26
+  mv x28, x25
+" ++
   ".Lmodexp_pow_loop_" ++ suffix ++ ":\n" ++
   "  beqz x28, .Lmodexp_result_ready_" ++ suffix ++ "\n" ++
   "  andi x31, x28, 1\n" ++
   "  beqz x31, .Lmodexp_pow_skip_mul_" ++ suffix ++ "\n" ++
-  "  mul x27, x27, x24\n" ++
-  "  remu x27, x27, x26\n" ++
+  "  mul x27, x27, x24
+  remu x27, x27, x26
+" ++
   ".Lmodexp_pow_skip_mul_" ++ suffix ++ ":\n" ++
   "  srli x28, x28, 1\n" ++
   "  beqz x28, .Lmodexp_pow_loop_" ++ suffix ++ "\n" ++
-  "  mul x24, x24, x24\n" ++
-  "  remu x24, x24, x26\n" ++
+  "  mul x24, x24, x24
+  remu x24, x24, x26
+" ++
   "  j .Lmodexp_pow_loop_" ++ suffix ++ "\n" ++
   ".Lmodexp_result_ready_" ++ suffix ++ ":\n" ++
-  "  sd x23, 8(x15)\n" ++
-  "  addi x28, x15, 16\n" ++
-  "  li x29, 0\n" ++
+  "  sd x23, 8(x15)
+  addi x28, x15, 16
+  li x29, 0
+" ++
   ".Lmodexp_result_store_loop_" ++ suffix ++ ":\n" ++
   "  beq x29, x23, .Lmodexp_result_store_done_" ++ suffix ++ "\n" ++
-  "  sub x31, x23, x29\n" ++
-  "  addi x31, x31, -1\n" ++
-  "  slli x31, x31, 3\n" ++
-  "  srl x16, x27, x31\n" ++
-  "  andi x16, x16, 255\n" ++
-  "  sb x16, 0(x28)\n" ++
-  "  addi x28, x28, 1\n" ++
-  "  addi x29, x29, 1\n" ++
+  "  sub x31, x23, x29
+  addi x31, x31, -1
+  slli x31, x31, 3
+  srl x16, x27, x31
+  andi x16, x16, 255
+  sb x16, 0(x28)
+  addi x28, x28, 1
+  addi x29, x29, 1
+" ++
   "  j .Lmodexp_result_store_loop_" ++ suffix ++ "\n" ++
   ".Lmodexp_result_store_done_" ++ suffix ++ ":\n" ++
   "  ld x22, " ++ toString outSizeOff ++ "(x12)\n" ++
@@ -245,16 +264,18 @@ def modexpPrecompileGasAsm
   "  bgeu x22, x24, .Lmodexp_copy_len_done_" ++ suffix ++ "\n" ++
   "  mv x24, x22\n" ++
   ".Lmodexp_copy_len_done_" ++ suffix ++ ":\n" ++
-  "  beqz x24, 7b\n" ++
-  "  addi x28, x15, 16\n" ++
+  "  beqz x24, 7b
+  addi x28, x15, 16
+" ++
   "  ld x29, " ++ toString outOffsetOff ++ "(x12)\n" ++
   "  add x29, x13, x29\n" ++
   ".Lmodexp_copy_loop_" ++ suffix ++ ":\n" ++
-  "  lbu x16, 0(x28)\n" ++
-  "  sb x16, 0(x29)\n" ++
-  "  addi x28, x28, 1\n" ++
-  "  addi x29, x29, 1\n" ++
-  "  addi x24, x24, -1\n" ++
+  "  lbu x16, 0(x28)
+  sb x16, 0(x29)
+  addi x28, x28, 1
+  addi x29, x29, 1
+  addi x24, x24, -1
+" ++
   "  bnez x24, .Lmodexp_copy_loop_" ++ suffix ++ "\n" ++
   "  j 7b\n" ++
   ".Lmodexp_backend_" ++ suffix ++ ":\n" ++
@@ -264,34 +285,37 @@ def modexpPrecompileGasAsm
   modexpStageComponentAsm suffix "exp" "x30" "x22" "modexp_exp_scratch" ++
   "  add x30, x30, x22\n" ++
   modexpStageComponentAsm suffix "modulus" "x30" "x23" "modexp_modulus_scratch" ++
-  "  mv s9, x13\n" ++
-  "  mv s10, x10\n" ++
-  "  mv s11, x12\n" ++
-  "  la a0, modexp_base_scratch\n" ++
-  "  mv a1, x5\n" ++
-  "  la a2, modexp_exp_scratch\n" ++
-  "  mv a3, x22\n" ++
-  "  la a4, modexp_modulus_scratch\n" ++
-  "  mv a5, x23\n" ++
-  "  la a6, modexp_output_scratch\n" ++
-  "  jal x1, zkvm_modexp\n" ++
-  "  mv t6, a0\n" ++
-  "  mv x13, s9\n" ++
-  "  mv x10, s10\n" ++
-  "  mv x12, s11\n" ++
-  "  la x15, evm_precompile_frame\n" ++
+  "  mv s9, x13
+  mv s10, x10
+  mv s11, x12
+  la a0, modexp_base_scratch
+  mv a1, x5
+  la a2, modexp_exp_scratch
+  mv a3, x22
+  la a4, modexp_modulus_scratch
+  mv a5, x23
+  la a6, modexp_output_scratch
+  jal x1, zkvm_modexp
+  mv t6, a0
+  mv x13, s9
+  mv x10, s10
+  mv x12, s11
+  la x15, evm_precompile_frame
+" ++
   "  bnez t6, .L" ++ suffix ++ "_bn254_fail_allot\n" ++
-  "  sd x23, 8(x15)\n" ++
-  "  la x28, modexp_output_scratch\n" ++
-  "  addi x29, x15, 16\n" ++
-  "  mv x24, x23\n" ++
+  "  sd x23, 8(x15)
+  la x28, modexp_output_scratch
+  addi x29, x15, 16
+  mv x24, x23
+" ++
   ".Lmodexp_backend_frame_copy_loop_" ++ suffix ++ ":\n" ++
   "  beqz x24, .Lmodexp_backend_frame_copy_done_" ++ suffix ++ "\n" ++
-  "  lbu x16, 0(x28)\n" ++
-  "  sb x16, 0(x29)\n" ++
-  "  addi x28, x28, 1\n" ++
-  "  addi x29, x29, 1\n" ++
-  "  addi x24, x24, -1\n" ++
+  "  lbu x16, 0(x28)
+  sb x16, 0(x29)
+  addi x28, x28, 1
+  addi x29, x29, 1
+  addi x24, x24, -1
+" ++
   "  j .Lmodexp_backend_frame_copy_loop_" ++ suffix ++ "\n" ++
   ".Lmodexp_backend_frame_copy_done_" ++ suffix ++ ":\n" ++
   "  ld x22, " ++ toString outSizeOff ++ "(x12)\n" ++
@@ -299,16 +323,18 @@ def modexpPrecompileGasAsm
   "  bgeu x22, x24, .Lmodexp_backend_copy_len_done_" ++ suffix ++ "\n" ++
   "  mv x24, x22\n" ++
   ".Lmodexp_backend_copy_len_done_" ++ suffix ++ ":\n" ++
-  "  beqz x24, 7b\n" ++
-  "  la x28, modexp_output_scratch\n" ++
+  "  beqz x24, 7b
+  la x28, modexp_output_scratch
+" ++
   "  ld x29, " ++ toString outOffsetOff ++ "(x12)\n" ++
   "  add x29, x13, x29\n" ++
   ".Lmodexp_backend_copy_loop_" ++ suffix ++ ":\n" ++
-  "  lbu x16, 0(x28)\n" ++
-  "  sb x16, 0(x29)\n" ++
-  "  addi x28, x28, 1\n" ++
-  "  addi x29, x29, 1\n" ++
-  "  addi x24, x24, -1\n" ++
+  "  lbu x16, 0(x28)
+  sb x16, 0(x29)
+  addi x28, x28, 1
+  addi x29, x29, 1
+  addi x24, x24, -1
+" ++
   "  bnez x24, .Lmodexp_backend_copy_loop_" ++ suffix ++ "\n" ++
   "  j 7b\n"
 

--- a/EvmAsm/Codegen/Programs/ModexpBackend.lean
+++ b/EvmAsm/Codegen/Programs/ModexpBackend.lean
@@ -34,8 +34,9 @@ def modexpBnMaxLimbs : Nat := 256
     splice this inline between `.text` functions must restore `.section .text`
     afterwards (see `Dispatch.lean`). -/
 def emitModexpBnScratchData : String :=
-  ".section .data\n" ++
-  ".balign 8\n" ++
+  ".section .data
+.balign 8
+" ++
   "modexp_bn_base:\n" ++ "  .zero 2048\n" ++
   "modexp_bn_exp:\n" ++ "  .zero 2048\n" ++
   "modexp_bn_mod:\n" ++ "  .zero 2048\n" ++
@@ -91,8 +92,9 @@ def modexpBnHelpers : String :=
   "  slli t2, t1, 3\n" ++
   "  add t3, a0, t2\n" ++ "  ld t4, 0(t3)\n" ++
   "  add t3, a1, t2\n" ++ "  ld t5, 0(t3)\n" ++
-  "  bltu t4, t5, .Lmcmp_lt\n" ++
-  "  beq t4, t5, .Lmcmp_eq\n" ++
+  "  bltu t4, t5, .Lmcmp_lt
+  beq t4, t5, .Lmcmp_eq
+" ++
   "  li t0, 1\n" ++ "  j .Lmcmp_done\n" ++
   ".Lmcmp_eq:\n" ++ "  addi t1, t1, -1\n" ++ "  j .Lmcmp_loop\n" ++
   ".Lmcmp_lt:\n" ++ "  li t0, 0\n" ++
@@ -170,13 +172,15 @@ def modexpBnHelpers : String :=
   "  slli t4, s3, 3\n" ++ "  add t4, t0, t4\n" ++ "  ld t4, 0(t4)\n" ++
   "  bnez t4, .Lmbinm_sub\n" ++
   "  mv a0, t0\n" ++ "  mv a1, s2\n" ++ "  mv a2, s3\n" ++
-  "  jal ra, modexp_cmpge\n" ++
-  "  beqz a0, .Lmbinm_next\n" ++
+  "  jal ra, modexp_cmpge
+  beqz a0, .Lmbinm_next
+" ++
   ".Lmbinm_sub:\n" ++
   "  la t0, modexp_bn_remainder\n" ++
   "  mv a0, t0\n" ++ "  mv a1, s2\n" ++ "  mv a2, s3\n" ++
-  "  jal ra, modexp_sub\n" ++
-  "  la t0, modexp_bn_remainder\n" ++
+  "  jal ra, modexp_sub
+  la t0, modexp_bn_remainder
+" ++
   "  slli t4, s3, 3\n" ++ "  add t4, t0, t4\n" ++ "  sd zero, 0(t4)\n" ++
   ".Lmbinm_next:\n" ++ "  addi s5, s5, -1\n" ++ "  j .Lmbinm_bit\n" ++
   ".Lmbinm_finish:\n" ++
@@ -202,8 +206,9 @@ def zkvmModexpBackendImpl : String :=
   modexpBnHelpers ++ "\n" ++
   ".globl zkvm_modexp\n" ++ "zkvm_modexp:\n" ++
   -- Save all inputs in s-regs before any jal call
-  "  addi sp, sp, -128\n" ++
-  "  sd ra, 0(sp)\n" ++
+  "  addi sp, sp, -128
+  sd ra, 0(sp)
+" ++
   "  sd s0, 8(sp)\n" ++     -- base_ptr
   "  sd s1, 16(sp)\n" ++    -- Blen
   "  sd s2, 24(sp)\n" ++    -- exp_ptr
@@ -220,10 +225,11 @@ def zkvmModexpBackendImpl : String :=
   "  mv s3, a3\n" ++ "  mv s4, a4\n" ++ "  mv s5, a5\n" ++
   "  mv s6, a6\n" ++
   -- Validate lengths
-  "  li t0, 2048\n" ++
-  "  bltu t0, s1, .Lmexp_err\n" ++
-  "  bltu t0, s3, .Lmexp_err\n" ++
-  "  bltu t0, s5, .Lmexp_err\n" ++
+  "  li t0, 2048
+  bltu t0, s1, .Lmexp_err
+  bltu t0, s3, .Lmexp_err
+  bltu t0, s5, .Lmexp_err
+" ++
   -- nm = ceil(Mlen / 8)
   "  addi t0, s5, 7\n" ++ "  srli s7, t0, 3\n" ++
   -- nb = ceil(Blen / 8)
@@ -238,8 +244,9 @@ def zkvmModexpBackendImpl : String :=
   "  jal ra, modexp_be_to_le\n" ++
   -- Check modulus == 0 → fill output with Mlen zeros
   "  la a0, modexp_bn_mod\n" ++ "  mv a1, s7\n" ++
-  "  jal ra, modexp_iszero\n" ++
-  "  bnez a0, .Lmexp_modzero\n" ++
+  "  jal ra, modexp_iszero
+  bnez a0, .Lmexp_modzero
+" ++
   -- Parse base → modexp_bn_base
   "  mv a0, s0\n" ++ "  mv a1, s1\n" ++
   "  la a2, modexp_bn_base\n" ++ "  li a3, 2048\n" ++
@@ -251,8 +258,9 @@ def zkvmModexpBackendImpl : String :=
   -- Reduce base mod modulus: binmod(base, nb, mod, nm) → base
   "  la a0, modexp_bn_base\n" ++ "  mv a1, s8\n" ++
   "  la a2, modexp_bn_mod\n" ++ "  mv a3, s7\n" ++
-  "  la a4, modexp_bn_base\n" ++
-  "  jal ra, modexp_binmod\n" ++
+  "  la a4, modexp_bn_base
+  jal ra, modexp_binmod
+" ++
   -- Result = 1 (set result[0] = 1, rest zero)
   "  la t0, modexp_bn_result\n" ++
   "  addi t1, s7, 1\n" ++ "  slli t1, t1, 3\n" ++
@@ -263,8 +271,9 @@ def zkvmModexpBackendImpl : String :=
   "  la t0, modexp_bn_result\n" ++ "  li t1, 1\n" ++ "  sd t1, 0(t0)\n" ++
   -- Check exp == 0: if so, result = 1 mod modulus (0 when modulus == 1)
   "  la a0, modexp_bn_exp\n" ++ "  mv a1, s9\n" ++
-  "  jal ra, modexp_iszero\n" ++
-  "  bnez a0, .Lmexp_expzero\n" ++
+  "  jal ra, modexp_iszero
+  bnez a0, .Lmexp_expzero
+" ++
   -- Find highest set bit in exp: scan from MSB limb/bit down
   -- s10 = current bit index (global), start at ne*64-1
   "  slli s10, s9, 6\n" ++ "  addi s10, s10, -1\n" ++
@@ -285,14 +294,16 @@ def zkvmModexpBackendImpl : String :=
   -- product = result * result
   "  la a0, modexp_bn_result\n" ++ "  mv a1, s7\n" ++
   "  la a2, modexp_bn_result\n" ++ "  mv a3, s7\n" ++
-  "  la a4, modexp_bn_product\n" ++
-  "  jal ra, modexp_mul\n" ++
+  "  la a4, modexp_bn_product
+  jal ra, modexp_mul
+" ++
   -- result = product mod modulus (product has 2*nm limbs)
   "  la a0, modexp_bn_product\n" ++
   "  li a1, 0\n" ++ "  add a1, s7, s7\n" ++  -- na = 2*nm
   "  la a2, modexp_bn_mod\n" ++ "  mv a3, s7\n" ++
-  "  la a4, modexp_bn_result\n" ++
-  "  jal ra, modexp_binmod\n" ++
+  "  la a4, modexp_bn_result
+  jal ra, modexp_binmod
+" ++
   -- If exp bit s10 is set: result = result * base mod modulus
   "  srli t0, s10, 6\n" ++ "  andi t1, s10, 63\n" ++
   "  slli t2, t0, 3\n" ++
@@ -303,24 +314,28 @@ def zkvmModexpBackendImpl : String :=
   -- product = result * base
   "  la a0, modexp_bn_result\n" ++ "  mv a1, s7\n" ++
   "  la a2, modexp_bn_base\n" ++ "  mv a3, s7\n" ++
-  "  la a4, modexp_bn_product\n" ++
-  "  jal ra, modexp_mul\n" ++
+  "  la a4, modexp_bn_product
+  jal ra, modexp_mul
+" ++
   -- result = product mod modulus
   "  la a0, modexp_bn_product\n" ++
   "  li a1, 0\n" ++ "  add a1, s7, s7\n" ++
   "  la a2, modexp_bn_mod\n" ++ "  mv a3, s7\n" ++
-  "  la a4, modexp_bn_result\n" ++
-  "  jal ra, modexp_binmod\n" ++
+  "  la a4, modexp_bn_result
+  jal ra, modexp_binmod
+" ++
   ".Lmexp_next_bit:\n" ++
-  "  addi s10, s10, -1\n" ++
-  "  bgez s10, .Lmexp_sqmul\n" ++
+  "  addi s10, s10, -1
+  bgez s10, .Lmexp_sqmul
+" ++
   -- exp == 0: pow(base, 0, m) = 1 % m. result currently holds 1; reduce it mod
   -- modulus so modulus == 1 yields 0 (EIP-198). modulus == 0 handled earlier.
   ".Lmexp_expzero:\n" ++
   "  la a0, modexp_bn_result\n" ++ "  mv a1, s7\n" ++
   "  la a2, modexp_bn_mod\n" ++ "  mv a3, s7\n" ++
-  "  la a4, modexp_bn_result\n" ++
-  "  jal ra, modexp_binmod\n" ++
+  "  la a4, modexp_bn_result
+  jal ra, modexp_binmod
+" ++
   -- fall through to format
   -- Format output: result (nm LE limbs) → output (Mlen BE bytes)
   ".Lmexp_format:\n" ++
@@ -337,8 +352,9 @@ def zkvmModexpBackendImpl : String :=
   "  ld s6, 56(sp)\n" ++ "  ld s7, 64(sp)\n" ++
   "  ld s8, 72(sp)\n" ++ "  ld s9, 80(sp)\n" ++
   "  ld s10, 88(sp)\n" ++ "  ld s11, 96(sp)\n" ++
-  "  addi sp, sp, 128\n" ++
-  "  ret\n" ++
+  "  addi sp, sp, 128
+  ret
+" ++
   ".Lmexp_modzero:\n" ++
   -- Fill output with Mlen zeros
   "  mv t0, s6\n" ++ "  mv t1, s5\n" ++


### PR DESCRIPTION
Concatenate maximal runs of adjacent pure string literals in the modexp
codegen into **true multiline literals**: one asm instruction per source line
inside a single quote pair, no `++` between merged lines, no backslash
continuation.

This is purely a source-readability change. **The emitted assembly is
byte-identical.**

## Why this form is byte-correct

A Lean string literal spanning source lines includes the real newline *and*
the continuation line's leading indentation. The emitted asm needs exactly
`"\n"` followed by two spaces, and these asm lines are already indented two
spaces in source — so **the source line break and indent are precisely the
bytes required**.

That correctness therefore *depends* on uniform indentation within a run:

- only **uniform-indent runs** are merged; a label or directive at column 0
  breaks a run
- the closing quote sits on its own line at column 0 when the run's last
  instruction ends in `\n`, because that final source line break *is* that `\n`
- runs never fold across an interpolation (`suffix`, `dstReg`,
  `toString fieldOff`) — the run ends at the interpolation and resumes after it

## Selection

Chosen by measuring *mergeable* lines rather than raw append counts, which are
misleading: `ModexpBackend` has more total appends than `Modexp` but two thirds
of them interpolate and cannot be merged.

| file | mergeable / total appends | last touched before this PR |
|---|---|---|
| `Modexp.lean` | 105 / 127 | 2026-07-02 |
| `ModexpBackend.lean` | 55 / 156 | 2026-07-05 |

## Verification

Byte-identity was established by **emitting a baseline from a demonstrably
clean tree, applying the change, and re-emitting** — not by observing an empty
diff, which cannot distinguish a passing check from a regeneration that never
ran. Both emitted `.s` files hash to the same sha256, and `cmp` is silent.

No pin movement is expected or present: emission is unchanged, so `text`,
`data` and `bss` are identical to `main`.

## Note for reviewers

This form costs **+1 source line per merged run** (the closing quote's own
line), so the two files grow by 42 lines net. The payoff is contiguous,
quote-free asm text, not line count.
