### PR TITLE
codegen: suppress stale CREATE effects after same-tx SELFDESTRUCT

### DIFF
--- a/EvmAsm/Codegen/Programs/AccountWriteMap.lean
+++ b/EvmAsm/Codegen/Programs/AccountWriteMap.lean
@@ -309,6 +309,26 @@ def accountWritesEmitBuilderTxFunction : String :=
   "  la t0, current_block_access_index; ld s7, 0(t0); la s0, tx_account_writes_count; ld s1, 0(s0); li s2, 0xa2720000; li s3, 0\n" ++
   ".Laweb_loop:\n" ++
   "  bgeu s3, s1, .Laweb_done; slli t0, s3, 7; add s4, s2, t0\n" ++
+  -- Same-tx-created SELFDESTRUCT entries are tracked by the producer.  A
+  -- distinct-beneficiary clear is access-only in the BAL; self-destruction to
+  -- self preserves the live balance, so only its nonce/code are suppressed.
+  -- Byte 20 is producer metadata; overflow leaves the conservative path.
+  "  sd zero, 96(sp)\n" ++
+  "  la t0, evm_selfdestruct_destroyed_overflow; ld t0, 0(t0); bnez t0, .Laweb_destroyed_done\n" ++
+  "  la t0, evm_selfdestruct_destroyed_count; ld t1, 0(t0); beqz t1, .Laweb_destroyed_done\n" ++
+  "  la t2, evm_selfdestruct_destroyed_table\n" ++
+  ".Laweb_destroyed_scan:\n" ++
+  "  mv t3, t2; mv t4, s4; li t5, 20\n" ++
+  ".Laweb_destroyed_cmp:\n" ++
+  "  beqz t5, .Laweb_destroyed_hit\n" ++
+  "  lbu t6, 0(t3); lbu a0, 0(t4); bne t6, a0, .Laweb_destroyed_next\n" ++
+  "  addi t3, t3, 1; addi t4, t4, 1; addi t5, t5, -1; j .Laweb_destroyed_cmp\n" ++
+  ".Laweb_destroyed_next:\n" ++
+  "  addi t2, t2, 32; addi t1, t1, -1; bnez t1, .Laweb_destroyed_scan\n" ++
+  "  j .Laweb_destroyed_done\n" ++
+  ".Laweb_destroyed_hit:\n" ++
+  "  lbu t0, 20(t2); addi t0, t0, 1; sd t0, 96(sp)\n" ++
+  ".Laweb_destroyed_done:\n" ++
   -- Find this address in the block-cumulative map.  A hit may still lack an
   -- individual field, in which case that component keeps the pre-state base.
   "  la t0, account_writes_count; ld t1, 0(t0); li t2, 0xa24a0000; li t3, 0; li s5, 0\n" ++
@@ -333,6 +353,7 @@ def accountWritesEmitBuilderTxFunction : String :=
   -- account_resolve_pre_state's fixed account scratch output.
   "  mv a0, s4; la a1, account_builder_pre_account; la t0, sv_pre_rlp_ptr; ld a2, 0(t0); la t0, sv_pre_rlp_len; ld a3, 0(t0); la t0, bv_witness_state_ptr; ld a4, 0(t0); la t0, bv_witness_state_len; ld a5, 0(t0); jal ra, account_resolve_pre_state\n" ++
   "  ld s8, 112(s4)\n" ++
+  "  ld t0, 96(sp); li t1, 1; beq t0, t1, .Laweb_advance\n" ++
   -- Balance: the resolver has already materialised the block/durable/header
   -- precedence into the shared account scratch.
   "  andi t0, s8, 1; bnez t0, .Laweb_balance_have; j .Laweb_nonce\n" ++
@@ -364,6 +385,7 @@ def accountWritesEmitBuilderTxFunction : String :=
   "  ld t1, 0(s4); la t0, bald_bal_eq_addr_a; sd t1, 0(t0); ld t1, 8(s4); la t0, bald_bal_eq_addr_b; sd t1, 0(t0)\n" ++
   -- Nonce: read the resolver's canonical pre-state scratch.
   ".Laweb_nonce:\n" ++
+  "  ld t0, 96(sp); li t1, 2; beq t0, t1, .Laweb_advance\n" ++
   "  andi t0, s8, 2; bnez t0, .Laweb_nonce_have; j .Laweb_code\n" ++
   ".Laweb_nonce_have:\n" ++
   -- Diagnostic cell, before the `la t0` that this block needs: t1 is dead here

