### PR TITLE
Apply deferred EIP-6780 deletes to account writes

### DIFF
--- a/EvmAsm/Codegen/Programs/AccountWriteMap.lean
+++ b/EvmAsm/Codegen/Programs/AccountWriteMap.lean
@@ -273,20 +273,13 @@ def accountWritesBlockUpsertFunction : String :=
     EIP-6780 records a same-transaction-created SELFDESTRUCT in the deferred
     `account_state_delete` set.  The AccountState commit consumes that set at
     the transaction boundary, but the account-write map is a separate
-    transaction-local mirror and must receive the same transition before its
-    builder walk.  Preserve the map key as a state-only `None` tombstone and
-    journal the overwrite so an enclosing frame can still restore it.  The
-    incorporation walk omits this tombstone: a same-transaction-created
-    account has no prior block-map row, so omitting it is the block-level
-    representation of `account_changes[address] = None` and keeps the state
-    root enumerator from inventing a leaf.
-
-    The state-delete set does not carry the SELFDESTRUCT beneficiary.  The
-    producer's destroyed table does: byte 20 is 1 for origin == beneficiary
-    and 0 for a distinct beneficiary.  A self-destruction is a live-balance
-    no-op in `move_ether`, so its map row must retain the balance component
-    while suppressing nonce/code.  Distinct-beneficiary rows remain the
-    state-only `None` tombstone described above.
+    transaction-local mirror and must receive the same in-place account
+    transition before its builder walk.  The transition clears nonce and code,
+    destroys storage through the shared delete-read path, and leaves balance
+    untouched.  The row remains a present account; downstream account-change
+    descriptor logic applies the ordinary EIP-161 empty-account prune when all
+    final fields are empty.  Journal the overwrite so an enclosing frame can
+    still restore it.
 
     No arguments; a0 = 0 on success / 1 on bounded-arena failure. -/
 def accountWritesApplyDeletesFunction : String :=
@@ -308,25 +301,10 @@ def accountWritesApplyDeletesFunction : String :=
   "  addi s3, s3, 1; j .Lawd_tx_loop\n" ++
   ".Lawd_hit:\n" ++
   "  mv a5, s3; li a6, 0; jal ra, account_writes_undo_push; bnez a0, .Lawd_overflow\n" ++
-  -- The state-delete entry only identifies the origin.  Recover the
-  -- self-beneficiary bit from the producer table before rewriting the map row.
-  "  la t0, evm_selfdestruct_destroyed_overflow; ld t0, 0(t0); bnez t0, .Lawd_distinct\n" ++
-  "  la t0, evm_selfdestruct_destroyed_count; ld t1, 0(t0); beqz t1, .Lawd_distinct; la t2, evm_selfdestruct_destroyed_table\n" ++
-  ".Lawd_destroyed_scan:\n" ++
-  "  mv t3, t2; mv t4, s0; li t5, 20\n" ++
-  ".Lawd_destroyed_cmp:\n" ++
-  "  beqz t5, .Lawd_destroyed_hit; lbu t6, 0(t3); lbu a0, 0(t4); bne t6, a0, .Lawd_destroyed_next; addi t3, t3, 1; addi t4, t4, 1; addi t5, t5, -1; j .Lawd_destroyed_cmp\n" ++
-  ".Lawd_destroyed_next:\n" ++
-  "  addi t2, t2, 32; addi t1, t1, -1; bnez t1, .Lawd_destroyed_scan; j .Lawd_distinct\n" ++
-  ".Lawd_destroyed_hit:\n" ++
-  "  lbu t0, 20(t2); bnez t0, .Lawd_self\n" ++
-  ".Lawd_distinct:\n" ++
-  "  slli t0, s3, 7; li t1, 0xa2b20000; add t0, t1, t0; sd zero, 32(t0); sd zero, 40(t0); sd zero, 48(t0); sd zero, 56(t0); sd zero, 64(t0); sd zero, 72(t0); sd zero, 80(t0); sd zero, 88(t0); sd zero, 96(t0); sd zero, 104(t0); li t1, 8; sd t1, 112(t0); sd zero, 120(t0); j .Lawd_delete_next\n" ++
-  -- Selfdestruct to self preserves the live balance.  The balance producer
-  -- has already materialised that component in this row; retain it and mark
-  -- the final account as Some while clearing nonce/code.
-  ".Lawd_self:\n" ++
-  "  slli t0, s3, 7; li t1, 0xa2b20000; add t0, t1, t0; sd zero, 64(t0); li t1, 1; sd t1, 72(t0); sd zero, 80(t0); sd zero, 88(t0); sd zero, 96(t0); sd zero, 104(t0); li t1, 9; sd t1, 112(t0); sd zero, 120(t0); j .Lawd_delete_next\n" ++
+  -- clear_account_preserving_balance: preserve balance, clear nonce/code,
+  -- and keep the account present.  The mask is complete so the ordinary
+  -- builder and execution-map paths see the same final Account value.
+  "  slli t0, s3, 7; li t1, 0xa2b20000; add t0, t1, t0; sd zero, 64(t0); li t1, 1; sd t1, 72(t0); sd zero, 80(t0); sd zero, 88(t0); sd zero, 96(t0); sd zero, 104(t0); li t1, 15; sd t1, 112(t0); sd zero, 120(t0); j .Lawd_delete_next\n" ++
   ".Lawd_delete_next:\n" ++
   "  addi s1, s1, 1; j .Lawd_delete_loop\n" ++
   ".Lawd_ok:\n" ++
