### PR TITLE
docs(codegen): record zero-caller reachability for the two bal_sort routines

### DIFF
--- a/EvmAsm/Codegen/Programs/BalCanonicalSort.lean
+++ b/EvmAsm/Codegen/Programs/BalCanonicalSort.lean
@@ -358,6 +358,16 @@ theorem balCanonicalSortFunction_eq_prog :
     which key width belongs to which arena — the misuse the status codes 2 and 4
     exist to catch is not reachable from these. -/
 
+-- REACHABILITY (measured 2026-07-31 on ed50a5dbb): ZERO callers. No jal/jalr/la/call/
+-- tail/auipc materialisation of `bal_sort_storage_writes` anywhere in the 2,124,874-byte
+-- emitted guest stream (it appears only as its own `.globl` + label); no external
+-- `GuestAddrs.bal_sort_storage_writes` reference outside this module. The EIP-7928 BAL
+-- canonical ordering (incl. the address-major/slot-minor slot order this produces) is
+-- already achieved by the live path and proven correct by the #11016 correspondence
+-- (1149/1149 records: account / slot / per-index orders). So this routine is UNUSED — the
+-- ordering obligation is met without it. Kept, not deleted, because its address is pinned
+-- in `GuestAddrs.lean` (removal would force a repin cascade across GuestAddrs / the region
+-- map / address-pinned proofs). See #11017.
 /-- Sort the block-level `storage_writes` map into address-major, slot-minor
     order. a0 = 0 on success, else the `bal_canonical_sort` status. -/
 def balSortStorageWrites_prog : Program :=
@@ -393,6 +403,16 @@ theorem balSortStorageWritesFunction_eq_prog :
       "bal_sort_storage_writes:\n" ++ emitProgramR balSortStorageWrites_prog balSortStorageWrites_relocs := rfl
 
 
+-- REACHABILITY (measured 2026-07-31 on ed50a5dbb): ZERO callers. No jal/jalr/la/call/
+-- tail/auipc materialisation of `bal_sort_account_writes` anywhere in the 2,124,874-byte
+-- emitted guest stream (it appears only as its own `.globl` + label); no external
+-- `GuestAddrs.bal_sort_account_writes` reference outside this module. The EIP-7928 BAL
+-- canonical ordering (incl. the account order this produces) is already achieved by the
+-- live path and proven correct by the #11016 correspondence (1149/1149 records: account /
+-- slot / per-index orders). So this routine is UNUSED — the ordering obligation is met
+-- without it. Kept, not deleted, because its address is pinned in `GuestAddrs.lean`
+-- (removal would force a repin cascade across GuestAddrs / the region map / address-pinned
+-- proofs). See #11017.
 /-- Sort the block-level `account_writes` map into address order. -/
 def balSortAccountWrites_prog : Program :=
   [ .ADDI .x2 .x2 (-16 : BitVec 12),


### PR DESCRIPTION
Adds a zero-caller reachability comment to `bal_sort_storage_writes` and `bal_sort_account_writes` (refs #11017).

**Why a comment, not a deletion** (per the #11017 discussion): both routines have zero callers, but their addresses are pinned in `GuestAddrs.lean` (0x8002bf48 / 0x8002bf88), so deleting them would shift every following symbol and force a repin cascade across GuestAddrs / the region map / every address-pinned proof downstream. The benefit (a few hundred bytes of `.text`) is not worth that cost.

**Reachability (measured on ed50a5dbb):** no jal / jalr / la / call / tail / auipc materialisation of either symbol across the 2,124,874-byte emitted guest stream (each appears only as its own `.globl` + label); no external `GuestAddrs.bal_sort_*` reference outside `BalCanonicalSort.lean`.

**Dead vs unwired (answered):** the EIP-7928 BAL canonical ordering these routines would produce is already achieved by the live `bal_canonical_sort` (6 calls in `bal_serializer_rebuild_hash`) and proven correct by the #11016 correspondence (1149/1149 records: account / slot / per-index orders). So the ordering obligation is met without them — they are unused, kept (not deleted) only because removal is expensive.

**Byte-identical:** the emitted guest is unchanged (baseline + commented both sha256 `616b9b57…`, cmp silent). The added lines are Lean `--` comments that do not affect emission. The proof is a full-artefact sha256 + cmp comparison of the emitted guest, not a fixture-window one.

Refs #11017.
