### PR TITLE
docs(dispatch): the callee seed loop is NOT inert — it is the live consumer of the eager preload

### DIFF
--- a/EvmAsm/Codegen/Dispatch.lean
+++ b/EvmAsm/Codegen/Dispatch.lean
@@ -3035,10 +3035,34 @@ def emitRuntimeDispatcherPrologue : String :=
     it appends one 128 B persistent-exec-log entry (addrHash, slotKey, original=value,
     current=value — mirrors `exec_log_append_storage_seed`) and bumps
     env.persistentLogLength (env+448), so a nested callee's SLOAD finds its witness
-    value instead of cold 0. `callee_seed_count` is 0 for every current caller (the
-    top-level guest uses a different prologue; the verdict has not populated the table
-    yet), so this is INERT — depth-0 / recipient behaviour is byte-identical. The
-    enumeration that fills the table is 1.6.4.2.b (dispatch_tx_runtime_code). Uses only
+    value instead of cold 0.
+
+    ⛔ **THIS IS NOT INERT.** This docstring used to claim `callee_seed_count` "is 0 for
+    every current caller … so this is INERT — depth-0 / recipient behaviour is
+    byte-identical". **That was true when the loop was written and is false now**: the
+    enumeration it names as future work — 1.6.4.2.b, `seed_callee_storage` in
+    `dispatch_tx_runtime_code` — has since landed, and it populates the table on the
+    ordinary verdict path. ⇒ **this loop is the live consumer of the eager BAL-sourced
+    storage preload.** GH #11176.
+
+    MEASURED (2026-08-02), not inferred. Cited by input sha256 rather than index,
+    because an index is selector-relative and two agents reading "fixture 00192" from
+    two manifests differed by three orders of magnitude on the same day:
+      input sha256 `242fa1e11ec51d7b9f9395b93d3e02ebf6c7d9064196360eba1cefd367cdb13b`
+      relpath `blockchain_tests/for_amsterdam/amsterdam/eip7928_block_level_access_lists/`
+              `block_access_lists_eip7002/bal_7002_request_from_contract.json`
+    A commitlog dump of every access to
+    `callee_seed_count` shows it **walk 0 → 1 → 2 → 3 → 4 and keep going**, with the
+    bumps at the producer's own store and read-backs at the two loads this loop uses.
+    And disabling the producer flips **15 of 1,045** sampled rows from reject to accept
+    with **zero** reverse flips — an inert loop cannot do that.
+
+    ⚠️ **Why this mattered enough to write down:** the retired sentence is exactly the
+    one that would license deleting this loop as dead weight *without measuring
+    anything* — "byte-identical" is a claim a reader acts on. Trust the **why** in a
+    comment like that; measure the **happens**.
+
+    Uses only
     x5/x6/x7 (the dispatch loop re-inits them each iteration) and x28..x31 temps; never
     touches x10/x12/x13/x20/x21. -/
 def emitCalleeStorageSeedLoop : String :=


### PR DESCRIPTION
## A docstring that tells the next reader a **live consumer** is byte-identical dead weight

GH #11176. `emitCalleeStorageSeedLoop`'s docstring claimed:

> `callee_seed_count` is 0 for every current caller (the top-level guest uses a different prologue; the verdict has not populated the table yet), so this is **INERT** — depth-0 / recipient behaviour is **byte-identical**.

**That was true when the loop was written and is false now.** The enumeration the *same sentence* names as future work — 1.6.4.2.b, `seed_callee_storage` in `dispatch_tx_runtime_code` — has since landed, and it populates the table on the ordinary verdict path. ⇒ **this loop is the live consumer of the eager BAL-sourced storage preload.**

### Measured, not argued

Cited by **input sha256** rather than index, because an index is selector-relative — two agents reading "fixture 00192" from two manifests differed by three orders of magnitude on the same day:

* input sha256 `242fa1e11ec51d7b9f9395b93d3e02ebf6c7d9064196360eba1cefd367cdb13b`
* relpath `blockchain_tests/for_amsterdam/amsterdam/eip7928_block_level_access_lists/block_access_lists_eip7002/bal_7002_request_from_contract.json`

A `SPIKE_COMMITLOG` dump of **every** access to `callee_seed_count` (35 hits) shows it **walk `0 → 1 → 2 → 3 → 4` and keep going** — bumps at the producer's store, read-backs at the two loads this loop uses.

And independently: disabling the producer flips **15 of 1,045** sampled rows from reject to accept with **zero** reverse flips and FA = 0 on both legs. **An inert loop cannot do that.**

### Why this is worth its own PR

The retired sentence is precisely the one that would license **deleting this loop as dead weight without measuring anything** — "byte-identical" is a claim a reader acts on, and I was one step from acting on it while scoping #11176's retirement. It is the same class of defect as the `StorageWriteMap` "needs no overflow path" comment (#11189) and the `RegionMap` mechanism note (#11203): a stale reachability assertion in the file people read to decide what is safe to remove.

⚠️ **The general form, worth more than this one fix:** trust the **why** in a comment like that; measure the **happens**. Every such claim here has been a snapshot of a tree that has since moved.

### Scope

Comment only. **No emitted-asm change** — the edit is inside a `/-- … -/` docstring, so nothing reaches the `.s`. `lake build EvmAsm.Codegen.Dispatch` clean (1119 jobs).

### Not in scope

The retirement itself. It is **parked**, and #11176 records why: `seed_callee_storage` has **two** products — the storage seed table *and* `callee_balance_table`, a pre-resolved per-account balance read by `call_frame_descend` to stage a child frame's `env+32` for nested `SELFBALANCE` — and the 1,045-row A/B is **blind to the second one** (`h_SELFBALANCE` executes **zero** times on the row measured). A control that cannot fire proves nothing.