@@ -382,31 +360,6 @@ def accountWritesEmitBuilderTxFunction : String :=
   "  la t0, current_block_access_index; ld s7, 0(t0); la s0, tx_account_writes_count; ld s1, 0(s0); li s2, 0xa2b20000; li s3, 0\n" ++
   ".Laweb_loop:\n" ++
   "  bgeu s3, s1, .Laweb_done; slli t0, s3, 7; add s4, s2, t0\n" ++
-  -- A deferred same-transaction deletion has no BAL account post-value to
-  -- compare.  Keep the tombstone in the tx map for frame rollback, but do not
-  -- send it through the builder baseline resolver.
-  "  ld t0, 112(s4); li t1, 8; bne t0, t1, .Laweb_not_deleted; ld t1, 72(s4); beqz t1, .Laweb_advance\n" ++
-  ".Laweb_not_deleted:\n" ++
-  -- Same-tx-created SELFDESTRUCT entries are tracked by the producer.  A
-  -- distinct-beneficiary clear is access-only in the BAL; self-destruction to
-  -- self preserves the live balance, so only its nonce/code are suppressed.
-  -- Byte 20 is producer metadata; overflow leaves the conservative path.
-  "  sd zero, 96(sp)\n" ++
-  "  la t0, evm_selfdestruct_destroyed_overflow; ld t0, 0(t0); bnez t0, .Laweb_destroyed_done\n" ++
-  "  la t0, evm_selfdestruct_destroyed_count; ld t1, 0(t0); beqz t1, .Laweb_destroyed_done\n" ++
-  "  la t2, evm_selfdestruct_destroyed_table\n" ++
-  ".Laweb_destroyed_scan:\n" ++
-  "  mv t3, t2; mv t4, s4; li t5, 20\n" ++
-  ".Laweb_destroyed_cmp:\n" ++
-  "  beqz t5, .Laweb_destroyed_hit\n" ++
-  "  lbu t6, 0(t3); lbu a0, 0(t4); bne t6, a0, .Laweb_destroyed_next\n" ++
-  "  addi t3, t3, 1; addi t4, t4, 1; addi t5, t5, -1; j .Laweb_destroyed_cmp\n" ++
-  ".Laweb_destroyed_next:\n" ++
-  "  addi t2, t2, 32; addi t1, t1, -1; bnez t1, .Laweb_destroyed_scan\n" ++
-  "  j .Laweb_destroyed_done\n" ++
-  ".Laweb_destroyed_hit:\n" ++
-  "  lbu t0, 20(t2); addi t0, t0, 1; sd t0, 96(sp)\n" ++
-  ".Laweb_destroyed_done:\n" ++
   -- Find this address in the block-cumulative map.  A hit may still lack an
   -- individual field, in which case that component keeps the pre-state base.
   "  la t0, account_writes_count; ld t1, 0(t0); li t2, 0xa28a0000; li t3, 0; li s5, 0\n" ++
