### PR TITLE
tooling(spike): SPIKE_WATCH + headless DEBUG_CMD for guest debug

### DIFF
--- a/scripts/spike/README.md
+++ b/scripts/spike/README.md
@@ -60,31 +60,171 @@ Run one block: `scripts/spike/spike_run <guest.elf> <input> <output>`
 EEST backend: `EEST_BACKEND=spike scripts/codegen-eest-stateless-check.sh --limit 1000 --jobs 4`
 Parity gate: `scripts/spike/parity-check.sh 8 1`
 
-## Debugging: per-instruction commit log
+## Debugging the guest (recipe)
 
-`spike_run` supports an env-gated commit log for EVM-faithfulness / gas-model
-debugging. Set `SPIKE_COMMITLOG=<file>` and spike writes its standard per-instruction
-trace (RV64 `pc`, instruction word, register and memory writes) to that file.
-Unset, behavior is byte-identical to before (zero impact on parity/CI runs).
+### Headline: `hits=0` means nothing wrote here
+
+`SPIKE_COMMITLOG` is a **trace of writes**. It is structurally blind to the
+**absence** of a write — the correct-but-unfed class (global stays zero because
+no store ever targeted it). The fleet hit that class twice in one day; once it
+cost **~two hours of commitlog archaeology** to learn that `bsbd_deleg_target`
+held 24 zero bytes on a child path because nothing ever wrote it.
+
+`SPIKE_WATCH` is the cheap instrument for that question. Point it at a guest
+global on a **real fixture**. If the run ends with `hits=0`, you have the
+answer in one shot — stop hunting for a clobber and look for a missing store.
+
+**Worked example (known answer, real guest+fixture — not a toy):**
 
 ```bash
-SPIKE_COMMITLOG=/tmp/cl.log scripts/spike/spike_run <guest.elf> <input> /tmp/out
+# guest sha256 7c630c93fb53684b1c0f25d3a7873307bfdfe47fa9180c3ed87e4d8d30491337
+# run-20260801T112401Z-2945520 / 00000 selfdestructing_initcode…
+# nm: bsbd_deleg_target @ 0xbaeaa268  (re-nm after every rebuild)
+ELF=gen-out/eest-run/run-20260801T112401Z-2945520/stateless_guest.elf
+IN=gen-out/eest-run/run-20260801T112401Z-2945520/00000_*.input
+
+SPIKE_WATCH=0xbaeaa268 \
+  scripts/spike/spike_run "$ELF" "$IN" /tmp/out 2>/tmp/watch.log
 ```
 
