### PR TITLE
Audit RegionMap pins and phantom union entries

### DIFF
--- a/EvmAsm/Codegen/CallFrameLayout.lean
+++ b/EvmAsm/Codegen/CallFrameLayout.lean
@@ -136,33 +136,27 @@ def sszScratchBase : Nat := 0xbf980000
 /-- Total bytes the pre-allocated frame array occupies. -/
 def frameArrayBytes : Nat := frameSlotCount * frameStride
 
-/-! ## Placement: the frame arena UNIONS the BAL-replay basr pair (a1vvy, 200M)
+/-! ## Placement: the frame arena coalesces five BAL-replay children
 
-    ziskemu's RAM is 512 MiB (`0xa0000000..0xc0000000`). Under the former
-    1G-sized BAL arenas (`bsrMaxBalItems = 500000`, ~416 MiB) there was no free
-    window, so the frame arena *aliased* the contiguous, execution-dead
-    `basr_values`+`basr_accounts` pair (the #8513 union, 244 MiB ≥ 164 MiB).
-    The Amsterdam target is 200M block gas (`bsrMaxBalItems = 100000`), which
-    shrinks the BAL arenas to ~83 MiB; the union was retired (standalone arena)
-    while the BAL downsize left free RAM. The 200M log/receipt capacity lifts
-    (`vv4hr.3.4.*`) have since consumed that slack (measured `.data` headroom
-    fell to ~59 MiB), so a1vvy REINSTATES the union to reclaim ~49 MiB.
+    ziskemu's RAM is 512 MiB (`0xa0000000..0xc0000000`). The current Amsterdam
+    200M layout (`bsrMaxBalItems = 100000`) coalesces the execution-dead
+    `basr_values`/`basr_accounts` pair and the three `baap_storage_*` arrays
+    into the front of `call_frame_arena`. The current frame array is
+    `1025 * 0x19000 = 104,960,000 B` (about 100.1 MiB), larger than the
+    coalesced child prefix (about 61.6 MiB), with a trailing pad. The
+    `bv_system_storage_log` is deliberately standalone because it is read
+    post-dispatch; `evm_memory_pool` follows the frame arena.
 
-    The size relation flipped: the frame array (`frameArrayBytes` ~228 MiB at the
-    reconciled `0x39000` stride) is now
-    LARGER than the basr pair (~49 MiB), so the pair is coalesced into the FRONT
-    of `call_frame_arena` (`BlockVerdictDataSection.lean`) rather than the arena
-    aliasing into the pair. Soundness is the same execution-dead disjointness
-    #8513 established and is now load-bearing again: `basr_values`/`basr_accounts`
-    are referenced ONLY in `BlockVerdictStateRoot` (Phase H,
-    pre-dispatch state-root recompute) with no post-replay reader, while
-    `call_frame_arena` is referenced ONLY by `CallFrameBase`/`Descend`/`Return`
-    (Phase D dispatch) — sequential, disjoint live windows. See
-    `docs/call-frame-memory-layout.md` §5. -/
+    The historical 1G layout used a 244 MiB basr union and a 228 MiB frame
+    stride. Those values remain useful in the design history but are not live
+    geometry. The current phase-ownership argument is the same execution-dead
+    Phase-H / Phase-D sequencing: the five child arrays are used during the
+    pre-dispatch state-root recompute, while the frame arena is used during
+    dispatch. See `docs/call-frame-memory-layout.md` §5. -/
 
 /-- Total bytes of all 200M-sized BAL/state-replay static arenas
     (`bsr_changes` + `basr_records/paths/values/accounts` +
-    `baap_storage_desc/paths/delete_paths/values`), matching the `.zero`
+    `baap_storage_desc/paths/values`), matching the `.zero`
     declarations in `BlockVerdictDataSection.lean`. -/
 def balArenaTotalBytes : Nat :=
   bsrMaxStateChanges * bsrStateChangeBytes
@@ -170,7 +164,7 @@ def balArenaTotalBytes : Nat :=
     + bsrMaxStateChanges * bsrPathBytes
     + 2 * (bsrMaxStateChanges * bsrEncodedAccountBytes)
     + bsrMaxBalItems * baapStorageDescBytes
-    + 3 * (bsrMaxBalItems * bsrPathBytes)
+    + 2 * (bsrMaxBalItems * bsrPathBytes)
 
 /-! ## Verified consistency invariants (kernel-checked `decide`) -/
 
@@ -187,16 +181,13 @@ theorem frameMeta_within_stride : frameMetaOff + frameMetaBytes ≤ frameStride 
 /-- 1025 slots cover depths 0..1024 inclusive. -/
 theorem frameSlotCount_eq : frameSlotCount = 1025 := by decide
 
-/-- **Overrun closed (the `.71` fix, load-bearing):** the deepest reachable frame
-    is depth `maxCallDepth` (1024); the emitted `frame_base(d) = arena + (d-1)*stride`
-    places its slot at arena offset `(maxCallDepth-1)*frameStride`, so the slot spans
-    `[(maxCallDepth-1)*frameStride, maxCallDepth*frameStride)`. This slot end stays
-    within `frameArrayBytes`, i.e. the entire depth-1024 frame (memory/stack/env/…)
-    lands inside `call_frame_arena` and never overruns into the following `.data`.
-    With the STALE `frameStride = 0x29000` the arena was sized `1025*0x29000` while
-    `frame_base` stepped `0x39000`, so this failed for every depth ≥ ~738 — that
-    failure WAS the bug. It now passes for all 1025 slots against the corrected
-    `0x39000` stride/arena. -/
+/-- **Overrun closed (load-bearing):** the deepest reachable frame is depth
+    `maxCallDepth` (1024), and the current emitted `frame_base(d)` uses
+    `d * frameStride` with `frameStride = 0x19000`. The slot at depth 1024
+    therefore ends at `maxCallDepth * frameStride`, which is inside the
+    `frameArrayBytes = frameSlotCount * frameStride` arena. The old geometry
+    divergence is historical; this guard pins the current 1025-slot geometry
+    rather than carrying either old `0x29000` or `0x39000` as a live value. -/
 theorem frameArray_covers_all_depths :
     maxCallDepth * frameStride ≤ frameArrayBytes := by decide
 
@@ -210,12 +201,12 @@ theorem frameArray_covers_all_depths :
 theorem frameArray_unions_basr_pair :
     2 * (bsrMaxStateChanges * bsrEncodedAccountBytes) ≤ frameArrayBytes := by decide
 
-/-- **Union-fits gate (load-bearing), post-`4ch8f.73`:** the basr pair + the four
-    Phase-H `baap_storage_*` arenas (`baap_storage_desc` + 3 `* bsrPathBytes` path
-    arenas) all fit within the frame array, so the six coalesced foreign arenas
+/-- **Union-fits gate (load-bearing), post-`4ch8f.73`:** the basr pair + the three
+    Phase-H `baap_storage_*` arenas (`baap_storage_desc` + the `baap_storage_paths` and `baap_storage_values` arrays)
+    all fit within the frame array, so the five coalesced foreign arenas
     occupy distinct, non-overlapping, 32-aligned sub-ranges at the front of
     `call_frame_arena` (`[0,S)`, `[S,2S)`, then baap at `[2S, …)`) with a
-    non-negative trailing pad to `frameArrayBytes`. All six are Phase-H
+    non-negative trailing pad to `frameArrayBytes`. All five are Phase-H
     (state-root recompute) scratch, dead during the Phase-D dispatch window when
     the frame array is live. `bv_system_storage_log` is NO LONGER among them: it
     is read post-dispatch (a frame slot would clobber it), so `4ch8f.73` moved it
@@ -224,12 +215,12 @@ theorem frameArray_unions_basr_pair :
     `frameArray_unions_basr_and_syslog` / `frameArray_unions_basr_syslog_baap`. -/
 theorem frameArray_unions_basr_baap :
     2 * (bsrMaxStateChanges * bsrEncodedAccountBytes)
-      + bsrMaxBalItems * baapStorageDescBytes + 3 * (bsrMaxBalItems * bsrPathBytes)
+      + bsrMaxBalItems * baapStorageDescBytes + 2 * (bsrMaxBalItems * bsrPathBytes)
       ≤ frameArrayBytes := by decide
 
 /-- **The fits proof that actually matters (200M layout):** the BAL/state-replay
     arenas (~83 MiB at the 200M capacity) plus the standalone 1025-slot frame
-    array (~228 MiB at the reconciled `0x39000` stride) together stay well inside
+    array (104,960,000 B, about 100.1 MiB at the current `0x19000` stride) stay well inside
     the `.data`→`.sszscratch` span
     (456 MiB) — ~145 MiB of slack for the remaining `.data` objects (~80 MiB
     measured). The ELF-level ground truth is `readelf -lW`: the top RW LOAD
@@ -240,7 +231,8 @@ theorem frameArray_and_balArenas_fit :
 
 /-- The usable `.data`→`.sszscratch` span is `0x1c980000` = 479,723,520 B
     = 457.5 MiB. Under the 200M layout the BAL-replay arenas (~83 MiB) and the
-    standalone frame array (~228 MiB) leave ample room for the rest of `.data`. -/
+    current standalone frame array (104,960,000 B, about 100.1 MiB) leave ample
+    room for the rest of `.data`. -/
 theorem data_gap_bytes : sszScratchBase - dataBase = 0x1c980000 := by decide
 
 /-- **vv4hr.3.4.2 PACK:** the active block-log arena = packed descriptors

--- a/EvmAsm/Codegen/CallFramePhase.lean
+++ b/EvmAsm/Codegen/CallFramePhase.lean
@@ -8,10 +8,10 @@
 
   ## What is being modeled
 
-  `call_frame_arena` (`frameArrayBytes` ≈ 228 MiB, the Phase-D EVM
-  call-frame overlay) physically coalesces six execution-dead Phase-H
+  `call_frame_arena` (`frameArrayBytes` ≈ 100.1 MiB, the Phase-D EVM
+  call-frame overlay) physically coalesces five execution-dead Phase-H
   arenas into its front (`basr_values`, `basr_accounts`,
-  `baap_storage_{desc,paths,delete_paths,values}`;
+  `baap_storage_{desc,paths,values}`;
   `RegionMap.dataUnionChildren`).  (`bv_system_storage_log` was un-unioned in
   `4ch8f.73` — it is read post-dispatch, so a frame slot would clobber it.)
   Until now the no-corruption argument was
@@ -22,7 +22,7 @@
   * The arena is ONE separation-logic resource
     (`phaseDView base = anyBytes base frameArrayBytes`), never two.
   * The Phase-H view is a *tiling* of that same resource
-    (`phaseHView` = six havoc'd children + havoc'd pad), and
+    (`phaseHView` = five havoc'd children + havoc'd pad), and
     `phaseD_eq_phaseH` proves the two views are THE SAME assertion.
   * Phase transitions are rewrites across that equality.  Both directions
     **forget contents by construction** (`anyBytes` carries ownership and
@@ -56,7 +56,7 @@ namespace CallFramePhase
 
 open EvmAsm.Rv64 EvmAsm.Rv64.SAsm
 
-/-- Total bytes of the six coalesced Phase-H arenas (the union front). -/
+/-- Total bytes of the five coalesced Phase-H arenas (the union front). -/
 def unionBytes : Nat := (RegionMap.dataUnionChildren.map (·.size)).sum
 
 /-- Trailing pad: arena bytes past the union front, owned by neither Phase-H
@@ -67,7 +67,7 @@ def unionPadBytes : Nat := frameArrayBytes - unionBytes
     `RegionMap.dataUnionChildren_fit_arena` at the summed granularity). -/
 theorem unionBytes_le_arena : unionBytes ≤ frameArrayBytes := by decide
 
-/-- Phase-H tiling segment sizes: the six children in layout order, then
+/-- Phase-H tiling segment sizes: the five children in layout order, then
     the pad. -/
 def phaseHSegs : List Nat :=
   RegionMap.dataUnionChildren.map (·.size) ++ [unionPadBytes]
@@ -84,7 +84,7 @@ theorem phaseHSegs_dvd8 : ∀ s ∈ phaseHSegs, 8 ∣ s := by decide
     (the EVM call-frame overlay owns every byte, contents unspecified). -/
 def phaseDView (base : Word) : Assertion := anyBytes base frameArrayBytes
 
-/-- **Phase-H view**: the six coalesced arenas plus the pad, each a
+/-- **Phase-H view**: the five coalesced arenas plus the pad, each a
     havoc'd tile of the same byte range. -/
 def phaseHView (base : Word) : Assertion := anyTilesAt base 0 phaseHSegs
 
@@ -113,7 +113,7 @@ private def S : Nat := RegionMap.basrArenaBytes
 private def D : Nat := bsrMaxBalItems * baapStorageDescBytes
 private def P : Nat := bsrMaxBalItems * bsrPathBytes
 
-/-- The Phase-H view unfolded to the six named children plus the pad, each
+/-- The Phase-H view unfolded to the five named children plus the pad, each
     at its accumulated byte offset.  The offsets are stated as left-nested
     sums exactly as the tiling produces them;
     `children_offsets_match_regionMap` pins them to the audited