@@ -431,7 +384,6 @@ def accountWritesEmitBuilderTxFunction : String :=
   -- account_resolve_pre_state's fixed account scratch output.
   "  mv a0, s4; la a1, account_builder_pre_account; la t0, sv_pre_rlp_ptr; ld a2, 0(t0); la t0, sv_pre_rlp_len; ld a3, 0(t0); la t0, bv_witness_state_ptr; ld a4, 0(t0); la t0, bv_witness_state_len; ld a5, 0(t0); jal ra, account_resolve_pre_state\n" ++
   "  ld s8, 112(s4)\n" ++
-  "  ld t0, 96(sp); li t1, 1; beq t0, t1, .Laweb_advance\n" ++
   -- Balance: the resolver has already materialised the block/durable/header
   -- precedence into the shared account scratch.
   "  andi t0, s8, 1; bnez t0, .Laweb_balance_have; j .Laweb_nonce\n" ++
@@ -469,7 +421,6 @@ def accountWritesEmitBuilderTxFunction : String :=
   "  ld t1, 0(s4); la t0, bald_bal_eq_addr_a; sd t1, 0(t0); ld t1, 8(s4); la t0, bald_bal_eq_addr_b; sd t1, 0(t0)\n" ++
   -- Nonce: read the resolver's canonical pre-state scratch.
   ".Laweb_nonce:\n" ++
-  "  ld t0, 96(sp); li t1, 2; beq t0, t1, .Laweb_advance\n" ++
   "  andi t0, s8, 2; bnez t0, .Laweb_nonce_have; j .Laweb_code\n" ++
   ".Laweb_nonce_have:\n" ++
   -- Diagnostic cell, before the `la t0` that this block needs: t1 is dead here
@@ -524,11 +475,6 @@ def accountWritesIncorporateTxFunction : String :=
   ".Lawi_loop:\n" ++
   "  bgeu s3, s1, .Lawi_clear\n" ++
   "  slli a0, s3, 7; add a0, s2, a0\n" ++
-  -- A same-transaction-created SELFDESTRUCT is represented by a state-only
-  -- `None` tombstone until this transaction is incorporated.  It has no
-  -- block-level predecessor, so do not turn the tombstone into a synthetic
-  -- account row for the state-root enumerator.
-  "  ld t0, 112(a0); li t1, 8; bne t0, t1, .Lawi_merge; ld t1, 72(a0); beqz t1, .Lawi_next\n" ++
   ".Lawi_merge:\n" ++
   "  jal ra, account_writes_block_upsert\n" ++
   ".Lawi_next:\n" ++

--- a/EvmAsm/Codegen/Programs/AccountWriteMap.lean
+++ b/EvmAsm/Codegen/Programs/AccountWriteMap.lean
@@ -91,6 +91,7 @@
 -/
 
 import EvmAsm.Rv64.Program
+import EvmAsm.Codegen.ArenaCapacities
 import EvmAsm.Codegen.Programs.BlockVerdictParams
 import EvmAsm.Codegen.Programs.StorageWriteMap
 import EvmAsm.Stateless.MemoryLayout
@@ -267,6 +268,49 @@ def accountWritesBlockUpsertFunction : String :=
   "  addi sp, sp, 64\n" ++
   "  ret\n"
 