-The guest\'s EVM-bytecode interpreter has a single dispatch loop; its opcode
-fetch is the `lbu t0, 0(a0)` at the `.dispatch_loop` label (a0/x10 = EVM PC,
-t0/x5 = opcode byte). To extract the executed EVM bytecodes from the log, find
-that fetch instruction\'s address (e.g. via `riscv64-unknown-elf-objdump -d
-<guest.elf> | grep -A2 .dispatch_loop`) and filter:
+Actual stderr from that run:
+
+```
+spike_run: SPIKE_WATCH=0xbaeaa268 initial=0x0000000000000000
+spike_run: SPIKE_WATCH done hits=0 final=0x0000000000000000
+```
+
+`hits=0` = the two-hour answer, in one command. A new instrument proved against
+a **known** fleet answer is trustworthy in a way one proved only on unknowns
+never is.
+
+Unset every debug env var and `spike_run` is **byte-identical** to the
+pre-tooling path (`cmp` matched the prior 256-byte output on the same fixture).
+
+### Tool map
+
+| Tool | Best for | Cost |
+|------|----------|------|
+| `SPIKE_WATCH` | **"did anything write this address?"** (`hits=0` / who wrote) | steps 1 insn at a time; full guest slower but finishes |
+| `SPIKE_DEBUG_CMD` | break at PC/symbol, dump regs/mem, value-match `until mem` | headless; ~normal wall if breakpoint hits early |
+| `SPIKE_BREAK_PC` | one-shot reg dump at a PC, then continue | step-1 until hit, then batch |
+| `SPIKE_COMMITLOG` | "what writes happened?" archaeology | huge files (~0.5 GB/fixture) |
+
+### 0. Resolve addresses
+
+```bash
+ELF=gen-out/eest-run/<run>/stateless_guest.elf   # or whatever guest you built
+IN=gen-out/eest-run/<run>/00000_*.input
+riscv64-unknown-elf-nm "$ELF" | rg 'h_CREATE$|bsbd_deleg_target|create_balance_be'
+# addresses move every rebuild — always re-nm before watching
+```
+
+### 1. True write-watch (`SPIKE_WATCH`)
+
+Watches one **8-byte LE** cell. On any change, prints `pc`, old/new, and a
+useful register subset. End-of-run `hits=0` is the absence signal.
+
+```bash
+SPIKE_WATCH=0xbaeaa268 \
+  scripts/spike/spike_run "$ELF" "$IN" /tmp/out 2>/tmp/watch.log
+
+# Stop on first hit (don't wait for halt):
+SPIKE_WATCH=0xbaeaa268 SPIKE_WATCH_STOP=1 \
+  scripts/spike/spike_run "$ELF" "$IN" /tmp/out 2>/tmp/watch.log
+```
+
+### 2. Headless breakpoints (`SPIKE_DEBUG_CMD`)
+
+Stock spike's `-d` / `--debug-cmd` only run inside `sim.run()` → `idle()` →
+`interactive()`. Our driver **bypasses** that path (custom `p->step` loop +
+`HALT_FLAG` at `0x60008000`), so stock flags do nothing on `spike_run`.
+`SPIKE_DEBUG_CMD` is the harness-native replacement (same command shapes).
+
+```bash
+cat > /tmp/dbg.cmd <<'EOF'
+# stop at h_CREATE entry (re-nm the address!)
+until pc 0x80053704
+pc
+reg          # all XPR
+reg s4       # env base in many handlers
+mem 0xbd79d600   # create_balance_be (re-nm)
+until halt
+quit
+EOF
+SPIKE_DEBUG_CMD=/tmp/dbg.cmd \
+  scripts/spike/spike_run "$ELF" "$IN" /tmp/out 2>/tmp/dbg.log
+# worked example:
+#   until pc 0x80053704 …
+#   stopped pc=0x80053704
+#   s4 = factory env, etc.
+```
+
+Commands (one per line; `#` comments ok):
+
+| cmd | meaning |
+|-----|---------|
+| `pc` | print PC |
+| `reg` / `reg <name>` | all XPR, or one (`a0`, `s4`, `x10`, …) |
+| `mem <hex>` | print 8-byte LE at physical addr |
+| `until pc <hex>` | run until PC equals |
+| `until mem <hex> <hex>` | run until cell **equals** value (not a write watch!) |
+| `until reg <r> <hex>` | run until XPR equals |
+| `until halt` / `rs` / `run` | run until `HALT_FLAG != 0` |
+| `step [n]` | single-step |
+| `quit` | end script; driver still dumps the 256 B output |
+
+**Value-match vs write-watch:** stock spike and our `until mem ADDR VAL` only
+stop when the cell becomes `VAL`. They cannot prove "nothing wrote". Use
+`SPIKE_WATCH` for that.
+
+```bash
+# value-match: stop when halt flag becomes 1 (works)
+until mem 0x60008000 0x1
+```
+
+### 3. One-shot PC log (`SPIKE_BREAK_PC`)
+
+Logs regs once when PC equals the address, then continues to halt (no script):
+
+```bash
+SPIKE_BREAK_PC=0x80053704 \
+  scripts/spike/spike_run "$ELF" "$IN" /tmp/out 2>/tmp/brk.log
+# → SPIKE_BREAK_PC hit pc=0x80053704 + full reg dump
+```
+
+### 4. Commit log (existing)
+
+```bash
+SPIKE_COMMITLOG=/tmp/cl.log scripts/spike/spike_run "$ELF" "$IN" /tmp/out
+```
+
+Per-instruction trace (pc, insn word, reg/mem writes). Great for "show me the
+store that produced this value" once you know a write happened. Bad for absence.
+
+EVM opcode stream (dispatch fetch is `lbu t0, 0(a0)` at `.dispatch_loop`):
 
 ```bash
 rg "<fetch-addr> \(0x00054283\)" /tmp/cl.log \
   | rg -o 'x5\s+0x([0-9a-f]+)\s+mem\s+0x([0-9a-f]+)' -r '$1 $2'
-# column 1 = opcode/operand byte, column 2 = EVM PC (memory address)
+# col1 = opcode/operand byte, col2 = EVM PC address
 ```
 
