### PR TITLE
codegen: share precompile selectors and validity-kernel calls

### DIFF
--- a/EvmAsm/Codegen/Programs/BlockVerdictSimpleTransferPrecompileGas.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictSimpleTransferPrecompileGas.lean
@@ -36,25 +36,25 @@ def blockVerdictSimpleTransferPrecompileGasAsm : String :=
   "  mv t0, t2; addi t0, t0, 72\n" ++
   precompileAddressClassifyAsm "bv_tx_gas_precharge_pc0" "t0" "t3" "t1" "t4" ++
   "  beqz t3, .Lbv_tx_gas_precharge_value_check\n" ++
-  precompileSelectorBranchesAsm "t3" "t4"
-    [ (1, ".Lbv_simple_transfer_precompile_ecrecover")
-    , (2, ".Lbv_simple_transfer_precompile_sha256")
-    , (3, ".Lbv_simple_transfer_precompile_ripemd160")
-    , (4, ".Lbv_simple_transfer_precompile_identity")
-    , (5, ".Lbv_simple_transfer_precompile_modexp")
-    , (6, ".Lbv_simple_transfer_precompile_ecadd")
-    , (7, ".Lbv_simple_transfer_precompile_ecmul")
-    , (8, ".Lbv_simple_transfer_precompile_ecpairing")
-    , (9, ".Lbv_simple_transfer_precompile_blake2f")
-    , (10, ".Lbv_simple_transfer_precompile_point_eval")
-    , (11, ".Lbv_simple_transfer_precompile_bls_g1add")
-    , (12, ".Lbv_simple_transfer_precompile_bls_g1msm")
-    , (13, ".Lbv_simple_transfer_precompile_bls_g2add")
-    , (14, ".Lbv_simple_transfer_precompile_bls_g2msm")
-    , (15, ".Lbv_simple_transfer_precompile_bls_pairing")
-    , (16, ".Lbv_simple_transfer_precompile_bls_map_g1")
-    , (17, ".Lbv_simple_transfer_precompile_bls_map_g2")
-    , (256, ".Lbv_simple_transfer_precompile_p256") ] ++
+  precompileSelectorBranchesAsm "t3" "t4" true
+    [ ("1", ".Lbv_simple_transfer_precompile_ecrecover")
+    , ("2", ".Lbv_simple_transfer_precompile_sha256")
+    , ("3", ".Lbv_simple_transfer_precompile_ripemd160")
+    , ("4", ".Lbv_simple_transfer_precompile_identity")
+    , ("5", ".Lbv_simple_transfer_precompile_modexp")
+    , ("6", ".Lbv_simple_transfer_precompile_ecadd")
+    , ("7", ".Lbv_simple_transfer_precompile_ecmul")
+    , ("8", ".Lbv_simple_transfer_precompile_ecpairing")
+    , ("9", ".Lbv_simple_transfer_precompile_blake2f")
+    , ("10", ".Lbv_simple_transfer_precompile_point_eval")
+    , ("11", ".Lbv_simple_transfer_precompile_bls_g1add")
+    , ("12", ".Lbv_simple_transfer_precompile_bls_g1msm")
+    , ("13", ".Lbv_simple_transfer_precompile_bls_g2add")
+    , ("14", ".Lbv_simple_transfer_precompile_bls_g2msm")
+    , ("15", ".Lbv_simple_transfer_precompile_bls_pairing")
+    , ("16", ".Lbv_simple_transfer_precompile_bls_map_g1")
+    , ("17", ".Lbv_simple_transfer_precompile_bls_map_g2")
+    , ("256", ".Lbv_simple_transfer_precompile_p256") ] ++
   ".Lbv_tx_gas_precharge_value_check:\n" ++
   -- The MTx empty-code route enters this shared active-precompile recognizer
   -- with its context copied into the scalar scratch. Falling through here
@@ -75,25 +75,25 @@ def blockVerdictSimpleTransferPrecompileGasAsm : String :=
   "  mv t0, t2; addi t0, t0, 72\n" ++
   precompileAddressClassifyAsm "bv_tx_gas_precharge_pc" "t0" "t3" "t1" "t4" ++
   "  beqz t3, .Lbv_mtx_precompile_not_active\n" ++