@@ -125,43 +125,41 @@ theorem phaseHView_children (base : Word) :
         ** (anyBytes (base + BitVec.ofNat 64 (S + S)) D
         ** (anyBytes (base + BitVec.ofNat 64 (S + S + D)) P
         ** (anyBytes (base + BitVec.ofNat 64 (S + S + D + P)) P
-        ** (anyBytes (base + BitVec.ofNat 64 (S + S + D + P + P)) P
-        ** anyBytes (base + BitVec.ofNat 64 (S + S + D + P + P + P))
-            unionPadBytes)))))) := by
+        ** anyBytes (base + BitVec.ofNat 64 (S + S + D + P + P))
+            unionPadBytes))))) := by
   show anyTilesAt base 0 phaseHSegs = _
-  rw [show phaseHSegs = [S, S, D, P, P, P, unionPadBytes] from rfl]
+  rw [show phaseHSegs = [S, S, D, P, P, unionPadBytes] from rfl]
   simp only [anyTilesAt, Nat.zero_add, sepConj_emp_right']
 
 /-- The accumulated offsets above are exactly the audited
     `RegionMap.dataUnionChildren` offsets (and the pad starts at
     `unionBytes`). -/
 theorem children_offsets_match_regionMap :
-    [0, S, S + S, S + S + D, S + S + D + P, S + S + D + P + P]
+    [0, S, S + S, S + S + D, S + S + D + P]
       = RegionMap.dataUnionChildren.map (·.off)
-    ∧ S + S + D + P + P + P = unionBytes := by
+    ∧ S + S + D + P + P = unionBytes := by
   constructor <;> decide
 
 -- ============================================================================
 -- Phase transitions
 -- ============================================================================
 
-/-- **Phase-H → Phase-D handoff, from concrete buffers**: the six child
+/-- **Phase-H → Phase-D handoff, from concrete buffers**: the five child
     buffers with WHATEVER contents Phase H left in them, plus the untouched
     pad, assemble into the single arena resource Phase D owns.  Contents are
     forgotten here — this hypothesis shape is all a `block_verdict`-level
     composition needs at the dispatch boundary. -/
 theorem phaseH_to_phaseD (base : Word) (h : PartialState)
-    (bs₁ bs₂ bs₃ bs₄ bs₅ bs₆ : List (BitVec 8))
+    (bs₁ bs₂ bs₃ bs₄ bs₅ : List (BitVec 8))
     (hl₁ : bs₁.length = S) (hl₂ : bs₂.length = S) (hl₃ : bs₃.length = D)
-    (hl₄ : bs₄.length = P) (hl₅ : bs₅.length = P) (hl₆ : bs₆.length = P)
+    (hl₄ : bs₄.length = P) (hl₅ : bs₅.length = P)
     (hp : (bytesRegion (base + BitVec.ofNat 64 0) bs₁
         ** (bytesRegion (base + BitVec.ofNat 64 S) bs₂
         ** (bytesRegion (base + BitVec.ofNat 64 (S + S)) bs₃
         ** (bytesRegion (base + BitVec.ofNat 64 (S + S + D)) bs₄
         ** (bytesRegion (base + BitVec.ofNat 64 (S + S + D + P)) bs₅
-        ** (bytesRegion (base + BitVec.ofNat 64 (S + S + D + P + P)) bs₆
-        ** anyBytes (base + BitVec.ofNat 64 (S + S + D + P + P + P))
-            unionPadBytes)))))) h) :
+        ** anyBytes (base + BitVec.ofNat 64 (S + S + D + P + P))
+            unionPadBytes))))) h) :
     phaseDView base h := by
   have w : ∀ (b : Word) (n : Nat) (bs : List (BitVec 8)), bs.length = n →
       ∀ h', bytesRegion b bs h' → anyBytes b n h' :=
@@ -171,14 +169,13 @@ theorem phaseH_to_phaseD (base : Word) (h : PartialState)
   refine sepConj_mono_left (w _ _ _ hl₂) h₁ (sepConj_mono_right (fun h₂ hx₂ => ?_) h₁ hx₁)
   refine sepConj_mono_left (w _ _ _ hl₃) h₂ (sepConj_mono_right (fun h₃ hx₃ => ?_) h₂ hx₂)
   refine sepConj_mono_left (w _ _ _ hl₄) h₃ (sepConj_mono_right (fun h₄ hx₄ => ?_) h₃ hx₃)
-  refine sepConj_mono_left (w _ _ _ hl₅) h₄ (sepConj_mono_right (fun h₅ hx₅ => ?_) h₄ hx₄)
-  exact sepConj_mono_left (w _ _ _ hl₆) h₅ hx₅
+  exact sepConj_mono_left (w _ _ _ hl₅) h₄ hx₄
 
 /-- **Phase-D → Phase-H re-entry** (stated for completeness; the guest's
     phase order is H then D with no post-dispatch Phase-H reader — this
     direction documents that even if one existed, it would receive its
     buffers HAVOC'D, not with their old contents): the arena resource
-    re-partitions into the six child tiles + pad, contents unspecified. -/
+    re-partitions into the five child tiles + pad, contents unspecified. -/
 theorem phaseD_to_phaseH (base : Word) (h : PartialState)
     (hp : phaseDView base h) : phaseHView base h :=
   (phaseD_eq_phaseH base) ▸ hp

--- a/EvmAsm/Codegen/RegionMap.lean
+++ b/EvmAsm/Codegen/RegionMap.lean
@@ -746,12 +746,12 @@ theorem schemeA_matches_layout :
     ELF ground truth (`readelf -s`, this build; post-`4ch8f.73` — five children,
     `bv_system_storage_log` un-unioned):
     ```
-    add053a0  call_frame_arena  == basr_values
-    af5705a0  basr_accounts          (+  S)
-    b0ddb7a0  baap_storage_desc      (+ 2S)
-    b11ac0a0  baap_storage_paths
-    b17c68a0  baap_storage_values
-    b411e3a0  call_frame_arena_end   (== base + frameArrayBytes)
+    ad3dd7a0  call_frame_arena  == basr_values
+    aec489a0  basr_accounts          (+  S)
+    b04b3ba0  baap_storage_desc      (+ 2S)
+    b08844a0  baap_storage_paths
+    b0e9eca0  baap_storage_values
+    b37f67a0  call_frame_arena_end   (== base + frameArrayBytes)
     ```
     with `S = bsrMaxStateChanges * bsrEncodedAccountBytes`. These are relocatable
     symbols reached via independent `la`; only the *offsets within the arena* are
@@ -761,12 +761,12 @@ theorem schemeA_matches_layout :
 
 /-- Absolute base of `call_frame_arena` (== `basr_values`) in this build.
     LINK-LAYOUT-DEPENDENT — recorded so the drift guard can anchor the union. -/
-def callFrameArenaBase : Nat := 0xadd053a0
+def callFrameArenaBase : Nat := 0xad3dd7a0
 
 /-! The memory-pool base is link-dependent too. Naming it separately lets the
     drift guard compare this absolute pin with the linked ELF, rather than
     checking only the relative 96 MiB extent. -/
-def evmMemoryPoolBase : Nat := 0xb411e3a0
+def evmMemoryPoolBase : Nat := 0xb37f67a0
 
 /-- Absolute shared nested-frame EVM-memory pool, emitted immediately after
     `call_frame_arena`. Both endpoints are link-layout-dependent pins checked
@@ -777,8 +777,8 @@ def evmMemoryPoolRegion : GuestRegion :=
     evidence := "ELF evm_memory_pool..evm_memory_pool_end; 96 MiB shared LIFO frame memory" }
 
 theorem evmMemoryPoolRegion_matches_elf :
-    evmMemoryPoolRegion.base = 0xb411e3a0
-      ∧ evmMemoryPoolRegion.base + evmMemoryPoolRegion.size = 0xba11e3a0 := by decide
+    evmMemoryPoolRegion.base = 0xb37f67a0
+      ∧ evmMemoryPoolRegion.base + evmMemoryPoolRegion.size = 0xb97f67a0 := by decide
 
 /-- The two runtime frame allocations are adjacent, disjoint, fit RAM, and both
     lie inside `.bss`; this is the pool/slot non-aliasing soundness fence. -/
@@ -862,7 +862,7 @@ theorem callFrameArena_within_data :
 
 /-- Standalone base of `bv_system_storage_log` in this build (post-`.73`).
     LINK-LAYOUT-DEPENDENT — read from the ELF, guarded by `check-region-map.sh`. -/
-def syslogBase : Nat := 0xab9a2400
+def syslogBase : Nat := 0xab07a800
 
 /-- **The `.73` clobber is closed (load-bearing).** The un-unioned
     `bv_system_storage_log` region `[syslogBase, syslogBase + bvSystemStorageLogBytes)`

--- a/EvmAsm/Codegen/RegionMap.lean
+++ b/EvmAsm/Codegen/RegionMap.lean
@@ -746,12 +746,12 @@ theorem schemeA_matches_layout :
     ELF ground truth (`readelf -s`, this build; post-`4ch8f.73` — five children,
     `bv_system_storage_log` un-unioned):
     ```
-    ad3dd7a0  call_frame_arena  == basr_values
-    aec489a0  basr_accounts          (+  S)
-    b04b3ba0  baap_storage_desc      (+ 2S)
-    b08844a0  baap_storage_paths
-    b0e9eca0  baap_storage_values
-    b37f67a0  call_frame_arena_end   (== base + frameArrayBytes)
+    ad3dd5e0  call_frame_arena  == basr_values
+    aec487e0  basr_accounts          (+  S)
+    b04b39e0  baap_storage_desc      (+ 2S)
+    b08842e0  baap_storage_paths
+    b0e9eae0  baap_storage_values
+    b37f65e0  call_frame_arena_end   (== base + frameArrayBytes)
     ```
     with `S = bsrMaxStateChanges * bsrEncodedAccountBytes`. These are relocatable
     symbols reached via independent `la`; only the *offsets within the arena* are
@@ -761,12 +761,12 @@ theorem schemeA_matches_layout :
 
 /-- Absolute base of `call_frame_arena` (== `basr_values`) in this build.
     LINK-LAYOUT-DEPENDENT — recorded so the drift guard can anchor the union. -/
-def callFrameArenaBase : Nat := 0xad3dd7a0
+def callFrameArenaBase : Nat := 0xad3dd5e0
 
 /-! The memory-pool base is link-dependent too. Naming it separately lets the
     drift guard compare this absolute pin with the linked ELF, rather than
     checking only the relative 96 MiB extent. -/
-def evmMemoryPoolBase : Nat := 0xb37f67a0
+def evmMemoryPoolBase : Nat := 0xb37f65e0
 
 /-- Absolute shared nested-frame EVM-memory pool, emitted immediately after
     `call_frame_arena`. Both endpoints are link-layout-dependent pins checked
@@ -777,8 +777,8 @@ def evmMemoryPoolRegion : GuestRegion :=
     evidence := "ELF evm_memory_pool..evm_memory_pool_end; 96 MiB shared LIFO frame memory" }
 
 theorem evmMemoryPoolRegion_matches_elf :
-    evmMemoryPoolRegion.base = 0xb37f67a0
-      ∧ evmMemoryPoolRegion.base + evmMemoryPoolRegion.size = 0xb97f67a0 := by decide
+    evmMemoryPoolRegion.base = 0xb37f65e0
+      ∧ evmMemoryPoolRegion.base + evmMemoryPoolRegion.size = 0xb97f65e0 := by decide
 
 /-- The two runtime frame allocations are adjacent, disjoint, fit RAM, and both
     lie inside `.bss`; this is the pool/slot non-aliasing soundness fence. -/
@@ -862,7 +862,7 @@ theorem callFrameArena_within_data :
 
 /-- Standalone base of `bv_system_storage_log` in this build (post-`.73`).
     LINK-LAYOUT-DEPENDENT — read from the ELF, guarded by `check-region-map.sh`. -/
-def syslogBase : Nat := 0xab07a800
+def syslogBase : Nat := 0xab07a640
 
 /-- **The `.73` clobber is closed (load-bearing).** The un-unioned
     `bv_system_storage_log` region `[syslogBase, syslogBase + bvSystemStorageLogBytes)`

--- a/EvmAsm/Codegen/RegionMap.lean
+++ b/EvmAsm/Codegen/RegionMap.lean
@@ -25,14 +25,15 @@
   core → Codegen), so the region map lives here rather than under `Stateless/`.
 
   **Aliasing (soundness-critical, deferred proof).** The guest has exactly one