-This gives the executed-EVM-byte sequence (count includes PUSH operand bytes),
-useful for diffing guest vs execution-specs per-opcode traces (`ethereum.trace`).
+### What does NOT work (honest)
+
+| Approach | Status |
+|----------|--------|
+| Stock `spike -d` / `--debug-cmd=FILE` on our guest | **No** — no input preload, no zisk accel CSRs wired that way, no `HALT_FLAG` contract. Use `spike_run` env vars above. |
+| Stock `spike --halted --rbb-port=N` + gdb | **Impractical here today.** Needs OpenOCD (`openocd` not installed on this host) + a three-process dance (spike / openocd / gdb-multiarch). `spike_run` also does not expose `--rbb-port`. If someone installs OpenOCD later, wire rbb into `spike_run` and revisit; until then `SPIKE_WATCH` + `SPIKE_DEBUG_CMD` cover the fleet need. |
+| Hardware-style "break on any write" via stock interactive | **No** — stock only has value-match `until mem`. Our `SPIKE_WATCH` is the true write watch. |
+| Watching wider than 8 bytes with one `SPIKE_WATCH` | **No** — watches one dword. For a 24-byte buffer watch three addresses or the first dword (enough for "anything touched this object"). |
+| Fast full-run watch | **Slow** — watch/break force `step(1)`. Acceptable for one fixture; don't put it in CI. |
+
+### Rebuild after editing `spike_run.cc`
+
+```bash
+SPIKE_SRC=/path/to/riscv-isa-sim scripts/spike/build.sh
+# produces scripts/spike/spike_run
+```
 
 ## The guest's runtime contract (see ../../../.claude/plans for full map)
 - Memory: header `0x7ffff000`, `.text 0x80000000`, `.data 0xa3000000`,

--- a/scripts/spike/spike_run.cc
+++ b/scripts/spike/spike_run.cc
@@ -8,6 +8,14 @@
 //   - registers the zisk_accel crypto-CSR extension;
 //   - runs to HTIF exit, then writes SPIKE_OUTPUT_LEN bytes (default 256) from
 //     0xa0010000 to <output-file>.
+//
+// Debug env (optional; unset = previous byte-identical behavior):
+//   SPIKE_COMMITLOG=<file>   per-instruction commit log (existing)
+//   SPIKE_DEBUG_CMD=<file>   headless debug script (see scripts/spike/README.md)
+//   SPIKE_WATCH=<hex>        true 8-byte write watch: print PC+old+new on any change
+//   SPIKE_WATCH_STOP=1       stop the run after the first watch hit (default: log+continue)
+//   SPIKE_BREAK_PC=<hex>     stop after executing the insn at this PC (logs once)
+//   SPIKE_RUN_DEBUG=1        existing: dump first 60 steps
 #include <sys/syscall.h>
 #include "sim.h"
 #include "cfg.h"
@@ -21,11 +29,14 @@
 #include <cstdint>
 #include <cstring>
 #include <optional>
+#include <functional>
 #include <vector>
 #include <string>
 #include <fstream>
+#include <sstream>
 #include <iterator>
 #include <cstdlib>
+#include <cctype>
 
 extern extension_t* make_zisk_accel_extension();
 
@@ -62,8 +73,270 @@ static void rd(simif_t* s, reg_t a, uint8_t* d, size_t n) {
   for (size_t i = 0; i < n; ++i) { char* p = s->addr_to_mem(a + i); d[i] = p ? (uint8_t)*p : 0; }
 }
 
