### PR TITLE
docs: justify account-write undo reservation

### DIFF
--- a/EvmAsm/Codegen/Programs/AccountWriteMap.lean
+++ b/EvmAsm/Codegen/Programs/AccountWriteMap.lean
@@ -98,7 +98,11 @@ import EvmAsm.Stateless.MemoryLayout
 namespace EvmAsm.Codegen
 
 /-- Transaction-local entries. One transaction's CALL-tree bound is 15038, so
-    the existing 16384-row reservation remains sufficient. -/
+    the existing 16384-row map reservation remains sufficient. This is an
+    occupancy bound, not an undo-flow bound: a hit updates one map row while
+    still pushing a fresh rollback record. The undo-flow workload derivation
+    needs 4294 rows on the densest current path, so the 16384-row reservation
+    is intentionally retained with roughly 3.8x headroom. -/
 def txAccountWritesCapacity : Nat := 16384
 
 /-- Block-lifetime entries. Amsterdam permits at most 9523 minimum-cost plain
@@ -542,11 +546,15 @@ def accountResolvePreStateFunction : String :=
 
     a5 = entryIndex, a6 = wasAbsent (1 on append, 0 on overwrite).
     On an overwrite the superseded fields are read from the entry itself, so the
-    caller does not have to stage them. The journal has the same 16384-entry
-    capacity as the transaction map, but the push is separately bounded because
-    repeated updates can add undo rows without increasing the live map count.
-    On exhaustion it returns `a0 = 1` and latches both overflow flags before any
-    out-of-range store; success returns `a0 = 0`. -/
+    caller does not have to stage them. The journal has the same provisioned
+    16384-entry capacity as the transaction map, but the push is separately
+    bounded because repeated updates can add undo rows without increasing the
+    live map count. The current producer census derives 4294 rows for the
+    densest path: two pushes for each EIP-7702 MTx authorization at 7816 regular
+    gas, plus six fixed boundary records. This is workload justification for
+    retaining the physical reservation, not a replacement for its fail-closed
+    bound. On exhaustion it returns `a0 = 1` and latches both overflow flags
+    before any out-of-range store; success returns `a0 = 0`. -/
 def accountWritesUndoPushFunction : String :=
   "account_writes_undo_push:\n" ++
   -- GH #10810: save t5/t6 as well, so this routine's CONTRACT matches what its callers

--- a/EvmAsm/Codegen/RegionMap.lean
+++ b/EvmAsm/Codegen/RegionMap.lean
@@ -330,7 +330,10 @@ def schemeAAnchors : List GuestRegion :=
     -- copying the dict (state_tracker.py:800-806), unaffordable at capacity x call
     -- depth, so the bounded equivalent is a reverse-replayed journal.
     { name := "account_writes_undo_area", base := 0xa2d20000, size := 0x200000, mode := .rw, zone := .ram,
-      evidence := "MemoryLayout ACCOUNT_WRITES_UNDO_AREA; 2 MiB = 16384x128 "
+      evidence := "MemoryLayout ACCOUNT_WRITES_UNDO_AREA; 2 MiB = 16384x128 provisioned; "
+        ++ "current census needs 4294 (4288 auth pushes + 6 fixed records), "
+        ++ "about 3.8x headroom; per-tx regular cap 16777216; "
+        ++ "fail-closed bgeu-before-store and overflow latch; "
         ++ "(entryIndex, wasAbsent, prevNonce, prevPresent, prevBalance, prevCodeHash); "
         ++ "reverse-replayed by account_writes_restore_frame" } ]
 

--- a/EvmAsm/Stateless/MemoryLayout.lean
+++ b/EvmAsm/Stateless/MemoryLayout.lean
@@ -105,7 +105,7 @@
   | `STORAGE_WRITES_UNDO_AREA`   | `0xa23a0000`     | 5 MiB       |
   | `ACCOUNT_WRITES_AREA`        | `0xa28a0000`     | 2.5 MiB     |
   | `TX_ACCOUNT_WRITES_AREA`     | `0xa2b20000`     | 2 MiB       |
-  | `ACCOUNT_WRITES_UNDO_AREA`   | `0xa2d20000`     | 2 MiB       |
+  | `ACCOUNT_WRITES_UNDO_AREA`   | `0xa2d20000`     | 2 MiB (16384×128 provisioned; 4294 needed; 3.8× headroom) |
 
   (`EVM_MEMORY_AREA` budget is per-frame nominal; with max call depth
   1024 the precise per-frame slicing is tracked in `Stateless/VM/`.)
@@ -417,11 +417,29 @@ def STORAGE_WRITES_UNDO_AREA : Word := 0xa23a0000
 def ACCOUNT_WRITES_AREA      : Word := 0xa28a0000
 /-- Per-transaction `account_writes` — the target of `account_write_record`. -/
 def TX_ACCOUNT_WRITES_AREA   : Word := 0xa2b20000
-/-- Undo journal for `TX_ACCOUNT_WRITES_AREA` — 16384 × 128 B = 2 MiB.
+/-- Undo journal for `TX_ACCOUNT_WRITES_AREA` — 16384 × 128 B = 2 MiB
+    provisioned. The current workload derivation needs only 4294 rows on the
+    densest known path: with the per-transaction regular-gas ceiling of
+    16,777,216 and the minimum set-code intrinsic base of 12,000,
+    `2 × floor((16,777,216 - 12,000) / 7,816) = 4,288` EIP-7702 MTx
+    authorization pushes, plus six fixed boundary records (sender inclusion,
+    upfront debit, refund, coinbase credit, and both sides of a self value
+    transfer). The 200M block-gas limit is not the applicable bound because
+    this counter resets at transaction incorporation. The 16384-row physical
+    reservation is intentionally retained, giving 12090 rows and about 3.8×
+    headroom rather than shrinking the mapped region.
 
-    Same frame-rollback rationale as storage undo (dict copy unaffordable at
-    capacity × call depth). Account side has no destroy-style second undo, so
-    capacity stays 1:1 with the tx map (16384). Entry layout (128 B):
+    The producer census is closed over the current direct account-write
+    publication sites: `BlockVerdictMtxRuntime.lean` sender inclusion,
+    `TxIntrinsicStateGas.lean` EIP-7702 nonce/code effects,
+    `NonstorageEffectLog.lean` generic nonstorage effects (including value
+    transfer, sender upfront/refund, and coinbase), and
+    `CreateCodeEffectLog.lean` CREATE/code effects. It is not a formal proof over
+    future indirect dispatcher routes, so the extra headroom is deliberate. The
+    existing `account_writes_undo_push` guard checks the count before the first
+    store, returns failure, and latches the transaction/block overflow flags;
+    callers reject that status. Same frame-rollback rationale as storage undo
+    (dict copy unaffordable at capacity × call depth). Entry layout (128 B):
 
         +0   entryIndex   (8 B)   index into the tx-level map this write touched
         +8   wasAbsent    (8 B)   1 if the write APPENDED a new key, else 0


### PR DESCRIPTION
## Summary
- document the 4,294-row current workload derivation for account-write undo pushes
- retain the 16,384-row / 2 MiB reservation with about 3.8x intentional headroom
- record the producer census scope and existing fail-closed overflow behavior

## Verification
- `lake build`
- `scripts/check-region-map.sh`
- `scripts/check-asm-to-program.sh`
- `scripts/check-file-size.sh`
- `git diff --check`

No runtime, address, ELF, or generated-file changes.