### PR TITLE
docs(codegen): correct three refuted claims about the witness tier (#11105)

### DIFF
--- a/EvmAsm/Codegen/Programs/BlockVerdictDataSection.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictDataSection.lean
@@ -551,8 +551,10 @@ def ziskStatelessVerdictV2DataSection : String :=
   "csce_addrkey:\n  .zero 32\n" ++
   "csce_keys:\n  .zero " ++ toString (bsrAccountSlotCap * 32) ++ "\n" ++   -- .66.1.2: bsrAccountSlotCap x 32-byte slot keys (matches the gas-derived bal_recipient_storage_keys cap; the seed loop still skips accounts >128)
   -- 1ipxd.1: pre-resolved per-account balance table for nested-frame SELFBALANCE.
-  -- seed_callee_storage fills it (clean pre-execution context, where the witness MPT walk
-  -- works — it returns absent mid-EVM-execution); call_frame_descend reads it to stage a
+  -- seed_callee_storage fills it (clean pre-execution context). ⚠️ This used to add "where the
+  -- witness MPT walk works — it returns absent mid-EVM-execution"; GH #11105 refuted that as an
+  -- inherent restriction (the ACCOUNT walk resolved mid-execution from h_SSTORE's tier 3; it is
+  -- the SLOT walk that fails, 64 of 64, in every phase). call_frame_descend reads it to stage a
   -- child frame's env+32. Entry = 64 B: canonical-BE 20-byte address (zero-padded to 32) @0,
   -- balance @32 in LE-limb (stack-word) order so the descend copies it verbatim to the LE
   -- EVM stack via h_SELFBALANCE (odq06 byte-order lesson). 128 cap. csce_bal_struct = the

--- a/EvmAsm/Codegen/Programs/BlockVerdictDispatchTx.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictDispatchTx.lean
@@ -122,8 +122,15 @@ def seedCalleeStorageFunction : String :=
   "  la t0, csce_dlen; ld t1, 0(t0); li t2, 20; bne t1, t2, .Lscs_acct_next   # item0 not a 20B address\n" ++
   "  la t0, csce_doff; ld t1, 0(t0); add t1, s3, t1; la t0, csce_addrp; sd t1, 0(t0)   # addr ptr (BE)\n" ++
   -- 1ipxd.1: pre-resolve this BAL account's balance into callee_balance_table (clean
-  -- pre-execution context; the witness MPT walk returns absent if run mid-EVM-execution
-  -- inside call_frame_descend). Covers the recipient too (it IS a BAL account; the recipient
+  -- pre-execution context). ⚠️ This used to say "the witness MPT walk returns absent if run
+  -- mid-EVM-execution inside call_frame_descend" as if it were an inherent restriction. It is
+  -- not: GH #11105 measured h_SSTORE's tier-3 witness read running mid-EVM-execution and at
+  -- least 14 of its 16 well-formed calls RESOLVED an account from the witness there. What does
+  -- fail, in every phase and for every caller, is the SLOT walk (64 of 64 inside
+  -- mpt_lookup_by_key). The `call_frame_descend` window specifically was not measured, so
+  -- pre-resolving here is retained on the original conservative grounds -- but do not cite the
+  -- old sentence as a reason the demand-driven read cannot work. Covers the recipient too (it
+  -- IS a BAL account; the recipient
   -- skip below is storage-only). Key = canonical-BE 20-byte addr (csce_addrp); value = balance
   -- stored LE-limb so the descend copies it verbatim to the LE EVM stack (odq06 byte-order).
   -- Header = svf_parent_rlp (parent/witness root; the single-tx POST header bails). The verdict

--- a/EvmAsm/Codegen/Programs/Storage.lean
+++ b/EvmAsm/Codegen/Programs/Storage.lean
@@ -285,15 +285,52 @@ def storagePersistentLogFindAsm : String :=
     slot. That is why a demand-driven `h_SLOAD` must reuse this chain rather than
     call `sload_at_header_state_root`, which resolves the witness tier ALONE.
 