+static uint64_t rd_u64(simif_t* s, reg_t a) {
+  uint8_t b[8]; rd(s, a, b, 8);
+  uint64_t v = 0; memcpy(&v, b, 8); return v;
+}
+
+static unsigned long long parse_u64(const char* raw, const char* what) {
+  char* end = nullptr;
+  unsigned long long v = strtoull(raw, &end, 0);
+  if (!end || *end != '\0') {
+    fprintf(stderr, "spike_run: invalid %s=%s\n", what, raw);
+    exit(2);
+  }
+  return v;
+}
+
+// ABI / numeric register name -> x-reg index. Returns -1 on failure.
+static int parse_reg_name(const std::string& s) {
+  if (s.empty()) return -1;
+  if (s[0] == 'x' || s[0] == 'X') {
+    char* end = nullptr;
+    long n = strtol(s.c_str() + 1, &end, 10);
+    if (end && *end == '\0' && n >= 0 && n < 32) return (int)n;
+  }
+  static const char* abi[] = {
+    "zero","ra","sp","gp","tp","t0","t1","t2",
+    "s0","s1","a0","a1","a2","a3","a4","a5",
+    "a6","a7","s2","s3","s4","s5","s6","s7",
+    "s8","s9","s10","s11","t3","t4","t5","t6"
+  };
+  // fp == s0
+  if (s == "fp") return 8;
+  for (int i = 0; i < 32; ++i)
+    if (s == abi[i]) return i;
+  // bare number
+  char* end = nullptr;
+  long n = strtol(s.c_str(), &end, 10);
+  if (end && *end == '\0' && n >= 0 && n < 32) return (int)n;
+  return -1;
+}
+
+static void print_regs(processor_t* p) {
+  auto* st = p->get_state();
+  static const char* abi[] = {
+    "zero","ra","sp","gp","tp","t0","t1","t2",
+    "s0","s1","a0","a1","a2","a3","a4","a5",
+    "a6","a7","s2","s3","s4","s5","s6","s7",
+    "s8","s9","s10","s11","t3","t4","t5","t6"
+  };
+  for (int r = 0; r < 32; ++r) {
+    fprintf(stderr, "  %4s: 0x%016llx%s", abi[r],
+            (unsigned long long)st->XPR[r],
+            ((r + 1) % 4 == 0) ? "\n" : "");
+  }
+}
+
+static void print_watch_hit(processor_t* p, reg_t addr, uint64_t oldv, uint64_t newv) {
+  auto* st = p->get_state();
+  fprintf(stderr,
+          "SPIKE_WATCH hit addr=0x%llx old=0x%016llx new=0x%016llx pc=0x%llx\n"
+          "  ra=0x%llx sp=0x%llx a0=0x%llx a1=0x%llx a2=0x%llx a3=0x%llx\n"
+          "  s0=0x%llx s1=0x%llx s2=0x%llx s3=0x%llx s4=0x%llx\n",
+          (unsigned long long)addr,
+          (unsigned long long)oldv, (unsigned long long)newv,
+          (unsigned long long)st->pc,
+          (unsigned long long)st->XPR[1], (unsigned long long)st->XPR[2],
+          (unsigned long long)st->XPR[10], (unsigned long long)st->XPR[11],
+          (unsigned long long)st->XPR[12], (unsigned long long)st->XPR[13],
+          (unsigned long long)st->XPR[8], (unsigned long long)st->XPR[9],
+          (unsigned long long)st->XPR[18], (unsigned long long)st->XPR[19],
+          (unsigned long long)st->XPR[20]);
+}
+
+// Minimal headless debugger. Stock spike's interactive()/--debug-cmd is private
+// to sim_t and only runs inside sim.run()/idle(), which our driver bypasses
+// (custom step loop + HALT_FLAG). So we reimplement the useful subset here.
+//
+// Commands (one per line; # comments; blank ignored):
+//   help
+//   pc [core]                 print PC (core ignored; always hart 0)
+//   reg [core] [reg]          print one/all XPR
+//   mem <hex addr>            print 8-byte LE at physical addr
+//   until pc [core] <hex>     run until PC == val
+//   until mem <hex> <hex>     run until 8-byte LE at addr == val
+//   until reg [core] <r> <v>  run until XPR[r] == val
+//   until halt                run until HALT_FLAG nonzero
+//   rs / run                  alias for until halt
+//   step [n]                  step n instructions (default 1)
+//   quit / q                  end debug script; resume normal dump
+//
+// Note: stock `until mem ADDR VAL` is value-match, NOT a write watch.
+// Use SPIKE_WATCH=<addr> for true "any write" / "nothing wrote" detection.
+enum class DbgAction { Continue, Done, Quit };
+
+static DbgAction run_until(simif_t* memif, processor_t* p,
+                           const std::function<bool()>& pred,
+                           uint64_t* steps_left) {
+  while (*steps_left > 0) {
+    if (rd_u64(memif, HALT_FLAG)) return DbgAction::Done;
+    if (pred()) return DbgAction::Continue;
+    p->step(1);
+    (*steps_left)--;
+  }
+  fprintf(stderr, "spike_run: debug until: step cap reached\n");
+  return DbgAction::Done;
+}
+
+static DbgAction handle_debug_line(simif_t* memif, processor_t* p,
+                                   const std::string& line, uint64_t* steps_left) {
+  // strip comment
+  std::string s = line;
+  auto hash = s.find('#');
+  if (hash != std::string::npos) s = s.substr(0, hash);
+  // trim
+  while (!s.empty() && isspace((unsigned char)s.front())) s.erase(s.begin());
+  while (!s.empty() && isspace((unsigned char)s.back())) s.pop_back();
+  if (s.empty()) return DbgAction::Continue;
+
+  std::istringstream iss(s);
+  std::string cmd;
+  iss >> cmd;
+  auto* st = p->get_state();
+
+  if (cmd == "help" || cmd == "h") {
+    fprintf(stderr,
+            "spike_run debug commands:\n"
+            "  pc | reg [r] | mem <addr>\n"
+            "  until pc <addr> | until mem <addr> <val> | until reg <r> <val> | until halt\n"
+            "  step [n] | rs | run | quit\n"
+            "True write-watch: SPIKE_WATCH=<addr> (env), not 'until mem'.\n");
+    return DbgAction::Continue;
+  }
+  if (cmd == "quit" || cmd == "q") return DbgAction::Quit;
+  if (cmd == "pc") {
+    fprintf(stderr, "0x%llx\n", (unsigned long long)st->pc);
+    return DbgAction::Continue;
+  }
+  if (cmd == "reg") {
+    std::string a, b;
+    iss >> a;
+    if (a.empty()) { print_regs(p); return DbgAction::Continue; }
+    // optional core number then reg, or just reg
+    std::string rname = a;
+    if (iss >> b) rname = b; // skip core
+    else if (a.size() == 1 && isdigit((unsigned char)a[0]) && a[0] == '0') {
+      // bare "reg 0" means all regs of core 0 (stock spike)
+      print_regs(p); return DbgAction::Continue;
+    }
+    int ri = parse_reg_name(rname);
+    if (ri < 0) { fprintf(stderr, "bad reg %s\n", rname.c_str()); return DbgAction::Continue; }
+    fprintf(stderr, "0x%016llx\n", (unsigned long long)st->XPR[ri]);
+    return DbgAction::Continue;
+  }
+  if (cmd == "mem") {
+    std::string addr_s;
+    iss >> addr_s;
+    if (addr_s.empty()) { fprintf(stderr, "mem needs addr\n"); return DbgAction::Continue; }
+    reg_t addr = (reg_t)parse_u64(addr_s.c_str(), "mem addr");
+    fprintf(stderr, "0x%016llx\n", (unsigned long long)rd_u64(memif, addr));
+    return DbgAction::Continue;
+  }
+  if (cmd == "step") {
+    std::string n_s; iss >> n_s;
+    uint64_t n = n_s.empty() ? 1 : parse_u64(n_s.c_str(), "step count");
+    for (uint64_t i = 0; i < n && *steps_left > 0; ++i) {
+      if (rd_u64(memif, HALT_FLAG)) return DbgAction::Done;
+      p->step(1); (*steps_left)--;
+    }
+    fprintf(stderr, "pc=0x%llx\n", (unsigned long long)st->pc);
+    return DbgAction::Continue;
+  }
+  if (cmd == "rs" || cmd == "run" || cmd == "r") {
+    return run_until(memif, p, []() { return false; }, steps_left);
+  }
+  if (cmd == "until" || cmd == "untiln") {
+    std::string kind; iss >> kind;
+    if (kind == "halt") {
+      fprintf(stderr, "until halt …\n");
+      auto act = run_until(memif, p, []() { return false; }, steps_left);
+      fprintf(stderr, "halt_flag=0x%llx pc=0x%llx\n",
+              (unsigned long long)rd_u64(memif, HALT_FLAG),
+              (unsigned long long)st->pc);
+      return act;
+    }
+    if (kind == "pc") {
+      std::string a, b; iss >> a >> b;
+      // until pc <core> <val>  OR  until pc <val>
+      std::string val_s = b.empty() ? a : b;
+      reg_t want = (reg_t)parse_u64(val_s.c_str(), "until pc");
+      fprintf(stderr, "until pc 0x%llx …\n", (unsigned long long)want);
+      auto act = run_until(memif, p, [&]() { return st->pc == want; }, steps_left);
+      fprintf(stderr, "stopped pc=0x%llx\n", (unsigned long long)st->pc);
+      return act;
+    }
+    if (kind == "mem") {
+      std::string a, b, c; iss >> a >> b >> c;
+      // until mem [core] <addr> <val>  OR  until mem <addr> <val>
+      std::string addr_s, val_s;
+      if (!c.empty()) { addr_s = b; val_s = c; }
+      else { addr_s = a; val_s = b; }
+      reg_t addr = (reg_t)parse_u64(addr_s.c_str(), "until mem addr");
+      uint64_t want = parse_u64(val_s.c_str(), "until mem val");
+      fprintf(stderr, "until mem 0x%llx == 0x%llx …\n",
+              (unsigned long long)addr, (unsigned long long)want);
+      auto act = run_until(memif, p, [&]() { return rd_u64(memif, addr) == want; }, steps_left);
+      fprintf(stderr, "stopped pc=0x%llx mem=0x%016llx\n",
+              (unsigned long long)st->pc,
+              (unsigned long long)rd_u64(memif, addr));
+      return act;
+    }
+    if (kind == "reg") {
+      std::string a, b, c; iss >> a >> b >> c;
+      // until reg <core> <r> <v>  OR until reg <r> <v>
+      std::string r_s, v_s;
+      if (!c.empty()) { r_s = b; v_s = c; }
+      else { r_s = a; v_s = b; }
+      int ri = parse_reg_name(r_s);
+      if (ri < 0) { fprintf(stderr, "bad reg %s\n", r_s.c_str()); return DbgAction::Continue; }
+      uint64_t want = parse_u64(v_s.c_str(), "until reg val");
+      fprintf(stderr, "until reg %s == 0x%llx …\n", r_s.c_str(), (unsigned long long)want);
+      auto act = run_until(memif, p, [&]() { return st->XPR[ri] == want; }, steps_left);
+      fprintf(stderr, "stopped pc=0x%llx %s=0x%016llx\n",
+              (unsigned long long)st->pc, r_s.c_str(),
+              (unsigned long long)st->XPR[ri]);
+      return act;
+    }
+    fprintf(stderr, "until: unknown kind '%s' (pc|mem|reg|halt)\n", kind.c_str());
+    return DbgAction::Continue;
+  }
+  fprintf(stderr, "unknown debug cmd: %s (try help)\n", cmd.c_str());
+  return DbgAction::Continue;
+}
+
+static void run_debug_cmd_file(simif_t* memif, processor_t* p,
+                               const char* path, uint64_t* steps_left) {
+  std::ifstream in(path);
+  if (!in) {
+    fprintf(stderr, "spike_run: cannot open SPIKE_DEBUG_CMD=%s\n", path);
+    exit(2);
+  }
+  fprintf(stderr, "spike_run: SPIKE_DEBUG_CMD=%s\n", path);
+  std::string line;
+  while (std::getline(in, line)) {
+    DbgAction a = handle_debug_line(memif, p, line, steps_left);
+    if (a == DbgAction::Quit) {
+      fprintf(stderr, "spike_run: debug quit\n");
+      return;
+    }
+    if (a == DbgAction::Done) {
+      fprintf(stderr, "spike_run: debug done (halt or cap)\n");
+      return;
+    }
+  }
+  fprintf(stderr, "spike_run: debug-cmd EOF\n");
+}
+
 int main(int argc, char** argv) {
-  if (argc != 4) { fprintf(stderr, "usage: %s <guest.elf> <input> <output>\n", argv[0]); return 2; }
+  if (argc != 4) {
+    fprintf(stderr,
+            "usage: %s <guest.elf> <input> <output>\n"
+            "env: SPIKE_COMMITLOG SPIKE_DEBUG_CMD SPIKE_WATCH SPIKE_WATCH_STOP "
+            "SPIKE_BREAK_PC SPIKE_OUTPUT_LEN SPIKE_RUN_DEBUG\n",
+            argv[0]);
+    return 2;
+  }
 
   cfg_t cfg;
   cfg.isa  = "RV64IMAC_Zicclsm";
@@ -127,14 +400,78 @@ int main(int argc, char** argv) {
     }
   }
 