-  intentional physical overlap: `call_frame_arena` (~228 MiB, EVM call-frame
-  overlay) coalesces six execution-dead Phase-H arenas into its front
+  intentional physical overlap: `call_frame_arena` (104,960,000 B, about
+  100.1 MiB, EVM call-frame
+  overlay) coalesces five execution-dead Phase-H arenas into its front
   (`basr_values`, `basr_accounts`, `baap_storage_desc`,
-  `baap_storage_paths`, `baap_storage_delete_paths`, `baap_storage_values`).
+  `baap_storage_paths`, and `baap_storage_values`).
   (`bv_system_storage_log` was un-unioned in `4ch8f.73` — it is read
   post-dispatch, so it now lives standalone, `syslog_disjoint_from_frameArena`.)
   This file *documents* those overlaps precisely (`aliasedPairs` + the per-pair
-  `_overlap` theorems) and proves the six coalesced children are mutually
+  `_overlap` theorems) and proves the five coalesced children are mutually
   disjoint. It does **not** prove they are safe to share — the verified
   phase-ownership / separation-logic model is bead `.6`'s other (deferred) half.
   See `docs/4ch8f-region-map.md` §"Overlap inventory" and
@@ -154,11 +155,11 @@ def allPairwiseDisjoint : List GuestRegion → Bool
     | structure | cap | enforced at | AT THE CAP |
     |---|---|---|---|
     | persistent exec log | 16,384 rows | `h_SSTORE` (`li x14, 16384; bgeu x15, x14, .exit_outofgas`) | ⭐ **FAILS CLOSED** — rejects |
-    | storage-write undo journal | 32,768 entries | `storage_writes_undo_push` (`bgeu t1, t2, .Lswup_done`) | ⛔ **FAILS OPEN** — skips the push, does not bump the count |
+    | storage-write undo journal | 32,768 entries | `storage_writes_undo_push` (`bgeu t1, t2, .Lswup_fail`) | ⭐ **FAILS CLOSED** — latches overflow and rejects |
 
     ⭐ **THAT ASYMMETRY IS THE SINGLE MOST IMPORTANT FACT ABOUT THESE TWO BUFFERS.**
-    Only the journal can be exceeded silently, and past its cap
-    `write_sets_restore_frame` leaves a reverted write applied.
+    The journal is finite and may conservatively reject at its cap; it does not
+    silently omit a rollback record.
 
     **LIFETIMES — both per-transaction, but established by different mechanisms**,
     which is why one figure is block-derived and the other is not:
@@ -274,34 +275,20 @@ def schemeAAnchors : List GuestRegion :=
     -- (state_tracker.py:800-806) under the no-dynamic-allocation constraint --
     -- a per-frame copy would cost capacity x call depth.
     --
-    -- ⛔ GH #11189: THIS REGION IS UNDERSIZED AND ITS OVERFLOW IS FAIL-OPEN.  The
-    -- previous note here claimed it was "bounded by the SSTORE handler's own
-    -- 16384-row cap, so it needs no overflow path".  THAT IS FALSE, and the error is
-    -- CAPACITY-versus-FLOW: the 16384 cap bounds LIVE ROWS in the write map, not the
-    -- NUMBER OF WRITES.  destroy_storage DECREMENTS tx_storage_writes_count as it
-    -- drops rows (.Lds_drop), so each destruction frees map capacity that the next
-    -- write refills -- a slot can be written, destroyed, written, destroyed, pushing
-    -- one undo every time while live rows never exceed 16384.
-    --
-    -- MEASURED: fixture 00192 reaches storage_writes_undo_count = 32768 exactly (the
-    -- capacity), so the guard fires on a non-adversarial block today.  DERIVED bound:
-    -- per-transaction regular gas is capped at TX_MAX_GAS_LIMIT = 16,777,216
-    -- (transactions.py:63, fork.py:1098-1100) and the cheapest journal-pushing write
-    -- costs WARM_ACCESS = 100, so up to 167,772 entries are reachable -- 5.1x this
-    -- region.  At the current 160 B stride that is 25.6 MiB; at the 40 B achievable
-    -- width (GH #11189 row audit) 6.4 MiB.
-    --
-    -- ⚠️ AND THE OVERFLOW IS SILENT: storage_writes_undo_push does
-    -- `bgeu t1, t2, .Lswup_done`, skipping the push AND not bumping the count, so
-    -- write_sets_restore_frame leaves a reverted write applied.  Its unappend arm also
-    -- decrements tx_storage_writes_count per kind-1 entry, so past the cap the count
-    -- is inconsistent with the contents -- the guard must REJECT at the push; making
-    -- the omission observable afterwards is not sufficient.
+    -- GH #11189 / #11200: the journal has a finite capacity, but its overflow
+    -- behavior is now fail-closed. `storage_writes_undo_push` checks the cursor
+    -- before its first journal store, returns `a0 = 1`, and latches both
+    -- `tx_storage_writes_overflow` and `storage_writes_overflow`; its callers
+    -- reject or consume that latch before mutating/publishing the incomplete map.
+    -- `destroy_storage` also checks the cursor before its read/drop side effects.
+    -- Do not describe the cap as unreachable: value-unchanged SSTORE paths can
+    -- journal without advancing the persistent execution-log cursor, so the
+    -- capacity question is distinct from the fail-closed soundness fix.
     { name := "storage_writes_undo_area", base := 0xa23a0000, size := 0x500000, mode := .rw, zone := .ram,
       evidence := "MemoryLayout STORAGE_WRITES_UNDO_AREA; 5 MiB = 32768x160 "
         ++ "(entryIndex, wasAbsent, prevValue|fullRow); reverse-replayed by write_sets_restore_frame; "
         ++ "160 B stride journals full 128 B row for destroy_storage wasAbsent=2. "
-        ++ "⛔ UNDERSIZED 5.1x (167772 reachable per tx) AND FAIL-OPEN on overflow -- GH #11189. "
+        ++ "overflow is fail-closed: storage_writes_undo_push latches both tx/block flags and returns failure before any journal store; "
         ++ "Row audit: 16 B of the 160 (offsets 16..31) are never written and never read; "
         ++ "kind 0/1 need 40 B (32 B value + packed index/kind, 8-aligned), only kind 2 "
         ++ "needs the 128 B payload and it is bounded by distinct written slots, so "
@@ -538,16 +525,9 @@ def schemeAAnchors : List GuestRegion :=
 def textSizeBytes : Nat := 0x628c8
 
 /-- ELF-measured `.data` size for the `stateless_guest` unit
-    (`readelf -S`, `0x195726d0`). Link-layout-dependent. Shrank by `0x40` (64 B)
-    when t1iqb resized `bv_cdl_stage` `32→64` for the verified arena-free
-    CALLDATALOAD (`window ++ 32-byte zero pad` footprint). Earlier it grew by
-    `0x4010000` (~64 MiB) when the `.71` reconciliation raised `frameStride`
-    `0x29000→0x39000` (the `call_frame_arena` trailing pad). Grew by `0x4fb00`
-    (~318 KiB) when `evm_precompile_frame`'s returndata window was sized to
-    `precompileFrameReturndataCapBytes` so RETURNDATACOPY sees the full child
-    return (evm-asm-pwqhw). Grew by `0x40` (64 B) when the `.data`→`.bss`
-    splitter was fixed to keep mixed zero/nonzero groups (`blsg_b_be`,
-    `p256_one_be`) whole in `.data` (evm-asm-rowr9). -/
+    (`readelf -S`, current value `0x5370`). Link-layout-dependent; this is
+    intentionally a short current fact rather than a copied growth history.
+    The drift guard re-derives it from the linked ELF. -/
 def dataSizeBytes : Nat := 0x5370
 
 /-- ELF-measured `.bss` size for the `stateless_guest` unit. Grew by `0x77900`
@@ -598,8 +578,8 @@ def textRegion : GuestRegion :=
     -- value with no tripwire is the exposure, whether or not it currently agrees.
     evidence := "ELF -Ttext=0x80000000; size link-dependent (drift guard)" }
 
-/-- `.data` section (`-Tdata=0xa3000000`). Contains every static/verdict arena,
-    including the `call_frame_arena` union family enumerated in `dataUnionArenas`. -/
+/-- `.data` section (`-Tdata=0xa3000000`). Contains the initialized static and
+    verdict data; the call-frame union itself is in `.bss`. -/
 def dataRegion : GuestRegion :=
   { name := ".data", base := 0xa3000000, size := dataSizeBytes, mode := .rw, zone := .ram,
     evidence := "ELF -Tdata=0xa3000000; 0x" ++ natToHex dataSizeBytes ++ "-byte PROGBITS extent" }
@@ -665,7 +645,7 @@ def stateTrackerLiveRegion : GuestRegion :=
     `.9.3` frame against. It is GENUINELY pairwise disjoint with NO exception
     list: `zisk_system`→OUTPUT→`guest_stack` tile `[0xa0000000, 0xa0050000)`
     contiguously; `state_tracker_live` ends `0xa0830000` well below `.data`
-    (`0xa3000000`); `.data` ends `0xa3005370`, `.bss` ends `0xbf215000`,
+    (`0xa3000000`); `.data` ends `0xa3005370`, `.bss` ends `0xbe6a4860`,
     both below `.sszscratch`; INPUT and `.text` sit in their own zones. The
     guest's one intentional overlap lives strictly inside the `.bss` member and
     is expanded — as its own inventory —
@@ -763,16 +743,15 @@ theorem schemeA_matches_layout :
 
 /-! ## Within-`.bss` aliasing inventory (the `call_frame_arena` union).
 
-    ELF ground truth (`readelf -s`, this build; post-`4ch8f.73` — six children,
+    ELF ground truth (`readelf -s`, this build; post-`4ch8f.73` — five children,
     `bv_system_storage_log` un-unioned):
     ```
-    af420780  call_frame_arena  == basr_values
-    b0c8b980  basr_accounts          (+  S)
-    b24f6b80  baap_storage_desc      (+ 2S)
-    b28c7480  baap_storage_paths
-    b2ee1c80  baap_storage_delete_paths
-    b34fc480  baap_storage_values
-    b5839780  call_frame_arena_end   (== base + frameArrayBytes)
+    add053a0  call_frame_arena  == basr_values
+    af5705a0  basr_accounts          (+  S)
+    b0ddb7a0  baap_storage_desc      (+ 2S)
+    b11ac0a0  baap_storage_paths
+    b17c68a0  baap_storage_values
+    b411e3a0  call_frame_arena_end   (== base + frameArrayBytes)
     ```
     with `S = bsrMaxStateChanges * bsrEncodedAccountBytes`. These are relocatable
     symbols reached via independent `la`; only the *offsets within the arena* are
@@ -782,19 +761,24 @@ theorem schemeA_matches_layout :
 
 /-- Absolute base of `call_frame_arena` (== `basr_values`) in this build.
     LINK-LAYOUT-DEPENDENT — recorded so the drift guard can anchor the union. -/
-def callFrameArenaBase : Nat := 0xaf420780
+def callFrameArenaBase : Nat := 0xadd053a0
+
+/-! The memory-pool base is link-dependent too. Naming it separately lets the
+    drift guard compare this absolute pin with the linked ELF, rather than
+    checking only the relative 96 MiB extent. -/
+def evmMemoryPoolBase : Nat := 0xb411e3a0
 
 /-- Absolute shared nested-frame EVM-memory pool, emitted immediately after
     `call_frame_arena`. Both endpoints are link-layout-dependent pins checked
     against the ELF. -/
 def evmMemoryPoolRegion : GuestRegion :=
-  { name := "evm_memory_pool", base := 0xb5839780, size := evmMemoryPoolBytes,
+  { name := "evm_memory_pool", base := evmMemoryPoolBase, size := evmMemoryPoolBytes,
     mode := .rw, zone := .ram,
     evidence := "ELF evm_memory_pool..evm_memory_pool_end; 96 MiB shared LIFO frame memory" }
 
 theorem evmMemoryPoolRegion_matches_elf :
-    evmMemoryPoolRegion.base = 0xb5839780
-      ∧ evmMemoryPoolRegion.base + evmMemoryPoolRegion.size = 0xbb839780 := by decide
+    evmMemoryPoolRegion.base = 0xb411e3a0
+      ∧ evmMemoryPoolRegion.base + evmMemoryPoolRegion.size = 0xba11e3a0 := by decide
 
 /-- The two runtime frame allocations are adjacent, disjoint, fit RAM, and both
     lie inside `.bss`; this is the pool/slot non-aliasing soundness fence. -/
@@ -820,12 +804,12 @@ structure UnionChild where
   size : Nat
   deriving Repr
 
-/-- The six Phase-H arenas coalesced into the front of `call_frame_arena`,
+/-- The five Phase-H arenas coalesced into the front of `call_frame_arena`,
     in layout order, as arena-relative offset/size pairs. Mirrors the emit in
     `BlockVerdictDataSection.lean` (the `basr_values`/`basr_accounts` pair, then
-    the four `baap_storage_*` arenas). `bv_system_storage_log` was removed from
+    the three `baap_storage_*` arenas). `bv_system_storage_log` was removed from
     the union in `4ch8f.73` (it is read post-dispatch, so a frame slot would
-    clobber it — it now lives standalone, see `syslogRegion`). -/
+    clobber it — it now lives standalone at `syslogBase`). -/
 def dataUnionChildren : List UnionChild :=
   [ { name := "basr_values",              off := 0,                                          size := basrArenaBytes },
     { name := "basr_accounts",            off := basrArenaBytes,                             size := basrArenaBytes },
@@ -833,9 +817,7 @@ def dataUnionChildren : List UnionChild :=
                                           size := bsrMaxBalItems * baapStorageDescBytes },
     { name := "baap_storage_paths",       off := 2 * basrArenaBytes + bsrMaxBalItems * baapStorageDescBytes,
                                           size := bsrMaxBalItems * bsrPathBytes },
-    { name := "baap_storage_delete_paths",off := 2 * basrArenaBytes + bsrMaxBalItems * baapStorageDescBytes + bsrMaxBalItems * bsrPathBytes,
-                                          size := bsrMaxBalItems * bsrPathBytes },
-    { name := "baap_storage_values",      off := 2 * basrArenaBytes + bsrMaxBalItems * baapStorageDescBytes + 2 * (bsrMaxBalItems * bsrPathBytes),
+    { name := "baap_storage_values",      off := 2 * basrArenaBytes + bsrMaxBalItems * baapStorageDescBytes + bsrMaxBalItems * bsrPathBytes,
                                           size := bsrMaxBalItems * bsrPathBytes } ]
 
 /-- Two union children occupy disjoint arena-relative ranges. -/
@@ -849,7 +831,7 @@ def unionChildrenPairwiseDisjoint : List UnionChild → Bool
 /-- Each child's range fits inside the arena `[0, frameArrayBytes)`. -/
 def unionChildFitsArena (c : UnionChild) : Bool := decide (c.off + c.size ≤ frameArrayBytes)
 
-/-- **The six coalesced arenas are mutually disjoint** (each owns a distinct
+/-- **The five coalesced arenas are mutually disjoint** (each owns a distinct
     sub-range of `call_frame_arena`). This is the "no self-corruption *among the
     unioned arenas*" fact — NOT the phase-liveness fact that they may share bytes
     with the frame array (that is the deferred half). -/
@@ -880,7 +862,7 @@ theorem callFrameArena_within_data :
 
 /-- Standalone base of `bv_system_storage_log` in this build (post-`.73`).
     LINK-LAYOUT-DEPENDENT — read from the ELF, guarded by `check-region-map.sh`. -/
-def syslogBase : Nat := 0xad2defe0
+def syslogBase : Nat := 0xab9a2400
 
 /-- **The `.73` clobber is closed (load-bearing).** The un-unioned
     `bv_system_storage_log` region `[syslogBase, syslogBase + bvSystemStorageLogBytes)`
@@ -921,14 +903,13 @@ def aliasedPairs : List (String × String) :=
   dataUnionChildren.map (fun c => ("call_frame_arena", c.name))
 
 /-- Every aliased pair names `call_frame_arena` as the umbrella and a real
-    coalesced child; there are exactly six, matching `dataUnionChildren`
+    coalesced child; there are exactly five, matching `dataUnionChildren`
     (`bv_system_storage_log` was un-unioned in `4ch8f.73`). -/
 theorem aliasedPairs_shape :
     aliasedPairs = [ ("call_frame_arena", "basr_values"),
                      ("call_frame_arena", "basr_accounts"),
                      ("call_frame_arena", "baap_storage_desc"),
                      ("call_frame_arena", "baap_storage_paths"),
-                     ("call_frame_arena", "baap_storage_delete_paths"),
                      ("call_frame_arena", "baap_storage_values") ] := by decide
 
 /-- **Overlap ranges (precise).** Each coalesced child aliases the arena over
@@ -946,11 +927,7 @@ theorem aliasedPairs_overlap_ranges :
         (2 * basrArenaBytes + bsrMaxBalItems * baapStorageDescBytes
            + bsrMaxBalItems * bsrPathBytes,
            2 * basrArenaBytes + bsrMaxBalItems * baapStorageDescBytes
-             + 2 * (bsrMaxBalItems * bsrPathBytes)),
-        (2 * basrArenaBytes + bsrMaxBalItems * baapStorageDescBytes
-           + 2 * (bsrMaxBalItems * bsrPathBytes),
-           2 * basrArenaBytes + bsrMaxBalItems * baapStorageDescBytes
-             + 3 * (bsrMaxBalItems * bsrPathBytes)) ] := by decide
+             + 2 * (bsrMaxBalItems * bsrPathBytes)) ] := by decide
 
 /-! ## Linker-facts bridge (data arena bases derivable from the map).
 

