### PR TITLE
Reject malformed BAL account keys in storage consistency check

### DIFF
--- a/EvmAsm/Codegen/Programs/BalAllAccountsStorage.lean
+++ b/EvmAsm/Codegen/Programs/BalAllAccountsStorage.lean
@@ -45,8 +45,9 @@ open EvmAsm.Rv64
             (forward) by and cover (reverse) the exec log for that account
         1 : any parse failure / mismatch / omission (conservative reject)
 
-    A BAL account whose address item is not exactly 20 bytes is skipped (system /
-    malformed entries are not callee storage accounts). -/
+    A BAL account whose address item is not exactly 20 bytes is rejected.  AccountChanges
+    keys are exactly 20-byte addresses in the execution-specs model; accepting a malformed
+    key by skipping it would leave an unchecked entry in the consistency boundary. -/
 def balAllAccountsStorageConsistentFunction : String :=
   "bal_all_accounts_storage_consistent_skip_list:\n" ++
   "  addi sp, sp, -112\n" ++
@@ -73,7 +74,7 @@ def balAllAccountsStorageConsistentFunction : String :=
   "  bnez a2, .Lc2baas_fail\n" ++
   "  jal ra, rlp_walk_next                 # item 0 = address\n" ++
   "  bnez a1, .Lc2baas_fail\n" ++
-  "  li t2, 20; bne a2, t2, .Lc2baas_next   # not 20B -> skip\n" ++
+  "  li t2, 20; bne a2, t2, .Lc2baas_fail   # not 20B -> reject malformed entry\n" ++
   "  sub s10, a0, a2              # addr ptr (20B BE)\n" ++
   "  li t4, 0                    # skip-list index\n" ++
   ".Lc2baas_skip_outer:\n" ++
@@ -112,6 +113,12 @@ def balAllAccountsStorageConsistentFunction : String :=
   "  ld s9, 80(sp); ld s10, 88(sp)\n" ++
   "  addi sp, sp, 112\n" ++
   "  ret"
+
+-- #11245: malformed AccountChanges keys must take the conservative reject arm;
+-- keep the structural predicate next to the emitted helper so a future refactor
+-- cannot silently restore the old skip-to-next-account behaviour.
+#guard (balAllAccountsStorageConsistentFunction.splitOn ".Lc2baas_fail   # not 20B -> reject malformed entry").length == 2
+#guard (balAllAccountsStorageConsistentFunction.splitOn ".Lc2baas_next   # not 20B -> skip").length == 1
 
 /-- `zisk_bal_all_accounts_storage_consistent`: focused probe.
     Input (after the ziskemu length wrapper at 0x40000000):


### PR DESCRIPTION
## Summary

`AccountChanges` keys are 20-byte addresses in the execution-specs model.  The
old skip therefore left an impossible, malformed entry outside the consistency
check: an FA-surface hole.  The emitted helper now takes that path to its
existing conservative reject arm.

The live storage comparator is retained; this changes only the malformed-key
disposition from skip to reject.  It is not a retirement of the comparator.

This is a validation-boundary fix, not a system-address skip retirement.  The
live MTx skip list contains only gas/value-coupled senders, effective recipients,
and coinbase; the modeled-system classifier is probe-only in this wrapper.  The
7002/7251 producer work in #11257 is therefore related infrastructure but not
the reason for this branch.

Execution-specs `AccountChanges` is the six-field account record assembled by
`execution-specs/src/ethereum/forks/amsterdam/block_access_lists.py` (storage
changes/read fields and account list construction around lines 334--382 and
549--585).  A non-20-byte account key is not a valid record and must not be
silently ignored.

## Evidence

- Parent base: `c82461e28`.
- Candidate commit: `92e48fe30`.
- Parent ELF SHA256: `c9aa4313dafc632cf3cbca17c0225b62afa3fa76b88613cb91c6baa036d04d98`.
- Candidate ELF SHA256: `088667de7b5352b62fa615c1b10601a6e22b823287bc32a97d75036c33efcf8d`.
- Both ELFs: `.text=0x622a8`, `.data=0x5370`, `.bss=0x1a954460`.

Focused skip-list probe, using the same Spike runner and a synthetic outer
`c7 c6 01 c0 c0 c0 c0 c0` AccountChanges list:

- parent status `0` (the malformed account was skipped);
- candidate status `1` (the malformed account was rejected);
- empty-list control remains parent status `0`.

On the 1,036-row `oracle_succ=0` slice of the 26,104-row manifest, the candidate
reports `FA=0 FR=0 OK=1036`: every expected-invalid row still rejects.  This is
the reject-side certification for the boundary change.

The refreshed 200-row A/B (same manifest, `WORKERS=30`, `SPIKE_OUTPUT_LEN=256`)
reports parent `FA=0 FR=3 OK=197` and candidate `FA=0 FR=3 OK=197`, with
`forward=0`, `reverse=0`, and no changed rows.

The PR is intentionally unlabelled pending #11259's merge; no merge label is
being applied here.