-  precompileSelectorBranchesAsm "t3" "t4"
-    [ (1, ".Lbv_simple_transfer_precompile_ecrecover")
-    , (2, ".Lbv_simple_transfer_precompile_sha256")
-    , (3, ".Lbv_simple_transfer_precompile_ripemd160")
-    , (4, ".Lbv_simple_transfer_precompile_identity")
-    , (5, ".Lbv_simple_transfer_precompile_modexp")
-    , (6, ".Lbv_simple_transfer_precompile_ecadd")
-    , (7, ".Lbv_simple_transfer_precompile_ecmul")
-    , (8, ".Lbv_simple_transfer_precompile_ecpairing")
-    , (9, ".Lbv_simple_transfer_precompile_blake2f")
-    , (10, ".Lbv_simple_transfer_precompile_point_eval")
-    , (11, ".Lbv_simple_transfer_precompile_bls_g1add")
-    , (12, ".Lbv_simple_transfer_precompile_bls_g1msm")
-    , (13, ".Lbv_simple_transfer_precompile_bls_g2add")
-    , (14, ".Lbv_simple_transfer_precompile_bls_g2msm")
-    , (15, ".Lbv_simple_transfer_precompile_bls_pairing")
-    , (16, ".Lbv_simple_transfer_precompile_bls_map_g1")
-    , (17, ".Lbv_simple_transfer_precompile_bls_map_g2")
-    , (256, ".Lbv_simple_transfer_precompile_p256") ] ++
+  precompileSelectorBranchesAsm "t3" "t4" true
+    [ ("1", ".Lbv_simple_transfer_precompile_ecrecover")
+    , ("2", ".Lbv_simple_transfer_precompile_sha256")
+    , ("3", ".Lbv_simple_transfer_precompile_ripemd160")
+    , ("4", ".Lbv_simple_transfer_precompile_identity")
+    , ("5", ".Lbv_simple_transfer_precompile_modexp")
+    , ("6", ".Lbv_simple_transfer_precompile_ecadd")
+    , ("7", ".Lbv_simple_transfer_precompile_ecmul")
+    , ("8", ".Lbv_simple_transfer_precompile_ecpairing")
+    , ("9", ".Lbv_simple_transfer_precompile_blake2f")
+    , ("10", ".Lbv_simple_transfer_precompile_point_eval")
+    , ("11", ".Lbv_simple_transfer_precompile_bls_g1add")
+    , ("12", ".Lbv_simple_transfer_precompile_bls_g1msm")
+    , ("13", ".Lbv_simple_transfer_precompile_bls_g2add")
+    , ("14", ".Lbv_simple_transfer_precompile_bls_g2msm")
+    , ("15", ".Lbv_simple_transfer_precompile_bls_pairing")
+    , ("16", ".Lbv_simple_transfer_precompile_bls_map_g1")
+    , ("17", ".Lbv_simple_transfer_precompile_bls_map_g2")
+    , ("256", ".Lbv_simple_transfer_precompile_p256") ] ++
   "  j .Lbv_mtx_precompile_not_active\n" ++
   ".Lbv_simple_transfer_precompile_ecrecover:\n" ++
   -- At depth zero the precompile's returndata is intentionally not materialized:
@@ -176,7 +176,7 @@ def blockVerdictSimpleTransferPrecompileGasAsm : String :=
   precompileFrameAddi "a1" precompileFrameBls12G1Input1Off ++
   precompileFrameAddi "a2" precompileFrameBls12G1OutputOff ++
   precompileKernelCallAsm "ra" "zkvm_bn254_g1_add" "a0"
-    ".Lbv_simple_transfer_precompile_fail" "" ++
+    ".Lbv_simple_transfer_precompile_fail" "" "  " ++
   precompileFixedGasCostAsm 150 "t6" ++
   "  j .Lbv_simple_transfer_emit_tl_then_after_tx_gas_precharge\n" ++
   ".Lbv_simple_transfer_precompile_ecmul:\n" ++
@@ -192,9 +192,9 @@ def blockVerdictSimpleTransferPrecompileGasAsm : String :=
   ".Lbv_simple_transfer_ecmul_copy:\n" ++
   "  beq a0, t4, .Lbv_simple_transfer_ecmul_run; add a1, t5, a0; lbu a2, 0(a1); add a1, t3, a0; sb a2, 0(a1); addi a0, a0, 1; j .Lbv_simple_transfer_ecmul_copy\n" ++
   ".Lbv_simple_transfer_ecmul_run:\n" ++
-  "  mv a0, t3; addi a1, t3, 64; addi a2, t3, 128\n" ++
+  "  mv a0, t3; addi a1, t3, 64; addi a2, t3, 128" ++
   precompileKernelCallAsm "ra" "zkvm_bn254_g1_mul" "a0"
-    ".Lbv_simple_transfer_precompile_fail" "" ++
+    ".Lbv_simple_transfer_precompile_fail" "" "; " ++
   precompileFixedGasCostAsm 6000 "t6" ++
   "  j .Lbv_simple_transfer_emit_tl_then_after_tx_gas_precharge\n" ++
   ".Lbv_simple_transfer_precompile_ecpairing:\n" ++
@@ -207,7 +207,7 @@ def blockVerdictSimpleTransferPrecompileGasAsm : String :=
   "  la t2, bv_simple_transfer_tx; ld a0, 56(t2); ld t5, 64(t2); li t4, 192; divu a1, t5, t4\n" ++
   precompileFrameAddi "a2" precompileFrameBls12G1OutputOff ++
   precompileKernelCallAsm "ra" "zkvm_bn254_pairing" "a0"
