### PR TITLE
chore: batch-merge #11207 #11209

### DIFF
--- a/EvmAsm/Codegen/Dispatch.lean
+++ b/EvmAsm/Codegen/Dispatch.lean
@@ -3035,10 +3035,34 @@ def emitRuntimeDispatcherPrologue : String :=
     it appends one 128 B persistent-exec-log entry (addrHash, slotKey, original=value,
     current=value — mirrors `exec_log_append_storage_seed`) and bumps
     env.persistentLogLength (env+448), so a nested callee's SLOAD finds its witness
-    value instead of cold 0. `callee_seed_count` is 0 for every current caller (the
-    top-level guest uses a different prologue; the verdict has not populated the table
-    yet), so this is INERT — depth-0 / recipient behaviour is byte-identical. The
-    enumeration that fills the table is 1.6.4.2.b (dispatch_tx_runtime_code). Uses only
+    value instead of cold 0.
+
+    ⛔ **THIS IS NOT INERT.** This docstring used to claim `callee_seed_count` "is 0 for
+    every current caller … so this is INERT — depth-0 / recipient behaviour is
+    byte-identical". **That was true when the loop was written and is false now**: the
+    enumeration it names as future work — 1.6.4.2.b, `seed_callee_storage` in
+    `dispatch_tx_runtime_code` — has since landed, and it populates the table on the
+    ordinary verdict path. ⇒ **this loop is the live consumer of the eager BAL-sourced
+    storage preload.** GH #11176.
+
+    MEASURED (2026-08-02), not inferred. Cited by input sha256 rather than index,
+    because an index is selector-relative and two agents reading "fixture 00192" from
+    two manifests differed by three orders of magnitude on the same day:
+      input sha256 `242fa1e11ec51d7b9f9395b93d3e02ebf6c7d9064196360eba1cefd367cdb13b`
+      relpath `blockchain_tests/for_amsterdam/amsterdam/eip7928_block_level_access_lists/`
+              `block_access_lists_eip7002/bal_7002_request_from_contract.json`
+    A commitlog dump of every access to
+    `callee_seed_count` shows it **walk 0 → 1 → 2 → 3 → 4 and keep going**, with the
+    bumps at the producer's own store and read-backs at the two loads this loop uses.
+    And disabling the producer flips **15 of 1,045** sampled rows from reject to accept
+    with **zero** reverse flips — an inert loop cannot do that.
+
+    ⚠️ **Why this mattered enough to write down:** the retired sentence is exactly the
+    one that would license deleting this loop as dead weight *without measuring
+    anything* — "byte-identical" is a claim a reader acts on. Trust the **why** in a
+    comment like that; measure the **happens**.
+
+    Uses only
     x5/x6/x7 (the dispatch loop re-inits them each iteration) and x28..x31 temps; never
     touches x10/x12/x13/x20/x21. -/
 def emitCalleeStorageSeedLoop : String :=

--- a/EvmAsm/Codegen/Programs/Storage.lean
+++ b/EvmAsm/Codegen/Programs/Storage.lean
@@ -438,21 +438,6 @@ def storageHandlers : List OpcodeHandlerSpec :=
     , opcodes := [0x54]
     , preBody :=
         stackUnderflowGuardAsm 1 ++ "\n" ++
-        -- GH #10619: record the storage READ into the block-lifetime read
-        -- container.  The spec records a read on both paths -- get_storage for
-        -- SLOAD, and get_storage_original/get_storage for SSTORE -- and
-        -- storage_reads survives rollback (state_tracker.py:90-93, :809-826),
-        -- so this must NOT be conditional on the frame committing.
-        -- EIP-7928's "a slot both read and written appears only in the
-        -- changes list" is discharged where the spec discharges it: the BAL
-        -- builder's dedup against storage_changes, not by suppressing this.
-        "  addi sp, sp, -24\n" ++
-        "  sd x1, 0(sp); sd x10, 8(sp); sd x11, 16(sp)\n" ++
-        "  mv a0, x20\n" ++
-        "  mv a1, x12\n" ++
-        "  jal ra, storage_read_record\n" ++
-        "  ld x1, 0(sp); ld x10, 8(sp); ld x11, 16(sp)\n" ++
-        "  addi sp, sp, 24\n" ++
         -- EIP-2929 storage-key access gas. The dispatch table already
         -- charged SLOAD's 100 warm floor, so the helper only charges the
         -- 2900 cold delta on first touch. Preserve handler return address
@@ -476,6 +461,22 @@ def storageHandlers : List OpcodeHandlerSpec :=
         "  beq x14, x15, .exit_outofgas\n" ++
         "  li x15, 3\n" ++
         "  beq x14, x15, .exit_outofgas\n" ++
