### PR TITLE
docs(codegen): state the verdict-debug offset contract at the emitter

### DIFF
--- a/EvmAsm/Codegen/Programs/BlockVerdict.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdict.lean
@@ -85,7 +85,35 @@ namespace EvmAsm.Codegen
 open EvmAsm.Rv64
 
 /- `zisk_stateless_verdict_v2`: probe. Fed the SAME `-i` input as the guest.
-   Output OUTPUT+0 = verdict bit (system writes + withdrawals modeled). -/
+   Output OUTPUT+0 = verdict bit (system writes + withdrawals modeled).
+
+   ⚠️ THIS IS AN OFFSET-ADDRESSED DEBUG CONTRACT, NOT A PRIVATE SCRATCH BUFFER.
+   `scripts/codegen-eest-stateless-check.sh`'s `format_verdict_debug` decodes it
+   POSITIONALLY, via a bash label array that names each 8-byte word. The stores
+   below are the ONLY ground truth for what each offset holds; the label array is
+   an interpretation of them and can drift. **If you add, remove or reorder a
+   store here, update that array in the same commit** — otherwise every reader
+   silently mis-labels every field after the change.
+
+   Verified 2026-08-02 (GH #11105 follow-up): the label array matches these
+   stores, field for field. Recorded because four agents read this buffer by
+   offset and the mapping had to be re-derived from the emitter to be trusted —
+   a field NAME is not a contract, and a control row only validates the fields
+   that happen to be NON-ZERO in it.
+
+   The map, as emitted below:
+     +0   verdict bit                        +96  bvgr_receipt_gas_increments[1]
+     +8   bv_fail_code                       +104 bvgr_tx_total_state_gas[0]
+     +16  bv_header_status                   +112 bvgr_tx_total_state_gas[1]
+     +24  bv_state_status                    +120 bv_exact_net_status
+     +32  bsr_bal_count                      +128 bv_exact_net_index
+     +40  bsr_fail_code                      +136 bv_exact_block_status
+     +48  bsr_change_count                   +144 bv_exact_header_gas_used
+     +56  bsr_wl_v                           +152 bv_exact_expected_gas_used
+     +64  baacd_fail_code                    +160 brr_records[16]
+     +72  bacv_fail_code                     +168 sv_recomputed  (32 bytes)
+     +80  baap_fail_code                     +200 payload state root (32 bytes)
+     +88  bvgr_receipt_gas_increments[0]     +232 onward: gas-arena status/counts -/
 def ziskStatelessVerdictV2Prologue : String :=
   "  li sp, 0xa0050000\n" ++
   "  jal ra, stateless_verdict_v2\n" ++


### PR DESCRIPTION
Doc-only Lean comment. Guest **byte-identical** (`1d2176f0…`), so no repin and no layout regeneration.

## Why

The 256-byte verdict-debug buffer is decoded **positionally** by
`scripts/codegen-eest-stateless-check.sh`'s `format_verdict_debug`, via a bash label array that names each
8-byte word. **The stores in `ziskStatelessVerdictV2Prologue` are the only ground truth for what each offset
holds; the label array is an interpretation of them and can drift.**

Four agents read that buffer by offset. This states the contract next to the code, records the full offset
map, and asks that a change to the stores update the array **in the same commit** — otherwise every reader
silently mis-labels every field after the change.

## What prompted it

While locating a `bv_fail=53` row I needed `+88` and `+160`. I doubted the labels — `BlockVerdictStateRoot.lean:852`
stores `svf_witness_len` at `+88` of *a* buffer, which looked like a contradiction. So I read the emitter
instead of arguing about it.

**The labels were correct**, field for field (the `:852` store uses a different base register, so a different
buffer). Verifying a correct artefact is still the right move — it turned a guess into ground truth either
way — and now nobody has to re-doubt it.

## Two lessons the comment records, because they generalise

1. ⚠️ **A field NAME is not a contract.** The names live in a shell script; the offsets live in the guest.
2. ⚠️ **A control row only validates the fields that are NON-ZERO in it.** I validated the layout against a
   row whose log line names every field — six matched exactly. But `+88` and `+160` were **both zero** in that
   control, and those were precisely the two fields I needed. The control could not have caught a mislabel
   there even if one had existed. That is the same "a control that cannot fire proves nothing" shape as the
   dead lane-B drain in #11133's investigation.

## The map, as emitted

| | | | |
|---|---|---|---|
| +0 | verdict bit | +96 | `bvgr_receipt_gas_increments[1]` |
| +8 | `bv_fail_code` | +104 | `bvgr_tx_total_state_gas[0]` |
| +16 | `bv_header_status` | +112 | `bvgr_tx_total_state_gas[1]` |
| +24 | `bv_state_status` | +120 | `bv_exact_net_status` |
| +32 | `bsr_bal_count` | +128 | `bv_exact_net_index` |
| +40 | `bsr_fail_code` | +136 | `bv_exact_block_status` |
| +48 | `bsr_change_count` | +144 | `bv_exact_header_gas_used` |
| +56 | `bsr_wl_v` | +152 | `bv_exact_expected_gas_used` |
| +64 | `baacd_fail_code` | +160 | `brr_records[16]` |
| +72 | `bacv_fail_code` | +168 | `sv_recomputed` (32 B) |
| +80 | `baap_fail_code` | +200 | payload state root (32 B) |
| +88 | `bvgr_receipt_gas_increments[0]` | +232 → | gas-arena status / counts |

## Gates

`lake build` clean · `check-forbidden-tactics` OK · guest sha256 identical to `main` `d4215e262`
(`1d2176f0b5c49567b05340874871fe6248d38d4f2cbadf7ff919f0c10f96f70f`) · file 494 lines, well under the cap.

Refs #11105.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
