### PR TITLE
refactor(codegen): REVERT log restore from body slab; retire env+456/+480 (#10981)

### DIFF
--- a/EvmAsm/Codegen/Dispatch.lean
+++ b/EvmAsm/Codegen/Dispatch.lean
@@ -1151,7 +1151,7 @@ def emitDispatcherPrologue : String :=
   -- at STATE_TRACKER_AREA (0xa0630000 / 0xa0830000) outside `.data`;
   -- the regions are byte-accessed directly by the storage handlers.
   "  sd x0, 448(x20)\n" ++         -- env.persistentLogLengthOff = 0
-  "  sd x0, 456(x20)\n" ++         -- env.persistentLogCheckpointOff = 0
+  -- GH #10981: env+456 persistentLogCheckpoint retired (slab is sole source).
   "  la x5, evm_refund_acc; sd x0, 0(x5)\n" ++   -- bmvmx.1.6.3: reset per-tx refund counter
   "  la x5, evm_selfdestruct_staged; sd x0, 0(x5)\n" ++   -- reset per-tx SELFDESTRUCT execution flag
   "  la x5, evm_selfdestruct_seen_count; sd x0, 0(x5)\n" ++
@@ -1178,7 +1178,7 @@ def emitDispatcherPrologue : String :=
   "  sd x0, 472(x20)\n" ++         -- env.eventLogLengthOff = 0
   "  la x5, evm_log_data_used; sd x0, 0(x5)\n" ++       -- 8uld3.1a: reset per-tx full-log-data buffer cursor
   "  la x5, evm_log_data_overflow; sd x0, 0(x5)\n" ++   -- 8uld3.1a: reset per-tx full-log-data overflow flag
-  "  sd x0, 480(x20)\n" ++         -- env.eventLogCheckpointOff = 0
+  -- GH #10981: env+480 eventLogCheckpoint retired (slab is sole source).
   "  sd x0, 488(x20)\n" ++         -- runtime activeMemorySize = 0
   "  sd x0, 512(x20)\n" ++         -- M28: blobBaseFee trailer slot = 0
   "  sd x0, 520(x20)\n" ++
@@ -2532,7 +2532,7 @@ def emitRuntimeDispatcherSetupWithInputAsm (inputAsm : String) : String :=
   "  li x28, 16384\n" ++
   "  bgtu x6, x28, .exit_invalid\n" ++
   "  sd x6, 448(x20)\n" ++         -- env.persistentLogLengthOff = preload count
-  "  sd x6, 456(x20)\n" ++         -- env.persistentLogCheckpointOff = preload count
+  -- GH #10981: no env+456 checkpoint write; body slab captures 448 at tx start.
   "  sd x0, 464(x20)\n" ++         -- env.transientLogLengthOff = 0
   "  sd x0, 472(x20)\n" ++         -- env.eventLogLengthOff = 0
   -- 8uld3.2.1.3 FIX: reset the per-tx full-log-data globals via x28 (a dead scratch
@@ -2583,7 +2583,7 @@ def emitRuntimeDispatcherSetupWithInputAsm (inputAsm : String) : String :=
   -- The exceptional exits and RETURN/REVERT tails overwrite it during this
   -- dispatch; a clean STOP leaves this 0.
   "  li x28, 0xa0010000; sd x0, 32(x28)\n" ++
-  "  sd x0, 480(x20)\n" ++         -- env.eventLogCheckpointOff = 0
+  -- GH #10981: no env+480 checkpoint write; body slab is sole event checkpoint.
   "  sd x0, 488(x20)\n" ++         -- runtime activeMemorySize = 0
   "  sd x0, 512(x20)\n" ++         -- M28: blobBaseFee[0] = 0 (overwritten by trailer load below)
   "  sd x0, 520(x20)\n" ++         -- M28: blobBaseFee[1] = 0

--- a/EvmAsm/Codegen/Programs/BlockVerdictCreationStage.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictCreationStage.lean
@@ -573,7 +573,7 @@ def blockVerdictCreationRuntimeFunction : String :=
   -- execution effects/logs are rolled back to the pre-dispatch snapshots while
   -- the access rows are TRUNCATED to the pre-dispatch snapshot (GH #10654).
   ".Lbvcr_deposit_exception:\n" ++
-  "  la t0, evm_env; sd zero, 568(t0); sd zero, 472(t0); sd zero, 480(t0)\n" ++
+  "  la t0, evm_env; sd zero, 568(t0); sd zero, 472(t0)\n" ++
   "  la t0, evm_log_data_used; sd zero, 0(t0); la t0, evm_log_data_overflow; sd zero, 0(t0)\n" ++
   -- Roll back every body-written arena to the shared pre-dispatch mark.  In
   -- particular this deliberately leaves the read sets intact: the spec's
@@ -613,7 +613,7 @@ def blockVerdictCreationRuntimeFunction : String :=
   -- endowment Transfer re-emitted before initcode.  Match the normal
   -- top-level dispatch path before taking this transaction's log snapshot.
   "  bnez s3, .Lbvcr_tl7708_snapshot\n" ++
-  "  la t0, evm_env; sd x0, 472(t0); sd x0, 480(t0)\n" ++
+  "  la t0, evm_env; sd x0, 472(t0)\n" ++
   ".Lbvcr_tl7708_snapshot:\n" ++
   "  jal ra, block_log_window_snapshot\n" ++
 

--- a/EvmAsm/Codegen/Programs/BlockVerdictDispatchTx.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictDispatchTx.lean
@@ -1182,7 +1182,8 @@ def dispatchTxRuntimeCodeFunction : String :=
   -- after settlement has classified the top-level tx status. A failed top-level
   -- transaction rolls back all LOGs, even logs committed by successful child calls.
   "  bnez s2, .Ldtrc_snapshot_logs\n" ++
-  "  la t0, evm_env; sd x0, 472(t0); sd x0, 480(t0)\n" ++
+  -- GH #10981: failed top-level tx clears live event cursor only; env+480 retired.
+  "  la t0, evm_env; sd x0, 472(t0)\n" ++
   ".Ldtrc_snapshot_logs:\n" ++
   "  jal ra, block_log_window_snapshot\n" ++
   "  mv t3, s0                    # effective gas_left\n" ++

--- a/EvmAsm/Codegen/Programs/CallBalanceGate.lean
+++ b/EvmAsm/Codegen/Programs/CallBalanceGate.lean
@@ -64,8 +64,8 @@ def callBalanceGatePrologue : String :=
   "  li t0, 1000000\n  sd t0, 568(x20)\n" ++   -- gasRemaining
   "  li t0, 10\n  sd t0, 496(x20)\n" ++          -- codeSize (10-byte parent program)
   "  sd x0, 448(x20)\n" ++                       -- persistentLogLength = 0
-  "  sd x0, 456(x20); sd x0, 464(x20)\n" ++
-  "  sd x0, 472(x20); sd x0, 480(x20); sd x0, 488(x20)\n" ++
+  "  sd x0, 464(x20)\n" ++
+  "  sd x0, 472(x20); sd x0, 488(x20)\n" ++
   "  la t0, evm_call_depth; sd x0, 0(t0)\n" ++
   -- CALL stack: 7 args at x12 = evm_stack_top - 224 (gas@0, to@32, value@64, ...).
   "  la x12, evm_stack_top\n" ++

--- a/EvmAsm/Codegen/Programs/CallFrameDescend.lean
+++ b/EvmAsm/Codegen/Programs/CallFrameDescend.lean
@@ -361,13 +361,11 @@ def callFrameDescendFunction : String :=
   -- logs from the parent's current length (so child writes append and a child REVERT
   -- rolls back to here), and reset the child's memory size to 0 (fresh 128 KiB).
   "  ld t0, 448(s3); sd t0, 448(s9)   # persistentLogLength (continue global log)\n" ++
-  -- env+456/+480 remain live REVERT-tail checkpoints (NoopHalt reads them).
-  -- They deliberately duplicate the canonical depth-indexed body snapshot below;
-  -- a future NoopHalt retarget can retire them as its own behavioral change.
-  "  sd t0, 456(s9)                    # persistentLogCheckpoint = current (REVERT point)\n" ++
+  -- GH #10981: env+456/+480 REVERT checkpoints retired. NoopHalt REVERT reads
+  -- body_state_snapshot_by_depth[d] (+40 persistent, +56 event) instead; the
+  -- slab capture below is the sole checkpoint source.
   "  ld t0, 464(s3); sd t0, 464(s9)   # transientLogLength\n" ++
   "  ld t0, 472(s3); sd t0, 472(s9)   # eventLogLength\n" ++
-  "  sd t0, 480(s9)                    # eventLogCheckpoint = current\n" ++
   "  sd x0, 488(s9)                    # activeMemorySize = 0 (fresh child memory)\n" ++
   -- 8b2 (1ipxd): inherit the tx/block-constant env fields (txOrigin@128 .. chainId@384,
   -- a contiguous 288-byte block env+128..415) from the parent. call_frame_set_call_env

--- a/EvmAsm/Codegen/Programs/CallFrameRoundtrip.lean
+++ b/EvmAsm/Codegen/Programs/CallFrameRoundtrip.lean
@@ -58,8 +58,8 @@ def callFrameRoundtripPrologue : String :=
   "  la x21, rt_parent_code\n" ++
   "  li t0, 1000000\n  sd t0, 568(x20)\n" ++       -- parent gasRemaining
   "  li t0, 20\n  sd t0, 496(x20)\n" ++             -- parent codeSize
-  "  sd x0, 448(x20); sd x0, 456(x20); sd x0, 464(x20)\n" ++
-  "  sd x0, 472(x20); sd x0, 480(x20)\n" ++
+  "  sd x0, 448(x20); sd x0, 464(x20)\n" ++
+  "  sd x0, 472(x20)\n" ++
   "  la t0, evm_call_depth; sd x0, 0(t0)\n" ++
   -- Build the call descriptor for the manual descend (child = rt_child_code).
   "  la t2, rt_cd_desc\n" ++

--- a/EvmAsm/Codegen/Programs/CallValueEffect.lean
+++ b/EvmAsm/Codegen/Programs/CallValueEffect.lean
@@ -59,8 +59,8 @@ def callValueEffectPrologue : String :=
   "  li t0, 1000000\n  sd t0, 568(x20)\n" ++   -- gasRemaining
   "  li t0, 10\n  sd t0, 496(x20)\n" ++          -- codeSize (10-byte parent program)
   "  sd x0, 448(x20)\n" ++                       -- persistentLogLength = 0
-  "  sd x0, 456(x20); sd x0, 464(x20)\n" ++
-  "  sd x0, 472(x20); sd x0, 480(x20); sd x0, 488(x20)\n" ++
+  "  sd x0, 464(x20)\n" ++
+  "  sd x0, 472(x20); sd x0, 488(x20)\n" ++
   "  la t0, evm_call_depth; sd x0, 0(t0)\n" ++
   -- CALL stack: 7 args at x12 = evm_stack_top - 224 (gas@0, to@32, value@64, ...).
   "  la x12, evm_stack_top\n" ++

--- a/EvmAsm/Codegen/Programs/CreateRoundtrip.lean
+++ b/EvmAsm/Codegen/Programs/CreateRoundtrip.lean
@@ -54,8 +54,8 @@ def createRoundtripPrologue : String :=
   "  la x21, cr_parent_code\n" ++
   "  li t0, 1000000\n  sd t0, 568(x20)\n" ++        -- gasRemaining
   "  li t0, 21\n  sd t0, 496(x20)\n" ++             -- codeSize (2-CREATE verify)
-  "  sd x0, 448(x20); sd x0, 456(x20); sd x0, 464(x20)\n" ++   -- storage log length etc.
-  "  sd x0, 472(x20); sd x0, 480(x20)\n" ++
+  "  sd x0, 448(x20); sd x0, 464(x20)\n" ++   -- storage log length etc.
+  "  sd x0, 472(x20)\n" ++
   "  sd x0, 584(x20)\n" ++                          -- no account-witness ctx -> clean CREATE path
   "  la t0, evm_call_depth; sd x0, 0(t0)\n" ++
   -- Pre-load the 10-byte init code into evm_memory[0..10].

--- a/EvmAsm/Codegen/Programs/NoopHalt.lean
+++ b/EvmAsm/Codegen/Programs/NoopHalt.lean
@@ -6,6 +6,7 @@
 -/
 
 import EvmAsm.Codegen.Dispatch
+import EvmAsm.Codegen.Programs.BodyStateSnapshot
 import EvmAsm.Codegen.Programs.EvmAccessGas
 import EvmAsm.Codegen.Programs.EvmMemoryGas
 import EvmAsm.Codegen.Programs.Selfdestruct
@@ -783,11 +784,19 @@ def haltHandlers (depthAware : Bool) (sparseWindows : Bool := false) : List Opco
                  returnRevertMemoryGasAsm "revert" sparseWindows
     , body    := []
     , tail    := .custom <|
+        -- GH #10981: REVERT restores log cursors from the per-depth body slab
+        -- (offsets +40 persistent, +56 event — bodyStateCaptureCursorsAsm), not
+        -- from env+456/+480. Those cells duplicated the slab; CallFrameReturn
+        -- already reads the slab. Transient zero at 464 is unchanged (prior
+        -- behaviour). Depth d = evm_call_depth (still the reverting frame).
         returnRevertTail 2
-          ("  ld x17, 456(x20)\n" ++
+          ("  la t0, evm_call_depth; ld t0, 0(t0); " ++
+           bodyStateSlabStrideOps "t0" "t1" "t2" ++
+           "; la t2, body_state_snapshot_by_depth; add t2, t2, t1\n" ++
+           "  ld x17, 40(t2)\n" ++
            "  sd x17, 448(x20)\n" ++
            "  sd x0, 464(x20)\n" ++
-           "  ld x17, 480(x20)\n" ++
+           "  ld x17, 56(t2)\n" ++
            "  sd x17, 472(x20)\n") depthAware sparseWindows }
   , { label := "h_INVALID", opcodes := [0xfe]
     , body := []

--- a/EvmAsm/Codegen/Programs/Storage.lean
+++ b/EvmAsm/Codegen/Programs/Storage.lean
@@ -22,7 +22,7 @@
 
   Log lengths live in env:
     env+448  persistentLogLengthOff  (live counter; SSTORE increments)
-    env+456  persistentLogCheckpointOff  (set at prologue end; restored on REVERT)
+    env+456  retired (GH #10981; REVERT reads body_state_snapshot slab +40)
     env+464  transientLogLengthOff  (live counter; TSTORE increments; reset on REVERT)
 
   ## Semantics

--- a/EvmAsm/Codegen/Programs/StorageMultiContract.lean
+++ b/EvmAsm/Codegen/Programs/StorageMultiContract.lean
@@ -51,8 +51,8 @@ def storageMultiContractPrologue : String :=
   "  li t0, 0xAA\n  sd t0, 0(x20)\n" ++
   "  sd x0, 8(x20); sd x0, 16(x20); sd x0, 24(x20)\n" ++
   -- log-state cells (checkpoint / transient / event / memsize), all 0.
-  "  sd x0, 456(x20); sd x0, 464(x20)\n" ++
-  "  sd x0, 472(x20); sd x0, 480(x20); sd x0, 488(x20)\n" ++
+  "  sd x0, 464(x20)\n" ++
+  "  sd x0, 472(x20); sd x0, 488(x20)\n" ++
   -- pre-seed the persistent log with two prior cross-contract writes.
   "  li t1, 0xa0630000\n" ++
   -- log[0] = (addrHash B 0xBB, slotKey 7, original 0, current 0x99).


### PR DESCRIPTION
## Summary
Closes the #10981 deletion: retarget NoopHalt's REVERT log-cursor restore to the per-depth body slab, then stop writing the redundant `env+456` / `env+480` checkpoints.

## COMPARE before remove (required)
SPIKE_WATCH on **main** guest `a9ab01d44` / sha `3b424822…8d58`, nested CREATE fixture (selfdestructing_initcode 00001):

| cell | final | hits |
|---|---|---|
| child env+456 | `0x17` | 1 |
| `slab[d]+40` | `0x17` | 1 |
| child env+480 | `0x2` | 1 |
| `slab[d]+56` | `0x2` | 1 |

No mid-frame second write — **no divergence**. Source census agrees: only `call_frame_descend` (plus init/preload pairing 448 with 456) wrote the cells, always from the same parent live cursor the slab captures one block later.

## Change
- **NoopHalt REVERT rollbackAsm**: load persistent/event from `body_state_snapshot_by_depth[depth]+40/+56`; keep `sd x0, 464(x20)` transient behaviour
- **Remove writes** to env+456/+480 in CallFrameDescend, Dispatch (setup+preload), BlockVerdictDispatchTx failed-tx clear, BlockVerdictCreationStage, probe inits
- Physical env slots left as unused padding (no renumber of live 464/472/488)

## Measure (structural bar)
```
# fix (built)
scripts/codegen-eest-stateless-check.sh --backend spike --limit 200 --jobs 4 --progress
# main baseline
… --guest-elf <main a9ab01d44 guest>
```
| | guest | full pass | fail |
|---|---|---|---|
| main `a9ab01d44` | `3b424822…` | 123 | 77 |
| this PR | `3f4badda…` run-20260801T180549Z-375573 | 123 | 77 |

**200/200 actual_hex identical** — no deterioration, no forward flips.

## Out of scope
- Class B selfdestructing residual (parked)
- Env ABI renumber / reclaiming the two u64 holes