+/-! ## `account_writes_apply_deletes`
+
+    EIP-6780 records a same-transaction-created SELFDESTRUCT in the deferred
+    `account_state_delete` set.  The AccountState commit consumes that set at
+    the transaction boundary, but the account-write map is a separate
+    transaction-local mirror and must receive the same transition before its
+    builder walk.  Preserve the map key as a state-only `None` tombstone and
+    journal the overwrite so an enclosing frame can still restore it.  The
+    incorporation walk omits this tombstone: a same-transaction-created
+    account has no prior block-map row, so omitting it is the block-level
+    representation of `account_changes[address] = None` and keeps the state
+    root enumerator from inventing a leaf.
+
+    No arguments; a0 = 0 on success / 1 on bounded-arena failure. -/
+def accountWritesApplyDeletesFunction : String :=
+  "account_writes_apply_deletes:\n" ++
+  "  addi sp, sp, -48\n" ++
+  "  sd ra, 0(sp); sd s0, 8(sp); sd s1, 16(sp); sd s2, 24(sp); sd s3, 32(sp)\n" ++
+  "  la t0, account_state_delete_count; ld s2, 0(t0); li t0, " ++ toString accountStateDeleteCapacity ++ "; bgtu s2, t0, .Lawd_overflow\n" ++
+  "  li s1, 0\n" ++
+  ".Lawd_delete_loop:\n" ++
+  "  bgeu s1, s2, .Lawd_ok\n" ++
+  "  slli t0, s1, 5; la t1, account_state_delete; add s0, t1, t0; ld t0, 24(s0); beqz t0, .Lawd_delete_next\n" ++
+  "  la t0, tx_account_writes_count; ld t1, 0(t0); li t2, " ++ toString txAccountWritesCapacity ++ "; bgtu t1, t2, .Lawd_overflow; li s3, 0\n" ++
+  ".Lawd_tx_loop:\n" ++
+  "  bgeu s3, t1, .Lawd_delete_next\n" ++
+  "  slli t2, s3, 7; li t3, 0xa2b20000; add t2, t3, t2; mv t3, t2; mv t4, s0; li t5, 20\n" ++
+  ".Lawd_cmp:\n" ++
+  "  beqz t5, .Lawd_hit; lbu t6, 0(t3); lbu a0, 0(t4); bne t6, a0, .Lawd_next; addi t3, t3, 1; addi t4, t4, 1; addi t5, t5, -1; j .Lawd_cmp\n" ++
+  ".Lawd_next:\n" ++
+  "  addi s3, s3, 1; j .Lawd_tx_loop\n" ++
+  ".Lawd_hit:\n" ++
+  "  mv a5, s3; li a6, 0; jal ra, account_writes_undo_push; bnez a0, .Lawd_overflow\n" ++
+  "  slli t0, s3, 7; li t1, 0xa2b20000; add t0, t1, t0; sd zero, 32(t0); sd zero, 40(t0); sd zero, 48(t0); sd zero, 56(t0); sd zero, 64(t0); sd zero, 72(t0); sd zero, 80(t0); sd zero, 88(t0); sd zero, 96(t0); sd zero, 104(t0); li t1, 8; sd t1, 112(t0); sd zero, 120(t0); j .Lawd_delete_next\n" ++
+  ".Lawd_delete_next:\n" ++
+  "  addi s1, s1, 1; j .Lawd_delete_loop\n" ++
+  ".Lawd_ok:\n" ++
+  "  li a0, 0; j .Lawd_ret\n" ++
+  ".Lawd_overflow:\n" ++
+  "  la t0, tx_account_writes_overflow; li t1, 1; sd t1, 0(t0); la t0, account_writes_overflow; sd t1, 0(t0); li a0, 1\n" ++
+  ".Lawd_ret:\n" ++
+  "  ld ra, 0(sp); ld s0, 8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp); addi sp, sp, 48; ret\n"
+
 /-! ## `account_writes_incorporate_tx`
 
     Mirrors the account half of `incorporate_tx_into_block`: merge the