-    ".Lbv_simple_transfer_precompile_fail" "" ++
+    ".Lbv_simple_transfer_precompile_fail" "" "  " ++
   "  la t2, bv_simple_transfer_tx; ld t5, 64(t2)\n" ++
   precompilePerUnitGasCostAsm ".Lbv_simple_transfer_precompile_fail" 192 45000 34000
     "t5" "t6" "t5" "t4" ++

--- a/EvmAsm/Codegen/Programs/BlockVerdictSimpleTransferPrecompileGas.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictSimpleTransferPrecompileGas.lean
@@ -36,24 +36,25 @@ def blockVerdictSimpleTransferPrecompileGasAsm : String :=
   "  mv t0, t2; addi t0, t0, 72\n" ++
   precompileAddressClassifyAsm "bv_tx_gas_precharge_pc0" "t0" "t3" "t1" "t4" ++
   "  beqz t3, .Lbv_tx_gas_precharge_value_check\n" ++
-  "  li t4, 1; beq t3, t4, .Lbv_simple_transfer_precompile_ecrecover\n" ++
-  "  li t4, 2; beq t3, t4, .Lbv_simple_transfer_precompile_sha256\n" ++
-  "  li t4, 3; beq t3, t4, .Lbv_simple_transfer_precompile_ripemd160\n" ++
-  "  li t4, 4; beq t3, t4, .Lbv_simple_transfer_precompile_identity\n" ++
-  "  li t4, 5; beq t3, t4, .Lbv_simple_transfer_precompile_modexp\n" ++
-  "  li t4, 6; beq t3, t4, .Lbv_simple_transfer_precompile_ecadd\n" ++
-  "  li t4, 7; beq t3, t4, .Lbv_simple_transfer_precompile_ecmul\n" ++
-  "  li t4, 8; beq t3, t4, .Lbv_simple_transfer_precompile_ecpairing\n" ++
-  "  li t4, 9; beq t3, t4, .Lbv_simple_transfer_precompile_blake2f\n" ++
-  "  li t4, 10; beq t3, t4, .Lbv_simple_transfer_precompile_point_eval\n" ++
-  "  li t4, 11; beq t3, t4, .Lbv_simple_transfer_precompile_bls_g1add\n" ++
-  "  li t4, 12; beq t3, t4, .Lbv_simple_transfer_precompile_bls_g1msm\n" ++
-  "  li t4, 13; beq t3, t4, .Lbv_simple_transfer_precompile_bls_g2add\n" ++
-  "  li t4, 14; beq t3, t4, .Lbv_simple_transfer_precompile_bls_g2msm\n" ++
-  "  li t4, 15; beq t3, t4, .Lbv_simple_transfer_precompile_bls_pairing\n" ++
-  "  li t4, 16; beq t3, t4, .Lbv_simple_transfer_precompile_bls_map_g1\n" ++
-  "  li t4, 17; beq t3, t4, .Lbv_simple_transfer_precompile_bls_map_g2\n" ++
-  "  li t4, 256; beq t3, t4, .Lbv_simple_transfer_precompile_p256\n" ++
+  precompileSelectorBranchesAsm "t3" "t4"
+    [ (1, ".Lbv_simple_transfer_precompile_ecrecover")
+    , (2, ".Lbv_simple_transfer_precompile_sha256")
+    , (3, ".Lbv_simple_transfer_precompile_ripemd160")
+    , (4, ".Lbv_simple_transfer_precompile_identity")
+    , (5, ".Lbv_simple_transfer_precompile_modexp")
+    , (6, ".Lbv_simple_transfer_precompile_ecadd")
+    , (7, ".Lbv_simple_transfer_precompile_ecmul")
+    , (8, ".Lbv_simple_transfer_precompile_ecpairing")
+    , (9, ".Lbv_simple_transfer_precompile_blake2f")
+    , (10, ".Lbv_simple_transfer_precompile_point_eval")
+    , (11, ".Lbv_simple_transfer_precompile_bls_g1add")
+    , (12, ".Lbv_simple_transfer_precompile_bls_g1msm")
+    , (13, ".Lbv_simple_transfer_precompile_bls_g2add")
+    , (14, ".Lbv_simple_transfer_precompile_bls_g2msm")
+    , (15, ".Lbv_simple_transfer_precompile_bls_pairing")
+    , (16, ".Lbv_simple_transfer_precompile_bls_map_g1")
+    , (17, ".Lbv_simple_transfer_precompile_bls_map_g2")
+    , (256, ".Lbv_simple_transfer_precompile_p256") ] ++
   ".Lbv_tx_gas_precharge_value_check:\n" ++
   -- The MTx empty-code route enters this shared active-precompile recognizer
   -- with its context copied into the scalar scratch. Falling through here