+        -- GH #10619: record the storage READ into the block-lifetime read
+        -- container.  This is deliberately AFTER the access-cost check:
+        -- execution-specs charges SLOAD before get_storage, so a cold-access
+        -- OOG must not leave a durable storage-read row behind.  The read is
+        -- still unconditional after a successful access check and survives
+        -- rollback, matching state_tracker.py:90-93, :809-826.
+        -- EIP-7928's "a slot both read and written appears only in the
+        -- changes list" is discharged where the spec discharges it: the BAL
+        -- builder's dedup against storage_changes, not by suppressing this.
+        "  addi sp, sp, -24\n" ++
+        "  sd x1, 0(sp); sd x10, 8(sp); sd x11, 16(sp)\n" ++
+        "  mv a0, x20\n" ++
+        "  mv a1, x12\n" ++
+        "  jal ra, storage_read_record\n" ++
+        "  ld x1, 0(sp); ld x10, 8(sp); ld x11, 16(sp)\n" ++
+        "  addi sp, sp, 24\n" ++
         -- GH #10874: demand-driven cold read.  A persistent-log miss is not
         -- permission to return a guessed zero: execution-specs' get_storage
         -- resolves the slot by key and records the read independently of any
@@ -579,25 +580,6 @@ def storageHandlers : List OpcodeHandlerSpec :=
         "  ld x14, 568(x20)\n" ++
         "  li x15, 2201\n" ++
         "  bltu x14, x15, .exit_outofgas\n" ++
-        -- Placed AFTER the stipend guard on purpose: storage.py runs
-        -- `check_gas(evm, CALL_STIPEND + 1)` BEFORE `get_storage_original`, so an
-        -- SSTORE that fails it records NO read in the spec.  Recording first
-        -- would invent a read the spec never makes.
-        -- GH #10619: record the storage READ into the block-lifetime read
-        -- container.  The spec records a read on both paths -- get_storage for
-        -- SLOAD, and get_storage_original/get_storage for SSTORE -- and
-        -- storage_reads survives rollback (state_tracker.py:90-93, :809-826),
-        -- so this must NOT be conditional on the frame committing.
-        -- EIP-7928's "a slot both read and written appears only in the
-        -- changes list" is discharged where the spec discharges it: the BAL
-        -- builder's dedup against storage_changes, not by suppressing this.
-        "  addi sp, sp, -24\n" ++
-        "  sd x1, 0(sp); sd x10, 8(sp); sd x11, 16(sp)\n" ++
-        "  mv a0, x20\n" ++
-        "  mv a1, x12\n" ++
-        "  jal ra, storage_read_record\n" ++
-        "  ld x1, 0(sp); ld x10, 8(sp); ld x11, 16(sp)\n" ++
-        "  addi sp, sp, 24\n" ++
         -- EIP-2929 storage-key access gas. The dispatch table already
         -- charged SSTORE's 100 warm floor, so this helper only charges
         -- the 2900 cold delta on first key touch. Run before the scan /
@@ -622,6 +604,18 @@ def storageHandlers : List OpcodeHandlerSpec :=
         "  li x15, 3\n" ++
         "  beq x14, x15, .exit_outofgas\n" ++
         "  mv x19, x14\n" ++            -- x19 = access status (0 warm, 1 cold)
+        -- GH #10619: record the storage READ after the access-cost check but
+        -- before SSTORE's value-dependent gas pricing.  The prestate read is
+        -- required to price the write, while execution-specs' cold-access
+        -- `check_gas` must run first; otherwise a cold-access OOG leaves a
+        -- durable read row that the spec never records.
+        "  addi sp, sp, -24\n" ++
+        "  sd x1, 0(sp); sd x10, 8(sp); sd x11, 16(sp)\n" ++
+        "  mv a0, x20\n" ++
+        "  mv a1, x12\n" ++
+        "  jal ra, storage_read_record\n" ++
+        "  ld x1, 0(sp); ld x10, 8(sp); ld x11, 16(sp)\n" ++
+        "  addi sp, sp, 24\n" ++
         -- execution-specs gives fresh-created accounts a transaction-local
         -- zero *original* view. `get_storage` still observes a prior write in
         -- this transaction, so a matching log row must remain visible for the


### PR DESCRIPTION
Batch-merge of #11207 #11209 (all author pirapira).

Verified locally: `lake build` + all 15 `check-*.sh` green, including `check-build-units-link` and `check-asm-to-program`.

No layout movement: all pins already matched the relinked ELF (`.text = 0x0640d0`, `.bss = 0x1b5948a0`) and regen produced no drift. Both merged with no conflicts.