@@ -313,6 +357,11 @@ def accountWritesEmitBuilderTxFunction : String :=
   "  la t0, current_block_access_index; ld s7, 0(t0); la s0, tx_account_writes_count; ld s1, 0(s0); li s2, 0xa2b20000; li s3, 0\n" ++
   ".Laweb_loop:\n" ++
   "  bgeu s3, s1, .Laweb_done; slli t0, s3, 7; add s4, s2, t0\n" ++
+  -- A deferred same-transaction deletion has no BAL account post-value to
+  -- compare.  Keep the tombstone in the tx map for frame rollback, but do not
+  -- send it through the builder baseline resolver.
+  "  ld t0, 112(s4); li t1, 8; bne t0, t1, .Laweb_not_deleted; ld t1, 72(s4); beqz t1, .Laweb_advance\n" ++
+  ".Laweb_not_deleted:\n" ++
   -- Same-tx-created SELFDESTRUCT entries are tracked by the producer.  A
   -- distinct-beneficiary clear is access-only in the BAL; self-destruction to
   -- self preserves the live balance, so only its nonce/code are suppressed.
@@ -450,7 +499,14 @@ def accountWritesIncorporateTxFunction : String :=
   ".Lawi_loop:\n" ++
   "  bgeu s3, s1, .Lawi_clear\n" ++
   "  slli a0, s3, 7; add a0, s2, a0\n" ++
+  -- A same-transaction-created SELFDESTRUCT is represented by a state-only
+  -- `None` tombstone until this transaction is incorporated.  It has no
+  -- block-level predecessor, so do not turn the tombstone into a synthetic
+  -- account row for the state-root enumerator.
+  "  ld t0, 112(a0); li t1, 8; bne t0, t1, .Lawi_merge; ld t1, 72(a0); beqz t1, .Lawi_next\n" ++
+  ".Lawi_merge:\n" ++
   "  jal ra, account_writes_block_upsert\n" ++
+  ".Lawi_next:\n" ++
   "  addi s3, s3, 1; j .Lawi_loop\n" ++
   ".Lawi_clear:\n" ++
   -- state_tracker.py:874 `tx_state.account_writes.clear()`. The undo journal is
@@ -684,6 +740,7 @@ def accountWriteMapBssSection : String :=
 def accountWriteMapFunctions : String :=
   accountWriteRecordFunction ++
   accountWritesBlockUpsertFunction ++
+  accountWritesApplyDeletesFunction ++
   accountWritesEmitBuilderTxFunction ++
   accountWritesIncorporateTxFunction ++
   accountWritesUndoPushFunction ++
@@ -729,6 +786,7 @@ def accountWriteMapFunctions : String :=
 #guard (accountWriteMapFunctions.splitOn "account_writes_block_upsert:").length == 2
 #guard (accountWriteMapFunctions.splitOn "account_writes_emit_builder_tx:").length == 2
 #guard (accountWriteMapFunctions.splitOn "account_writes_incorporate_tx:").length == 2
+#guard (accountWriteMapFunctions.splitOn "account_writes_apply_deletes:").length == 2
 #guard (accountWriteMapFunctions.splitOn "account_writes_discard_tx:").length == 1
 -- GH #10810: the callee must preserve t5/t6, because `account_write_record`'s hit path holds the
 -- target row address in t5 ACROSS this call. Pin the save AND the restore: a prologue-only save

--- a/EvmAsm/Codegen/Programs/AccountWriteMap.lean
+++ b/EvmAsm/Codegen/Programs/AccountWriteMap.lean
@@ -281,6 +281,13 @@ def accountWritesBlockUpsertFunction : String :=
     representation of `account_changes[address] = None` and keeps the state
     root enumerator from inventing a leaf.
 
