### PR TITLE
fix: classify pre-dispatch OOG before recipient lookup

### DIFF
--- a/EvmAsm/Codegen/Dispatch.lean
+++ b/EvmAsm/Codegen/Dispatch.lean
@@ -2486,20 +2486,40 @@ private def emitTopLevelMessageD0Preparation : String :=
   "  add x8, x8, x7\n" ++
   "  sd x8, 0(x11)\n" ++
   ".runtime_tx_create_state_done:\n" ++
-  -- 4. top-level-only preparation halt, then top-frame gas and context
-  "  la x11, runtime_tx_prepare_only; ld x9, 0(x11); beqz x9, .runtime_tx_prepare_prefix_continue\n" ++
-  "  la x11, runtime_tx_prepare_prefix_status; li x9, 2; sd x9, 0(x11)\n" ++
-  "  la x11, runtime_tx_prepare_only; sd x0, 0(x11); j runtime_dispatcher_prepare_only_return\n" ++
+  -- 4. top-level-only preparation halt, then top-frame gas and context.  The
+  -- prepare-only return is deliberately after the staged top-frame charge:
+  -- execution-gas exhaustion is a transaction OOG, not an unresolved
+  -- recipient.  A successful preparation prefix still records status 2 and
+  -- returns below, preserving the genuine missing-witness verdict arm.
   ".runtime_tx_prepare_prefix_continue:\n" ++
   ".runtime_tx_gas_done:\n" ++
   "  sd x6, 568(x20)\n" ++
   "  la x11, runtime_tx_top_frame_regular_gas\n" ++
   "  ld x9, 0(x11)\n" ++
   "  beqz x9, .runtime_tx_top_frame_regular_done\n" ++
-  "  bltu x6, x9, .exit_outofgas\n" ++
+  "  bltu x6, x9, .runtime_tx_prepare_prefix_oog\n" ++
   "  sub x6, x6, x9\n" ++
   "  sd x6, 568(x20)\n" ++
   ".runtime_tx_top_frame_regular_done:\n" ++
+  "  la x11, runtime_tx_prepare_only; ld x9, 0(x11); beqz x9, .runtime_tx_prepare_body_continue\n" ++
+  "  la x11, runtime_tx_prepare_prefix_status; li x9, 2; sd x9, 0(x11)\n" ++
+  "  la x11, runtime_tx_prepare_only; sd x0, 0(x11); j runtime_dispatcher_prepare_only_return\n" ++
+  -- A staged top-frame ACCOUNT_WRITE charge is part of transaction
+  -- preparation.  If the exact intrinsic-gas transaction has no regular
+  -- gas left, return a transaction-level exceptional halt to the caller so
+  -- settlement burns regular gas and preserves block validation.  The
+  -- preparation snapshot must be unwound atomically before the caller's OOG
+  -- hook materializes the sender fee debit.  The hook is the same transaction
+  -- boundary used by the normal exceptional-exit path.
+  ".runtime_tx_prepare_prefix_oog:\n" ++
+  "  la x11, runtime_tx_prepare_only; ld x9, 0(x11); beqz x9, .runtime_tx_prepare_normal_oog\n" ++
+  "  la x11, runtime_tx_auth_phase_halted; li x9, 1; sd x9, 0(x11)\n" ++
+  "  j .exit_outofgas\n" ++
+  ".runtime_tx_prepare_normal_oog:\n" ++
+  "  sd x0, 568(x20)\n" ++
+  "  li x9, 6; li x11, 0xa0010000; sd x9, 32(x11)\n" ++
+  "  la x11, runtime_tx_prepare_only; sd x0, 0(x11); j runtime_dispatcher_prepare_only_return\n" ++
+  ".runtime_tx_prepare_body_continue:\n" ++
   "  ld x6, 0(x5)\n" ++
   "  sd x6, 584(x20)\n" ++
   "  ld x7, 8(x5)\n" ++

--- a/EvmAsm/Codegen/Programs/BlockVerdictDispatchTx.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictDispatchTx.lean
@@ -709,6 +709,7 @@ def dispatchTxRuntimeCodeFunction : String :=
   -- authorization phase.  On authorization-phase OOG it never reaches that
   -- point, so omit only this pre-dispatch raw lookup; all ordinary message
   -- outcomes (including body OOG/revert) retain the target touch.
+  "  la t4, runtime_tx_prepare_prefix_status; ld t5, 0(t4); li t6, 1; beq t5, t6, .Ldtrc_recipient_read_done\n" ++
   "  la t4, runtime_tx_auth_phase_halted; ld t5, 0(t4); bnez t5, .Ldtrc_recipient_read_done\n" ++
   "  addi a0, s2, 72; jal ra, account_read_record\n" ++
   ".Ldtrc_recipient_read_done:\n" ++
@@ -753,7 +754,13 @@ def dispatchTxRuntimeCodeFunction : String :=
   -- cursors, account-write/state undo checkpoints, state overflow, and the
   -- create-nonce checkpoint; settlement's only error stores zero the separate
   -- `evm_state_gas_used` and `evm_state_gas_spilled` counters.