--- a/docs/4ch8f-callframe-audit.md
+++ b/docs/4ch8f-callframe-audit.md
@@ -19,9 +19,9 @@ before filing.*
 | Frame operand stack | **SAFE** — push-before-pop, sp starts at stack-top, under/overflow guards repointed per frame (`CallFrameDescend.lean:500-505`, `CallFrameReturn.lean:250-266`). Stale bytes below sp never read as entries. |
 | Frame returndata / pc / codebase / meta sub-regions | **SAFE (vestigial)** — the runtime keeps this state in standalone `.data` (`frame_save_area`, `frame_call_ctx`, `frame_parent_bases`, `Dispatch.lean:3022-3033`; returndata in the global `evm_precompile_frame`). The arena sub-regions are never addressed, so their garbage is never read. |
 | Frame env block | **ONE BUG** — the descend write-set covers every handler read except `env+552/560` → **`.72`** below. |
-| `basr_values`, `basr_accounts`, `baap_storage_{desc,paths,delete_paths,values}` | **SAFE** — written *and* read entirely inside the single-shot, pre-dispatch `block_state_root` (`BlockVerdictFunction.lean:241`), which invokes no dispatcher internally (verified by grep over all its callees). Earlier derive-phase dispatcher scribbles are rewritten before any read. |
+| `basr_values`, `basr_accounts`, `baap_storage_{desc,paths,values}` | **SAFE** — written *and* read entirely inside the single-shot, pre-dispatch `block_state_root` (`BlockVerdictFunction.lean:241`), which invokes no dispatcher internally (verified by grep over all its callees). Earlier derive-phase dispatcher scribbles are rewritten before any read. |
 | `bv_system_storage_log` | **UNSAFE** → **`.73`** below. |
-| REVERT / mid-block Phase-H re-entry | **NONE** — `block_state_root` is called exactly once; REVERT only truncates the `0xa0630000` exec log (`BlockVerdictFunction.lean:902-923`). No phase token needed for the six safe children. |
+| REVERT / mid-block Phase-H re-entry | **NONE** — `block_state_root` is called exactly once; REVERT only truncates the `0xa0630000` exec log (`BlockVerdictFunction.lean:902-923`). No phase token needed for the five safe children. |
 | Layout constants vs emitted geometry | **DIVERGED** → **`.71`** (and `.74`) below. |
 
 ## The true phase timeline (not "H once, then D once")
@@ -50,6 +50,12 @@ writes (H₁) and reads (H₃) straddle the per-tx dispatch, whose frames
 physically cover the syslog extent from call depth ≈ 220 up.
 
 ## Filed bugs
+
+> **Historical snapshot.** The `.71`/`.74` stride and frame-address pins listed
+> below describe the pre-reconciliation artifact. The current Lean model is
+> re-pinned to `0x19000` stride, `+0x18400` env, and the five-child union; the
+> current standalone syslog placement is recorded in `RegionMap.lean`. These
+> defect records remain audit history, not current constants.
 
 ### `.71` (P0) — `CallFrameLayout` constants are stale vs the emitted geometry
 
@@ -107,9 +113,9 @@ constant reconciliation.
 1. Re-pin `CallFrameLayout` constants to the emitted geometry (or drive
    the emit from the constants) and re-run the fit proofs + the
    `check-region-map.sh` ELF drift guard (the arena grows ~64 MiB;
-   re-verify `.data` end vs `.sszscratch` at `0xbf500000`).
+   re-verify `.data` end vs `.sszscratch` at `0xbf980000`).
 2. Un-union `bv_system_storage_log` (or move the three validator reads
-   before per-tx dispatch); then the H-view tiling drops to six children
+   before per-tx dispatch); then the H-view tiling has five children
    + pad and `phaseHSegs` shrinks accordingly.
 3. After `.72`'s descend fix, the env write-set covers all handler
    reads, and the D-side `Own`-opening obligation is dischargeable for

--- a/docs/4ch8f-region-map.md
+++ b/docs/4ch8f-region-map.md
@@ -18,10 +18,10 @@ the machine-checked overlap inventory for the one intentional aliasing.
 > seven-child/`0x39000` snapshots below are retained only as history.
 
 > **Current linked snapshot:** `.text` is `0x80000000..0x806338c`, `.data` is
-> `0xa3000000..0xa3005370`, `.bss` is `0xa3110000..0xbdd7cb20`, and
-> `.sszscratch` starts at `0xbf980000`. `call_frame_arena` is `0xad3dd7a0`,
-> `evm_memory_pool` is `0xb37f67a0`, and `bv_system_storage_log` is
-> `0xab07a800` in the checked guest artifact.
+> `0xa3000000..0xa3005370`, `.bss` is `0xa3110000..0xbdd7c900`, and
+> `.sszscratch` starts at `0xbf980000`. `call_frame_arena` is `0xad3dd5e0`,
+> `evm_memory_pool` is `0xb37f65e0`, and `bv_system_storage_log` is
+> `0xab07a640` in the checked guest artifact.
 
 Source of truth, in order of authority:
 
@@ -131,7 +131,7 @@ carries `guestRegionMap_pairwise_disjoint` (no exceptions):
 | `state_tracker_live` | `0xa0630000` | `0x200000` | emitted storage-log window `..0xa0830000` | STABLE |
 | `.text` | `0x80000000` | `0x6338c` | `readelf -S` | **LINK-DEPENDENT** |
 | `.data` | `0xa3000000` | `0x5370` (ends `0xa3005370`) | `readelf -S` | base STABLE, **size LINK-DEPENDENT** |
-| `.bss` | `0xa3110000` | `0x1ac6cb20` (ends `0xbdd7cb20`) | `readelf -S` | base STABLE, **size LINK-DEPENDENT** |
+| `.bss` | `0xa3110000` | `0x1ac6c900` (ends `0xbdd7c900`) | `readelf -S` | base STABLE, **size LINK-DEPENDENT** |
 | `.sszscratch` | `0xbf980000` | linker NOBITS scratch | `readelf -S`; `MemoryLayout SSZ_SCRATCH_*` | STABLE |
 
 **Aspirational scheme-A anchors (`schemeAAnchors`)** — the port contract; size =
@@ -164,7 +164,7 @@ and move whenever any function or data object changes
 size; `RegionMap.textSizeBytes`/`dataSizeBytes` record the current ELF values and
 `check-region-map.sh` re-derives them (regenerate on drift — see §5).
 
-The top RW `LOAD` segment ends at `.bss` end `0xbdd7cb20`, comfortably below the
+The top RW `LOAD` segment ends at `.bss` end `0xbdd7c900`, comfortably below the
 `0xc0000000` ziskemu RAM ceiling (`readelf -lW`; checked structurally).
 
 ### Predicate-readiness audit (input to the proof lane)
@@ -181,7 +181,7 @@ Absolute addresses are image-specific drift-guard inputs, not predicate
 parameters. A separation-logic predicate must quantify `arena_base` and prove
 the structural slot relation `slot(d) = arena_base + (d - 1) * 0x19000` for
 `1 ≤ d ≤ 1024` (depth zero has no overlay slot), together with the 1,025-slot
-extent. `callFrameArenaBase = 0xad3dd7a0` below is therefore only the pin for
+extent. `callFrameArenaBase = 0xad3dd5e0` below is therefore only the pin for
 this linked ELF; another image may move the arena while satisfying the same
 parametric predicate.
 
@@ -225,17 +225,17 @@ execution-dead Phase-H arenas into its front. ELF ground truth
 
 | symbol | address | arena-relative offset | size |
 |---|---|---|---|
-| `call_frame_arena` == `basr_values` | `0xad3dd7a0` | `0` | `S` = 25,604,608 |
-| `basr_accounts` | `0xaec489a0` | `S` | `S` |
-| `baap_storage_desc` | `0xb04b3ba0` | `2S` | 4,000,000 |
-| `baap_storage_paths` | `0xb08844a0` | `2S+desc` | 6,400,000 |
-| `baap_storage_values` | `0xb0e9eca0` | `2S+desc+path` | 6,400,000 |
-| `call_frame_arena_end` | `0xb37f67a0` | `frameArrayBytes` | — |
+| `call_frame_arena` == `basr_values` | `0xad3dd5e0` | `0` | `S` = 25,604,608 |
+| `basr_accounts` | `0xaec487e0` | `S` | `S` |
+| `baap_storage_desc` | `0xb04b39e0` | `2S` | 4,000,000 |
+| `baap_storage_paths` | `0xb08842e0` | `2S+desc` | 6,400,000 |
+| `baap_storage_values` | `0xb0e9eae0` | `2S+desc+path` | 6,400,000 |
+| `call_frame_arena_end` | `0xb37f65e0` | `frameArrayBytes` | — |
 
 `bv_system_storage_log` is deliberately **not** a union child: it is a
-standalone 4 MiB region at `0xab07a800`, below the frame arena, because the
+standalone 4 MiB region at `0xab07a640`, below the frame arena, because the
 post-dispatch BAL validators read it after frame zeroing. The 96 MiB
