### PR TITLE
fix(codegen): honest nonstorage effect mask (Class B FR44)

### DIFF
--- a/EvmAsm/Codegen/Programs/EIP7708Logs.lean
+++ b/EvmAsm/Codegen/Programs/EIP7708Logs.lean
@@ -443,8 +443,8 @@ def messageValueTransferFunction : String :=
   "  la s5, message_value_transfer_sender_post\n" ++
   ".Lrmvt_recipient_pre:\n" ++
   "  mv a0, s5; mv a1, s2; la a2, message_value_transfer_recipient_post; jal ra, u256_add_be; bnez a0, .Lrmvt_done\n" ++
-  -- Equal nonce inputs make `record_nonstorage_effect` derive an honest
-  -- balance-only AccountWrite mask rather than asserting a nonce component.
+  -- Equal dummy nonces: record_nonstorage_effect derives balance-only raw mask
+  -- and AccountWrite bits (pre_nonce == post_nonce clears hasNonce).
   "  mv a0, s0; mv a1, s4; la a2, message_value_transfer_sender_post; li a3, 0; li a4, 0; jal ra, record_nonstorage_effect\n" ++
   "  mv a0, s1; mv a1, s5; la a2, message_value_transfer_recipient_post; li a3, 0; li a4, 0; jal ra, record_nonstorage_effect\n" ++
   ".Lrmvt_done:\n" ++

--- a/EvmAsm/Codegen/Programs/NonstorageEffectLog.lean
+++ b/EvmAsm/Codegen/Programs/NonstorageEffectLog.lean
@@ -93,7 +93,15 @@ def nonstorageEffectHasNonce : Nat := 2
     `record_nonstorage_effect_nonce_only_after_account_state` is the EIP-7702
     authorization variant.  It carries an honest nonce-only raw mask while
     retaining the AccountWrite publication at the authorization's current BAI;
-    the authorization already owns the AccountState mutation. -/
+    the authorization already owns the AccountState mutation.
+
+    Raw component mask (byte 20) is derived from actual pre/post deltas — the same
+    rule AccountWrite already used — so balance-only producers that pass equal
+    dummy nonces (notably `record_message_value_transfer` with a3=a4=0) do not
+    publish a stale nonce-0 component.  Mixing those with a later real nonce
+    record used to make `nonstorage_effect_aggregate` report a phantom nonce
+    change (first pre=0, max post=real) and trip bv_fail=44 on BAL-empty
+    accounts (Class B selfdestructing_initcode_preserves_balance post_send SD). -/
 def recordNonstorageEffectFunction : String :=
   "record_nonstorage_effect:\n  li a5, 0\n  j .Lrnse_entry\n" ++
   "record_nonstorage_effect_after_account_state:\n  li a5, 1\n" ++
@@ -116,7 +124,20 @@ def recordNonstorageEffectFunction : String :=
   "  beqz t6, .Lrnse_cpa_d\n" ++
   "  lbu a0, 0(t4); sb a0, 0(t5); addi t4, t4, 1; addi t5, t5, 1; addi t6, t6, -1; j .Lrnse_cpa\n" ++
   ".Lrnse_cpa_d:\n" ++
-  "  li t4, " ++ toString (nonstorageEffectHasBalance + nonstorageEffectHasNonce) ++ "; li t5, 2; bne a5, t5, .Lrnse_mask_ready; li t4, " ++ toString nonstorageEffectHasNonce ++ "\n" ++
+  -- a5=2: force nonce-only (EIP-7702 auth). Else derive mask from real deltas so
+  -- balance-only callers that pass equal dummy nonces do not set hasNonce.
+  "  li t5, 2; beq a5, t5, .Lrnse_mask_nonce_only\n" ++
+  "  li t4, 0\n" ++
+  "  ld t0, 0(s1); ld t1, 0(s2); bne t0, t1, .Lrnse_mask_bal\n" ++
+  "  ld t0, 8(s1); ld t1, 8(s2); bne t0, t1, .Lrnse_mask_bal\n" ++
+  "  ld t0, 16(s1); ld t1, 16(s2); bne t0, t1, .Lrnse_mask_bal\n" ++
+  "  ld t0, 24(s1); ld t1, 24(s2); beq t0, t1, .Lrnse_mask_nonce\n" ++
+  ".Lrnse_mask_bal:\n" ++
+  "  ori t4, t4, " ++ toString nonstorageEffectHasBalance ++ "\n" ++
+  ".Lrnse_mask_nonce:\n" ++
+  "  beq s3, s4, .Lrnse_mask_ready; ori t4, t4, " ++ toString nonstorageEffectHasNonce ++ "; j .Lrnse_mask_ready\n" ++
+  ".Lrnse_mask_nonce_only:\n" ++
+  "  li t4, " ++ toString nonstorageEffectHasNonce ++ "\n" ++
   ".Lrnse_mask_ready:\n" ++
   "  sb t4, 20(t3)\n" ++
   "  ld t4, 0(s1); sd t4, 32(t3); ld t4, 8(s1); sd t4, 40(t3); ld t4, 16(s1); sd t4, 48(t3); ld t4, 24(s1); sd t4, 56(t3)\n" ++  -- pre_balance