-    ⛔ AND TIER 3 DOES NOT WORK. `slot_at_header_state_root` returns status 4
-    (header parse / state_root size fail) on EVERY call from this chain -- measured
-    16 for 16 the first time anything reached it (GH #11105). Three operand sources
-    were tried, including the verbatim operands the two working callers pass, and
-    all three failed identically, so the cause is the frame/phase rather than the
-    arguments. This chain has never executed in production because the preload
-    means SSTORE never sees a cold miss either. Do not build on tier 3 until #11105
-    is fixed, and note that every non-zero status is flattened to value 0 -- so a
-    broken authenticated read is indistinguishable from an absent slot.
+    ⛔ AND TIER 3 DOES NOT WORK -- BUT NOT WHERE THIS DOCSTRING USED TO SAY.
+    The failure is total and it is in the SLOT WALK, not the header. Measured on
+    `main` at `d97788890` over two rows that both have a NONZERO pre-state slot
+    (`00000_test_sstore_xto_y_...d4-g0__b0`, `00163_test_sstore_xto_x_...d1-g0__b0`),
+    with the preload starved so cold misses actually occur, counting every internal
+    exit of `slot_at_header_state_root` and pooling all callers. Identical on both
+    rows (GH #11105):
+
+    | | count |
+    |---|---|
+    | total calls | 82 |
+    | died in `header_extract_state_root` (status 4) | 16 |
+    | reached `account_at_address` -- header OK | 66 |
+    | died in `account_at_address` | 2 |
+    | reached `slot_at_index` -- header AND account resolved | 64 |
+    | died in `slot_at_index` | **64** |
+    | succeeded | **0** |
+
+    One level down, all 64 fail inside `mpt_lookup_by_key` and ZERO reach
+    `slot_decode_u256`: the trie walk finds no key, ever. The attribution is forced
+    rather than plausible -- `h_SSTORE` makes 32 calls of which exactly 16 load a
+    ZERO header length, matching the status-4 count exactly, and
+    16 + 34 (`bal_emit_storage_changes`) + 16 (`predeploy_preload`) = 66 = the
+    header-OK count with nothing left over. `h_SSTORE`'s other 16 calls carry a
+    well-formed header (len `0x27c`) and a witness pointer at header+len, and they
+    still fail.
+
+    ⚠️ THREE CLAIMS WERE REFUTED BY THAT MEASUREMENT and are recorded here so nobody
+    re-derives them:
+    * that status 4 comes back on EVERY call -- it is 16 of 82;
+    * that `seed_callee_storage` / `stage_predeploy_storage_preload` are WORKING
+      callers -- `seed_callee_storage` made ZERO calls on both rows, so the phrase
+      had no evidence behind it and no caller of this routine is known to succeed;
+    * that the raw slot key needs keccak-hashing first -- `mpt_lookup_by_key` calls
+      `zkvm_keccak256` itself, and `account_at_address` reaches the trie through the
+      SAME routine and succeeds at least 64 times in the same run.
+
+    That last one is also the control: 168 `mpt_lookup_by_key` calls in one run, 64
+    via `slot_at_index` with ZERO successes and 104 elsewhere with at least 64.
+    Same routine, same run, same hashing -- differing only in root and node
+    container.
+
+    Do not build on tier 3. Note that every non-zero status is flattened to value 0,
+    so a broken authenticated read is indistinguishable from an absent slot; and
+    that this chain never executes in production anyway, because the preload means
+    SSTORE never sees a cold miss.
 
     `p` prefixes the named labels so both handlers can instantiate it.
     `out` is a 64-byte scratch buffer, also used to stage the canonical


### PR DESCRIPTION
Doc-only. Three prose claims about the witness tier are **refuted by measurement**; this replaces them
with the funnel that was actually measured. No emitted asm changes — see the byte-identity gate below.

## Why prose, and why now

The sentence *"the witness MPT walk returns absent if run mid-EVM-execution"* was a **symptom of a null
pointer written as an inherent restriction** (#11105 → fixed by #11110). While it stood it foreclosed
the demand-driven direction #10874 needs. The three claims corrected here are the same failure mode in
the same file family, and two of them actively misled a reader this afternoon: the
compare-against-a-working-caller method was built on one, and a resolves-now-versus-not-sufficient
dichotomy was framed on the other.

## What was wrong

`Storage.lean` / `storagePrestateResolveAsm`:

| claim | status |
|---|---|
| `slot_at_header_state_root` returns status 4 on **EVERY** call | ⛔ true for **16 of 82** |
| `seed_callee_storage` / `stage_predeploy_storage_preload` are **WORKING callers** | ⛔ `seed_callee_storage` made **zero** calls; **no** caller is known to succeed |
| (implied elsewhere) the raw slot key needs keccak-hashing first | ⛔ `mpt_lookup_by_key` hashes its own key |

`BlockVerdictDispatchTx.lean` and `BlockVerdictDataSection.lean`: *"the witness MPT walk returns absent
mid-EVM-execution"* — stated unqualified, refuted for the **account** walk.

## What is true, measured

`main` at `d97788890`, preload starved so cold misses occur, counting **every** internal exit of
`slot_at_header_state_root` and pooling all callers. Two rows, both with a **nonzero pre-state slot** —
`00000_test_sstore_xto_y_…d4-g0__b0` and `00163_test_sstore_xto_x_…d1-g0__b0`. **Identical on both.**

| | count |
|---|---|
| total calls | 82 |
| died in `header_extract_state_root` (status 4) | 16 |
| reached `account_at_address` — header OK | 66 |
| died in `account_at_address` | 2 |
| reached `slot_at_index` — header **and** account resolved | 64 |
| **died in `slot_at_index`** | **64** |
| **succeeded** | **0** |

One level down: all 64 fail in `mpt_lookup_by_key`, **zero** reach `slot_decode_u256`. The trie walk
finds no key, ever.

The attribution is **forced, not plausible**: `h_SSTORE` makes 32 calls of which exactly **16** load a
zero header length, matching the status-4 count exactly; then 16 + 34 + 16 = **66** = the header-OK
count, nothing left over. Row 2 shifts the caller split to 17 + 33 + 16 and still totals 82 / 66.

**The control, and it can fail** — 168 `mpt_lookup_by_key` calls in one run: 64 via `slot_at_index` with
**0** successes, 104 elsewhere (incl. ≥64 `account_at_address`) with **≥64**. Same routine, same run,
same hashing, differing only in root and node container.

## Bound, not overclaimed

The mid-execution correction says the **account** walk resolved mid-execution — at least **14 of
`h_SSTORE`'s 16** well-formed tier-3 calls, since only 2 of 66 account lookups failed in total. It does
**not** claim the `call_frame_descend` window specifically is fine; that was not measured, so the
pre-resolution stays on its original conservative grounds. The docstring says so explicitly.

## Gate: byte-identical guest

Doc-only means the emitted guest must not move, and that is checked rather than asserted:

| | sha256 |
|---|---|
| `main` `d97788890` | `fbb83b69b167506518644fa38a7e73f17322c30c4cc80ba7f5ebc04c0dde54d3` |
| this branch | `fbb83b69b167506518644fa38a7e73f17322c30c4cc80ba7f5ebc04c0dde54d3` |

Consequently **no RegionMap repin and no layout regeneration**, which is the correct outcome for a
comment-only change and the reason it is worth separating from any behavioural work.

## Deliberately not here

The surviving observation — that every call site passes the witness **state** section where the
**storage** section is expected (`h_SSTORE` loads `a4` and `a6` both from `env+592`;
`bal_emit_storage_changes` both from `bv_witness_state_ptr`; `BlockVerdictStateRoot.lean:758` sets
`sps_storage` from `svf_witness`, the same value as `sps_state`) — is recorded on #11105 and **not**
acted on here. It lands on the Tier-2 storage-container question, which is not settled by a docstring.

Refs #11105, #10874.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