@@ -74,24 +75,25 @@ def blockVerdictSimpleTransferPrecompileGasAsm : String :=
   "  mv t0, t2; addi t0, t0, 72\n" ++
   precompileAddressClassifyAsm "bv_tx_gas_precharge_pc" "t0" "t3" "t1" "t4" ++
   "  beqz t3, .Lbv_mtx_precompile_not_active\n" ++
-  "  li t4, 1; beq t3, t4, .Lbv_simple_transfer_precompile_ecrecover\n" ++
-  "  li t4, 2; beq t3, t4, .Lbv_simple_transfer_precompile_sha256\n" ++
-  "  li t4, 3; beq t3, t4, .Lbv_simple_transfer_precompile_ripemd160\n" ++
-  "  li t4, 4; beq t3, t4, .Lbv_simple_transfer_precompile_identity\n" ++
-  "  li t4, 5; beq t3, t4, .Lbv_simple_transfer_precompile_modexp\n" ++
-  "  li t4, 6; beq t3, t4, .Lbv_simple_transfer_precompile_ecadd\n" ++
-  "  li t4, 7; beq t3, t4, .Lbv_simple_transfer_precompile_ecmul\n" ++
-  "  li t4, 8; beq t3, t4, .Lbv_simple_transfer_precompile_ecpairing\n" ++
-  "  li t4, 9; beq t3, t4, .Lbv_simple_transfer_precompile_blake2f\n" ++
-  "  li t4, 10; beq t3, t4, .Lbv_simple_transfer_precompile_point_eval\n" ++
-  "  li t4, 11; beq t3, t4, .Lbv_simple_transfer_precompile_bls_g1add\n" ++
-  "  li t4, 12; beq t3, t4, .Lbv_simple_transfer_precompile_bls_g1msm\n" ++
-  "  li t4, 13; beq t3, t4, .Lbv_simple_transfer_precompile_bls_g2add\n" ++
-  "  li t4, 14; beq t3, t4, .Lbv_simple_transfer_precompile_bls_g2msm\n" ++
-  "  li t4, 15; beq t3, t4, .Lbv_simple_transfer_precompile_bls_pairing\n" ++
-  "  li t4, 16; beq t3, t4, .Lbv_simple_transfer_precompile_bls_map_g1\n" ++
-  "  li t4, 17; beq t3, t4, .Lbv_simple_transfer_precompile_bls_map_g2\n" ++
-  "  li t4, 256; beq t3, t4, .Lbv_simple_transfer_precompile_p256\n" ++
+  precompileSelectorBranchesAsm "t3" "t4"
+    [ (1, ".Lbv_simple_transfer_precompile_ecrecover")
+    , (2, ".Lbv_simple_transfer_precompile_sha256")
+    , (3, ".Lbv_simple_transfer_precompile_ripemd160")
+    , (4, ".Lbv_simple_transfer_precompile_identity")
+    , (5, ".Lbv_simple_transfer_precompile_modexp")
+    , (6, ".Lbv_simple_transfer_precompile_ecadd")
+    , (7, ".Lbv_simple_transfer_precompile_ecmul")
+    , (8, ".Lbv_simple_transfer_precompile_ecpairing")
+    , (9, ".Lbv_simple_transfer_precompile_blake2f")
+    , (10, ".Lbv_simple_transfer_precompile_point_eval")
+    , (11, ".Lbv_simple_transfer_precompile_bls_g1add")
+    , (12, ".Lbv_simple_transfer_precompile_bls_g1msm")
+    , (13, ".Lbv_simple_transfer_precompile_bls_g2add")
+    , (14, ".Lbv_simple_transfer_precompile_bls_g2msm")
+    , (15, ".Lbv_simple_transfer_precompile_bls_pairing")
+    , (16, ".Lbv_simple_transfer_precompile_bls_map_g1")
+    , (17, ".Lbv_simple_transfer_precompile_bls_map_g2")
+    , (256, ".Lbv_simple_transfer_precompile_p256") ] ++
   "  j .Lbv_mtx_precompile_not_active\n" ++
   ".Lbv_simple_transfer_precompile_ecrecover:\n" ++
   -- At depth zero the precompile's returndata is intentionally not materialized:
@@ -173,8 +175,8 @@ def blockVerdictSimpleTransferPrecompileGasAsm : String :=
   precompileFrameAddi "a0" precompileFrameBls12G1Input0Off ++
   precompileFrameAddi "a1" precompileFrameBls12G1Input1Off ++
   precompileFrameAddi "a2" precompileFrameBls12G1OutputOff ++
-  "  jal ra, zkvm_bn254_g1_add\n" ++
-  "  bnez a0, .Lbv_simple_transfer_precompile_fail\n" ++
+  precompileKernelCallAsm "ra" "zkvm_bn254_g1_add" "a0"
+    ".Lbv_simple_transfer_precompile_fail" "" ++
   precompileFixedGasCostAsm 150 "t6" ++
   "  j .Lbv_simple_transfer_emit_tl_then_after_tx_gas_precharge\n" ++
   ".Lbv_simple_transfer_precompile_ecmul:\n" ++
