### PR TITLE
fix(codegen): honest fail code for dispatch-status bail (#11119)

### DIFF
--- a/EvmAsm/Codegen/Programs/BlockVerdictReceiptsTail.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictReceiptsTail.lean
@@ -123,14 +123,17 @@ def blockVerdictReceiptsTail : String :=
   "  j .Lbv_receipts_accept\n" ++
   ".Lbv_receipt_logs_helper_status:\n" ++
   "  j .Lbv_receipts_helper_fail\n" ++
-  ".Lbv_receipts_accept:\n" ++
-  -- dispatch_tx_runtime_code produces 0 on complete replay and 1..7 on a
-  -- conservative bail; the single-tx destroyed-empty detector may replace a
-  -- successful result with 62.  Every nonzero route bypasses the single-tx
-  -- all-account storage/tuple comparators, so none may accept based only on a
-  -- matching attacker-chosen receipts root.
-  "  la t0, bv_dispatch_runtime_status; ld t0, 0(t0); bnez t0, .Lbv_bal_storage_omit_fail\n" ++
-  "  li a0, 1; j .Lbv_ret\n" ++
+   ".Lbv_receipts_accept:\n" ++
+   -- dispatch_tx_runtime_code produces 0 on complete replay and 1..7 on a
+   -- conservative bail; the single-tx destroyed-empty detector may replace a
+   -- successful result with 62.  Every nonzero route bypasses the single-tx
+   -- all-account storage/tuple comparators, so none may accept based only on a
+   -- matching attacker-chosen receipts root.
+   -- #11119: this is a DISPATCH-status bail, not a storage-omit comparator.
+   -- Formerly jumped to .Lbv_bal_storage_omit_fail (bv_fail=36), which lied
+   -- about the cause.  Omit property stays CONTAINER_DEPENDENT under 37.
+   "  la t0, bv_dispatch_runtime_status; ld t0, 0(t0); bnez t0, .Lbv_dispatch_runtime_status_fail\n" ++
+   "  li a0, 1; j .Lbv_ret\n" ++
   ".Lbv_receipts_no_runtime_gas:\n" ++
   "  la t2, bv_exec_p; ld a0, 0(t2)\n" ++
   "  li a1, 0\n" ++
@@ -224,10 +227,17 @@ def blockVerdictReceiptsTail : String :=
   "  li t0, 34; la t1, bv_fail_code; sd t0, 0(t1); j .Lbv_zero\n" ++
   ".Lbv_bal_recipient_field_fail:\n" ++    -- bmvmx.1.6.3: recipient BAL nonce/code claims a change execution didn't make
   "  li t0, 35; la t1, bv_fail_code; sd t0, 0(t1); j .Lbv_zero\n" ++
-  ".Lbv_bal_storage_omit_fail:\n" ++       -- bmvmx.1.6.5: recipient BAL omits a storage change execution made
-  "  li t0, 36; la t1, bv_fail_code; sd t0, 0(t1); j .Lbv_zero\n" ++
-  ".Lbv_bal_allaccounts_fail:\n" ++        -- bmvmx.1.6.4.3: a non-recipient BAL account's storage != execution
-  "  li t0, 37; la t1, bv_fail_code; sd t0, 0(t1); j .Lbv_zero\n" ++
+   ".Lbv_bal_storage_omit_fail:\n" ++       -- bmvmx.1.6.5: recipient BAL omits a storage change execution made
+   -- #11119: sink retained for the named property; currently unreachable from
+   -- the verdict path (sole former reacher was the dispatch-status bail above,
+   -- now on .Lbv_dispatch_runtime_status_fail / code 64).  Real reverse storage
+   -- coverage lives inside allaccounts (37).  Standalone 36 waits on container
+   -- convergence (#10765 CONTAINER_DEPENDENT).
+   "  li t0, 36; la t1, bv_fail_code; sd t0, 0(t1); j .Lbv_zero\n" ++
+   ".Lbv_dispatch_runtime_status_fail:\n" ++  -- #11119: bv_dispatch_runtime_status ≠ 0 at receipts-accept
+   "  li t0, 64; la t1, bv_fail_code; sd t0, 0(t1); j .Lbv_zero\n" ++
+   ".Lbv_bal_allaccounts_fail:\n" ++        -- bmvmx.1.6.4.3: a non-recipient BAL account's storage != execution
+   "  li t0, 37; la t1, bv_fail_code; sd t0, 0(t1); j .Lbv_zero\n" ++
   ".Lbv_bal_reads_fail:\n" ++              -- bmvmx.1.6.7: recipient BAL storage_read slot never accessed in execution
   "  li t0, 38; la t1, bv_fail_code; sd t0, 0(t1); j .Lbv_zero\n" ++
   ".Lbv_sender_bal_fail:\n" ++             -- bmvmx.1.6.3: BAL sender post balance != execution-derived (pre - gas_charge - value)


### PR DESCRIPTION
## Summary

`bv_fail=36` / `.Lbv_bal_storage_omit_fail` was documented as **recipient BAL omits a storage change** (`bal_storage_covers_exec_log`). In the emitted guest the **sole reacher** was a dispatch-runtime-status bail on `.Lbv_receipts_accept`:

```
la t0, bv_dispatch_runtime_status; ld t0, 0(t0); bnez t0, .Lbv_bal_storage_omit_fail
```

So a dispatch/runtime conservative bail presented as a storage-omission rejection and sent debuggers to the wrong subsystem.

## Fix (miswire only)

In `BlockVerdictReceiptsTail.lean`:

- Retarget the bail to `.Lbv_dispatch_runtime_status_fail` with **honest code 64**.
- Leave `.Lbv_bal_storage_omit_fail` / code 36 as an unreachable named sink. The omit **property** is CONTAINER_DEPENDENT (#10765); reverse coverage stays inside allaccounts **37**. Do **not** restore a standalone omit comparator here.

## Liveness of the bail (structural, not fixture-search)

**Kind: reachable safety net; unexercised on the limit200 sample.**

From emitted assembly + source (sole writer / sole call site):

1. **Sole writer** of `bv_dispatch_runtime_status`: MTx postlude after the **only** `jal ra, dispatch_tx_runtime_code` in the guest (`BlockVerdictMtxRuntime` → `sd a0, …`). BSS init is 0; nothing else stores the cell. (Debug snapshot at `BlockVerdict.lean` only *reads* it.)

2. **Producer of nonzero**: `dispatch_tx_runtime_code` returns
   - `0` complete replay
   - `1..7` structured unsupported (code lookup / non-self-contained / BAL cap / storage proof / payload cap / staging / access-list)
   - `8` recipient unresolvable → separate immediate reject (not this bail)

3. **On `a0 ∈ 1..7`**: status is stored, then `bnez a0, .Lbv_mtx_dispatch_unsupported` — this does **not** `Lbv_zero`. It sets receipts shape 61 + `enforce_enabled=1` and continues via `.Lbv_after_tx_gas_precharge` → gas-result gate → receipts materialize/enforce → **`.Lbv_receipts_accept`**.

4. **At accept**: `bnez status → code 64` (was 36). That is the intentional last-line reject when dispatch bailed but an attacker-chosen receipts root still matched — nonzero dispatch bypasses the single-tx storage/tuple comparators, so receipts alone must not accept.

5. **On `a0=0`** (common case): status stays 0; the accept-gate is a no-op.

So the path is **structurally live and producible** whenever dispatch returns 1–7 and later gates still reach receipts-accept. It is **not** a renamed dead sink. Earlier gates (gas completeness skip, eip7778, receipts helper/root/bloom, etc.) often reject first after a dispatch bail, which is why a finite sample can miss code 36/64 without the edge being dead.

## Measure (FR bar) — honest form

Population is rows already rejecting for *other* reasons or accepting with status=0. **Nothing should change verdict.**

| leg | commit | guest sha256 | limit200 |
|---|---|---|---|
| main baseline | `5cfc7b560` | `d23eb355…888cb7e` | 174 full / 26 fail — `run-20260801T225451Z-2602972` |
| fix | `c03782c75` | `1e9b4b00…d4e6fd9` | 174 full / 26 fail — `run-20260801T225735Z-2625635` |

- **Pass/fail counts:** identical (harness 174/26; succ-byte split 158/42 both legs).
- **Reverse flips:** 0.
- **actual_hex:** **identical 200/200** (full 256B OUTPUT including fail_code region).
- **Fail-code histogram (both legs, succ=0):** 5×16, 47×1, 53×5, 60×18, 62×2.
- **`fc=36` appears on no row of this 200.** Therefore no 36→64 movement was observed. The 200-of-200 identity confirms **only that nothing broke**; it does **not** exercise the retargeted edge. Proof of the retarget is structural: emitted `.s` sole reacher changes from `bnez … bal_storage_omit_fail` to `bnez … dispatch_runtime_status_fail`, and code-64 is the sink that edge targets. Code 64 will appear the next time dispatch returns 1–7 and control still reaches receipts-accept.

## What this PR deliberately does not do

- Does not delete the 36 sink (kept unreachable + named).
- Does not restore a standalone omit comparator (CONTAINER_DEPENDENT under 37).
- Does not ask whether the bail should stop rejecting entirely (larger finding if ever raised).

## Files

- `EvmAsm/Codegen/Programs/BlockVerdictReceiptsTail.lean` only

Fixes #11119