+  uint64_t steps_left = STEP_CAP;
+
+  // Headless debug script (SPIKE_DEBUG_CMD) — runs before free-run.
+  if (const char* dcmd = getenv("SPIKE_DEBUG_CMD")) {
+    if (*dcmd) run_debug_cmd_file(&sim, p, dcmd, &steps_left);
+  }
+
+  // Optional true write-watch / PC log. Stock `until mem` cannot prove absence.
+  bool have_watch = false;
+  reg_t watch_addr = 0;
+  uint64_t watch_prev = 0;
+  uint64_t watch_hits = 0;
+  if (const char* w = getenv("SPIKE_WATCH")) {
+    if (*w) {
+      have_watch = true;
+      watch_addr = (reg_t)parse_u64(w, "SPIKE_WATCH");
+      watch_prev = rd_u64(&sim, watch_addr);
+      fprintf(stderr, "spike_run: SPIKE_WATCH=0x%llx initial=0x%016llx\n",
+              (unsigned long long)watch_addr, (unsigned long long)watch_prev);
+    }
+  }
+  bool watch_stop = false;
+  if (const char* ws = getenv("SPIKE_WATCH_STOP"))
+    watch_stop = ws[0] != '\0' && ws[0] != '0';
+
+  bool have_break_pc = false;
+  reg_t break_pc = 0;
+  bool break_hit = false;
+  if (const char* b = getenv("SPIKE_BREAK_PC")) {
+    if (*b) {
+      have_break_pc = true;
+      break_pc = (reg_t)parse_u64(b, "SPIKE_BREAK_PC");
+      fprintf(stderr, "spike_run: SPIKE_BREAK_PC=0x%llx\n", (unsigned long long)break_pc);
+    }
+  }
+
   // step until the handler signals halt (HALT_FLAG nonzero) or the cap is hit.
   // flag==1 clean halt; flag==2 guest fault (info at HALT_FLAG+0x10/0x18/0x20).