+    The state-delete set does not carry the SELFDESTRUCT beneficiary.  The
+    producer's destroyed table does: byte 20 is 1 for origin == beneficiary
+    and 0 for a distinct beneficiary.  A self-destruction is a live-balance
+    no-op in `move_ether`, so its map row must retain the balance component
+    while suppressing nonce/code.  Distinct-beneficiary rows remain the
+    state-only `None` tombstone described above.
+
     No arguments; a0 = 0 on success / 1 on bounded-arena failure. -/
 def accountWritesApplyDeletesFunction : String :=
   "account_writes_apply_deletes:\n" ++
@@ -301,7 +308,25 @@ def accountWritesApplyDeletesFunction : String :=
   "  addi s3, s3, 1; j .Lawd_tx_loop\n" ++
   ".Lawd_hit:\n" ++
   "  mv a5, s3; li a6, 0; jal ra, account_writes_undo_push; bnez a0, .Lawd_overflow\n" ++
+  -- The state-delete entry only identifies the origin.  Recover the
+  -- self-beneficiary bit from the producer table before rewriting the map row.
+  "  la t0, evm_selfdestruct_destroyed_overflow; ld t0, 0(t0); bnez t0, .Lawd_distinct\n" ++
+  "  la t0, evm_selfdestruct_destroyed_count; ld t1, 0(t0); beqz t1, .Lawd_distinct; la t2, evm_selfdestruct_destroyed_table\n" ++
+  ".Lawd_destroyed_scan:\n" ++
+  "  mv t3, t2; mv t4, s0; li t5, 20\n" ++
+  ".Lawd_destroyed_cmp:\n" ++
+  "  beqz t5, .Lawd_destroyed_hit; lbu t6, 0(t3); lbu a0, 0(t4); bne t6, a0, .Lawd_destroyed_next; addi t3, t3, 1; addi t4, t4, 1; addi t5, t5, -1; j .Lawd_destroyed_cmp\n" ++
+  ".Lawd_destroyed_next:\n" ++
+  "  addi t2, t2, 32; addi t1, t1, -1; bnez t1, .Lawd_destroyed_scan; j .Lawd_distinct\n" ++
+  ".Lawd_destroyed_hit:\n" ++
+  "  lbu t0, 20(t2); bnez t0, .Lawd_self\n" ++
+  ".Lawd_distinct:\n" ++
   "  slli t0, s3, 7; li t1, 0xa2b20000; add t0, t1, t0; sd zero, 32(t0); sd zero, 40(t0); sd zero, 48(t0); sd zero, 56(t0); sd zero, 64(t0); sd zero, 72(t0); sd zero, 80(t0); sd zero, 88(t0); sd zero, 96(t0); sd zero, 104(t0); li t1, 8; sd t1, 112(t0); sd zero, 120(t0); j .Lawd_delete_next\n" ++
+  -- Selfdestruct to self preserves the live balance.  The balance producer
+  -- has already materialised that component in this row; retain it and mark
+  -- the final account as Some while clearing nonce/code.
+  ".Lawd_self:\n" ++
+  "  slli t0, s3, 7; li t1, 0xa2b20000; add t0, t1, t0; sd zero, 64(t0); li t1, 1; sd t1, 72(t0); sd zero, 80(t0); sd zero, 88(t0); sd zero, 96(t0); sd zero, 104(t0); li t1, 9; sd t1, 112(t0); sd zero, 120(t0); j .Lawd_delete_next\n" ++
   ".Lawd_delete_next:\n" ++
   "  addi s1, s1, 1; j .Lawd_delete_loop\n" ++
   ".Lawd_ok:\n" ++

--- a/EvmAsm/Codegen/Programs/CreateCodeEffectLog.lean
+++ b/EvmAsm/Codegen/Programs/CreateCodeEffectLog.lean
@@ -221,7 +221,7 @@ def accountStateUpsertDurableFunction : String :=
     this helper: they rewind the pending count to the saved high-water mark.
     EIP-161 deletion is applied after pending snapshots merge: therefore a
     same-transaction CALL can still see its created contract's code, while the