@@ -450,9 +471,9 @@ def nonstorageEffectAggregateFunction : String :=
   "  sd zero, 104(sp)\n" ++
   -- The raw record's byte 20 independently marks balance and nonce. Fold the
   -- run component-wise: first valid pre / last balance post / maximum nonce
-  -- post. `record_nonstorage_effect` carries a nonce word on every value
-  -- record, including balance-only records with a stale zero, so nonce cannot
-  -- use last-post semantics (execution-specs block_access_lists.py:440-447).
+  -- post. Nonce uses max-post (execution-specs block_access_lists.py:440-447);
+  -- hasNonce is set only when pre_nonce != post_nonce at record time, so
+  -- balance-only producers with equal dummy nonces do not supply a stale pre=0.
   "  sb zero, 20(s11); mv t6, s8\n" ++
   ".Lnea_emit_component_loop:\n" ++
   "  bgeu t6, s10, .Lnea_emit_component_done; li t0, 112; mul t0, t6, t0; add t0, s5, t0; lbu t1, 20(t0)\n" ++


### PR DESCRIPTION
## Summary

`record_nonstorage_effect` set the raw component mask to `hasBalance|hasNonce` unconditionally (except EIP-7702 nonce-only). `record_message_value_transfer` passes dummy equal nonces `(0,0)` for balance-only moves. AccountWrite already derived bits from real deltas; the raw mask lied. Aggregate folded first hasNonce pre=0 with a later real nonce into a phantom `0→1` and tripped **bv_fail=44** against BAL-empty accounts.

Fix: derive both raw mask bits from real pre/post deltas (same rule as AccountWrite). `a5=2` stays forced nonce-only.

Fixes #11125. May also clear the phantom-nonce shape in #11115 (same `pre_nonce=0 post_nonce=1 mask=0x03` on BAL-empty row).

## Why the family split that way

`selfdestructing_initcode_preserves_balance` residual Class B (after #11082/#11092 Class A):

| `post_send_opcode_SELFDESTRUCT` count | result |
|---|---|
| 0 | PASS |
| 1 or 3 | FAIL bv44, **equal length** rb==sp |

Equal lengths made length/digest diffs useless — only per-entry exec-agg vs BAL decode shows the defect.

count≥1 path: post_send is `CALL(donor)` where donor code is `SELFDESTRUCT(victim)` (pre-deployed, nonce=1), not entry SD. CALL value credit records nonce 0→0 with hasNonce; SD clear records live nonce 1→1 with hasNonce; agg reports phantom 0→1; BAL correctly empty for donor. count=0 never touches the donor.

## Mask population

Exactly **two** bits in this routine: `hasBalance=1`, `hasNonce=2` (no hasCode). Pre-fix both always-set on `a5!=2`. Class size 2; live break was hasNonce + dummy zeros. hasBalance-always was latent (rmv only records when value ≠ 0).

## Measure (FR bar)

| leg | guest sha256 | result |
|---|---|---|
| main `d97788890` family limit40 | `fbb83b69…dde54d3` | 32 pass / 8 fail bv44 — `run-20260801T221948Z-2362052` |
| fix family limit40 | `dd3fdb40…54e83678` | **40/40 full** — `run-20260801T223247Z-2465040` |
| main limit200 | `fbb83b69…` | 123/77 — `run-20260801T215641Z-2143636` |
| fix limit200 | `dd3fdb40…` | 123/77 — `run-20260801T223358Z-2478848` |

Reverse flips pass→fail: **0**. limit200 actual_hex **identical** 200/200 vs main baseline (root+succ+tail+full same). Family movement 32→40 is outside default limit200 order.

## Files

- `EvmAsm/Codegen/Programs/NonstorageEffectLog.lean` — honest raw mask
- `EvmAsm/Codegen/Programs/EIP7708Logs.lean` — comment only

No layout regen (body size change does not require GuestAddrs for string-emitted path; EEST rebuild emits ELF directly).

## Note

main is moving (#11114 labelled). Rebase if mergebot needs it; do not add merge! from author.