--- a/EvmAsm/Codegen/Programs/Selfdestruct.lean
+++ b/EvmAsm/Codegen/Programs/Selfdestruct.lean
@@ -675,12 +675,16 @@ def selfdestructBeneficiaryNonstorageAsm : String :=
   -- self-destruct-to-self it remains the live balance in sp+32, matching
   -- `clear_account_preserving_balance`.
   "  sd zero, 0(sp); sd zero, 8(sp); sd zero, 16(sp); sd zero, 24(sp)\n" ++
-  "  la t0, sdai_origin_address; la t1, evm_selfdestruct_beneficiary; li t2, 20\n" ++
+  "  sd zero, 224(sp); la t0, sdai_origin_address; la t1, evm_selfdestruct_beneficiary; li t2, 20\n" ++
   ".L_sdbn_clear_self_cmp:\n" ++
   "  beqz t2, .L_sdbn_clear_self\n" ++
   "  lbu t3, 0(t0); lbu t4, 0(t1); bne t3, t4, .L_sdbn_clear_distinct\n" ++
   "  addi t0, t0, 1; addi t1, t1, 1; addi t2, t2, -1; j .L_sdbn_clear_self_cmp\n" ++
   ".L_sdbn_clear_self:\n" ++
+  -- Existing destroyed-table readers consume only the first 20 bytes.  Keep
+  -- byte 20 as metadata so the BAL consumer can preserve self-transfer
+  -- balance while suppressing stale CREATE fields for a distinct beneficiary.
+  "  li t0, 1; sd t0, 224(sp)\n" ++
   "  addi a1, sp, 32; mv a2, a1; j .L_sdbn_record_clear\n" ++
   ".L_sdbn_clear_distinct:\n" ++
   "  mv a1, sp; mv a2, sp\n" ++
@@ -698,6 +702,7 @@ def selfdestructBeneficiaryNonstorageAsm : String :=
   "  beqz t5, .L_sdbn_destroyed_copied\n" ++
   "  lbu t6, 0(t4); sb t6, 0(t3); addi t4, t4, 1; addi t3, t3, 1; addi t5, t5, -1; j .L_sdbn_destroyed_copy\n" ++
   ".L_sdbn_destroyed_copied:\n" ++
+  "  ld t5, 224(sp); sb t5, 0(t3)\n" ++
   "  addi t1, t1, 1; sd t1, 0(t0); j .L_sdbn_destroyed_done\n" ++
   ".L_sdbn_destroyed_overflow:\n" ++
   "  la t0, evm_selfdestruct_destroyed_overflow; li t1, 1; sd t1, 0(t0)\n" ++


### PR DESCRIPTION
## Spec-aligned fix

execution-specs queues same-transaction SELFDESTRUCT origins for deletion (`execution-specs/src/ethereum/forks/amsterdam/vm/instructions/system.py:691-694`), applies `clear_account_preserving_balance` before BAL incorporation (`fork.py:1201-1204`), and clears nonce/code while preserving only balance (`state_tracker.py:536-557`). BAL rows are derived from the final transaction account-write feed (`block_access_lists.py:637-664`).

The guest was retaining stale CREATE nonce/code fields for a created-in-this-transaction SELFDESTRUCT victim. This change records producer metadata for each destroyed-table entry and makes the account-write emitter suppress stale fields for a distinct beneficiary. For self-destruction to self, the live balance is preserved and only nonce/code are suppressed. The metadata byte is documented at both producer and consumer; table overflow retains the conservative path.

## Evidence

- 16-row `test_selfdestruct_to_precompile_state_access_boundary` family: `FA=0, FR=3, OK=13`.
- The three expected-valid rows still reject at the separate code-44 nonstorage-consistency gate, but their BALs now match exactly:
  - `915e96f535cfbf3a`: `409/397 shadow1` before -> `397/397 shadow0` after.
  - `ea8766f464b07db0`: `400/391` before -> `391/391 shadow0` after.
  - `1addede5103fdeb4`: `400/391` before -> `391/391 shadow0` after.
- The remaining code-44 residual is filed as #11089 with the three SHAs and fresh parity evidence; it is exposed by this fix, not caused by it.
- 200-row A/B on the frozen `x998` manifest: parent `FA=0 FR=13 OK=187`, candidate `FA=0 FR=13 OK=187`; zero guest-success transitions in either direction.
- Parent provenance: the parent leg was measured on base `37da3b456` using ELF SHA256 `aa9af7753b74176a2e30d31d39e816da385601622b29388981f6f00fd6e7dacf`; main has since advanced to `95a2a436f`.
- Re-measurement was not warranted: the source diff is confined to `AccountWriteMap.lean` and `Selfdestruct.lean`, and the A/B showed zero success transitions in either direction.
- Candidate ELF SHA256: `7425d5a9e59b866a57cc038b9fed22dc74e97c065cafe74e4f48c94348b5f14d`.

Closes #11087; residual tracked in #11089.