@@ -190,8 +192,9 @@ def blockVerdictSimpleTransferPrecompileGasAsm : String :=
   ".Lbv_simple_transfer_ecmul_copy:\n" ++
   "  beq a0, t4, .Lbv_simple_transfer_ecmul_run; add a1, t5, a0; lbu a2, 0(a1); add a1, t3, a0; sb a2, 0(a1); addi a0, a0, 1; j .Lbv_simple_transfer_ecmul_copy\n" ++
   ".Lbv_simple_transfer_ecmul_run:\n" ++
-  "  mv a0, t3; addi a1, t3, 64; addi a2, t3, 128; jal ra, zkvm_bn254_g1_mul\n" ++
-  "  bnez a0, .Lbv_simple_transfer_precompile_fail\n" ++
+  "  mv a0, t3; addi a1, t3, 64; addi a2, t3, 128\n" ++
+  precompileKernelCallAsm "ra" "zkvm_bn254_g1_mul" "a0"
+    ".Lbv_simple_transfer_precompile_fail" "" ++
   precompileFixedGasCostAsm 6000 "t6" ++
   "  j .Lbv_simple_transfer_emit_tl_then_after_tx_gas_precharge\n" ++
   ".Lbv_simple_transfer_precompile_ecpairing:\n" ++
@@ -203,8 +206,8 @@ def blockVerdictSimpleTransferPrecompileGasAsm : String :=
   -- and a non-subgroup G2 component take the same exceptional-halt route.
   "  la t2, bv_simple_transfer_tx; ld a0, 56(t2); ld t5, 64(t2); li t4, 192; divu a1, t5, t4\n" ++
   precompileFrameAddi "a2" precompileFrameBls12G1OutputOff ++
-  "  jal ra, zkvm_bn254_pairing\n" ++
-  "  bnez a0, .Lbv_simple_transfer_precompile_fail\n" ++
+  precompileKernelCallAsm "ra" "zkvm_bn254_pairing" "a0"
+    ".Lbv_simple_transfer_precompile_fail" "" ++
   "  la t2, bv_simple_transfer_tx; ld t5, 64(t2)\n" ++
   precompilePerUnitGasCostAsm ".Lbv_simple_transfer_precompile_fail" 192 45000 34000
     "t5" "t6" "t5" "t4" ++

--- a/EvmAsm/Codegen/Programs/ChildFrameHandlerTails.lean
+++ b/EvmAsm/Codegen/Programs/ChildFrameHandlerTails.lean
@@ -245,34 +245,21 @@ def precompileMessageProcessorAsm
     successfulPrecompileNewAccountStateGasAsm tag valueOff? ++
     "  li x15, 4\n" ++
     "  bgeu x15, x14, 11f\n" ++
-    "  li x15, 5\n" ++
-    "  beq x14, x15, .Lmodexp_zero_header_" ++ tag ++ "\n" ++
-    "  li x15, 0x06\n" ++
-    "  beq x14, x15, .L" ++ tag ++ "_bn254_add\n" ++
-    "  li x15, 0x07\n" ++
-    "  beq x14, x15, .L" ++ tag ++ "_bn254_mul\n" ++
-    "  li x15, 0x08\n" ++
-    "  beq x14, x15, .L" ++ tag ++ "_bn254_pairing\n" ++
-    "  li x15, 0x09\n" ++
-    "  beq x14, x15, .L" ++ tag ++ "_blake2f\n" ++
-    "  li x15, 0x0a\n" ++
-    "  beq x14, x15, .L" ++ tag ++ "_kzg_point_eval\n" ++
-    "  li x15, 0x0b\n" ++
-    "  beq x14, x15, 13f\n" ++
-    "  li x15, 0x0c\n" ++
-    "  beq x14, x15, 14f\n" ++
-    "  li x15, 0x0d\n" ++
-    "  beq x14, x15, 15f\n" ++
-    "  li x15, 0x0e\n" ++
-    "  beq x14, x15, 16f\n" ++
-    "  li x15, 0x0f\n" ++
-    "  beq x14, x15, 17f\n" ++
-    "  li x15, 0x10\n" ++
-    "  beq x14, x15, 18f\n" ++
-    "  li x15, 0x11\n" ++
-    "  beq x14, x15, 19f\n" ++
-    "  li x15, 0x100\n" ++
-    "  beq x14, x15, .L" ++ tag ++ "_p256verify\n" ++
+    precompileSelectorBranchesAsm "x14" "x15"
+      [ (5, ".Lmodexp_zero_header_" ++ tag)
+      , (6, ".L" ++ tag ++ "_bn254_add")
+      , (7, ".L" ++ tag ++ "_bn254_mul")
+      , (8, ".L" ++ tag ++ "_bn254_pairing")
+      , (9, ".L" ++ tag ++ "_blake2f")
+      , (10, ".L" ++ tag ++ "_kzg_point_eval")
+      , (11, "13f")
+      , (12, "14f")
+      , (13, "15f")
+      , (14, "16f")
+      , (15, "17f")
+      , (16, "18f")
+      , (17, "19f")
+      , (256, ".L" ++ tag ++ "_p256verify") ] ++
     "  j .L" ++ tag ++ "_nonprecompile_fallthrough\n" ++
     "11:\n" ++
     "  la x15, evm_precompile_frame\n" ++