-`evm_memory_pool` begins at `0xb37f67a0`, immediately after the frame arena.
+`evm_memory_pool` begins at `0xb37f65e0`, immediately after the frame arena.
 
 where `S = bsrMaxStateChanges·bsrEncodedAccountBytes`,
 `L = bvSystemStorageLogBytes` (`BlockVerdictParams.lean`).

--- a/docs/4ch8f-region-map.md
+++ b/docs/4ch8f-region-map.md
@@ -4,17 +4,24 @@ This document reconciles the two memory-layout schemes the stateless guest has
 carried unreconciled, records the evidence for every region's extent, and gives
 the machine-checked overlap inventory for the one intentional aliasing.
 
-> **Status update (2026-07-05, bead `.6` CLOSED):** the phase-ownership proof
+> **Status update (2026-08-02, bead `.6` CLOSED):** the phase-ownership proof
 > this doc originally deferred is DELIVERED — `EvmAsm/Rv64/SAsm/PhaseSplit.lean`
 > + `EvmAsm/Codegen/CallFramePhase.lean` (#9724, one-resource/two-views model),
 > plus the soundness audits in `docs/4ch8f-callframe-audit.md` (#9851). The
-> audits found and led to fixing the stride/geometry divergence (beads
-> `.71`/`.74`, fixed by #9852 — `CallFrameLayout` re-pinned to the emitted
-> `0x39000`/128 KiB geometry, arena resized). Two residual bugs remain open:
-> `.72` (child env 552/560) and `.73` (`bv_system_storage_log` is read
-> POST-dispatch — the "Phase-H-only" liveness claim below is FALSE for that one
-> child; see the audit doc). Numeric snapshot tables in this file may lag the
-> ELF — `RegionMap.lean` + `scripts/check-region-map.sh` are the live authority.
+> current emitted geometry is `frameStride = 0x19000`,
+> `frameArrayBytes = 104,960,000 B` (about 100.1 MiB), with a 96 MiB
+> `evm_memory_pool` immediately after the frame arena. The union has exactly
+> five children (`basr_values`, `basr_accounts`, `baap_storage_desc`,
+> `baap_storage_paths`, `baap_storage_values`); `bv_system_storage_log` is
+> standalone because it is read post-dispatch. The absolute pins and closed
+> union inventory are now checked by `scripts/check-region-map.sh`; historical
+> seven-child/`0x39000` snapshots below are retained only as history.
+
+> **Current linked snapshot:** `.text` is `0x80000000..0x80640d0`, `.data` is
+> `0xa3000000..0xa3005370`, `.bss` is `0xa3110000..0xbe6a4860`, and
+> `.sszscratch` starts at `0xbf980000`. `call_frame_arena` is `0xadd053a0`,
+> `evm_memory_pool` is `0xb411e3a0`, and `bv_system_storage_log` is
+> `0xab9a2400` in the checked guest artifact.
 
 Source of truth, in order of authority:
 
@@ -39,7 +46,7 @@ lake build EvmAsm.Codegen.RegionMap  # the disjointness/fit/overlap theorems
 | | Scheme A (working-RAM anchors) | Scheme B (linked sections) |
 |---|---|---|
 | Where | `EvmAsm/Stateless/MemoryLayout.lean` | `-Ttext/-Tdata/--section-start` + `.data` labels |
-| Window | `0xa0020000 .. 0xa1ba0000` (working RAM below `.data`) | `.text` `0x80000000`; `.data` `0xa3000000`; `.sszscratch` `0xbf500000` |
+| Window | `0xa0020000 .. 0xa1ba0000` (working RAM below `.data`) | `.text` `0x80000000`; `.data` `0xa3000000`; `.sszscratch` `0xbf980000` |
 | Consumer | the **verified stateless port** under `EvmAsm/Stateless/` (the 4ch8f epic target) | the **currently-emitted** `stateless_guest` (Dispatch.lean + BlockVerdict) |
 | Prior proof | **none** (sizes implicit in anchor gaps) | fit lemmas for the 3 giant arenas only |
 
@@ -58,32 +65,30 @@ inside Scheme A's `execution_witness_area`. So the map is split into two lists:
   separate, proved internally consistent (`schemeAAnchors_pairwise_disjoint`) but
   NOT merged into the emitted map, because it collides with the stack (§3.1).
 
-### FINDING — Scheme A is almost entirely unreferenced by the emitted guest
+### FINDING — Scheme A is still aspirational and only partly referenced by the emitted guest
 
 A literal + `lui`-immediate scan of the emitted `stateless_guest.s` for each
 Scheme-A anchor address:
 
 | anchor | address | refs in emitted guest |
 |---|---|---|
-| `STATE_TRACKER_AREA` | `0xa0630000` | **17** (live: "persistent/live storage log base") |
-| all ten others (`SSZ_INPUT_DECODED`, `EXECUTION_WITNESS_AREA`, `NODE_DB_BUCKETS`, `CODE_DB_BUCKETS`, `EVM_FRAME_STACK`, `EVM_VALUE_STACK`, `EVM_MEMORY_AREA`, `KECCAK/ECRECOVER/SHA256_SCRATCH`) | `0xa0…` | **0** |
+| `STATE_TRACKER_AREA` | `0xa0630000` | **14** (live storage-log/transaction-state references) |
+| six read containers (`STORAGE_READS_AREA`, `ACCOUNT_READS_AREA`, `CODE_READS_AREA`, and the three `TX_*_READS_AREA`) | `0xa1…` | **referenced** |
+| six write/undo containers (`STORAGE_WRITES_AREA`, `TX_STORAGE_WRITES_AREA`, `STORAGE_WRITES_UNDO_AREA`, and the three account-write areas) | `0xa1…`/`0xa2…` | **referenced** |
+| remaining ten Scheme-A anchors | `0xa0…` | **0** |
 
-Only `STATE_TRACKER_AREA` is wired into the current guest, and it uses a **2 MiB**
-window `0xa0630000..0xa0830000` (16384×128 storage-log rows — confirmed by the
-2 refs to `0xa0830000` and the `BlockVerdictParams` comment), not the 4 MiB slab
-budgeted in `MemoryLayout.lean`. The current guest's actual EVM memory / stack /
-opcode tables live in the linked `.data`, not the anchors:
-`evm_memory@0xb796dac0`, `evm_stack_low@0xb8938040`, `lp64_stack@0xb88f7e40`,
-`opcode_handlers@0xb8945270`.
+The current audit finds **13 of 23** Scheme-A anchors referenced by absolute
+address in the emitted guest: this state-tracker anchor, the six read
+containers, and the six write/undo containers. The remaining ten anchors are
+still aspirational. This is not a soundness claim for those 13 regions: they
+are intentionally kept in the separate `schemeAAnchors` list and are not
+included in `guestRegionMap`'s emitted-reality disjointness theorem.
 
-This is **not a soundness bug** — `MemoryLayout.lean` states it is the contract
-for the `Stateless/` port, which does not yet drive the emit. It IS a
-doc/reality gap worth flagging: `guestRegionMap` (emitted reality) uses the one
-live anchor's real 2 MiB window (`state_tracker_live`); the ten unused anchors
-stay in the separate aspirational `schemeAAnchors` list. The current guest's
-actual EVM memory / stack / opcode tables live in the linked `.data`, not the
-anchors: `evm_memory@0xb796dac0`, `evm_stack_low@0xb8938040`,
-`lp64_stack@0xb88f7e40`, `opcode_handlers@0xb8945270`.
+This is **not a soundness bug** by itself — `MemoryLayout.lean` states that it
+is the contract for the `Stateless/` port, while the emitted-reality map is
+kept separate. It is a doc/reality boundary that must remain explicit until
+the verified port drives the emit. The current guest's EVM memory, stack, and
+opcode tables are linked `.bss` symbols, not Scheme-A anchors.
 
 ### FINDING — two realities the section/anchor lists omit (added after review)
 
@@ -124,9 +129,10 @@ carries `guestRegionMap_pairwise_disjoint` (no exceptions):
 | OUTPUT | `0xa0010000` | `0x10000` | `Programs OUTPUT_ADDR` | STABLE |
 | `guest_stack` | `0xa0020000` | `0x30000` | `_start li sp,0xa0050000` (grows down) | top STABLE; depth unguarded |
 | `state_tracker_live` | `0xa0630000` | `0x200000` | emitted storage-log window `..0xa0830000` | STABLE |
-| `.text` | `0x80000000` | `0x58150` | `readelf -S` | **LINK-DEPENDENT** |
-| `.data` | `0xa3000000` | `0x15945a70` (ends `0xb8945a70`) | `readelf -S` | base STABLE, **size LINK-DEPENDENT** |
-| `.sszscratch` | `0xbf500000` | `0x680000` | `readelf -S`; `MemoryLayout SSZ_SCRATCH_*` | STABLE |
+| `.text` | `0x80000000` | `0x640d0` | `readelf -S` | **LINK-DEPENDENT** |
+| `.data` | `0xa3000000` | `0x5370` (ends `0xa3005370`) | `readelf -S` | base STABLE, **size LINK-DEPENDENT** |
+| `.bss` | `0xa3110000` | `0x1b594860` (ends `0xbe6a4860`) | `readelf -S` | base STABLE, **size LINK-DEPENDENT** |
+| `.sszscratch` | `0xbf980000` | linker NOBITS scratch | `readelf -S`; `MemoryLayout SSZ_SCRATCH_*` | STABLE |
 
 **Aspirational scheme-A anchors (`schemeAAnchors`)** — the port contract; size =
 gap to next anchor (reserved slab). `schemeA_matches_layout` pins each base to
@@ -158,28 +164,78 @@ and move whenever any function or data object changes
 size; `RegionMap.textSizeBytes`/`dataSizeBytes` record the current ELF values and
 `check-region-map.sh` re-derives them (regenerate on drift — see §5).
 
-The top RW `LOAD` segment ends at `.data` end `0xb8945a70`, comfortably below the
+The top RW `LOAD` segment ends at `.bss` end `0xbe6a4860`, comfortably below the
 `0xc0000000` ziskemu RAM ceiling (`readelf -lW`; checked structurally).
+
+### Predicate-readiness audit (input to the proof lane)
+
+The map currently establishes byte extents, selected offsets, and the one
+intentional aliasing inventory. That is not yet a separation-logic vocabulary
+for every buffer. Before a predicate is written, each region needs a settled
+entry shape (fields, offsets, widths, and exact capacity × stride), count
+semantics (live count or high-water mark), entry invariant, ownership/reset
+lifetime, and aliasing rule. The findings below are deliberately structural:
+they identify where the shape must be settled before proof work can start.
+
+Absolute addresses are image-specific drift-guard inputs, not predicate
+parameters. A separation-logic predicate must quantify `arena_base` and prove
+the structural slot relation `slot(d) = arena_base + (d - 1) * 0x19000` for
+`1 ≤ d ≤ 1024` (depth zero has no overlay slot), together with the 1,025-slot
+extent. `callFrameArenaBase = 0xadd053a0` below is therefore only the pin for
+this linked ELF; another image may move the arena while satisfying the same
+parametric predicate.
+
+| region | currently pinned | predicate-readiness finding |
+|---|---|---|
+| INPUT, OUTPUT, `zisk_system`, `guest_stack`, `.text`, `.data`, `.bss`, `.sszscratch` | byte ranges and section/linker bases | Ready only for byte-region predicates; these have no per-entry invariant. |
+| `state_tracker_live` / storage log | 16,384 × 128-byte rows = 2 MiB; the runtime cursor is at `env + 448` | Capacity and row width are exact, but the predicate must settle whether the cursor is a live-entry count or high-water mark and identify every reset/truncation boundary. |
+| `call_frame_arena` | 1,025 × `0x19000` frame slots; current absolute base is ELF-guarded | Slot stride is pinned, but the complete field/ownership predicate and interaction with frame lifetime still need one common shape. |
+| `evm_memory_pool` | 96 MiB immediately after the frame arena | No entry schema or cursor invariant is recorded here; pool LIFO/cursor semantics are a separate active investigation and are not duplicated by this audit. |
+| five `dataUnionChildren` | exact arena-relative offsets, extents, and pairwise disjointness; `baap_storage_values` is 6,400,000 bytes in this `stateless_guest` image | This is an extent/aliasing inventory, not yet an entry predicate. Fields, count/reset protocol, initialization invariant, and Phase-H ownership must be settled per child. Other build units report different `baap_storage_values` symbol sizes; they are not substituted for this linked image. |
+| `bv_system_storage_log` | standalone 4 MiB region, 16,384 × 128-byte rows, outside the frame arena | Row geometry is pinned, but the live-count invariant and pre-dispatch write/post-dispatch read lifetime must be made explicit in its predicate. |
+| Scheme-A anchors | 23 base constants and anchor-gap slabs; only 13 are currently reached by emitted absolute addresses | Not predicate-ready: anchor gaps do not define entry fields, counts, initialization, lifetime, or aliasing. The 10 aspirational anchors must not be treated as emitted buffers. |
+| `baap_storage_delete_paths` | no current ELF symbol and no current `RegionMap.dataUnionChildren` entry | Finding, not a predicate gap. The former proof-list consumer was removed; the probe-only emitter and historical docs still need an explicit lifecycle decision before this name can return. |
+
+The current image qualification matters: `baap_storage_values` is 6,400,000
+bytes in the linked `stateless_guest` map above. A predicate cannot silently
+reuse that extent for another build unit whose symbol has a different size.
+
+The artefact dependency classes are also part of the audit:
+
+| class | examples | repair cost / rule |
+|---|---|---|
+| no current emitted consumer | the removed `baap_storage_delete_paths` image entry | Free to remove from the emitted map, but a probe emitter must settle its shape before reintroducing it. |
+| generated consumers | `symbol-addresses.tsv`, `GuestAddrs.lean`, `GuestImageEntries.lean` | Regenerate cheaply, provided the generator derives link-dependent values from the ELF and the guard checks the generated result. |
+| handwritten proof consumers | `GuestImage.lean`'s `SatWithin` literals and `guestScratch_matches_regionMap`; `CallFramePhase.lean`'s union tiling; RegionMap's `decide` fit/disjointness theorems | Expensive proof repair. The six-child `CallFramePhase` proof typechecked while naming the nonexistent `baap_storage_delete_paths`; removing the phantom forced the proof to be repaired to the five real children. This is why structural shape precedes predicate authoring. |
+
+The generator pins are now corrected to the linked `.bss` (`0xa3110000`) and
+`.sszscratch` (`0xbf980000`) bases and include all six write/undo Scheme-A
+anchors. The checked-in generated table remains ELF-derived: no committed
+generated value was sourced from the stale literals, so regeneration changes
+classification authority rather than fabricating a new address.
 
 ---
 
 ## 3. Overlap inventory (the `call_frame_arena` union) — the ONLY aliasing
 
 The guest has exactly one intentional physical overlap. `call_frame_arena`
-(~228 MiB EVM call-frame overlay, `frameArrayBytes = 1025 × 0x39000`) coalesces
-**seven** execution-dead Phase-H arenas into its front. ELF ground truth
+(about 100.1 MiB, `frameArrayBytes = 1025 × 0x19000`) coalesces **five**
+execution-dead Phase-H arenas into its front. ELF ground truth
 (`readelf -s`, this build) — all offsets confirmed by `check-region-map.sh`:
 
 | symbol | address | arena-relative offset | size |
 |---|---|---|---|
-| `call_frame_arena` == `basr_values` | `0xac44d520` | `0` | `S` = 25,604,608 |
-| `basr_accounts` | `0xadcb8720` | `S` | `S` |
-| `bv_system_storage_log` | `0xaf523920` | `2S` | `L` = 76,800,000 |
-| `baap_storage_desc` | `0xb3e61920` | `2S+L` | 4,000,000 |
-| `baap_storage_paths` | `0xb4232220` | `2S+L+desc` | 6,400,000 |
-| `baap_storage_delete_paths` | `0xb484ca20` | `+path` | 6,400,000 |
-| `baap_storage_values` | `0xb4e67220` | `+2·path` | 6,400,000 |
-| `call_frame_arena_end` | `0xb6876520` | `frameArrayBytes` | — |
+| `call_frame_arena` == `basr_values` | `0xadd053a0` | `0` | `S` = 25,604,608 |
+| `basr_accounts` | `0xaf5705a0` | `S` | `S` |
+| `baap_storage_desc` | `0xb0ddb7a0` | `2S` | 4,000,000 |
+| `baap_storage_paths` | `0xb11ac0a0` | `2S+desc` | 6,400,000 |
+| `baap_storage_values` | `0xb17c68a0` | `2S+desc+path` | 6,400,000 |
+| `call_frame_arena_end` | `0xb411e3a0` | `frameArrayBytes` | — |
+
+`bv_system_storage_log` is deliberately **not** a union child: it is a
+standalone 4 MiB region at `0xab9a2400`, below the frame arena, because the
+post-dispatch BAL validators read it after frame zeroing. The 96 MiB
+`evm_memory_pool` begins at `0xb411e3a0`, immediately after the frame arena.
 
 where `S = bsrMaxStateChanges·bsrEncodedAccountBytes`,
 `L = bvSystemStorageLogBytes` (`BlockVerdictParams.lean`).
@@ -188,24 +244,24 @@ Machine-checked in `RegionMap.lean`:
 
 - `aliasedPairs` — the exhaustive list of overlapping pairs, each
   `(call_frame_arena, <child>)`; `aliasedPairs_shape` fixes it to exactly the
-  seven above.
+  five children above.
 - `aliasedPairs_overlap_ranges` — the precise overlap RANGE (arena-relative
   `[off, off+size)`) of every aliased pair, as a machine-checked table.
-- `dataUnionChildren_pairwise_disjoint` — the seven children own **mutually
+- `dataUnionChildren_pairwise_disjoint` — the five children own **mutually
   disjoint** sub-ranges (no self-corruption *among the coalesced arenas*).
 - `dataUnionChildren_fit_arena` + `callFrameArena_within_data` — the union stays
   inside `call_frame_arena`, which stays inside `.data`.
 
 These reproduce, at the region-map level, the fit gates already in
-`CallFrameLayout.lean` (`frameArray_unions_basr_syslog_baap`), now anchored to
-the actual ELF addresses.
+`CallFrameLayout.lean` (`frameArray_unions_basr_baap`), now anchored to the
+actual ELF addresses.
 
 **Design note (judgment call).** `guestRegionMap` is kept at *section/anchor*
 granularity, where it is genuinely disjoint with **no** exception list — the one
 aliasing lives entirely inside the single `.data` member and is expanded as its
 own inventory (`dataUnionChildren`/`aliasedPairs`). This is cleaner than folding
 the union arenas into `guestRegionMap` and carrying a mixed containment+aliasing
-exception list, and keeps the soundness-relevant overlap set (the seven pairs)
+exception list, and keeps the soundness-relevant overlap set (the five pairs)
 unmuddied. `callFrameArena_within_data` composes the two views.
 
 ---
@@ -214,7 +270,7 @@ unmuddied. `callFrameArena_within_data` composes the two views.
 
 The overlaps above are documented, **not** proven safe. The current safety
 argument (`CallFrameLayout.lean:99-120`, `docs/call-frame-memory-layout.md` §5)
-is a prose phase-liveness claim: the seven coalesced arenas are **Phase-H**
+is a prose phase-liveness claim: the five coalesced arenas are **Phase-H**
 scratch (built and consumed entirely within the pre-dispatch `block_state_root`
 recompute — `BalAccountStateRoot`/`BlockVerdictStateRoot`/`BalAccountApplyPostFields`/
 `BlockVerdictSysChange`), while `call_frame_arena` is **Phase-D** scratch
@@ -229,9 +285,9 @@ separation-logic / phase-ownership model:
 1. A formal notion of the two live windows (Phase-H state-root recompute vs
    Phase-D dispatch) over the guest's control flow.
 2. A proof that no Phase-D reader/writer of `call_frame_arena` is reachable while
-   any of the seven arenas is live, and vice versa (the `#8513` execution-dead
+   any of the five arenas is live, and vice versa (the `#8513` execution-dead
    gate, made kernel-checked instead of a grep).
-3. A guard that any future post-`block_state_root` read of the seven arenas
+3. A guard that any future post-`block_state_root` read of the five arenas
    breaks the model loudly (the union is otherwise a silent corruption vector).
 
 This overlap inventory (`aliasedPairs` + the `_overlap` theorems + the mutual

--- a/docs/4ch8f-region-map.md
+++ b/docs/4ch8f-region-map.md
@@ -17,11 +17,11 @@ the machine-checked overlap inventory for the one intentional aliasing.
 > union inventory are now checked by `scripts/check-region-map.sh`; historical
 > seven-child/`0x39000` snapshots below are retained only as history.
 
-> **Current linked snapshot:** `.text` is `0x80000000..0x80640d0`, `.data` is
-> `0xa3000000..0xa3005370`, `.bss` is `0xa3110000..0xbe6a4860`, and
-> `.sszscratch` starts at `0xbf980000`. `call_frame_arena` is `0xadd053a0`,
-> `evm_memory_pool` is `0xb411e3a0`, and `bv_system_storage_log` is
-> `0xab9a2400` in the checked guest artifact.
+> **Current linked snapshot:** `.text` is `0x80000000..0x806338c`, `.data` is
+> `0xa3000000..0xa3005370`, `.bss` is `0xa3110000..0xbdd7cb20`, and
+> `.sszscratch` starts at `0xbf980000`. `call_frame_arena` is `0xad3dd7a0`,
+> `evm_memory_pool` is `0xb37f67a0`, and `bv_system_storage_log` is
+> `0xab07a800` in the checked guest artifact.
 
 Source of truth, in order of authority:
 
@@ -129,9 +129,9 @@ carries `guestRegionMap_pairwise_disjoint` (no exceptions):
 | OUTPUT | `0xa0010000` | `0x10000` | `Programs OUTPUT_ADDR` | STABLE |
 | `guest_stack` | `0xa0020000` | `0x30000` | `_start li sp,0xa0050000` (grows down) | top STABLE; depth unguarded |
 | `state_tracker_live` | `0xa0630000` | `0x200000` | emitted storage-log window `..0xa0830000` | STABLE |
-| `.text` | `0x80000000` | `0x640d0` | `readelf -S` | **LINK-DEPENDENT** |
+| `.text` | `0x80000000` | `0x6338c` | `readelf -S` | **LINK-DEPENDENT** |
 | `.data` | `0xa3000000` | `0x5370` (ends `0xa3005370`) | `readelf -S` | base STABLE, **size LINK-DEPENDENT** |
-| `.bss` | `0xa3110000` | `0x1b594860` (ends `0xbe6a4860`) | `readelf -S` | base STABLE, **size LINK-DEPENDENT** |
+| `.bss` | `0xa3110000` | `0x1ac6cb20` (ends `0xbdd7cb20`) | `readelf -S` | base STABLE, **size LINK-DEPENDENT** |
 | `.sszscratch` | `0xbf980000` | linker NOBITS scratch | `readelf -S`; `MemoryLayout SSZ_SCRATCH_*` | STABLE |
 
 **Aspirational scheme-A anchors (`schemeAAnchors`)** — the port contract; size =
@@ -164,7 +164,7 @@ and move whenever any function or data object changes
 size; `RegionMap.textSizeBytes`/`dataSizeBytes` record the current ELF values and
 `check-region-map.sh` re-derives them (regenerate on drift — see §5).
 
-The top RW `LOAD` segment ends at `.bss` end `0xbe6a4860`, comfortably below the
+The top RW `LOAD` segment ends at `.bss` end `0xbdd7cb20`, comfortably below the
 `0xc0000000` ziskemu RAM ceiling (`readelf -lW`; checked structurally).
 
 ### Predicate-readiness audit (input to the proof lane)
@@ -181,7 +181,7 @@ Absolute addresses are image-specific drift-guard inputs, not predicate
 parameters. A separation-logic predicate must quantify `arena_base` and prove
 the structural slot relation `slot(d) = arena_base + (d - 1) * 0x19000` for
 `1 ≤ d ≤ 1024` (depth zero has no overlay slot), together with the 1,025-slot
-extent. `callFrameArenaBase = 0xadd053a0` below is therefore only the pin for
+extent. `callFrameArenaBase = 0xad3dd7a0` below is therefore only the pin for
 this linked ELF; another image may move the arena while satisfying the same
 parametric predicate.
 
@@ -225,17 +225,17 @@ execution-dead Phase-H arenas into its front. ELF ground truth
 
 | symbol | address | arena-relative offset | size |
 |---|---|---|---|
-| `call_frame_arena` == `basr_values` | `0xadd053a0` | `0` | `S` = 25,604,608 |
-| `basr_accounts` | `0xaf5705a0` | `S` | `S` |
-| `baap_storage_desc` | `0xb0ddb7a0` | `2S` | 4,000,000 |
-| `baap_storage_paths` | `0xb11ac0a0` | `2S+desc` | 6,400,000 |
-| `baap_storage_values` | `0xb17c68a0` | `2S+desc+path` | 6,400,000 |
-| `call_frame_arena_end` | `0xb411e3a0` | `frameArrayBytes` | — |
+| `call_frame_arena` == `basr_values` | `0xad3dd7a0` | `0` | `S` = 25,604,608 |
+| `basr_accounts` | `0xaec489a0` | `S` | `S` |
+| `baap_storage_desc` | `0xb04b3ba0` | `2S` | 4,000,000 |
+| `baap_storage_paths` | `0xb08844a0` | `2S+desc` | 6,400,000 |
+| `baap_storage_values` | `0xb0e9eca0` | `2S+desc+path` | 6,400,000 |
+| `call_frame_arena_end` | `0xb37f67a0` | `frameArrayBytes` | — |
 
 `bv_system_storage_log` is deliberately **not** a union child: it is a
-standalone 4 MiB region at `0xab9a2400`, below the frame arena, because the
+standalone 4 MiB region at `0xab07a800`, below the frame arena, because the
 post-dispatch BAL validators read it after frame zeroing. The 96 MiB
-`evm_memory_pool` begins at `0xb411e3a0`, immediately after the frame arena.
+`evm_memory_pool` begins at `0xb37f67a0`, immediately after the frame arena.
 
 where `S = bsrMaxStateChanges·bsrEncodedAccountBytes`,
 `L = bvSystemStorageLogBytes` (`BlockVerdictParams.lean`).

--- a/docs/agents/eest-static-layout.md
+++ b/docs/agents/eest-static-layout.md
@@ -28,15 +28,17 @@ The source of truth is
 This means a complete static layout is complete only relative to a declared
 maximum supported **actual BAL item count**, not merely a declared block gas
 limit. For the execution-specs default block gas limit of 120,000,000, the BAL
-item budget is 60,000. The current static replay arenas are sized for 500,000
-BAL items, the same worst-case item budget implied by a 1,000,000,000 gas
-block. A layout with that capacity must cover both extreme shapes:
+item budget is 60,000. The current emitted static replay arenas are sized for
+100,000 BAL items (the 200M target); the older 500,000-item/1G layout is
+historical. A layout with a declared capacity must cover both extreme shapes:
 
 - many account rows, which stress `basr_*` account-record arrays and the
   top-level `bsr_*` state-change arrays;
 - one/few accounts with many storage keys, which stress per-account storage
   replay arrays such as `baap_storage_desc`, `baap_storage_paths`,
-  `baap_storage_delete_paths`, and `baap_storage_values`.
+  `baap_storage_delete_paths`, and `baap_storage_values`. The
+  `baap_storage_delete_paths` child is historical/probe-only in the current
+  guest; the emitted `RegionMap.dataUnionChildren` has no such symbol.
 
 Do not resize only the first array that failed. Follow every index that derives
 from the same count and resize the matching backing storage together.
@@ -46,7 +48,7 @@ that happens, treat the ELF memory map as part of the layout: keep linked
 `.data`, fixed working-RAM anchors, public output, and `.sszscratch` disjoint.
 The current stateless guest layout (sized for the Amsterdam 200M block-gas
 target, `bsrMaxBalItems = 100000`) puts `.data` at `0xa3000000` and
-`.sszscratch` at `0xbf500000`, both inside the verified RAM zone. Keep the
+`.sszscratch` at `0xbf980000`, both inside the verified RAM zone. Keep the
 linked `.data` growth below the `.sszscratch` start and leave headroom below
 `0xc0000000`.
 

--- a/docs/call-frame-memory-layout.md
+++ b/docs/call-frame-memory-layout.md
@@ -19,8 +19,8 @@
 > a 96 MiB `evm_memory_pool` immediately after the frame arena. The five
 > coalesced children are `basr_values`, `basr_accounts`, `baap_storage_desc`,
 > `baap_storage_paths`, and `baap_storage_values`; the standalone system log
-> is 4 MiB. Current linked anchors are `call_frame_arena = 0xad3dd7a0`,
-> `evm_memory_pool = 0xb37f67a0`, and `.sszscratch = 0xbf980000`.
+> is 4 MiB. Current linked anchors are `call_frame_arena = 0xad3dd5e0`,
+> `evm_memory_pool = 0xb37f65e0`, and `.sszscratch = 0xbf980000`.
 
 Design for bead `evm-asm-fhsxz.2.4.2.61.2` (P0, foundational). Owner: claude-c2.
 This settles the guest `.data` layout and register conventions for nested EVM

--- a/docs/call-frame-memory-layout.md
+++ b/docs/call-frame-memory-layout.md
@@ -1,6 +1,7 @@
 # Nested CALL/CREATE frame memory layout (depth-indexed pre-allocated frame array)
 
-> **STATUS (2026-07-05): historical design record — superseded on three points.**
+> **STATUS (2026-08-02): historical design record; current emitted geometry is
+> summarized below and the Lean sources are authoritative.**
 > The live authorities are `EvmAsm/Codegen/CallFrameLayout.lean` (constants,
 > re-pinned to the emitted geometry by #9852), `EvmAsm/Codegen/RegionMap.lean`
 > (region extents + overlap inventory, ELF-drift-guarded), and
@@ -8,11 +9,18 @@
 > (the union-aliasing soundness story). Specifically superseded here:
 > (1) §5's grep-based "SOUNDNESS GATE" is replaced by the verified
 > phase-ownership model + the Own-not-Is / sequencing audits; (2) the union now
-> coalesces SEVEN Phase-H children (not just the basr pair), inventoried in
-> `RegionMap.dataUnionChildren`; (3) one child — `bv_system_storage_log` — is
-> in fact read post-dispatch, violating the phase-liveness assumption (open
-> P0 bug bead `evm-asm-4ch8f.73`). Sizes/addresses below are design-time
+> coalesces FIVE Phase-H children, inventoried in `RegionMap.dataUnionChildren`;
+> (3) `bv_system_storage_log` is standalone because it is read post-dispatch.
+> Older seven-child tables and `0x39000`/228 MiB figures below are historical
 > snapshots; trust the Lean constants + `scripts/check-region-map.sh`.
+
+> **Current emitted artifact:** `frameStride = 0x19000`,
+> `frameArrayBytes = 1025 × 0x19000 = 104,960,000 B` (about 100.1 MiB), with
+> a 96 MiB `evm_memory_pool` immediately after the frame arena. The five
+> coalesced children are `basr_values`, `basr_accounts`, `baap_storage_desc`,
+> `baap_storage_paths`, and `baap_storage_values`; the standalone system log
+> is 4 MiB. Current linked anchors are `call_frame_arena = 0xadd053a0`,
+> `evm_memory_pool = 0xb411e3a0`, and `.sszscratch = 0xbf980000`.
 
 Design for bead `evm-asm-fhsxz.2.4.2.61.2` (P0, foundational). Owner: claude-c2.
 This settles the guest `.data` layout and register conventions for nested EVM
@@ -66,7 +74,7 @@ operand stack / `evm_env`), left **completely unchanged** — depth-0 is the onl
 currently-executed path and the verdict-critical one, so it must stay
 byte-identical. Frames **1..1024** (the nested children) live in the overlay
 arena: `frame[d] = call_frame_arena + (d-1) * FRAME_STRIDE` for `d ≥ 1`
-(1024 slots × `FRAME_STRIDE` = 228 MiB ≤ the 244 MiB union). A CALL descends by
+    (1024 slots × `FRAME_STRIDE`; current emitted geometry is 100.1 MiB). A CALL descends by
 bumping a depth counter and, for `d ≥ 1`, computing the child register bases
 from `call_frame_arena + (d-1)*FRAME_STRIDE`; the parent of a depth-1 child is
 `frame[0]` (the existing `evm_memory`/env). This **avoids rebasing the
@@ -177,25 +185,25 @@ Each depth slot is a contiguous, 32-aligned block:
 ```
 frame[d] for d>=1 (at call_frame_arena + (d-1)*FRAME_STRIDE); frame[0] = the
 existing dispatcher evm_memory/stack/env (see §1, NOT in this arena):
-  +0x00000  frame_mem:        .zero 0x20000   (128 KiB EVM memory)         x13
-  +0x10000  frame_stack_glo:  .zero 512        (guard)
-  +0x10200  frame_stack_low:  .zero 0x8000    (32 KiB operand stack)
-  +0x28200  frame_stack_top:                   (x12 init = here, grows ↓)
-  +0x28200  frame_stack_ghi:  .zero 512        (guard)
-  +0x28400  frame_returndata: .zero 0x10000   (64 KiB last-subcall returndata) 
-  +0x38400  frame_env:        .zero 0x300     (768 B per-frame env, §3)     x20
-  +0x28700  frame_pc:         .zero 8          (saved PC / x10 on descent)
-  +0x28708  frame_codebase:   .zero 8          (saved x21 = witness.codes slice)
-  +0x28710  frame_meta:       .zero 0xF0       (caller depth, ret-offset/len in
+  +0x00000  frame_stack_glo:  .zero 512        (guard)
+  +0x00200  frame_stack_low:  .zero 0x8000    (32 KiB operand stack)
+  +0x08200  frame_stack_top:                   (x12 init = here, grows ↓)
+  +0x08200  frame_stack_ghi:  .zero 512        (guard)
+  +0x08400  frame_returndata: .zero 0x10000   (64 KiB last-subcall returndata)
+  +0x18400  frame_env:        .zero 0x300     (768 B per-frame env, §3)     x20
+  +0x18700  frame_pc:         .zero 8          (saved PC / x10 on descent)
+  +0x18708  frame_codebase:   .zero 8          (saved x21 = witness.codes slice)
+  +0x18710  frame_meta:       .zero 0xF0       (caller depth, ret-offset/len in
                                                 parent mem, is_static, is_create,
                                                 created-address, state checkpoint id)
-  ── round up to FRAME_STRIDE = 0x39000 (228 KiB, 32-aligned) ──
+  ── round up to FRAME_STRIDE = 0x19000 (100 KiB, 32-aligned) ──
 ```
 
-`FRAME_STRIDE = 0x39000` (228 KiB). Components: 128 KiB mem + 33 KiB stack(+guards)
-+ 64 KiB returndata + 768 B env + meta, rounded.
+`FRAME_STRIDE = 0x19000` (100 KiB). Nested-frame memory is in the shared 96 MiB
+pool; the slot contains the stack/guards, returndata, env, saved registers, and
+metadata, rounded to the stride.
 
-Total frame array = `1025 * 0x39000` = `0xE439000` ≈ **228.2 MiB** (depths
+Total frame array = `1025 * 0x19000` = `104,960,000 B` ≈ **100.1 MiB** (depths
 0..1024 inclusive — see §1).
 
 > **Returndata sizing.** Returndata is per-frame (RETURNDATASIZE/COPY read the
@@ -208,18 +216,19 @@ Total frame array = `1025 * 0x39000` = `0xE439000` ≈ **228.2 MiB** (depths
 
 ---
 
-## 5. Memory-map placement — overlay RETIRED; standalone arena under the 200M layout
+## 5. Memory-map placement — five-child union plus standalone memory pool
 
-> **UPDATE (2026-06-11).** The BAL-replay arenas were right-sized from the 1G
-> worst case (`bsrMaxBalItems = 500000`, ~416 MiB) to the Amsterdam 200M target
-> (`bsrMaxBalItems = 100000`, ~83 MiB), freeing ~333 MiB of the 512 MiB window.
-> `call_frame_arena` is now a **standalone** pre-zeroed `.zero` block emitted
-> after `basr_accounts` (`BlockVerdictDataSection.lean`) — the union described
-> below no longer exists (the shrunken `basr_values`+`basr_accounts` pair, ~49
-> MiB, could not host the 164 MiB frame array anyway), and the execution-dead
-> soundness gate on `basr_values`/`basr_accounts` is no longer load-bearing.
-> Fit: `frameArray_and_balArenas_fit` in `CallFrameLayout.lean` + `readelf -lW`.
-> §5's union design is kept below as the historical record.
+> **CURRENT (2026-08-02).** The Amsterdam 200M target uses
+> `bsrMaxBalItems = 100000`. The current emitted `call_frame_arena` is
+> coalesced with the five Phase-H children listed in `RegionMap.lean`; its
+> `104,960,000 B` frame extent is followed by the standalone 96 MiB
+> `evm_memory_pool`. `bv_system_storage_log` is outside that union because
+> post-dispatch validators read it after frame zeroing. Fit and absolute
+> placement are checked by `frameArray_unions_basr_baap`,
+> `RegionMap.callFrameArena_within_data`, and `scripts/check-region-map.sh`.
+
+> The old 1G/228 MiB/244 MiB layout is retained below only as historical
+> rationale; it is not a description of the current guest.
 
 > **CORRECTION (empirically validated 2026-06-08).** An earlier draft of this
 > section assumed `.data` is ~16 MiB and the `0xa4000000..0xbf980000` window is

--- a/docs/call-frame-memory-layout.md
+++ b/docs/call-frame-memory-layout.md
@@ -19,8 +19,8 @@
 > a 96 MiB `evm_memory_pool` immediately after the frame arena. The five
 > coalesced children are `basr_values`, `basr_accounts`, `baap_storage_desc`,
 > `baap_storage_paths`, and `baap_storage_values`; the standalone system log
-> is 4 MiB. Current linked anchors are `call_frame_arena = 0xadd053a0`,
-> `evm_memory_pool = 0xb411e3a0`, and `.sszscratch = 0xbf980000`.
+> is 4 MiB. Current linked anchors are `call_frame_arena = 0xad3dd7a0`,
+> `evm_memory_pool = 0xb37f67a0`, and `.sszscratch = 0xbf980000`.
 
 Design for bead `evm-asm-fhsxz.2.4.2.61.2` (P0, foundational). Owner: claude-c2.
 This settles the guest `.data` layout and register conventions for nested EVM

--- a/docs/memory-arena-gas-bound.md
+++ b/docs/memory-arena-gas-bound.md
@@ -64,7 +64,9 @@ false-reject band: live child memories occupy disjoint LIFO slices, and the
 All must provision up to ~2.90 MiB/frame and ~90 MiB total-live. Following
 execution-specs (flat growable `bytearray`, every window op via
 `memory_read_bytes`/`memory_write`), three shapes fit within the RAM window
-(`.data` ≈ 473 MiB budget; current frame arena = `0x39000 × 1025` ≈ 228 MiB):
+(`.bss`/`.sszscratch` span is the relevant reserved window; current
+`call_frame_arena = 0x19000 × 1025` ≈ 100.1 MiB, followed by the implemented
+96 MiB shared pool):
 
 1. **Grow the shared sparse store toward the total-live bound (~90 MiB / ~3M
    words)** + per-opcode sparse-awareness (the `evm-asm-274cr` families).

--- a/scripts/check-region-map.sh
+++ b/scripts/check-region-map.sh
@@ -28,19 +28,37 @@
 #     See docs/regenerating-generated-files.md. This keeps the Lean map matching
 #     the ELF (the .6 contract) instead of quietly diverging.
 #
-# Skips gracefully (exit 0) when the RISC-V toolchain is absent, mirroring
-# scripts/check-asm-to-program.sh.
+# This is a blocking drift guard.  Missing tooling is a configuration error,
+# not a reason to report success: a guard that cannot inspect the ELF must fail
+# loudly instead of silently becoming inert in CI.
 set -euo pipefail
 cd "$(dirname "$0")/.."
 
-if ! command -v riscv64-unknown-elf-as >/dev/null 2>&1 && ! command -v riscv64-elf-as >/dev/null 2>&1; then
-  echo "check-region-map: riscv64 cross toolchain not found; skipping (install to enable)"
-  exit 0
+die_missing() {
+  echo "check-region-map: missing required command: $1" >&2
+  exit 2
+}
+
+for required_cmd in lake python3 awk grep sed sort comm paste mktemp diff; do
+  command -v "$required_cmd" >/dev/null 2>&1 || die_missing "$required_cmd"
+done
+
+if command -v riscv64-unknown-elf-as >/dev/null 2>&1; then
+  :
+elif command -v riscv64-elf-as >/dev/null 2>&1; then
+  :
+else
+  echo "check-region-map: missing required RISC-V cross assembler (riscv64-unknown-elf-as or riscv64-elf-as)" >&2
+  exit 2
 fi
-READELF="$(command -v readelf || command -v riscv64-unknown-elf-readelf || true)"
-if [[ -z "$READELF" ]]; then
-  echo "check-region-map: readelf not found; skipping"
-  exit 0
+
+if command -v readelf >/dev/null 2>&1; then
+  READELF="$(command -v readelf)"
+elif command -v riscv64-unknown-elf-readelf >/dev/null 2>&1; then
+  READELF="$(command -v riscv64-unknown-elf-readelf)"
+else
+  echo "check-region-map: missing required readelf (readelf or riscv64-unknown-elf-readelf)" >&2
+  exit 2
 fi
 
 ELF_DIR="${ELF_DIR:-gen-out/regionmap}"
@@ -173,13 +191,13 @@ done
 # proof subject with no emitted storage.
 GUEST_ADDRS="EvmAsm/Codegen/GuestAddrs.lean"
 guest_addrs_missing="$(comm -23 \
-  <(rg '^def [A-Za-z0-9_]+ : Nat := 0x' "$GUEST_ADDRS" |
+  <(grep -E '^def [A-Za-z0-9_]+ : Nat := 0x' "$GUEST_ADDRS" |
       sed -E 's/^def ([A-Za-z0-9_]+) : Nat := 0x.*/\1/' | sort -u) \
   <("$READELF" -sW "$ELF" |
       awk 'NF >= 8 && $7 != "UND" && $4 != "SECTION" && $4 != "FILE" && $8 !~ /^\$/ {print $8}' |
       sort -u))"
 if [[ -z "$guest_addrs_missing" ]]; then
-  guest_addrs_count="$(rg -c '^def [A-Za-z0-9_]+ : Nat := 0x' "$GUEST_ADDRS")"
+  guest_addrs_count="$(grep -cE '^def [A-Za-z0-9_]+ : Nat := 0x' "$GUEST_ADDRS")"
   note "OK   GuestAddrs symbols all exist in ELF ($guest_addrs_count names)"
 else
   note "DRIFT GuestAddrs names absent from ELF: $guest_addrs_missing"

--- a/scripts/check-region-map.sh
+++ b/scripts/check-region-map.sh
@@ -14,7 +14,7 @@
 #       --section-start flags and RegionMap constants;
 #     * the top RW LOAD segment stays below the 0xc0000000 RAM ceiling;
 #     * .data ends below .sszscratch;
-#     * the call_frame_arena union: call_frame_arena == basr_values, the six
+#     * the call_frame_arena union: call_frame_arena == basr_values, the five
 #       coalesced children sit at the RegionMap arena-relative offsets, the arena
 #       is fully inside .bss, and its extent == frameArrayBytes.
 #
@@ -110,7 +110,81 @@ PY
 
 # --- union arena (soundness-critical placement) ---
 echo "== call_frame_arena union =="
-symaddr() { "$READELF" -sW "$ELF" | awk -v n="$1" '$8==n {print $2; exit}'; }
+symaddr() {
+  # Consume all readelf output: an early awk exit makes readelf receive
+  # SIGPIPE, which is fatal under this script's `pipefail` setting.
+  "$READELF" -sW "$ELF" | awk -v n="$1" '$8==n && !found {print $2; found=1}'
+}
+
+# Absolute link-dependent pins are part of the map contract too. Keep this
+# check next to the relative union checks: a relative extent can remain valid
+# after every symbol moves while an absolute RegionMap pin silently goes stale.
+LEAN_MAP="EvmAsm/Codegen/RegionMap.lean"
+lean_def_hex() {
+  sed -nE "s/^def $1 : Nat := 0x([0-9a-fA-F]+)$/\1/p" "$LEAN_MAP" | head -n 1
+}
+check_link_pin() {
+  local desc="$1" def_name="$2" symbol="$3" map_hex actual expected
+  map_hex="$(lean_def_hex "$def_name")"
+  actual="$(symaddr "$symbol")"
+  if [[ -z "$map_hex" || -z "$actual" ]]; then
+    note "DRIFT $desc: RegionMap def or ELF symbol is missing (map=$map_hex elf=$actual)"
+    fail=1
+    return
+  fi
+  printf -v expected '%016x' "$((16#$map_hex))"
+  check "$desc" "$expected" "$actual"
+}
+check_link_pin "RegionMap.callFrameArenaBase" callFrameArenaBase call_frame_arena
+check_link_pin "RegionMap.evmMemoryPoolBase" evmMemoryPoolBase evm_memory_pool
+check_link_pin "RegionMap.syslogBase" syslogBase bv_system_storage_log
+
+# The union inventory is a closed set for this emitted guest. Checking only
+# the three symbols used by the relative arithmetic would let a phantom map
+# child survive indefinitely, so check the map's names and every ELF symbol.
+map_union_names="$(awk '
+  /^def dataUnionChildren/ {inside=1; next}
+  inside && /name :=/ {
+    line=$0; sub(/^.*name := "/, "", line); sub(/".*$/, "", line); print line
+  }
+  inside && /^$/ {exit}
+' "$LEAN_MAP" | sort | paste -sd' ' -)"
+expected_union_names="baap_storage_desc baap_storage_paths baap_storage_values basr_accounts basr_values"
+if [[ "$map_union_names" == "$expected_union_names" ]]; then
+  note "OK   RegionMap.dataUnionChildren names = $expected_union_names"
+else
+  note "DRIFT RegionMap.dataUnionChildren names: expected $expected_union_names, map has $map_union_names"
+  fail=1
+fi
+for union_name in $expected_union_names; do
+  union_addr="$(symaddr "$union_name")"
+  if [[ -n "$union_addr" ]]; then
+    note "OK   union symbol $union_name = $union_addr"
+  else
+    note "DRIFT union symbol $union_name is absent from ELF"
+    fail=1
+  fi
+done
+
+# GuestAddrs.lean is generated from the linked symbol table and is consumed by
+# handwritten proof/relocation code. Check the whole generated symbol set
+# against this ELF, not only the five union children above. This makes a name
+# that exists only in Lean fail as a phantom instead of silently becoming a
+# proof subject with no emitted storage.
+GUEST_ADDRS="EvmAsm/Codegen/GuestAddrs.lean"
+guest_addrs_missing="$(comm -23 \
+  <(rg '^def [A-Za-z0-9_]+ : Nat := 0x' "$GUEST_ADDRS" |
+      sed -E 's/^def ([A-Za-z0-9_]+) : Nat := 0x.*/\1/' | sort -u) \
+  <("$READELF" -sW "$ELF" |
+      awk 'NF >= 8 && $7 != "UND" && $4 != "SECTION" && $4 != "FILE" && $8 !~ /^\$/ {print $8}' |
+      sort -u))"
+if [[ -z "$guest_addrs_missing" ]]; then
+  guest_addrs_count="$(rg -c '^def [A-Za-z0-9_]+ : Nat := 0x' "$GUEST_ADDRS")"
+  note "OK   GuestAddrs symbols all exist in ELF ($guest_addrs_count names)"
+else
+  note "DRIFT GuestAddrs names absent from ELF: $guest_addrs_missing"
+  fail=1
+fi
 python3 - "$(symaddr call_frame_arena)" "$(symaddr basr_values)" "$(symaddr basr_accounts)" \
   "$(symaddr bv_system_storage_log)" "$(symaddr baap_storage_desc)" "$(symaddr baap_storage_paths)" \
   "$(symaddr baap_storage_values)" \

--- a/scripts/gen-symbol-addresses.py
+++ b/scripts/gen-symbol-addresses.py
@@ -46,8 +46,8 @@ STABLE_BASES = {
     "OUTPUT_ADDR":  0xa0010000,
     ".text":        0x80000000,
     ".data":        0xa3000000,
-    ".bss":         0xa4000000,
-    ".sszscratch":  0xbf800000,
+    ".bss":         0xa3110000,
+    ".sszscratch":  0xbf980000,
     "ssz_input_decoded":      0xa0020000,
     "execution_witness_area": 0xa0030000,
     "node_db_buckets":        0xa0130000,
@@ -69,6 +69,12 @@ STABLE_BASES = {
     "tx_storage_reads_area":  0xa1da0000,
     "tx_account_reads_area":  0xa1ea0000,
     "tx_code_reads_area":     0xa1f20000,
+    "storage_writes_area":    0xa1fa0000,
+    "tx_storage_writes_area": 0xa21a0000,
+    "storage_writes_undo_area": 0xa23a0000,
+    "account_writes_area":    0xa28a0000,
+    "tx_account_writes_area": 0xa2b20000,
+    "account_writes_undo_area": 0xa2d20000,
 }
 
 


### PR DESCRIPTION
## Headline

Before this change, a kernel-checked `CallFramePhase` proof asserted a six-child union that included `baap_storage_delete_paths`, a region absent from the emitted `stateless_guest` image. The Lean constant existed, so the proof typechecked while describing nonexistent storage. Removing the phantom repaired the full phase-tiling theorem family to the five real children; no load-bearing theorem was silently weakened.

## Changes

- Re-pin the current-main ELF facts in `RegionMap.lean`: call-frame arena, memory-pool, syslog, section sizes, and current five-child offsets.
- Repair `CallFrameLayout` and `CallFramePhase` from stale six/seven-child and 228/244 MiB descriptions to the current five-child, 100.1 MiB geometry.
- Correct stale fail-open storage-undo prose to match the emitted fail-closed `.Lswup_fail` path.
- Extend `check-region-map.sh` to reject stale absolute pins, phantom/missing union symbols, and any generated `GuestAddrs.lean` name absent from the freshly linked ELF.
- Correct `gen-symbol-addresses.py`'s `.bss`/`.sszscratch` pins and add all six write/undo Scheme-A anchors. Regeneration produced no TSV diff because the committed table was already ELF-derived.
- Document predicate readiness: entry shape, exact capacity×stride, count semantics, invariants, lifetime/reset, aliasing, and the rule that predicates quantify `arena_base` rather than baking an image-specific address. The current linked image's `baap_storage_values` entry is explicitly 6,400,000 bytes; other build units remain separate.

## Validation

- `lake build` — 4,796 jobs
- `scripts/check-no-warnings.sh`
- `scripts/check-forbidden-tactics.sh`
- `scripts/check-file-size.sh`
- `scripts/check-asm-to-program.sh`
- `NO_BUILD=1 scripts/check-region-map.sh`
- `scripts/check-memorylayout-region-coverage.sh`
- guard perturbations: stale arena pin and phantom child both produce `DRIFT`/exit 1
- current ELF sweep: all five union names and all 1,091 generated `GuestAddrs` names exist

Refs #11221. The original fail-open claim in #11189 was closed separately after verifying the current fail-closed source; identity-skip and cross-unit capacity questions remain separate.