### PR TITLE
chore: batch-merge #11141 #11143

### DIFF
--- a/EvmAsm/Codegen/Programs/BlockVerdict.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdict.lean
@@ -85,7 +85,35 @@ namespace EvmAsm.Codegen
 open EvmAsm.Rv64
 
 /- `zisk_stateless_verdict_v2`: probe. Fed the SAME `-i` input as the guest.
-   Output OUTPUT+0 = verdict bit (system writes + withdrawals modeled). -/
+   Output OUTPUT+0 = verdict bit (system writes + withdrawals modeled).
+
+   ⚠️ THIS IS AN OFFSET-ADDRESSED DEBUG CONTRACT, NOT A PRIVATE SCRATCH BUFFER.
+   `scripts/codegen-eest-stateless-check.sh`'s `format_verdict_debug` decodes it
+   POSITIONALLY, via a bash label array that names each 8-byte word. The stores
+   below are the ONLY ground truth for what each offset holds; the label array is
+   an interpretation of them and can drift. **If you add, remove or reorder a
+   store here, update that array in the same commit** — otherwise every reader
+   silently mis-labels every field after the change.
+
+   Verified 2026-08-02 (GH #11105 follow-up): the label array matches these
+   stores, field for field. Recorded because four agents read this buffer by
+   offset and the mapping had to be re-derived from the emitter to be trusted —
+   a field NAME is not a contract, and a control row only validates the fields
+   that happen to be NON-ZERO in it.
+
+   The map, as emitted below:
+     +0   verdict bit                        +96  bvgr_receipt_gas_increments[1]
+     +8   bv_fail_code                       +104 bvgr_tx_total_state_gas[0]
+     +16  bv_header_status                   +112 bvgr_tx_total_state_gas[1]
+     +24  bv_state_status                    +120 bv_exact_net_status
+     +32  bsr_bal_count                      +128 bv_exact_net_index
+     +40  bsr_fail_code                      +136 bv_exact_block_status
+     +48  bsr_change_count                   +144 bv_exact_header_gas_used
+     +56  bsr_wl_v                           +152 bv_exact_expected_gas_used
+     +64  baacd_fail_code                    +160 brr_records[16]
+     +72  bacv_fail_code                     +168 sv_recomputed  (32 bytes)
+     +80  baap_fail_code                     +200 payload state root (32 bytes)
+     +88  bvgr_receipt_gas_increments[0]     +232 onward: gas-arena status/counts -/
 def ziskStatelessVerdictV2Prologue : String :=
   "  li sp, 0xa0050000\n" ++
   "  jal ra, stateless_verdict_v2\n" ++

--- a/EvmAsm/Codegen/Programs/BlockVerdictExactGas.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictExactGas.lean
@@ -22,6 +22,31 @@ def blockVerdictExactGasCheck : String :=
   -- floor bind the block-regular dimension too (state gas subtracted
   -- FIRST, so the floor is not discounted by state spending); it was
   -- receipt-only at v0.5.0.
+  --
+  -- ⚠️ `header.gas_used` IS A **MAX** OVER TWO INDEPENDENT DIMENSIONS, NOT A SUM,
+  -- AND NOT THE RECEIPT'S `cumulative_gas_used`. This contradicts pre-8037
+  -- intuition and it has already misled two readers, so it is stated here rather
+  -- than left to be re-derived. At `execution-specs` @ `e5a8caf1b`:
+  --
+  --   fork.py:1181   block_output.block_gas_used       += tx_regular_gas
+  --   fork.py:1182   block_output.block_state_gas_used += max(0, tx_state_gas)
+  --   fork.py:1185   block_output.cumulative_gas_used  += tx_gas_used   -- RECEIPT
+  --   fork.py:370-375
+  --       block_gas_used = max(block_output.block_gas_used,
+  --                            block_output.block_state_gas_used)
+  --       if block_gas_used != block.header.gas_used: raise InvalidBlock
+  --
+  -- ⇒ THREE accumulators, not one. The header is validated against the **max** of
+  -- the regular and state dimensions; the receipt carries the **full** per-tx
+  -- `tx_gas_used` (regular + state). So on a SINGLE-TRANSACTION block the receipt
+  -- cumulative can legitimately EXCEED `header.gas_used` — e.g. `scenarios`
+  -- `program_GASPRICE-debug __b18`: header 97920, state total 97920, regular
+  -- 83799, receipt cumulative 181719. All four are CORRECT and consistent.
+  --
+  -- Do not "fix" a receipt cumulative that differs from `header.gas_used`; a
+  -- defect was nearly filed on exactly that reading. The loop below plus
+  -- `eip8037_block_gas_used` implement the max, which is why that row's
+  -- `bv_exact_block_status` is 0 while its receipts root still mismatches.
   "  la t0, bvgr_arena_tx_count; ld t0, 0(t0); li t1, 0\n" ++
   ".Lbv_regular_eip8037_loop:\n" ++
   "  beq t1, t0, .Lbv_regular_eip8037_done\n" ++


### PR DESCRIPTION
Batch-merge of #11141 #11143 (all author pirapira).

Verified locally: `lake build` + all `check-*.sh` green, **including `check-build-units-link`** (the gate that failed on the previous attempt).

No layout movement: all pins already matched the relinked ELF and regen produced no drift.

Replaces #11144, which also contained #11139 and failed CI on the unit link — see #11139 for the diagnosis.