### PR TITLE
docs(codegen): admit live-first balance_at_header_state_root (#11019)

### DIFF
--- a/EvmAsm/Codegen/Programs/CallBalanceGate.lean
+++ b/EvmAsm/Codegen/Programs/CallBalanceGate.lean
@@ -7,10 +7,11 @@
 
   The gate (`callDescendFallThrough`, ChildFrameHandlers.lean) rejects a
   value-bearing CALL/CALLCODE — pushing 0 and NOT descending — when the caller's
-  balance (looked up via `balance_at_header_state_root` against the attached
-  header/state witness) is below the transfer value. This probe drives the live
-  `callFrameGuestRegistry` h_CALL handler (with the gate wired in, unlike the
-  push-0 `callFrameProbeRegistry`) so the rejection is exercised end-to-end.
+  **live** balance is below the transfer value. The handlers read env+32
+  (`.selfBalance`), not `balance_at_header_state_root` (drj99.1; #11019).
+  This probe drives the live `callFrameGuestRegistry` h_CALL handler (with the
+  gate wired in, unlike the push-0 `callFrameProbeRegistry`) so the rejection
+  is exercised end-to-end.
 
   Setup (witness supplied at runtime via `ziskemu -i`, built by
   codegen-zisk-call-balance-gate-check.sh, reusing the balance-at-header-state-root

--- a/EvmAsm/Codegen/Programs/ChildFrameCreateTail.lean
+++ b/EvmAsm/Codegen/Programs/ChildFrameCreateTail.lean
@@ -394,9 +394,10 @@ def createUnsupportedTail (netPopBytes : Nat) (hasSalt : Bool) : String :=
     -- unconditional (alive := 0).
     "  la t0, create_target_alive_current_tx\n  sd x0, 0(t0)\n" ++
     "  ld t3, 584(x20)\n  beqz t3, .Lcr_alive_known_" ++ (if hasSalt then "f5" else "f0") ++ "\n" ++
-    -- spec is_account_alive(target): the TARGET's header-state balance
-    -- (code/nonce holders already took the collision branch) plus the shared
-    -- current CodeState overlay for prior creation.
+    -- spec is_account_alive(target) on mutable tx_state (state_tracker.py):
+    -- LIVE balance via balance_at_header_state_root (live-first, #11019), not
+    -- pure header. Code/nonce holders already took the collision branch; plus
+    -- the shared current CodeState overlay for prior same-tx creation.
     "  addi sp, sp, -32\n  sd x10, 0(sp)\n  sd x12, 8(sp)\n  sd x13, 16(sp)\n" ++
     "  ld a0, 576(x20)\n  ld a1, 584(x20)\n  la a2, create_address_be\n  ld a3, 592(x20)\n  ld a4, 600(x20)\n  la a5, cr_alive_bal\n" ++
     "  jal ra, balance_at_header_state_root\n" ++

--- a/EvmAsm/Codegen/Programs/EvmBalance.lean
+++ b/EvmAsm/Codegen/Programs/EvmBalance.lean
@@ -22,8 +22,9 @@ private def balanceWitnessAddressCopy : String :=
   sb t2, {i}(t1)
 "
 
-/-- Copy the big-endian u256 returned by `balance_at_header_state_root` into
-    the dispatcher's little-endian stack-word layout. -/
+/-- Copy the big-endian u256 returned by `balance_at_header_state_root`
+    (live-first helper, #11019 — not pure header) into the dispatcher's
+    little-endian stack-word layout. -/
 private def balanceWitnessOutputCopy : String :=
   String.intercalate "" <|
     (List.range 32).map fun i =>
@@ -31,7 +32,8 @@ private def balanceWitnessOutputCopy : String :=
   sb t2, {i}(x12)
 "
 
-/-- Raw dispatcher handler for BALANCE backed by `balance_at_header_state_root`.
+/-- Raw dispatcher handler for BALANCE via live-else-header balance lookup
+    (`balance_at_header_state_root`; name is historical — #11019).
 
     Net stack delta is zero: the input address word is overwritten with the
     account balance, or zero for missing accounts / missing witness context. -/

--- a/EvmAsm/Codegen/Programs/EvmOpcodes.lean
+++ b/EvmAsm/Codegen/Programs/EvmOpcodes.lean
@@ -327,24 +327,39 @@ def ziskExtcodehashAtHeaderStateRootProbeUnit : BuildUnit := {
 
 /-! ## balance_at_header_state_root  (EVM BALANCE opcode)
 
-    Witness-side implementation of the EVM `BALANCE` opcode.
-    Given a parent header RLP, an address, and an SSZ
-    `witness.state` list section, return the u256 balance an
-    `BALANCE(addr)` frame would push.
+    **LIVE-FIRST, not header-only.** The symbol name is historical and
+    misdescribes the body (#11019). Every production caller wants
+    live-else-header; the code is correct and the name/docs used to lie.
 
-    BALANCE has the same "absent → 0" flattening as SLOAD: a
-    missing account returns balance 0 without any error
-    signalling. That's the natural EVM-semantic of "all addresses
-    are conceptually defined; uninitialised ones have zero
-    balance".
+    Spec baseline (execution-specs Amsterdam): one mutable
+    `TransactionState`; `BALANCE` reads
+    `get_account(tx_state, address).balance`
+    (`vm/instructions/environment.py`) and `is_account_alive` uses the
+    same `get_account_optional(tx_state, …)`
+    (`state_tracker.py`). Reads return the last write — not a frozen
+    header snapshot. Live-first matches that baseline.
 
-    Composes K201 `header_extract_state_root` + K28
-    `account_at_address`, then extracts the 32-byte balance
-    field (struct + 8 .. + 40) and flattens status 1 to (0, 0).
+    Behaviour:
+    1. Pad the 20B address and call `account_state_latest_balance`
+       (AccountState pending/durable). On a hit, write that post
+       balance and return success — **no header path**.
+    2. On a miss only: K201 `header_extract_state_root` + K28
+       `account_at_address`, copy balance (struct + 8 .. + 40), flatten
+       missing account (status 1) to `(0, balance=0)`.
 
-    Distinct from `account_at_header_state_root` which surfaces
-    the missing-account case as status 1: BALANCE callers
-    shouldn't have to special-case absence.
+    **Contrast — do not confuse with header-only helpers:**
+    - `account_at_header_state_root` **is** a true header-only source
+      (header → state root → account_at_address, no live overlay) with
+      many callers.
+    - A pure **balance**-header-only helper **does not exist**. Anyone
+      who genuinely needs pre-state balance must build it from
+      `account_at_header_state_root` (or accept this miss path). The
+      name of *this* routine must not be read as that helper.
+    - Callers that need a non-settlement snapshot deliberately **avoid**
+      this symbol (e.g. DispatchTx SELFBALANCE staging).
+
+    BALANCE absent → 0 flattening matches SLOAD: missing accounts are
+    conceptually defined with zero balance (no status-1 to the caller).
 
     Calling convention:
       a0 (input)  : header_rlp ptr
@@ -363,6 +378,9 @@ def ziskExtcodehashAtHeaderStateRootProbeUnit : BuildUnit := {
 
       (Code 1 is intentionally absent: missing accounts map to
       `status=0, balance=0` per the EVM BALANCE semantic.)
+
+    Rename to `balance_live_else_header_state_root` tracked separately
+    (regen cost); do not treat the current name as a contract.
 -/
 def balanceAtHeaderStateRootFunction : String :=
   "balance_at_header_state_root:\n" ++
@@ -378,10 +396,11 @@ def balanceAtHeaderStateRootFunction : String :=
   "  mv s5, a5                  # 32-byte u256 BE output ptr\n" ++
   "  # Pre-zero output -- BALANCE default value.\n" ++
   "  sd zero,  0(s5); sd zero,  8(s5); sd zero, 16(s5); sd zero, 24(s5)\n" ++
-  -- yisv8 .spine.2: prefer the LIVE balance -- the latest non-storage effect post_balance for this
-  -- addr (a value transfer's result) -- so BALANCE reflects mid-execution credits/debits, not just
-  -- the pre-state. Build a 32B padded addr (s2's 20B BE in 0..19, 0 in 20..31) to match the effect
-  -- record's zero-padded addr@0; on a hit s5 holds post_balance and we return success.
+  -- LIVE-FIRST (#11019): account_state_latest_balance before any header path.
+  -- Spec: one mutable TransactionState; BALANCE / is_account_alive read last write.
+  -- Build a 32B padded addr (s2's 20B BE in 0..19, 0 in 20..31) to match the
+  -- effect record's zero-padded addr@0; on a hit s5 holds post_balance and we
+  -- return success. Header path is miss-only fallback — not the primary source.
   "  la t0, bal_addr_padded; sd zero, 0(t0); sd zero, 8(t0); sd zero, 16(t0); sd zero, 24(t0)\n" ++
   "  mv t1, s2; mv t2, t0; li t3, 20\n" ++
   ".Lbal_padcp:\n" ++


### PR DESCRIPTION
## Summary

Byte-identical docs fix for #11019. `balance_at_header_state_root` **returns live balance first** (`account_state_latest_balance`); header path is miss-only. The code is correct for every production caller; the **name and docstring lied**.

**No rename tonight** (regen / pin surface). Rename filed separately.

## Changes (prose only — no emitted bytes)

1. **`EvmOpcodes.lean`** module header + body comment: admit LIVE-FIRST; cite Amsterdam one mutable `TransactionState` (`environment.py` BALANCE, `state_tracker.py` `is_account_alive`); **explicit contrast**: `account_at_header_state_root` is true header-only with many callers; a pure **balance**-header-only helper does **not** exist; DispatchTx deliberately avoids this helper for SELFBALANCE staging.
2. **`CallBalanceGate.lean`**: gate uses **env+32**, not this helper (drj99.1).
3. **`ChildFrameCreateTail.lean`**: CREATE alive = `is_account_alive` on live tx_state, not pure header.
4. **`EvmBalance.lean`**: pointer comments.

## Evidence (close-out census)

Main `6b75068fe` guest `07f36a6d…`: emitted `@0x8003570c` jals `account_state_latest_balance` first.

| site | wants | match |
|---|---|---|
| Mtx coinbase fee | LIVE accumulate | yes |
| h_BALANCE | LIVE | yes (spec) |
| SD surcharge origin | LIVE nonzero | yes |
| CREATE/CREATE2 alive | `is_account_alive` live | yes (comment was wrong) |

Not an FR producer by itself. Wrong-stage trap excluded on all five.

## Test plan

- [x] Diff is comment/docstring only (no `.s` / layout change)
- [ ] CI green (docs-only Lean still elaborates)
