### PR TITLE
docs: pin generic storage preload dormancy

### DIFF
--- a/EvmAsm/Codegen/Dispatch.lean
+++ b/EvmAsm/Codegen/Dispatch.lean
@@ -2553,6 +2553,27 @@ private def emitTopLevelMessageD0Preparation : String :=
   -- guest records that distinction explicitly for the later reconciliation.
   "  la x11, runtime_tx_post_preparation_reached; li x9, 1; sd x9, 0(x11)\n"
 
+/-! ### Generic input-driven storage preload: dormant in production
+
+    The input-driven `.preload_expand_loop` below is retained for standalone
+    runtime-input compatibility and for `zisk_sstore_clear_gas_probe`. Every
+    production caller of `stage_runtime_payload_code` passes `a5 = 0` and
+    `a6 = 0`: the user-transaction dispatcher path, creation staging, and
+    system-call staging all use the demand-driven authenticated storage path.
+    The production call sites carry build-time `#guard` pins in their program
+    modules.
+
+    This is a dormant mechanism, not a live production hazard. If a future
+    caller feeds nonzero rows again, two independent conventions must be
+    addressed: BAL forward/reverse comparators consume the live row arena
+    without consulting `exec_log_seed_flag`, while tuple validation observes
+    generic rows as `exec_log_txindex = 0` because this producer does not stamp
+    that field. The flag itself must remain: authenticated `h_SLOAD` miss seeds
+    use it, and system-storage capture skips those seed rows by reading it.
+    The SSTORE-clear probe is the sole remaining nonzero consumer and needs
+    the preload to exercise the clean nonzero-to-zero gas class; re-feeding it
+    through production would require a new seed seam.
+-/
 def emitRuntimeDispatcherSetupWithInputAsm (inputAsm : String) : String :=
   "  la sp, lp64_sp_top\n" ++   -- M16: LP64 stack ptr for ECALL-bridge helpers
                                 -- (e.g. zkvm_keccak256's `addi sp, sp, -32`)

--- a/EvmAsm/Codegen/Programs/BlockVerdictCreationStage.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictCreationStage.lean
@@ -319,6 +319,9 @@ def blockVerdictCreationRuntimeFunction : String :=
   "  la a1, bv_runtime_payload\n" ++
   "  mv a2, s1\n" ++
   "  ld a3, 56(s0); ld a4, 40(sp)\n" ++
+  -- Production creation staging uses the authenticated demand-driven storage
+  -- path. Keep the generic input-preload arguments literal-zero; the guard
+  -- below makes this no-preload contract visible to the build.
   "  li a5, 0; li a6, 0\n" ++
   "  jal ra, stage_runtime_payload_code\n" ++
   "  ld t0, 40(sp); sd t0, 64(s0)\n" ++
@@ -733,5 +736,8 @@ def blockVerdictCreationRuntimeFunction : String :=
   "  ld s0, 8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp)\n" ++
   "  addi sp, sp, 48\n" ++
   "  ret"
+
+/-! Production creation staging is intentionally not a generic preload caller. -/
+#guard (blockVerdictCreationRuntimeFunction.splitOn "  li a5, 0; li a6, 0\n").length = 2
 
 end EvmAsm.Codegen

--- a/EvmAsm/Codegen/Programs/BlockVerdictDispatchTx.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictDispatchTx.lean
@@ -49,7 +49,7 @@ def delegationAccessChargeAsm (addressLabel : String) : String :=
 /-! ## dispatch_tx_runtime_code
 
     Measure one contract-recipient transaction's runtime gas by staging its
-    bytecode + recipient storage preload and running the callable runtime
+    bytecode + the documented empty storage-preload arguments and running the callable runtime
     dispatcher. Reaches the dispatcher only when execution is exact (the recipient
     code is self-contained — own storage only, no un-staged state); any miss or
     unsupported shape returns a non-zero status so the caller stays conservative
@@ -414,8 +414,11 @@ def dispatchTxRuntimeCodeFunction : String :=
   "  addi t1, t1, 584; li t2, " ++ toString (bsrAccountSlotCap * 64 + 65536) ++ "; bgtu t1, t2, .Ldtrc_payload_cap_unsupported\n" ++       -- payload > buffer (4jczt-lifted) -> conservative bail
   "  mv a0, s2; la a1, bv_runtime_payload; la t2, bv_exec_p; ld a2, 0(t2)\n" ++
   "  la t0, bvcd_code_ptr; ld a3, 0(t0); la t0, bvcd_code_len; ld a4, 0(t0)\n" ++
-  -- GH #11176: no recipient storage preload. a5/a6 = the routine's documented
-  -- empty-preload default, which its count-driven copy loop already handles.
+  -- Production no-preload contract (GH #11176): all production callers use
+  -- the authenticated demand-driven storage path and pass literal zeroes.
+  -- Keep this callsite pinned by the #guard below. If a future caller feeds
+  -- rows again, BAL comparators do not consult exec_log_seed_flag and generic
+  -- rows have no exec_log_txindex stamp, so tuple validation sees txindex 0.
   "  li a5, 0; li a6, 0\n" ++
   "  jal ra, stage_runtime_payload_code\n" ++
   "  bnez a0, .Ldtrc_stage_unsupported\n" ++
@@ -810,5 +813,11 @@ def dispatchTxRuntimeCodeFunction : String :=
   "  li t0, 0xa0010000; sd zero, 0(t0); sd zero, 8(t0); sd zero, 16(t0); sd zero, 24(t0); li t1, 6; sd t1, 32(t0)\n" ++
   "  la t0, bv_mtx_precompile_lane; sd zero, 0(t0)\n" ++
   "  j .exit_no_epilogue"
+
+/-! The production dispatcher callsite must remain the empty-preload form.
+    This pins the literal ABI convention in the emitted function string; the
+    generic input-driven producer is retained only for standalone/probe input.
+-/
+#guard (dispatchTxRuntimeCodeFunction.splitOn "  li a5, 0; li a6, 0\n").length = 2
 
 end EvmAsm.Codegen

--- a/EvmAsm/Codegen/Programs/EvmDispatchUnits.lean
+++ b/EvmAsm/Codegen/Programs/EvmDispatchUnits.lean
@@ -935,7 +935,8 @@ def ziskDeriveBlockSystemRequestsProbeUnit : BuildUnit := {
     (cold clean-changing SSTORE-clear: 3000 cold access + 10000 write) + 50 pushes =
     151050 (full) -> gas_left = 0, log count = 10 preload + 10 SSTORE appends =
     20. (The probe originally pinned the d' undercharge — gas_left 25200 —
-    which had TWO causes, both fixed: the BAL preload keys were staged BE and
+    This is the sole remaining production consumer of the generic input-driven
+    preload path; production callers pass zero. The probe had TWO causes, both fixed: the BAL preload keys were staged BE and
     invisible to the LE exec-log scan, and this probe's own preload mirrored
     that BE staging.) Stages via stage_runtime_payload_code with the 10-slot
     LE preload; bundles the same dispatcher + frame-helper closure as the

--- a/EvmAsm/Codegen/Programs/ExecLogStorageSeed.lean
+++ b/EvmAsm/Codegen/Programs/ExecLogStorageSeed.lean
@@ -7,13 +7,17 @@
   (the `preload_expand_loop` format is used by the top-level guest's zkVM input via
   scripts/eest-stateless-to-input.py, so it must not change).
 
-  The verdict's contract-dispatch path preloads only the recipient's own storage via
-  the shared expand loop + #8561 re-tag (addrHash = env.ADDRESS). To make NESTED
+  Production block-verdict callers pass zero for this shared preload input;
+  the nonzero format remains for standalone runtime-input compatibility and
+  the SSTORE-clear probe.
+
+  Production contract dispatch now leaves the shared input preload empty and resolves
+  the recipient's slots through authenticated demand-driven reads. To make NESTED
   CALLEES read their witness storage (instead of cold 0) the verdict appends each
   callee's slots to the exec log keyed on that callee's address. This helper is that
   append primitive: it writes one 128-byte entry and bumps the entry count. A seeded
   slot has original == current == value (a pre-tx value, no net change — matching the
-  recipient preload-expand, which sets both to the preloaded value).
+  retained standalone/probe preload format, which sets both to the preloaded value).
 
   Exec-log entry layout (Storage.lean): 128 bytes = addrHash@0, slotKey@32,
   original@64, current@96.

--- a/EvmAsm/Codegen/Programs/Storage.lean
+++ b/EvmAsm/Codegen/Programs/Storage.lean
@@ -54,14 +54,13 @@
 
   - Persistent SLOAD/SSTORE and transient TLOAD/TSTORE key on the frame's
     env.ADDRESS (multi-contract isolated).
-  - Cold `SLOAD` reads of non-preloaded slots return 0. ⛔ The reason recorded here
-    used to be *"the BAL-driven preload stages every slot a block reads, so this is
-    not observed (GH #10874 measured zero misses on the corpus); a demand-driven read
-    is blocked on GH #11105"*. **All three clauses are false.** Measured on the
-    UNMODIFIED guest: `h_SSTORE`'s cold-miss resolve runs **16 and 17 times** on two
-    rows, so the preload does NOT stage every slot and misses are NOT zero; and
-    GH #11105 is closed with no code change, so nothing is blocked on it.
-    What a demand-driven `SLOAD` read still needs is a **present-slot** case — every
+  - Cold `SLOAD` misses are resolved through the authenticated state path;
+    genuinely absent slots produce zero. The generic input-driven preload is
+    retained for standalone/probe compatibility, but every production caller
+    passes zero preload arguments, so it does not provide production coverage
+    for storage reads. ⛔ The earlier claim that a BAL preload stages every
+    slot is refuted: measured cold-miss resolution runs in production. What a
+    demand-driven `SLOAD` read still needs is a **present-slot** case — every
     measured cold miss resolved a genuinely-absent slot, so the found path is
     unexercised. See `storagePrestateResolveAsm` below for the full funnel.
   - 4 MiB per log = ~32K entries each — well past any test workload.

--- a/EvmAsm/Codegen/Programs/SystemCallStaging.lean
+++ b/EvmAsm/Codegen/Programs/SystemCallStaging.lean
@@ -75,6 +75,7 @@ def stageSystemCallPayloadFunction : String :=
   -- GH #11176: request-predeploy storage is read through the authenticated,
   -- demand-driven state path. Do not seed ordinary execution-log rows from
   -- BAL data before the call; both storage arguments are intentionally empty.
+  -- This literal-zero production contract is pinned by the guard below.
   "  la a0, scc_ctx\n  mv a1, s4\n  mv a2, s3\n  mv a3, s1\n  mv a4, s2\n" ++
   "  li a5, 0; li a6, 0\n" ++
   "  jal ra, stage_runtime_payload_code\n" ++
@@ -107,6 +108,10 @@ def stageSystemCallPayloadFunction : String :=
   "  ld s0, 8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp); ld s4, 40(sp)\n" ++
   "  addi sp, sp, 48\n" ++
   "  ret"
+
+/-! Production system-call staging keeps both generic preload arguments empty.
+    The retained nonzero input path is standalone/probe-only. -/
+#guard (stageSystemCallPayloadFunction.splitOn "  li a5, 0; li a6, 0\n").length = 2
 
 /-! ## stage_system_call (8uld3.2.1c) — compose the full system call -> return_data.
     a0 = target (predeploy) addr ptr   a1 = predeploy code ptr   a2 = code length


### PR DESCRIPTION
## Summary

Follow-up to #11176 / #11353 documenting that the generic input-driven storage
preload is dormant in production rather than a live hazard.

## Scope

- Keep the generic producer, `exec_log_seed_flag`, probe, and input fixtures.
- Document that all three production staging callsites pass literal zero
  preload arguments.
- Record the two independent risks if a future caller re-feeds nonzero rows:
  BAL comparators do not consult `exec_log_seed_flag`, and tuple validation
  sees generic rows as `exec_log_txindex = 0`.
- Add `#guard` pins for the three production callsite strings.
- Amend issue #11355 with the corrected dormant-status rationale and probe
  coverage explanation.

No emitted assembly or layout pins change.

## Verification

- `lake build` — 4809 jobs, clean.
- `scripts/check-no-warnings.sh` — clean, 0 warnings.
- `scripts/check-forbidden-tactics.sh` — pass.
- `scripts/check-layering.sh` — pass.
- `scripts/check-unimported.sh` — 2831/2831 reachable, 0 orphans.
- `scripts/check-heartbeats-approved.sh` — pass.
- `scripts/check-file-size.sh` — pass.

This branch is intentionally stacked on the current #11353 head and has not
rebased or regenerated the #11353 artifacts.
