### PR TITLE
proof(#11289): witness the 7 Correspondence.lean routine specs, make it strict

### DIFF
--- a/EvmAsm/Progress/AxiomWitnesses.lean
+++ b/EvmAsm/Progress/AxiomWitnesses.lean
@@ -23,17 +23,34 @@
   rather than whole-routine, so populating every one is not a single change.
   What is registered is witnessed; what is not registered is still outside the
   gate.  Stated here rather than left implicit, because the assumption this
-  file exists to break is "covered by CI".
+  file exists to break is "covered by CI".  #11290 tracks turning that residual
+  into a measured coverage number rather than prose.  As of #11289 all three
+  registries are strict, so within a *registered* file an unwitnessed row is a
+  build error — the gap is only in what has not been registered yet.
 -/
 import EvmAsm.Progress
 import EvmAsm.Progress.Routines
 import EvmAsm.Progress.Correspondence
+
+#print axioms EvmAsm.Codegen.RlpBytesEncodedSizeSAsm.rlpBytesEncodedSize_spec
 
 #print axioms EvmAsm.Codegen.RlpEncodeUintBeSAsm.reub_spec_encode_within
 
 #print axioms EvmAsm.Codegen.RlpEncodeUintBeSAsm.reub_spec_within
 
 #print axioms EvmAsm.Codegen.RlpEncodeUintBeSAsm.reub_spec_within_of_length_le
+
+#print axioms EvmAsm.Codegen.RlpFieldToU256BeSAsm.rlpFieldToU256Be_spec_within
+
+#print axioms EvmAsm.Codegen.RlpFieldToU64SAsm.rlpFieldToU64_spec_within
+
+#print axioms EvmAsm.Codegen.RlpListCountItemsSAsm.rlp_list_count_items_spec_within
+
+#print axioms EvmAsm.Codegen.RlpListEncodedSizeSAsm.rlpListEncodedSize_spec
+
+#print axioms EvmAsm.Codegen.RlpListNthItemSAsm.rlpListNthItem_spec_within
+
+#print axioms EvmAsm.Codegen.RlpSpliceHelperSpec.rlp_encode_list_prefix_short_pinned_spec_within
 
 #print axioms EvmAsm.Codegen.RlpSpliceHelperSpec.rlp_item_size_spec_within
 

--- a/EvmAsm/Progress/Routines.lean
+++ b/EvmAsm/Progress/Routines.lean
@@ -58,6 +58,12 @@ import EvmAsm.Progress
 import EvmAsm.Evm64.AccountAccessorSpec
 import EvmAsm.Codegen.Programs.RlpEncodeUintBeComposeSAsm
 import EvmAsm.Codegen.Programs.RlpSpliceHelperSpec
+import EvmAsm.Codegen.Programs.RlpBytesEncodedSizeSAsm
+import EvmAsm.Codegen.Programs.RlpFieldToU256BeWholeSAsm
+import EvmAsm.Codegen.Programs.RlpFieldToU64WholeSAsm
+import EvmAsm.Codegen.Programs.RlpListEncodedSizeSAsm
+import EvmAsm.Codegen.Programs.RlpListNthItemSAsm
+import EvmAsm.Codegen.Programs.RlpListCountItemsSAsm
 
 namespace EvmAsm.Progress
 
@@ -158,7 +164,38 @@ def routineRegistry : List RoutineEntry := [
   routine "account_rlp_content_to_u256_be" .proven
       (some "account_rlp_content_to_u256_be_balance_spec_within")
       (notes := "writes the 32-byte balance; step bound "
-        ++ "`7 * (Nat.toBytesBE a.balance.toNat).length + 16`")
+        ++ "`7 * (Nat.toBytesBE a.balance.toNat).length + 16`"),
+
+  -- #11289: the RLP size / field / list routines whose specs `Correspondence`
+  -- names but nothing witnessed. All whole-routine triples at their linked
+  -- guest addresses (`B := GuestAddrs.<symbol>`), confirmed via the correspondence
+  -- registry's `spec` refs. Tiers read per this module's header: only a
+  -- nonvacuous input-domain gate is `.conditional`; buffer-slack, alignment,
+  -- `isValidByteAccess`, register encoding and u64-representability are ABI.
+  routine "rlp_bytes_encoded_size" .proven (some "rlpBytesEncodedSize_spec")
+      (notes := "total: computes `rbesSize` for any byte payload whose length "
+        ++ "matches the `len` register; only ABI hyps (ptr/len consistency, "
+        ++ "alignment, validity)"),
+  routine "rlp_field_to_u256_be" .proven (some "rlpFieldToU256Be_spec_within")
+      (notes := "whole-routine triple over the `…Whole` module; 32-byte output "
+        ++ "buffer, list-slack and register-encoding hyps are ABI, no form gate"),
+  routine "rlp_field_to_u64" .proven (some "rlpFieldToU64_spec_within")
+      (notes := "companion to `rlp_field_to_u256_be` for the u64 field width"),
+  routine "rlp_list_encoded_size" .proven (some "rlpListEncodedSize_spec")
+      (notes := "total: the result covers BOTH the `ult v 56` short branch and "
+        ++ "the long branch, so it is not form-gated — the only hyp is `halignRet`"),
+  routine "rlp_list_nth_item" .proven (some "rlpListNthItem_spec_within")
+      (notes := "whole-routine triple at `GuestAddrs.rlp_list_nth_item`; the "
+        ++ "consumer of the account decode / apply paths"),
+  routine "rlp_list_count_items" .proven (some "rlp_list_count_items_spec_within")
+      (notes := "whole-routine triple at `GuestAddrs.rlp_list_count_items`"),
+  routine "rlp_encode_list_prefix" .conditional
+      (some "rlp_encode_list_prefix_short_pinned_spec_within")
+      (gate := "`len.toNat < 56` — the RLP short-form list-prefix bound. The "
+        ++ "`lenlen ≥ 2` long forms are the documented cut (#10780 item 3), the "
+        ++ "same boundary as `rlp_item_size`")
+      (notes := "per-form (\"short\") pinned triple; writes header byte "
+        ++ "`0xC0 + len` and sets the cell flag to 1")
 ]
 
 /-! ## Counts (kernel-checked) -/