-    next transaction sees the durable tombstone. -/
+    next transaction sees the durable cleared-account snapshot. -/
 def accountStateCommitPendingFunction : String :=
   "account_state_commit_pending:\n" ++
   -- The generic read-set promotion is deliberately NOT here.  The spec
@@ -249,17 +249,17 @@ def accountStateCommitPendingFunction : String :=
   "  addi s1, s1, 1; j .Lascp_loop\n" ++
   ".Lascp_clear:\n" ++
   -- EIP-6780's deferred delete set is also the authoritative source for the
-  -- transaction AccountWrite `None` transition.  Apply it before consuming
-  -- the set below, so the subsequent BAL builder walk and block incorporation
-  -- cannot publish a same-transaction-created account that was deleted before
-  -- transaction finalization.
+  -- transaction AccountWrite in-place clear.  Apply it before consuming the
+  -- set below, so the subsequent BAL builder walk and block incorporation see
+  -- the same final account fields as AccountState.
   "  jal ra, account_writes_apply_deletes; bnez a0, .Lascp_over\n" ++
   "  la t0, account_state_delete_count; ld s0, 0(t0); li t0, " ++ toString accountStateDeleteCapacity ++ "; bgtu s0, t0, .Lascp_over; li s1, 0\n" ++
   ".Lascp_delete_loop:\n" ++
   "  bgeu s1, s0, .Lascp_finish; slli t0, s1, 5; la s2, account_state_delete; add s2, s2, t0; ld t1, 24(s2); beqz t1, .Lascp_delete_next\n" ++
-  -- EIP-161 preserves an empty account whose final balance is nonzero.  The
-  -- AccountState tombstone must therefore distinguish `exists, no code` from
-  -- a deleted account using execution state, never the BAL comparison input.
+  -- EIP-161 preserves an empty-code account whose final balance is nonzero.
+  -- The AccountState final snapshot must therefore distinguish `exists, no
+  -- code` from a fully empty account using execution state, never the BAL
+  -- comparison input.
   "  mv a0, s2; jal ra, code_state_final_balance_nonzero; li t1, 2; beq a0, t1, .Lascp_over; li t1, 17; beqz a0, .Lascp_delete_flags; li t1, 51\n" ++
   ".Lascp_delete_flags:\n" ++
   "  sd t1, 40(sp)\n" ++

--- a/EvmAsm/Codegen/Programs/CreateCodeEffectLog.lean
+++ b/EvmAsm/Codegen/Programs/CreateCodeEffectLog.lean
@@ -248,6 +248,12 @@ def accountStateCommitPendingFunction : String :=
   ".Lascp_next:\n" ++
   "  addi s1, s1, 1; j .Lascp_loop\n" ++
   ".Lascp_clear:\n" ++
+  -- EIP-6780's deferred delete set is also the authoritative source for the
+  -- transaction AccountWrite `None` transition.  Apply it before consuming
+  -- the set below, so the subsequent BAL builder walk and block incorporation
+  -- cannot publish a same-transaction-created account that was deleted before
+  -- transaction finalization.
+  "  jal ra, account_writes_apply_deletes; bnez a0, .Lascp_over\n" ++
   "  la t0, account_state_delete_count; ld s0, 0(t0); li t0, " ++ toString accountStateDeleteCapacity ++ "; bgtu s0, t0, .Lascp_over; li s1, 0\n" ++
   ".Lascp_delete_loop:\n" ++
   "  bgeu s1, s0, .Lascp_finish; slli t0, s1, 5; la s2, account_state_delete; add s2, s2, t0; ld t1, 24(s2); beqz t1, .Lascp_delete_next\n" ++


### PR DESCRIPTION
## Summary

- Propagate the authoritative `account_state_delete` set into transaction `account_writes` at the deferred end-of-transaction commit point.
- Apply the same in-place account transition as Amsterdam `clear_account_preserving_balance`: clear nonce and code, leave balance untouched, and retain the present account row.
- Let the ordinary account-change descriptor apply EIP-161 empty-account pruning; storage destruction remains owned by the shared delete-read path.