-  "  bnez s2, .Ldtrc_body_state_kept; jal ra, dispatcher_restore_body_state\n" ++
+  "  bnez s2, .Ldtrc_body_state_kept\n" ++
+  -- A preparation ExceptionalHalt has no message body to restore.  Keep the
+  -- sender's staged upfront debit visible through settlement; the MTx
+  -- preparation-halt arm restores the authorization frame after refunding.
+  "  la t4, runtime_tx_prepare_prefix_status; ld t5, 0(t4); li t6, 1; beq t5, t6, .Ldtrc_body_state_kept\n" ++
+  "  la t4, runtime_tx_auth_phase_halted; ld t5, 0(t4); bnez t5, .Ldtrc_body_state_kept\n" ++
+  "  jal ra, dispatcher_restore_body_state\n" ++
   ".Ldtrc_body_state_kept:\n" ++
   -- .63.1.6.2.1: snapshot this tx's event-log window into the block log arena
   -- after settlement has classified the top-level tx status. A failed top-level

--- a/EvmAsm/Codegen/Programs/BlockVerdictMtxRuntime.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictMtxRuntime.lean
@@ -694,7 +694,13 @@ def blockVerdictMtxRuntimeLoop : String :=
   -- The debit was materialized before execution; apply the spec's later
   -- sender `create_ether` refund before AccountState commits this transaction.
   blockVerdictMtxRecordSenderRefund ++
-  "  la t0, runtime_tx_auth_phase_halted; ld t2, 0(t0); beqz t2, .Lbv_mtx_code_commit\n" ++
+  "  la t0, runtime_tx_auth_phase_halted; ld t2, 0(t0); bnez t2, .Lbv_mtx_preparation_rollback\n" ++
+  -- A pre-dispatch execution-gas OOG is marked by the preparation-prefix
+  -- status rather than by the authorization-phase halt flag.  Refund the
+  -- staged sender debit first; then discard the preparation overlay exactly
+  -- as the auth-halt arm does.
+  "  la t0, runtime_tx_prepare_prefix_status; ld t2, 0(t0); li t3, 1; bne t2, t3, .Lbv_mtx_code_commit\n" ++
+  ".Lbv_mtx_preparation_rollback:\n" ++
   -- `process_message` restores the preparation snapshot when preparation
   -- itself halts.  The map's direct auth producer mirrors that control-flow
   -- fact with its own cursor, rather than reusing the dead frame checkpoint.


### PR DESCRIPTION
Related to #11305 (pre-dispatch OOG misclassified as deferred recipient failure).

## Change

The prepare-only success return used to run before the staged top-frame regular-gas charge. An exact intrinsic-gas transaction could therefore exhaust at that charge and fall through as an unresolved recipient. The return is now reached only when `runtime_tx_prepare_only` is genuinely active, after the top-frame charge. Preparation-active OOG marks the authorization-phase halt and uses the OOG transaction boundary; ordinary body OOG keeps normal settlement/body-snapshot behavior.

The recipient read remains skipped for the preparation-halt statuses, while the genuine deferred-recipient path remains live: deferred status 2 -> `a0=8` -> `.Lbv_mtx_recipient_unresolvable_fail` -> `bv_fail=47`.

## Evidence

- Candidate ELF: SHA-256 `81cfd8303c67ed0d4058687dffd4463c87db7c9faee096c1b529196d726dab6e`, mtime `2026-08-03 17:30:57 +0200`.
- `lake build`: passed, 4800 jobs.
- Body-OOG persistence controls 00023 and 00024: parent baseline PASS and candidate PASS; both match the expected first 69 bytes, including `success=1` and both authorization effects.
- In-scope rows 00030, 24497, and 24513: expected prefixes match and `bv_fail=0`. 24498 is explicitly out of scope for #11305 and is attributed to #11310: `bv_fail=60`, shadow status 1, and a 27-byte rebuilt/supplied digest divergence.
- Oracle-invalid reject-1036 sweep: `OK=1036`, `FA=0`, `FR=0`.
- Seeded random-200 (seed `20260803`, manifest SHA `4fb8f2b48f0b5c03efb967f9bad4b1bc0a0cad7fd9474cbea39d010a55589e94`): parent `OK=195 FR=5 FA=0`; candidate `OK=199 FR=1 FA=0`; four forward `FR->OK` repairs, zero reverse `OK->FR` flips, and no FA. The sole candidate FR, `00156_test_selfdestructing_initcode_preserves_balance...success-precompil`, is also FR on the parent (`oracle=1`, parent guest=0, candidate guest=0), so it is FR-equal/non-regressive.
- On the same 1068-row diagnostic population, `bv_fail=47` is `4 -> 0`; the four parent rows are 00030, 24497, 24498, and 24513.
- The retained unresolved-recipient arm is demonstrated by the emitted routing above and the historical txcount-gate v1 KAT, which recorded a fresh-recipient tx17 rejection via `bv_fail=47` when that recipient was omitted from the invalid-block witness. The v2 self-send control keeps the recipient resolvable and candidate9 returns the expected invalid result via `bv_fail=1`.

## Gates

`check-no-warnings`, `check-heartbeats-approved`, `check-axioms` (with `LAKE_ARTIFACT_CACHE=false`), `check-forbidden-tactics`, `check-layering`, `check-unimported`, `check-no-hardcoded-guest-pc`, `check-file-size`, `check-opcode-structure`, and `git diff --check` pass.