@@ -170,10 +207,10 @@ def routineCount : Nat := routineRegistry.length
 def routineCountTier (t : ProofTier) : Nat :=
   (routineRegistry.filter (fun e => e.tier == t)).length
 
-theorem routineCount_eq : routineCount = 11 := by decide
+theorem routineCount_eq : routineCount = 18 := by decide
 
-theorem routineProvenCount_eq      : routineCountTier .proven      = 4 := by decide
-theorem routineConditionalCount_eq : routineCountTier .conditional = 7 := by decide
+theorem routineProvenCount_eq      : routineCountTier .proven      = 10 := by decide
+theorem routineConditionalCount_eq : routineCountTier .conditional = 8 := by decide
 theorem routinePartlyCount_eq      : routineCountTier .partly      = 0 := by decide
 
 /-- Every row names a witness theorem. The `none` case is what
@@ -187,7 +224,7 @@ theorem routineRegistry_all_witnessed :
 def routineSymbols : List String :=
   routineRegistry.map (·.symbol) |>.eraseDups
 
-theorem routineSymbols_eq : routineSymbols.length = 6 := by decide
+theorem routineSymbols_eq : routineSymbols.length = 13 := by decide
 
 /-! ## Witness `abbrev`s
 
@@ -228,5 +265,20 @@ private noncomputable abbrev _account_rlp_content_to_u64_nonce_routine_witness :
   @EvmAsm.Evm64.account_rlp_content_to_u64_nonce_spec_within
 private noncomputable abbrev _account_rlp_content_to_u256_be_balance_routine_witness :=
   @EvmAsm.Evm64.account_rlp_content_to_u256_be_balance_spec_within
+-- #11289: the 7 specs `Correspondence.lean` named but nothing witnessed.
+private noncomputable abbrev _rlp_bytes_encoded_size_routine_witness :=
+  @EvmAsm.Codegen.RlpBytesEncodedSizeSAsm.rlpBytesEncodedSize_spec
+private noncomputable abbrev _rlp_field_to_u256_be_routine_witness :=
+  @EvmAsm.Codegen.RlpFieldToU256BeSAsm.rlpFieldToU256Be_spec_within
+private noncomputable abbrev _rlp_field_to_u64_routine_witness :=
+  @EvmAsm.Codegen.RlpFieldToU64SAsm.rlpFieldToU64_spec_within
+private noncomputable abbrev _rlp_list_encoded_size_routine_witness :=
+  @EvmAsm.Codegen.RlpListEncodedSizeSAsm.rlpListEncodedSize_spec
+private noncomputable abbrev _rlp_list_nth_item_routine_witness :=
+  @EvmAsm.Codegen.RlpListNthItemSAsm.rlpListNthItem_spec_within
+private noncomputable abbrev _rlp_list_count_items_routine_witness :=
+  @EvmAsm.Codegen.RlpListCountItemsSAsm.rlp_list_count_items_spec_within
+private noncomputable abbrev _rlp_encode_list_prefix_short_routine_witness :=
+  @EvmAsm.Codegen.RlpSpliceHelperSpec.rlp_encode_list_prefix_short_pinned_spec_within
 
 end EvmAsm.Progress

--- a/scripts/gen-axiom-witnesses.py
+++ b/scripts/gen-axiom-witnesses.py
@@ -53,19 +53,23 @@ WITNESS = ROOT / "EvmAsm" / "Progress" / "AxiomWitnesses.lean"
 # `strict` controls the row cross-check, NOT whether the file is scanned — every
 # source's abbrevs reach the gate either way.
 #
