### PR TITLE
fix(codegen): credit child env+32 on nested value-CALL

### DIFF
--- a/EvmAsm/Codegen/Programs/ChildFrameHandlers.lean
+++ b/EvmAsm/Codegen/Programs/ChildFrameHandlers.lean
@@ -1039,16 +1039,18 @@ def callDescendFallThrough
      "  lbu t3, 0(t0); sb t3, 0(t1)\n" ++
      "  addi t0, t0, -1; addi t1, t1, 1; addi t2, t2, -1\n" ++
      "  bnez t2, .Lcd_child_sb_rev_" ++ tag ++ "\n" ++
-     "  addi sp, sp, -32\n  sd x10, 0(sp)\n  sd x12, 8(sp)\n  sd x13, 16(sp)\n" ++
-     "  la a0, cd_caller_newbal\n  la a1, cd_value_be\n  la a2, cd_caller_newbal\n" ++
-     "  jal ra, u256_add_be\n" ++
-     "  ld x10, 0(sp)\n  ld x12, 8(sp)\n  ld x13, 16(sp)\n  addi sp, sp, 32\n" ++
-     "  la t0, cd_caller_newbal\n  addi t1, x20, 63\n  li t2, 32\n" ++
-     ".Lcd_child_sb_wb_" ++ tag ++ ":\n" ++
-     "  lbu t3, 0(t0); sb t3, 0(t1)\n" ++
-     "  addi t0, t0, 1; addi t1, t1, -1; addi t2, t2, -1\n" ++
-     "  bnez t2, .Lcd_child_sb_wb_" ++ tag ++ "\n" ++
-     ".Lcd_child_sb_done_" ++ tag ++ ":\n") ++
+      -- Save set = write set of the helper args: a0=x10, a1=x11, a2=x12.
+      -- (Inherited CREATE comment claimed a0-a2 alias x10/x12/x13 — wrong.)
+      "  addi sp, sp, -32\n  sd x10, 0(sp)\n  sd x11, 8(sp)\n  sd x12, 16(sp)\n" ++
+      "  la a0, cd_caller_newbal\n  la a1, cd_value_be\n  la a2, cd_caller_newbal\n" ++
+      "  jal ra, u256_add_be\n" ++
+      "  ld x10, 0(sp)\n  ld x11, 8(sp)\n  ld x12, 16(sp)\n  addi sp, sp, 32\n" ++
+      "  la t0, cd_caller_newbal\n  addi t1, x20, 63\n  li t2, 32\n" ++
+      ".Lcd_child_sb_wb_" ++ tag ++ ":\n" ++
+      "  lbu t3, 0(t0); sb t3, 0(t1)\n" ++
+      "  addi t0, t0, 1; addi t1, t1, -1; addi t2, t2, -1\n" ++
+      "  bnez t2, .Lcd_child_sb_wb_" ++ tag ++ "\n" ++
+      ".Lcd_child_sb_done_" ++ tag ++ ":\n") ++
    -- fva3w: x20 now = CHILD env (call_frame_descend repointed it; eventLogCheckpoint@480 is
    -- set to the current count). Emit the deferred EIP-7708 value-CALL transfer log HERE so it
    -- lands in the child frame's logs: frame_return rolls it back on a child REVERT/exceptional

--- a/EvmAsm/Codegen/Programs/ChildFrameHandlers.lean
+++ b/EvmAsm/Codegen/Programs/ChildFrameHandlers.lean
@@ -1007,17 +1007,53 @@ def callDescendFallThrough
   -- nse_callee_be, cd_value_be, cd_balance_be, and nse_acct are static scratch
   -- reused by nested calls, so they are valid only in this post-descend,
   -- pre-dispatch window.
