### PR TITLE
docs(codegen): correct the module header's three stale clauses; the probe was corrupted, not starved

### DIFF
--- a/EvmAsm/Codegen/Programs/Storage.lean
+++ b/EvmAsm/Codegen/Programs/Storage.lean
@@ -53,9 +53,16 @@
 
   - Persistent SLOAD/SSTORE and transient TLOAD/TSTORE key on the frame's
     env.ADDRESS (multi-contract isolated).
-  - Cold `SLOAD` reads of non-preloaded slots return 0. The BAL-driven preload
-    stages every slot a block reads, so this is not observed (GH #10874 measured
-    zero misses on the corpus); a demand-driven read is blocked on GH #11105.
+  - Cold `SLOAD` reads of non-preloaded slots return 0. ⛔ The reason recorded here
+    used to be *"the BAL-driven preload stages every slot a block reads, so this is
+    not observed (GH #10874 measured zero misses on the corpus); a demand-driven read
+    is blocked on GH #11105"*. **All three clauses are false.** Measured on the
+    UNMODIFIED guest: `h_SSTORE`'s cold-miss resolve runs **16 and 17 times** on two
+    rows, so the preload does NOT stage every slot and misses are NOT zero; and
+    GH #11105 is closed with no code change, so nothing is blocked on it.
+    What a demand-driven `SLOAD` read still needs is a **present-slot** case — every
+    measured cold miss resolved a genuinely-absent slot, so the found path is
+    unexercised. See `storagePrestateResolveAsm` below for the full funnel.
   - 4 MiB per log = ~32K entries each — well past any test workload.
   - Inline asm, not verified bodies. Verified-loop bodies follow later.
 -/
@@ -310,9 +317,16 @@ def storagePersistentLogFindAsm : String :=
     ⛔ FOUR CLAIMS THAT USED TO BE HERE WERE REFUTED BY MEASUREMENT (GH #11105,
     GH #11122 closed invalid). Recorded so nobody re-derives them:
     * *"tier 3 does not work / returns status 4 on every call"* -- it works. The
-      82-call funnel that produced that reading came from a build with the preload
-      **starved**, an artificial condition; the starve itself added the 16
-      zero-length-header calls, and production has **zero**.
+      82-call funnel that produced that reading came from a probe build whose log was
+      ⚠️ **CORRUPTED, not starved** -- an earlier revision of this note said "the
+      preload starved" and that was wrong about its own instrument. The probe zeroed
+      only the scan bound (`env+448`); `.preload_expand_loop` is guarded by the count
+      REGISTER `x6` and still wrote all 16 arena entries, which each SSTORE then
+      appended over from index 0. That is a state production cannot reach, and it is
+      what manufactured the 16 zero-length-header calls -- production has **zero**.
+      The tell was that `h_SSTORE` ran **312 times in both builds**: an intervention
+      that leaves a downstream count identical did not land. See PLAN.md
+      "Probe discipline" before building another one.
     * *"this chain never executes in production, the preload means SSTORE never sees
       a cold miss"* -- it executes 16 times on a single row of the unmodified guest.
       Production does see cold misses.


### PR DESCRIPTION
⚠️ **Stacked on #11124** — base is `scoper/tier3-reachability-correction`, so this diff is one commit.
Doc-only; guest **byte-identical** to #11124's (`d23eb355…`), no repin.

Two claims survived #11121 and #11124. One of them is in #11124 itself.

## 1. The module header — three false clauses in one sentence

`Storage.lean`'s **module header** (not a `def` docstring, which is why both earlier PRs missed it) recorded
the cold-read limitation as:

> *"The BAL-driven preload stages every slot a block reads, so this is not observed (GH #10874 measured zero
> misses on the corpus); a demand-driven read is blocked on GH #11105."*

| clause | status |
|---|---|
| the preload stages every slot a block reads | ⛔ `h_SSTORE`'s cold-miss resolve runs **16 and 17 times** on two rows of the **unmodified** guest |
| #10874 measured zero misses on the corpus | ⛔ not zero |
| a demand-driven read is blocked on #11105 | ⛔ **#11105 is closed with no code change** |

As written it told the next reader that #10874 is blocked by something untrue — the same
prose-that-forecloses-a-direction failure this file has now produced three times in one day. It is replaced
with what was measured, plus what a demand-driven read **does** still need: a **present-slot** case, since
every measured cold miss resolved a genuinely-absent slot and the found path is unexercised.

## 2. #11124's own provenance sentence — the probe was corrupted, not starved

#11124 says the 82-call funnel came from a build with the preload **starved**. **It was not starved**, and
that was wrong about my own instrument:

| | production | the probe build |
|---|---|---|
| `.preload_expand_loop` body executed | 16 | **16** |
| arena writes at `0xa0630000` | 16 | **16** |
| `h_SSTORE` invocations | 312 | **312** |

The loop is guarded by **`x6`, the preload count *register***; the probe zeroed only the **scan bound**
`env+448`. All 16 entries were still written and each SSTORE then appended over them from index 0 — a
**corrupted** log, and a state production cannot reach. That is what manufactured the 16
zero-length-header calls; production has **zero**.

⚠️ The tell was `h_SSTORE` running **312 times in both builds** — an intervention that leaves a downstream
count identical did not land. The note now says so and points at PLAN.md "Probe discipline" (#11127).

This is the one-sentence fix folded into the next `Storage.lean` touch rather than opened as a third
standalone docstring PR, which is why it is bundled with (1) instead of racing #11124 on the same file.

## Gates

| | sha256 |
|---|---|
| #11124 (`ef63520c1`) | `d23eb355be3cc6ae0bc5052f30ebdfdb824fada3b0432ec078df4c952888cb7e` |
| this branch | `d23eb355be3cc6ae0bc5052f30ebdfdb824fada3b0432ec078df4c952888cb7e` |

`lake build` clean · `check-forbidden-tactics` OK · 933 lines (cap 1500) · comment-only, so no RegionMap
repin and no layout regeneration.

## Ordering

* Depends on **#11124** (shares the file). Land that first.
* Forward-references **#11127** for the PLAN.md "Probe discipline" section. Harmless if #11127 lands second,
  but landing #11127 first makes the reference live on arrival.

Refs #11105, #11122, #11124, #11127, #10874.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