@@ -478,14 +465,14 @@ def precompileMessageProcessorAsm
     precompileFrameAddi "a0" precompileFrameBls12G1Input0Off ++
     precompileFrameAddi "a1" precompileFrameBls12G1Input1Off ++
     precompileFrameAddi "a2" precompileFrameBls12G1OutputOff ++
-    "  jal x1, zkvm_bn254_g1_add\n" ++
     -- a0 IS x10: stash the kernel status before restoring the saved
     -- PC into x10 (the ecrecover-path landmine, #8721 stack notes).
-    "  mv x16, a0\n" ++
-    "  mv x13, s9\n" ++
-    "  mv x10, s10\n" ++
-    "  mv x12, s11\n" ++
-    "  bnez x16, .L" ++ tag ++ "_bn254_kfail\n" ++
+    precompileKernelCallAsm "x1" "zkvm_bn254_g1_add" "x16"
+      (".L" ++ tag ++ "_bn254_kfail")
+      ("  mv x16, a0\n" ++
+       "  mv x13, s9\n" ++
+       "  mv x10, s10\n" ++
+       "  mv x12, s11\n") ++
     precompileSuccess64FromFrameAsm
       (tag ++ "_bn254_add_success") outOffsetOff outSizeOff precompileFrameBls12G1OutputOff ++
     -- BN254 G1 MUL (EIP-196 ecMul): fixed 6000 gas, one 64-byte point plus
@@ -507,14 +494,14 @@ def precompileMessageProcessorAsm
     precompileFrameAddi "a0" precompileFrameBls12G1Input0Off ++
     precompileFrameAddi "a1" precompileFrameBls12G1Input1Off ++
     precompileFrameAddi "a2" precompileFrameBls12G1OutputOff ++
-    "  jal x1, zkvm_bn254_g1_mul\n" ++
     -- a0 IS x10: stash the kernel status before restoring the saved
     -- PC into x10 (the ecrecover-path landmine, #8721 stack notes).
-    "  mv x16, a0\n" ++
-    "  mv x13, s9\n" ++
-    "  mv x10, s10\n" ++
-    "  mv x12, s11\n" ++
-    "  bnez x16, .L" ++ tag ++ "_bn254_kfail\n" ++
+    precompileKernelCallAsm "x1" "zkvm_bn254_g1_mul" "x16"
+      (".L" ++ tag ++ "_bn254_kfail")
+      ("  mv x16, a0\n" ++
+       "  mv x13, s9\n" ++
+       "  mv x10, s10\n" ++
+       "  mv x12, s11\n") ++
     precompileSuccess64FromFrameAsm
       (tag ++ "_bn254_mul_success") outOffsetOff outSizeOff precompileFrameBls12G1OutputOff ++
     -- BN254 pairing (EIP-197): cost = 45000 + 34000 * floor(len / 192),
@@ -543,13 +530,13 @@ def precompileMessageProcessorAsm
     "  add a0, x13, x17\n" ++
     "  mv a1, x22\n" ++
     precompileFrameAddi "a2" precompileFrameBls12G1OutputOff ++
-    "  jal x1, zkvm_bn254_pairing\n" ++
     -- a0 IS x10: stash the kernel status before the saved-PC restore.
-    "  mv x16, a0\n" ++
-    "  mv x13, s9\n" ++
-    "  mv x10, s10\n" ++
-    "  mv x12, s11\n" ++
-    "  bnez x16, .L" ++ tag ++ "_bn254_kfail\n" ++
+    precompileKernelCallAsm "x1" "zkvm_bn254_pairing" "x16"
+      (".L" ++ tag ++ "_bn254_kfail")
+      ("  mv x16, a0\n" ++
+       "  mv x13, s9\n" ++
+       "  mv x10, s10\n" ++
+       "  mv x12, s11\n") ++
     precompileSuccessBoolFromFrameAsm
       (tag ++ "_bn254_pairing_success") outOffsetOff outSizeOff precompileFrameBls12G1OutputOff ++
     -- BLAKE2F: exact 213-byte payload, then charge gas equal to the BE

--- a/EvmAsm/Codegen/Programs/ChildFrameHandlerTails.lean
+++ b/EvmAsm/Codegen/Programs/ChildFrameHandlerTails.lean
@@ -245,21 +245,21 @@ def precompileMessageProcessorAsm
     successfulPrecompileNewAccountStateGasAsm tag valueOff? ++
     "  li x15, 4\n" ++
     "  bgeu x15, x14, 11f\n" ++
-    precompileSelectorBranchesAsm "x14" "x15"
-      [ (5, ".Lmodexp_zero_header_" ++ tag)
-      , (6, ".L" ++ tag ++ "_bn254_add")
-      , (7, ".L" ++ tag ++ "_bn254_mul")
-      , (8, ".L" ++ tag ++ "_bn254_pairing")
-      , (9, ".L" ++ tag ++ "_blake2f")
-      , (10, ".L" ++ tag ++ "_kzg_point_eval")
-      , (11, "13f")
-      , (12, "14f")
-      , (13, "15f")
-      , (14, "16f")
-      , (15, "17f")
-      , (16, "18f")
-      , (17, "19f")
-      , (256, ".L" ++ tag ++ "_p256verify") ] ++
+    precompileSelectorBranchesAsm "x14" "x15" false
+      [ ("5", ".Lmodexp_zero_header_" ++ tag)
+      , ("0x06", ".L" ++ tag ++ "_bn254_add")
+      , ("0x07", ".L" ++ tag ++ "_bn254_mul")
+      , ("0x08", ".L" ++ tag ++ "_bn254_pairing")
+      , ("0x09", ".L" ++ tag ++ "_blake2f")
+      , ("0x0a", ".L" ++ tag ++ "_kzg_point_eval")
+      , ("0x0b", "13f")
+      , ("0x0c", "14f")
+      , ("0x0d", "15f")
+      , ("0x0e", "16f")
+      , ("0x0f", "17f")
+      , ("0x10", "18f")
+      , ("0x11", "19f")
+      , ("0x100", ".L" ++ tag ++ "_p256verify") ] ++
     "  j .L" ++ tag ++ "_nonprecompile_fallthrough\n" ++
     "11:\n" ++
     "  la x15, evm_precompile_frame\n" ++
@@ -472,7 +472,7 @@ def precompileMessageProcessorAsm
       ("  mv x16, a0\n" ++
        "  mv x13, s9\n" ++
        "  mv x10, s10\n" ++
-       "  mv x12, s11\n") ++
+       "  mv x12, s11\n") "  " ++
     precompileSuccess64FromFrameAsm
       (tag ++ "_bn254_add_success") outOffsetOff outSizeOff precompileFrameBls12G1OutputOff ++
     -- BN254 G1 MUL (EIP-196 ecMul): fixed 6000 gas, one 64-byte point plus
@@ -501,7 +501,7 @@ def precompileMessageProcessorAsm
       ("  mv x16, a0\n" ++
        "  mv x13, s9\n" ++
        "  mv x10, s10\n" ++
-       "  mv x12, s11\n") ++
+       "  mv x12, s11\n") "  " ++
     precompileSuccess64FromFrameAsm
       (tag ++ "_bn254_mul_success") outOffsetOff outSizeOff precompileFrameBls12G1OutputOff ++
     -- BN254 pairing (EIP-197): cost = 45000 + 34000 * floor(len / 192),