The delete sweep consumes the already-authoritative `account_state_delete` set; it does not rederive the condition. That set is populated only when the SELFDESTRUCT originator is in `tx_state.created_accounts`, mirroring Amsterdam `system.py` around lines 635-700. The placement remains immediately before the AccountState delete-set consumption and transaction incorporation, matching `fork.py` around lines 1201-1204.

## Corrected account shape

The first candidate exposed a real regression in row `00130 ... selfdestructing_initcode_preserves_balance ... success-self-no_s`: candidate byte 32 was 0 while the parent was 1, and the candidate output carried `bv_fail_code=60` (BAL digest mismatch). The cause was the initial implementation zeroing balance and encoding a `None` tombstone for every deferred delete.

That was the wrong state shape. Amsterdam `system.py:682` reads `originator_balance`, `system.py:685` calls `move_ether` unconditionally, and `system.py:692-693` registers the delete afterward. `state_tracker.py:536-557` implements the deferred clear with `modify_state`, clearing nonce/code/storage while preserving balance and account presence. The corrected `AccountWriteMap.lean:302-307` now applies that uniform final account to every matching row: preserve balance, set nonce to zero, clear code pointer/length, set state `Some`, and mark all four components valid. The builder and transaction-to-block incorporation no longer special-case or omit the row. The existing `BalAccountChangeDescriptor` emptiness test then chooses the ordinary trie delete only when the final account is genuinely empty; a nonzero balance remains a leaf.

## Parent and candidate comparison

Parent forward baseline on seed `20260802`: FA=0, FR=12, OK=188. Parent commit: `58306c025beb2c54fcf2b32b5ae154495e18937b`. Parent guest ELF sha256: `5cebd0ac540275d1775339cf8fbf6040e12187585fc83fb7e7f7ffdf7efcdad0`.

Fixed candidate commit: `2197dd7fc`. Fresh guest ELF sha256: `f1e464d9b186501707770ae225d687284009bff5b359b63999ed5f8a8d7fe88d`.

- Forward seed `20260802`: FA=0, FR=11, OK=189. The only parent/candidate flip is `00081 ... GASPRICE-debug__b6` FR to OK; `00130` is now OK and is no longer a flip.
- Reverse seed `20260802`: FA=0, FR=11, OK=189. The only parent/candidate flip is the same `00081` row; there are no other reverse flips.

The exact current-full forward replay covers the requested rows `00052`, `00067`, `00130`, and `00156`; all four are OK, as are all 157 rows. A separate 50-row `selfdestructing_initcode_preserves_balance` family run is 50/50 on full output, root, success byte, and tail, and the same manifest is 50/50 with the parent.

The reject-side check covered exactly 1,036 oracle-invalid rows from the sweep manifest: FA=0, FR=0, OK=1,036. All 1,036 still reject.

## Transaction and block lifetime

The account row is transaction-scoped until the normal incorporation. `AccountWriteMap.lean:302-307` journals and updates it before the builder walk. `AccountWriteMap.lean:468-481` incorporates every transaction row into the block map, and `AccountWriteMap.lean:482-492` then clears the transaction map and undo journal. This matches `state_tracker.py:864-874`: the final account value is merged, then the transaction map is cleared. No account-write tombstone is retained or omitted; EIP-161 decides whether the final present account produces a trie delete.

## Validation

- `lake build` passed all 4,796 jobs.
- Stateless guest link check passed with the fresh ELF above.
- Exact current-full replay passed 157/157 rows, including 00052, 00067, 00130, and 00156.
- Targeted `selfdestructing_initcode_preserves_balance` run passed 50/50 full/root/success/tail checks.
- The pinned self-beneficiary `00130` fixture passed directly with the fresh ELF.
- Reverted-create behavior was not measured and is out of scope for this PR; it should be tracked separately if needed.