-  uint64_t flagv = 0;
-  for (uint64_t done = 0; done < STEP_CAP; done += STEP_BATCH) {
-    p->step(STEP_BATCH);
-    uint8_t flag[8]; rd(&sim, HALT_FLAG, flag, 8);
-    memcpy(&flagv, flag, 8);
-    if (flagv) break;
+  uint64_t flagv = rd_u64(&sim, HALT_FLAG);
+  if (!flagv) {
+    const bool fine = have_watch || have_break_pc;
+    const size_t batch = fine ? 1 : STEP_BATCH;
+    while (steps_left > 0) {
+      size_t n = batch;
+      if ((uint64_t)n > steps_left) n = (size_t)steps_left;
+      if (have_break_pc && !break_hit && p->get_state()->pc == break_pc) {
+        break_hit = true;
+        fprintf(stderr, "SPIKE_BREAK_PC hit pc=0x%llx\n", (unsigned long long)break_pc);
+        print_regs(p);
+        // fall through: execute the insn at break_pc, then continue
+      }
+      p->step(n);
+      steps_left -= n;
+      if (have_watch) {
+        uint64_t cur = rd_u64(&sim, watch_addr);
+        if (cur != watch_prev) {
+          print_watch_hit(p, watch_addr, watch_prev, cur);
+          watch_prev = cur;
+          watch_hits++;
+          if (watch_stop) {
+            fprintf(stderr, "spike_run: SPIKE_WATCH_STOP — ending run after hit\n");
+            break;
+          }
+        }
+      }
+      flagv = rd_u64(&sim, HALT_FLAG);
+      if (flagv) break;
+    }
+  }
+  if (have_watch) {
+    fprintf(stderr, "spike_run: SPIKE_WATCH done hits=%llu final=0x%016llx\n",
+            (unsigned long long)watch_hits, (unsigned long long)watch_prev);
   }
   if (flagv == 2) {
     uint8_t b[8]; uint64_t mcause=0, mtval=0, mepc=0;
@@ -144,7 +481,7 @@ int main(int argc, char** argv) {
     fprintf(stderr, "spike_run: guest FAULT mcause=0x%llx mtval=0x%llx mepc=0x%llx\n",
             (unsigned long long)mcause, (unsigned long long)mtval, (unsigned long long)mepc);
   } else if (flagv == 0) {
-    fprintf(stderr, "spike_run: step cap reached without halt\n");
+    fprintf(stderr, "spike_run: step cap reached without halt (or watch-stop)\n");
   }
   bool halted = (flagv == 1);
 


### PR DESCRIPTION
## Summary

Harness-native guest debugger for `spike_run`: **true write-watch** (`SPIKE_WATCH`) whose headline answer is **`hits=0` = nothing wrote this address**, plus headless breakpoints (`SPIKE_DEBUG_CMD`) and one-shot PC breaks (`SPIKE_BREAK_PC`).

### Why (the argument for this PR)

`SPIKE_COMMITLOG` is a trace of **writes**. It is structurally blind to the **absence** of a write — the correct-but-unfed class (a global stays zero because no store ever targeted it). The fleet hit that class twice in one day; once it cost **~two hours of commitlog archaeology** (codex on `bsbd_deleg_target` holding 24 zero bytes on a child path) to learn that nothing ever wrote the cell.

A watchpoint that reports **zero hits** is the only cheap instrument that detects nothing-wrote-here. That is the product.

### Worked example (known answer, real guest+fixture — not a toy)

```
guest sha256 7c630c93fb53684b1c0f25d3a7873307bfdfe47fa9180c3ed87e4d8d30491337
run-20260801T112401Z-2945520 / 00000 selfdestructing_initcode…
nm: bsbd_deleg_target @ 0xbaeaa268

SPIKE_WATCH=0xbaeaa268 scripts/spike/spike_run "$ELF" "$IN" /tmp/out
→ spike_run: SPIKE_WATCH=0xbaeaa268 initial=0x0000000000000000
→ spike_run: SPIKE_WATCH done hits=0 final=0x0000000000000000
```

`hits=0` = the two-hour answer, in one command. An instrument proved against a **known** fleet answer is trustworthy in a way one proved only on unknowns never is.

Also validated: `until pc 0x80053704` (h_CREATE) dump regs/mem; `until mem 0x60008000 1` halt; `SPIKE_BREAK_PC` full reg dump; continue to clean halt.

### Byte-identical unset path

With no debug env set, `spike_run` is unchanged:

```
cmp -s /tmp/grok-nodbg.out <prior-run-00000.output>  → MATCH (256 bytes)
```

A debug facility that perturbs the default path is worse than none.

### Honest limits

- `until mem ADDR VAL` is **value-match**, not a write-watch — cannot prove absence; use `SPIKE_WATCH`
- `SPIKE_WATCH` / `SPIKE_BREAK_PC` force `step(1)` — slower full guest; not for CI
- Watch is **8 bytes LE** only (for a 24-byte buffer, watch first dword or three addrs)
- Stock `spike -d` / `--debug-cmd` / `--halted --rbb-port` do **not** apply to our guest: `spike_run` bypasses `sim.run()`→`interactive()` (private), uses custom step loop + `HALT_FLAG` + zisk accel + input preload
- GDB attach impractical today: OpenOCD not installed; `spike_run` has no rbb wire. `SPIKE_WATCH` + `SPIKE_DEBUG_CMD` cover the fleet need without it

### Files

- `scripts/spike/spike_run.cc` — env: `SPIKE_WATCH`, `SPIKE_WATCH_STOP`, `SPIKE_DEBUG_CMD`, `SPIKE_BREAK_PC` (plus existing `SPIKE_COMMITLOG`)
- `scripts/spike/README.md` — full recipe, lead with hits=0 + worked example

Rebuild: `SPIKE_SRC=/path/to/riscv-isa-sim scripts/spike/build.sh`

## Test plan

- [x] `SPIKE_WATCH=0xbaeaa268` on real fixture → hits=0 (known answer)
- [x] `SPIKE_DEBUG_CMD` until pc h_CREATE + until halt
- [x] `SPIKE_BREAK_PC` h_CREATE reg dump
- [x] unset env → cmp byte-identical to prior output
- [ ] reviewer: rebuild spike_run and re-run the one-liner on a local guest