@@ -536,7 +536,7 @@ def precompileMessageProcessorAsm
       ("  mv x16, a0\n" ++
        "  mv x13, s9\n" ++
        "  mv x10, s10\n" ++
-       "  mv x12, s11\n") ++
+       "  mv x12, s11\n") "  " ++
     precompileSuccessBoolFromFrameAsm
       (tag ++ "_bn254_pairing_success") outOffsetOff outSizeOff precompileFrameBls12G1OutputOff ++
     -- BLAKE2F: exact 213-byte payload, then charge gas equal to the BE

--- a/EvmAsm/Codegen/Programs/PrecompileRuntime.lean
+++ b/EvmAsm/Codegen/Programs/PrecompileRuntime.lean
@@ -50,20 +50,24 @@ def precompileAddressClassifyAsm
     helper only emits caller-owned targets, so output, success, continuation,
     and gas-allotment policy remain at each call site. -/
 def precompileSelectorBranchesAsm
-    (selectorReg scratchReg : String) : List (Nat × String) → String
+    (selectorReg scratchReg : String) (inline : Bool) : List (String × String) → String
   | [] => ""
   | (selector, target) :: rest =>
-      "  li " ++ scratchReg ++ ", " ++ toString selector ++ "\n" ++
-      "  beq " ++ selectorReg ++ ", " ++ scratchReg ++ ", " ++ target ++ "\n" ++
-      precompileSelectorBranchesAsm selectorReg scratchReg rest
+      (if inline then
+        "  li " ++ scratchReg ++ ", " ++ selector ++ "; beq " ++
+          selectorReg ++ ", " ++ scratchReg ++ ", " ++ target ++ "\n"
+       else
+        "  li " ++ scratchReg ++ ", " ++ selector ++ "\n" ++
+          "  beq " ++ selectorReg ++ ", " ++ scratchReg ++ ", " ++ target ++ "\n") ++
+      precompileSelectorBranchesAsm selectorReg scratchReg inline rest
 
 /-- Call a precompile validity kernel and branch on its status. The optional
     post-call text is for caller-local ABI restoration (the child path saves
     its dispatch registers around LP64 kernels); it deliberately does not
     encode output, success, continuation, or gas-allotment policy. -/
 def precompileKernelCallAsm
