### PR TITLE
docs(plan): add probe discipline — measure the intervention, not just the result

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -5209,3 +5209,39 @@ through ECALL bridges (extending `EvmAsm/EL/Keccak*EcallBridge.lean`).
 8. **IO standard**: The STF program uses `read_input`/`write_output` per
    the zkvm IO standard. Input = block + pre-state witness. Output =
    post-state root hash.
+
+## Probe discipline (read this before building one)
+
+Guest measurements here routinely require a probe that **suppresses, disables or starves**
+something so an otherwise-unreached path executes. Two failures of that method cost a full
+evening on 2026-08-01 and produced a GitHub issue that had to be closed as invalid within the
+hour (#11122). Both are one counter away from being caught.
+
+1. **Measure that your intervention did what you think — before measuring anything through
+   it.** Count the thing you believe you removed. "Starving the preload" turned out to zero
+   only the *scan bound* (`env+448`) while `.preload_expand_loop`, guarded by the count
+   **register** `x6`, still wrote all 16 arena entries. The probe produced a **corrupted** log,
+   not an empty one — a state production cannot reach, which manufactured 16 phantom faults.
+   ⚠️ The tell was there and was read as reassurance: `h_SSTORE` ran **312 times in both
+   builds**. When an intervention meant to change behaviour leaves a downstream count
+   *identical*, that is evidence it did not land.
+
+2. **Run the UNMODIFIED build and check the condition exists there at all.** Do this before
+   investigating any fault a probe surfaces. 16 "header faults" in the probe build were
+   **zero** in production. This step is what caught failure (1) — from the other end, hours
+   late.
+
+3. **Establish the expected value from the data, never from a name.** `test_sstore_xto_y` was
+   read as "this contract has a nonzero pre-state slot"; the fixture's `pre` says
+   `storage_entries=0` for every account the code looked up, so the "failing" lookups were
+   returning the *correct* answer. The `x` is written by a transaction **in the block**. Open
+   the fixture.
+
+4. **Look for the direct oracle first.** `scripts/eest-stateless-to-input.py
+   --verify-run-stateless-guest` runs execution-specs' own `run_stateless_guest` on the exact
+   input blob and compares to the fixture's `statelessOutputBytes`. One command; it refutes
+   any "our input is deficient" theory before you write it up.
+
+5. **Prefer PC counters read from the objdump to added probe code.** Nothing to leave behind,
+   nothing to mis-place, and a funnel's *every* exit can be counted at once — entry == sum of
+   exits is what makes an attribution forced rather than plausible.


### PR DESCRIPTION
Docs-only, `PLAN.md` only. No `EvmAsm/` changes, so nothing to build or repin.

Two method failures on 2026-08-01 cost a full evening and produced #11122, which I closed as **invalid
within the hour**. Both were **one counter** away from being caught, which is what makes them worth
institutionalising rather than just remembering. `CLAUDE.md` mandates reading `PLAN.md` at session start, so
that is where the next person building a probe will actually meet them.

## The load-bearing one

A probe described everywhere — a #11105 comment, the #11122 body, #11124's body and docstring — as
*"starving the preload"* **starved nothing**:

| | production | the "starved" build |
|---|---|---|
| `.preload_expand_loop` body executed | 16 | **16** |
| arena writes at `0xa0630000` | 16 | **16** |
| `h_SSTORE` invocations | 312 | **312** |

The loop is guarded by **`x6`, the preload count *register***; the edit zeroed only the **scan bound**
`env+448`. So all 16 entries were still written and each SSTORE then appended from index 0 *over* them — a
**corrupted** log, not an empty one, and a state production cannot reach. That manufactured 16 phantom
zero-header-length faults which are **zero** in production.

⚠️ **The tell was present and was read as reassurance:** `h_SSTORE` ran **312 times in both builds**. When an
intervention meant to change behaviour leaves a downstream count *identical*, that is evidence it did not
land — not a passing control.

## The other four

* **Run the unmodified build first**, before investigating any probe-surfaced fault. This is what caught the
  above, from the other end, hours late.
* **Take the expected value from the data, never from a name.** `test_sstore_xto_y` was read as "this
  contract has a nonzero pre-state slot"; the fixture's `pre` says `storage_entries=0` for every account the
  code looked up, so the "failing" lookups were returning the **correct** answer. The `x` is written by a
  transaction *in the block*.
* **Look for the direct oracle first.** `--verify-run-stateless-guest` runs execution-specs' own
  `run_stateless_guest` on the exact blob against the fixture's `statelessOutputBytes` — one command, and it
  refutes any "our input is deficient" theory before it gets written up.
* **Prefer objdump PC counters to added probe code** — nothing left behind, nothing mis-placed, and every
  exit of a funnel can be counted at once so that `entry == sum of exits` makes an attribution forced rather
  than plausible.

## Scope

Five numbered steps appended as a new `## Probe discipline` section after `## Design Decisions`. Nothing
else in `PLAN.md` is touched and no code is touched.

⚠️ **Separately, and not in this PR:** `Storage.lean`'s **module header** still carries the same stale claim
in a third place — *"The BAL-driven preload stages every slot a block reads, so this is not observed (GH
#10874 measured zero misses on the corpus); a demand-driven read is blocked on GH #11105."* All three
clauses are now false (16–17 cold misses per row on the unmodified guest; #11105 closed with no code
change). #11124 does not touch that header. It is being folded into the next `Storage.lean` touch rather
than opened as a competing edit to the same file while #11124 is labelled.

Refs #11105, #11122, #11124, #10874.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