-  (if mode != 0 then "" else
-    -- GH #10938: the setup is the shared `recordMessageValueTransferAsm`, which the
-    -- CREATE-endowment site also uses.  The spec has ONE `move_ether` for both, since
-    -- `process_create_message` delegates to `process_message` (`interpreter.py:212`).
-    recordMessageValueTransferAsm "cd_caller_be" "nse_callee_be" "cd_value_be" "li a3, 1"
-      "cd_balance_be" "nse_acct" (recipientPreAdjust := "addi a5, a5, 8")) ++
-  -- fva3w: x20 now = CHILD env (call_frame_descend repointed it; eventLogCheckpoint@480 is
-  -- set to the current count). Emit the deferred EIP-7708 value-CALL transfer log HERE so it
-  -- lands in the child frame's logs: frame_return rolls it back on a child REVERT/exceptional
-  -- halt and propagates it on success -- matching spec emit_transfer_log inside process_message.
-  emitPendingXferLog "desc_" ++
+   (if mode != 0 then "" else
+     -- GH #10938: the setup is the shared `recordMessageValueTransferAsm`, which the
+     -- CREATE-endowment site also uses.  The spec has ONE `move_ether` for both, since
+     -- `process_create_message` delegates to `process_message` (`interpreter.py:212`).
+     recordMessageValueTransferAsm "cd_caller_be" "nse_callee_be" "cd_value_be" "li a3, 1"
+       "cd_balance_be" "nse_acct" (recipientPreAdjust := "addi a5, a5, 8") ++
+     -- Credit child env+32 (.selfBalance) with the transferred value so nested-frame
+     -- SELFBALANCE and the child's own CREATE value-gate see pre + call.value.
+     -- call_frame_descend stages env+32 from pre-transfer balance only; the parent
+     -- debit above updates the caller frame, but until now nothing wrote the callee
+     -- frame. CREATE already credits its child after descend (ChildFrameCreateTail
+     -- drj99.1 part 2); mirror that here. Inside the child rollback interval: a
+     -- REVERT/exceptional halt discards the frame, so the credit dies with it.
+     -- Skip value==0 (cd_value_be may be stale) and self-call (net-zero; parent debit
+     -- also skips — adding V would make SELFBALANCE read B+V).
+     "  la t0, cd_value_be\n" ++
+     "  ld t1, 0(t0); ld t2, 8(t0); or t1, t1, t2\n" ++
+     "  ld t2, 16(t0); or t1, t1, t2\n" ++
+     "  ld t2, 24(t0); or t1, t1, t2\n" ++
+     "  beqz t1, .Lcd_child_sb_done_" ++ tag ++ "\n" ++
+     "  la t0, cd_caller_be\n  la t1, nse_callee_be\n  li t2, 20\n" ++
+     ".Lcd_child_sb_self_" ++ tag ++ ":\n" ++
+     "  beqz t2, .Lcd_child_sb_done_" ++ tag ++ "\n" ++
+     "  lbu t3, 0(t0); lbu t4, 0(t1); bne t3, t4, .Lcd_child_sb_credit_" ++ tag ++ "\n" ++
+     "  addi t0, t0, 1; addi t1, t1, 1; addi t2, t2, -1\n" ++
+     "  j .Lcd_child_sb_self_" ++ tag ++ "\n" ++
+     ".Lcd_child_sb_credit_" ++ tag ++ ":\n" ++
+     "  addi t0, x20, 63\n  la t1, cd_caller_newbal\n  li t2, 32\n" ++
+     ".Lcd_child_sb_rev_" ++ tag ++ ":\n" ++
+     "  lbu t3, 0(t0); sb t3, 0(t1)\n" ++
+     "  addi t0, t0, -1; addi t1, t1, 1; addi t2, t2, -1\n" ++
+     "  bnez t2, .Lcd_child_sb_rev_" ++ tag ++ "\n" ++
+     "  addi sp, sp, -32\n  sd x10, 0(sp)\n  sd x12, 8(sp)\n  sd x13, 16(sp)\n" ++
+     "  la a0, cd_caller_newbal\n  la a1, cd_value_be\n  la a2, cd_caller_newbal\n" ++
+     "  jal ra, u256_add_be\n" ++
+     "  ld x10, 0(sp)\n  ld x12, 8(sp)\n  ld x13, 16(sp)\n  addi sp, sp, 32\n" ++
+     "  la t0, cd_caller_newbal\n  addi t1, x20, 63\n  li t2, 32\n" ++
+     ".Lcd_child_sb_wb_" ++ tag ++ ":\n" ++
+     "  lbu t3, 0(t0); sb t3, 0(t1)\n" ++
+     "  addi t0, t0, 1; addi t1, t1, -1; addi t2, t2, -1\n" ++
+     "  bnez t2, .Lcd_child_sb_wb_" ++ tag ++ "\n" ++
+     ".Lcd_child_sb_done_" ++ tag ++ ":\n") ++
+   -- fva3w: x20 now = CHILD env (call_frame_descend repointed it; eventLogCheckpoint@480 is
+   -- set to the current count). Emit the deferred EIP-7708 value-CALL transfer log HERE so it
+   -- lands in the child frame's logs: frame_return rolls it back on a child REVERT/exceptional
+   -- halt and propagates it on success -- matching spec emit_transfer_log inside process_message.
+   emitPendingXferLog "desc_" ++
   -- Every successfully descended CALL-family kind reaches the existing
   -- dispatcher resume sequence through the child entry. The entry is after all
   -- root-only setup and begins with the dispatcher-resume sequence that


