### PR TITLE
docs(codegen): header.gas_used is a MAX over two dimensions, not a sum

### DIFF
--- a/EvmAsm/Codegen/Programs/BlockVerdictExactGas.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictExactGas.lean
@@ -22,6 +22,31 @@ def blockVerdictExactGasCheck : String :=
   -- floor bind the block-regular dimension too (state gas subtracted
   -- FIRST, so the floor is not discounted by state spending); it was
   -- receipt-only at v0.5.0.
+  --
+  -- ⚠️ `header.gas_used` IS A **MAX** OVER TWO INDEPENDENT DIMENSIONS, NOT A SUM,
+  -- AND NOT THE RECEIPT'S `cumulative_gas_used`. This contradicts pre-8037
+  -- intuition and it has already misled two readers, so it is stated here rather
+  -- than left to be re-derived. At `execution-specs` @ `e5a8caf1b`:
+  --
+  --   fork.py:1181   block_output.block_gas_used       += tx_regular_gas
+  --   fork.py:1182   block_output.block_state_gas_used += max(0, tx_state_gas)
+  --   fork.py:1185   block_output.cumulative_gas_used  += tx_gas_used   -- RECEIPT
+  --   fork.py:370-375
+  --       block_gas_used = max(block_output.block_gas_used,
+  --                            block_output.block_state_gas_used)
+  --       if block_gas_used != block.header.gas_used: raise InvalidBlock
+  --
+  -- ⇒ THREE accumulators, not one. The header is validated against the **max** of
+  -- the regular and state dimensions; the receipt carries the **full** per-tx
+  -- `tx_gas_used` (regular + state). So on a SINGLE-TRANSACTION block the receipt
+  -- cumulative can legitimately EXCEED `header.gas_used` — e.g. `scenarios`
+  -- `program_GASPRICE-debug __b18`: header 97920, state total 97920, regular
+  -- 83799, receipt cumulative 181719. All four are CORRECT and consistent.
+  --
+  -- Do not "fix" a receipt cumulative that differs from `header.gas_used`; a
+  -- defect was nearly filed on exactly that reading. The loop below plus
+  -- `eip8037_block_gas_used` implement the max, which is why that row's
+  -- `bv_exact_block_status` is 0 while its receipts root still mismatches.
   "  la t0, bvgr_arena_tx_count; ld t0, 0(t0); li t1, 0\n" ++
   ".Lbv_regular_eip8037_loop:\n" ++
   "  beq t1, t0, .Lbv_regular_eip8037_done\n" ++


### PR DESCRIPTION
Doc-only. Guest **byte-identical** (`1d2176f0…`), so no repin.

## The non-obvious fact

⚠️ **`header.gas_used` is a MAX over two independent dimensions — not a sum, and not the receipt's
`cumulative_gas_used`.** At `execution-specs` @ `e5a8caf1b`:

```
fork.py:1181   block_output.block_gas_used       += tx_regular_gas
fork.py:1182   block_output.block_state_gas_used += max(0, tx_state_gas)
fork.py:1185   block_output.cumulative_gas_used  += tx_gas_used        # RECEIPT
fork.py:370-375
    block_gas_used = max(block_output.block_gas_used,
                         block_output.block_state_gas_used)
    if block_gas_used != block.header.gas_used: raise InvalidBlock
```

⇒ **Three accumulators, not one.** The header is validated against the **max** of the regular and state
dimensions; the receipt carries the **full** per-tx `tx_gas_used`.

⇒ On a **single-transaction** block the receipt cumulative can legitimately **exceed** `header.gas_used`.

## Why it is worth a comment

It contradicts pre-8037 intuition, where `header.gas_used` and the last receipt's cumulative *are* the same
accumulated quantity. **It has already misled two readers tonight, and a defect was nearly filed on it.**

Concretely, on `scenarios` `program_GASPRICE-debug __b18` (`bv_fail=53`, receipts root):

| quantity | value |
|---|---|
| header `gasUsed` (decoded from the pinned input blob, `number=18`) | 97920 |
| `bvgr_tx_total_state_gas[0]` | 97920 |
| regular (derived) | 83799 |
| `bvgr_receipt_gas_increments[0]` | 181719 |

**All four are correct and mutually consistent.** 181719 − 97920 = 83799 looked exactly like a defect — one
transaction, a receipts-root failure, and a clean decomposition — and it is simply the spec's two-dimensional
accounting. What refuted it was reading four lines of `fork.py` rather than partitioning the arithmetic a
third way.

The comment also records that this file's loop plus `eip8037_block_gas_used` **already implement the max
correctly**, which is why that row's `bv_exact_block_status` is `0` while its receipts root still mismatches —
so the gas trail is a dead end for that row and the next reader should not re-walk it.

## Gates

`lake build` clean · guest sha256 identical to `main` `d4215e262`
(`1d2176f0b5c49567b05340874871fe6248d38d4f2cbadf7ff919f0c10f96f70f`) · comment-only, so no RegionMap repin and
no layout regeneration.

Refs #11105.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