-    (linkReg kernel statusReg failLabel afterCall : String) : String :=
-  "  jal " ++ linkReg ++ ", " ++ kernel ++ "\n" ++
+    (linkReg kernel statusReg failLabel afterCall callPrefix : String) : String :=
+  callPrefix ++ "jal " ++ linkReg ++ ", " ++ kernel ++ "\n" ++
   afterCall ++
   "  bnez " ++ statusReg ++ ", " ++ failLabel ++ "\n"
 

--- a/EvmAsm/Codegen/Programs/PrecompileRuntime.lean
+++ b/EvmAsm/Codegen/Programs/PrecompileRuntime.lean
@@ -45,6 +45,28 @@ def precompileAddressClassifyAsm
   "  li " ++ resultReg ++ ", 0\n" ++
   ".L" ++ tag ++ "_precompile_done:\n"
 
+/-- Emit the selector-to-handler branch table shared by root and child
+    precompile dispatchers.  Classification owns the numeric selector; this
+    helper only emits caller-owned targets, so output, success, continuation,
+    and gas-allotment policy remain at each call site. -/
+def precompileSelectorBranchesAsm
+    (selectorReg scratchReg : String) : List (Nat × String) → String
+  | [] => ""
+  | (selector, target) :: rest =>
+      "  li " ++ scratchReg ++ ", " ++ toString selector ++ "\n" ++
+      "  beq " ++ selectorReg ++ ", " ++ scratchReg ++ ", " ++ target ++ "\n" ++
+      precompileSelectorBranchesAsm selectorReg scratchReg rest
+
+/-- Call a precompile validity kernel and branch on its status. The optional
+    post-call text is for caller-local ABI restoration (the child path saves
+    its dispatch registers around LP64 kernels); it deliberately does not
+    encode output, success, continuation, or gas-allotment policy. -/
+def precompileKernelCallAsm
+    (linkReg kernel statusReg failLabel afterCall : String) : String :=
+  "  jal " ++ linkReg ++ ", " ++ kernel ++ "\n" ++
+  afterCall ++
+  "  bnez " ++ statusReg ++ ", " ++ failLabel ++ "\n"
+
 private def precompileGasRemainingOff : Nat := 568
 
 def chargePrecompileGasAsm (costReg remainingReg : String) : String :=


### PR DESCRIPTION
## Summary

Partial structural slice for #11163. The root and child precompile dispatchers now use the same selector branch-table emitter, and the BN254 ADD/MUL/pairing validity-kernel call/status sequence is shared. Caller-specific input staging, gas charging/allotment, output copying, success signaling, continuation, and MTx settlement remain unchanged.

This follows the pinned execution-spec structure: `execution-specs` `interpreter.py:398-401` dispatches a selected precompile from the shared processor after the common message work. The three validity kernels are the same spec operations at `vm/precompiled_contracts/alt_bn128.py:139-164`, `:167-192`, and `:195-223`; only the caller ABI and result sink differ.

## Scope boundaries

- No ECRECOVER/MODEXP root-output changes (the existing items 5/6 exclusions).
- No deletion of the MTx adapter or settlement path; producer re-homing remains a prerequisite.
- No `merge!` label applied.

## Verification

- `LAKE_ARTIFACT_CACHE=false lake build EvmAsm.Codegen.Programs.PrecompileRuntime EvmAsm.Codegen.Programs.BlockVerdictSimpleTransferPrecompileGas EvmAsm.Codegen.Programs.ChildFrameHandlerTails` — 1124/1124 pass.
- `LAKE_ARTIFACT_CACHE=false scripts/codegen-stateless-link-check.sh --out gen-out/11163-selector/candidate-stateless_guest-v4` — full `lake build codegen` (4294 jobs), emission, assembly, and link pass.
- Parent rebuilt from `9bac6a15a32583881155d2f54f01a44606016237` in `/var/tmp/evm-asm3-parent-11163` with the same non-cache command and a separate output.
- Parent and candidate emitted assembly are byte-identical: both 2,067,230 bytes, SHA-256 `d623c646dc85f3914989b357f4a5fd78452bd665ee67c5290554662135ee27b4`.
- The comparison is non-vacuous: candidate ELF SHA-256 `49403d71bca4b62733f4bd51125c3d60b375135aedc677fd4730fca82a9cc3f1`; parent ELF SHA-256 `abcb70d25dd98a5c02d975d71215e47bfc90d0e6d1b35c514fd6896b29a89f3e`.
- Because emitted assembly is byte-identical across independently built parent/candidate artifacts, no EEST sweep is warranted for this behavior-preserving factoring slice.