### PR DESCRIPTION
## Summary

Fixes nested value-`CALL` never crediting the **callee** frame-local live balance at `env+32` (`.selfBalance`). Parent was already debited pre-descend; only nonstorage/BAL was recorded post-descend. CREATE/CREATE2 already credit the child (`ChildFrameCreateTail` ~434–458); CALL was the missing path.

Closes the wrong-value execution defect where **`SELFBALANCE` (and the callee CREATE endowment gate)** see a stale balance after a nested value-CALL. Tracked as **#11081**.

The child-credit sequence was deliberately mirrored from the working CREATE path, then **register liveness was re-derived at the CALL site from emitted asm** (not inherited from CREATE). That caught a save-set/write-set mismatch in the copied prelude; fixed in a follow-up commit (see below). CREATE’s own copy of the trap is filed separately as **#11083** (latent; no failure attributed).

## Change

`EvmAsm/Codegen/Programs/ChildFrameHandlers.lean` — after `recordMessageValueTransferAsm` on CALL mode-0 post-descend:

- if `cd_value_be ≠ 0` and not self-call: reverse child `env+32` LE→BE, `u256_add_be cd_value_be`, write back LE
- save/restore **x10/x11/x12** around the helper (match a0/a1/a2 write set; RV ABI, not the CREATE comment’s x10/x12/x13)
- inside the child rollback interval (reverting child discards the frame with the credit)

## Readers of `env+32` (why this is serious)

| site | role |
|---|---|
| **`h_SELFBALANCE` @ `0x8004d694`** | **READ** opcode 0x47 — stale after nested value-CALL |
| `h_CREATE` / `h_CREATE2` | gate + creator debit + **child credit** (already present) |
| `h_CALL` | caller debit; **child credit was missing** |
| `h_CALLCODE` / `h_SELFDESTRUCT` / descend staging / top-level tx credit | other readers/writers |

## Same-population evidence (family `selfdestructing_initcode_preserves_balance`, limit=40)

| | guest sha256 | RAN | full pass | fail | root match | run dir |
|---|---|---:|---:|---:|---:|---|
| **baseline** | `aa9af7753b74176a2e30d31d39e816da385601622b29388981f6f00fd6e7dacf` | 40 | **16** | **24** | 40 | `run-20260801T111722Z-2916928` (`--guest-elf`) |
| **fix (pre save-set fix)** | `e3907f356d71c0b118f0e301249c1e4b9ad2b827bc742c001fe41da1bfa1916d` | 40 | **28** | **12** | 40 | `run-20260801T110956Z-2896086` |
| **fix (this PR HEAD, regenerated)** | `7c630c93fb53684b1c0f25d3a7873307bfdfe47fa9180c3ed87e4d8d30491337` | 40 | **28** | **12** | 40 | `run-20260801T112401Z-2945520` (built) |

Net vs baseline: **+12 full pass / −12 fail** on the identical 40-row population. Save-set correction did not change the score (as expected: x11/ra dead at site). All remaining fails are false rejects (`succ guest=00 exp=01`) with matching state root.

Reviewer rebuild: checkout this branch, run
`scripts/codegen-eest-stateless-check.sh --backend spike --filter selfdestructing_initcode_preserves_balance --limit 40 --jobs 4`
and confirm guest sha256 `7c630c93…1337`.

Witnessing path fixed first: `initial_balance=1` + factory CREATE after value-CALL (CREATE gate saw `create_balance_be=0`).

## Residuals (not in this PR)

- **Class A** (`bv60`, short Δ3): `post_send_opcode=CALL` ∧ `post_send_count∈{1,3}` ∧ `initial_balance=1`. Hypothesis: parent `env+32` debit not re-credited when child fails — reverse edge; overlaps **#11001**. Pin by reading `env+32` at the boundary before fixing.
- **Class B** (`bv44`): `post_send_opcode=SELFDESTRUCT` ∧ `post_send_count∈{1,3}`. On `ibal=0` lengths equal → per-entry BAL decode, not byte-diff.

Related: #11001, #11081, #11083 (CREATE save-set hygiene).

## Test plan

- [x] Same-pop baseline vs fix limit 40 on `selfdestructing_initcode_preserves_balance`
- [x] Re-measure after save-set fix on regenerated ELF `7c630c93…`
- [ ] CI eest / codegen gates
- [ ] Follow-up: pin Class A parent restore; per-entry decode Class B