-#   * strict=True  — a row naming a theorem with no witness abbrev in the same
-#     file is an error. Correct where this change owns the rows.
-#   * strict=False — the shortfall is COUNTED AND PRINTED instead. Used for
-#     Correspondence.lean, whose 12 `spec := some "…"` rows carry only 4
-#     abbrevs; the other 8 live in modules that file does not import, so making
-#     it strict would demand 8 new imports into a registry another change is
-#     actively editing (#11276). Declared, not hidden — the count is on stdout
-#     every run, which is the difference between a known residual and a silent
-#     skip.
+#   * strict=True  — a row naming a theorem with no witness abbrev in ANY
+#     scanned registry is an error.
+#   * strict=False — the shortfall is COUNTED AND PRINTED instead.
+#
+# All three sources are now strict (#11289). Correspondence.lean was
+# temporarily non-strict when introduced (#11278): its `spec := some "…"` rows
+# named 7 theorems no registry witnessed, whose modules it does not import, and
+# #11276 was in flight in the neighbouring file. #11289 registered those 7 as
+# `RoutineEntry` rows in Routines.lean (which does import their modules), so the
+# cross-check — run against the UNION of all registries below — now finds a
+# witness for every Correspondence row. Flipping this to strict is what stops
+# the defect class recurring: a future Correspondence row naming an unwitnessed
+# theorem is a build error, not a printed note nobody reads.
 SOURCES = [
     (PROGRESS, "EvmAsm.Progress", True),
     (ROUTINES, "EvmAsm.Progress.Routines", True),
-    (CORRESPOND, "EvmAsm.Progress.Correspondence", False),
+    (CORRESPOND, "EvmAsm.Progress.Correspondence", True),
 ]
 
 # Any `EvmAsm.*` witness abbrev target, in any namespace.  Narrowing the
@@ -110,7 +114,10 @@ HEADER = """\
   rather than whole-routine, so populating every one is not a single change.
   What is registered is witnessed; what is not registered is still outside the
   gate.  Stated here rather than left implicit, because the assumption this
-  file exists to break is "covered by CI".
+  file exists to break is "covered by CI".  #11290 tracks turning that residual
+  into a measured coverage number rather than prose.  As of #11289 all three
+  registries are strict, so within a *registered* file an unwitnessed row is a
+  build error — the gap is only in what has not been registered yet.
 -/
 """
 


### PR DESCRIPTION
Closes #11289.

`Correspondence.lean` named 7 whole-routine RLP specs in its `spec := some "…"` rows — the repo makes a spec-correspondence claim about each — while no registry witnessed the theorem, so all 7 were outside the kernel-truth gate. Any could regress to `sorryAx` with CI green. The generator printed a note about it on every run, which is the same failure mode #11042 was filed about: a green check quietly covering less than a reader assumes.

## What landed

**Registered, not bolted on.** All 7 become `RoutineEntry` rows in `Progress/Routines.lean` (6 new imports; `RlpSpliceHelperSpec` was already imported), so they get tier/gate/notes rather than bare abbrevs in `Correspondence.lean`. Witnesses **111 → 118**. All 7 are whole-routine triples at their linked guest addresses (`B := GuestAddrs.<symbol>`), confirmed against the correspondence `spec` refs.

**Tiers read honestly** per `Routines.lean`'s header — resource/ABI hyps do not make a row conditional:

| routine | tier | why |
|---|---|---|
| `rlp_bytes_encoded_size` | `.proven` | ptr/len consistency + alignment + validity only |
| `rlp_field_to_u256_be` | `.proven` | 32-byte output, list-slack, register-encoding — all ABI |
| `rlp_field_to_u64` | `.proven` | u64-width companion of the above |
| `rlp_list_encoded_size` | `.proven` | **total** — result covers both the `ult v 56` short branch and the long branch; only hyp is `halignRet` |
| `rlp_list_nth_item` | `.proven` | buffer-slack + alignment + u64-representability |
| `rlp_list_count_items` | `.proven` | same shape |
| `rlp_encode_list_prefix` | `.conditional` | `len.toNat < 56` — the RLP short-form bound, same `lenlen ≥ 2` cut as `rlp_item_size` (#10780 item 3) |

⭐ **The recurrence fix (issue item 2).** `Correspondence.lean`'s `SOURCES` entry flips to `strict=True`. All three registries are now strict and the cross-check runs against their **union**, so a future row naming a theorem no registry witnesses is a **build error**, not a printed note. Non-strictness was only ever a bridge around #11276 being in flight; that's merged, so the bridge is gone.

## Verification

- Gate: **OK at 118 witnesses**, classical axioms only. The 7 new witnesses each print `[propext, Classical.choice, Quot.sound]` (or a subset) — zero non-classical across all 115 with-axiom reports.
- The gate's independent witness grep and the generator produce **identical** 118-name sets.
- `gen-axiom-witnesses.py` prints **no note** and exits 0.
- `lake build` clean (4800 jobs); `check-{axioms,layering,forbidden-tactics,unimported,no-warnings,file-size,progress,naming}.sh` all pass.
- ⭐ **Both negative controls bite** (issue's "verify it bites"):
  - a `sorry`-carrying witness → `check-axioms.sh` fails with `FORBIDDEN (sorry): … sorryAx`;
  - deleting `rlpListNthItem_spec_within`'s abbrev while leaving its rows → the now-strict cross-check **errors** naming it (from both the Routines row and the Correspondence row), where before this PR the Correspondence side would have been a silent note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)