### PR TITLE
fix(bal): remove obsolete modeled-system storage skip

### DIFF
--- a/EvmAsm/Codegen/Programs/BalAllAccountsStorage.lean
+++ b/EvmAsm/Codegen/Programs/BalAllAccountsStorage.lean
@@ -77,21 +77,6 @@ def balAllAccountsStorageConsistentFunction : String :=
   "  bnez a1, .Lc2baas_fail\n" ++
   "  li t2, 20; bne a2, t2, .Lc2baas_next   # not 20B -> skip\n" ++
   "  sub s10, a0, a2              # addr ptr (20B BE)\n" ++
-  -- fhsxz.2.4.2.57.11.6.5.1: skip the EIP-2935 (history) / EIP-4788 (beacon-roots) system
-  -- contracts. Their storage is written by the block-level system calls and verified by the
-  -- verdict's explicit EIP-2935/4788 replay, NOT the per-tx exec log; every Amsterdam block's BAL
-  -- carries their storage rows, so comparing them here vs the (legitimately exec-log-absent) per-tx
-  -- log would false-reject the instant contract-recipient dispatch succeeds. SOUND: the explicit
-  -- replay independently pins their storage (mirrors BalAccountRecordArray's bara_skip_modeled_system).
-  -- CONVERGENCE DEPENDENCY (#10765): this skip is load-bearing until a rebuilt BAL has
-  -- BAI-0 system rows. Do not retire it independently: a digest built only from per-tx
-  -- rows cannot replace the explicit system replay that currently validates these accounts.
-  -- s7/s9 = AccountChanges ptr/len. The helper preserves saved registers and uses its own
-  -- bams_* scratch, so s10 stays valid for the recipient compare below.
-  "  mv a0, s7; mv a1, s9\n" ++
-  "  jal ra, bal_account_is_modeled_system\n" ++
-  "  li t0, 1; beq a0, t0, .Lc2baas_next       # EIP-2935 history row -> skip\n" ++
-  "  li t0, 2; beq a0, t0, .Lc2baas_next       # EIP-4788 beacon-roots row -> skip\n" ++
   "  li t4, 0                    # skip-list index\n" ++
   ".Lc2baas_skip_outer:\n" ++
   "  beq t4, s8, .Lc2baas_check  # not in skip-list -> check it\n" ++


### PR DESCRIPTION
## Summary

Removes the EIP-2935/EIP-4788 special-case branches from `bal_all_accounts_storage_consistent`. The classifier remains because `BalAccountRecordArray`, `BlockVerdictStateRoot`, and `BlockVerdictFunction` still consume it; this comparator is now one consumer lighter.

The skip was a guest-only compensation for a comparator blind spot. Main already repaired that blind spot by materializing modeled BAI-0 rows into `bv_system_storage_log` and scanning the system and per-transaction side arenas (`328f53f9`, `b2a729a0`, `9747eb3c`, `50244aa1`). No comparator code was added here: the before/after measurements showed no exposed failures to repair.

`execution-specs` Amsterdam has no corresponding account exclusion and no BAL consistency comparator; it includes the modeled system effects in the block-level access-list container. The guest-only address skip therefore has no remaining spec basis.

## History

- `f177244638`: introduced the modeled-system classifier.
- `585b633e83`: added this all-account skip after `bv_fail=37` on the 16-row `multi_transaction_gas_accounting` probe.
- `0ae9741196`: extended the same compensation to the single-transaction path.
- The later comparator repairs listed above remove the cause of the compensation.

## Validation

All runs used the custom Spike runner with `SPIKE_OUTPUT_LEN=1024`: runner SHA256 `5b383a7702fb05dea16a2cc37dc313b82491fdf194f39c12306cb387a5a2b6b0`, fixture tag `tests-zkevm@v0.6.2`, and execution-specs `e5a8caf1b8055e4d805c7fb169edfa710914b7da`. Measurements were refreshed after rebasing onto main `366691458c7c04175c77893544c63a1e3208393b`; the PR head is `f5be2e440ca54a527b38a7e7754ce0db6c559f37`.

Current-tip guest artifacts: pre-deletion ELF SHA256 `6b900b918309527f699886dcec096e53a4a7681af307827a9365116481977569`, final ELF SHA256 `331c3758a087fedcfe4200d6688c477bd8f5104fae1110218a9d7517c3f4d098`; assembly SHA256s are `03d67059e1c479e46b7d601759a47e2d29a91d985245ee09a3c75ac5eb0ad69d` and `a549fbf55e5efb6fc23dc6d41e372fa7ee23f8ce8f5b58d199262f91b5abe3e7`.

| Population | Before | After |
| --- | --- | --- |
| `multi_transaction_gas_accounting` (16) | 16/16 full, fail 0, `bv_fail=37` 0 | 16/16 full, fail 0, `bv_fail=37` 0 |
| EIP-2935 (24) | 24/24 full, fail 0 | 24/24 full, fail 0 |
| EIP-4788 (22) | 22/22 full, fail 0 | 22/22 full, fail 0 |
| seeded random 200, seed `20260801` | 195/200 full, fail 5 | 195/200 full, fail 5 |

The random sample produced the exact same five unrelated false rejects in both legs: `tx_entry_point`, `selfdestructing_initcode_preserves_balance`, `bal_precompile_funded`, `gas_price_diff_places`, and `scenarios SUICIDE`. No storage-skip delta or `bv_fail=37` exposure appeared.

`lake build` passed (4800 jobs) and `git diff --check` passed.

Relates to #10684.