### PR TITLE
Add BAL producer differential probe

### DIFF
--- a/docs/bal-producer-differential.md
+++ b/docs/bal-producer-differential.md
@@ -1,0 +1,38 @@
+# BAL producer differential probe
+
+This probe is a tooling-only check of the final BAL-builder rows in the
+emitted guest. It does not change the guest or feed guest rows into SpecRef.
+The guest runs on SPIKE; the reference rows are decoded from the pinned
+execution-specs Amsterdam `BlockAccessList` in the fixture payload and are
+pre-registered in
+[`scripts/spike/bal-balance-changes.expectation.json`](../scripts/spike/bal-balance-changes.expectation.json).
+
+The first registered fixture is
+`bal_balance_changes.json` (manifest label
+`00318_test_bal_balance_changes_fork_Amsterdam-blockchain_test__b0`). It
+exercises nine account rows, two storage rows, three balance rows, and one
+nonce row. The expectation records the execution-specs pin and the input
+SHA-256; regenerate it only when deliberately changing the fixture:
+
+```bash
+uv run --directory execution-specs --quiet python3 ../scripts/spike/bal_producer_diff.py \
+  --register-expectation \
+  --spike ../scripts/spike/spike_run \
+  --guest-elf ../gen-out/regionmap/stateless_guest.elf \
+  --manifest /var/tmp/fc668/manifest.tsv \
+  --label 00318_test_bal_balance_changes_fork_Amsterdam-blockchain_test__b0 \
+  --expectation ../scripts/spike/bal-balance-changes.expectation.json \
+  --out-dir /tmp/bal-producer-diff
+```
+
+The run supplies `SPIKE_DUMP_RANGES` from the ELF's `nm` symbols and the row
+sizes/capacities from `BlockAccessListBuilder.lean`. It reports attempted,
+decoded, skipped, undecodable, overflow, and final row counts. Any skipped or
+undecodable row is a hard failure. It also requires the final rebuilt BAL hash
+to equal the supplied BAL hash. `SPIKE_COMMITLOG` remains a separate
+attempted-write audit and is not used as the producer extraction.
+
+The tracked `fixtures/kat` JSONs are intentionally mutated reject-side KATs;
+they are not a clean producer oracle for this check. The approved 26,104-row
+manifest under `/var/tmp/fc668` is therefore the input corpus for the
+pre-registered real fixture.

--- a/docs/bal-producer-differential.md
+++ b/docs/bal-producer-differential.md
@@ -2,17 +2,26 @@
 
 This probe is a tooling-only check of the final BAL-builder rows in the
 emitted guest. It does not change the guest or feed guest rows into SpecRef.
-The guest runs on SPIKE; the reference rows are decoded from the pinned
-execution-specs Amsterdam `BlockAccessList` in the fixture payload and are
-pre-registered in
+The primary assertion is exact element-by-element equality of each decoded
+guest row stream (address, BAI, and payload fields) against the pre-registered
+rows. A count match alone is insufficient: a mismatch names the affected
+stream and fails the run. The guest runs on SPIKE; the reference rows are
+decoded from the pinned execution-specs Amsterdam `BlockAccessList` in each
+fixture payload and are pre-registered in
 [`scripts/spike/bal-balance-changes.expectation.json`](../scripts/spike/bal-balance-changes.expectation.json).
 
-The first registered fixture is
-`bal_balance_changes.json` (manifest label
-`00318_test_bal_balance_changes_fork_Amsterdam-blockchain_test__b0`). It
-exercises nine account rows, two storage rows, three balance rows, and one
-nonce row. The expectation records the execution-specs pin and the input
-SHA-256; regenerate it only when deliberately changing the fixture:
+The registered fixture set is deliberately small but spans the producer
+classes:
+
+| expectation | fixture | final rows (accounts/storage/balance/nonce/code) |
+| --- | --- | --- |
+| `bal-balance-changes` | balance-change fixture | 9 / 2 / 3 / 1 / 0 |
+| `bal-storage-writes` | storage-write fixture | 9 / 4 / 2 / 1 / 0 |
+| `bal-code-changes` | code-change fixture | 10 / 2 / 2 / 3 / 1 |
+| `bal-all-transaction-types` | five-transaction, multi-BAI fixture | 18 / 7 / 10 / 6 / 1 |
+
+Each expectation records the execution-specs pin and input SHA-256. Regenerate
+one only when deliberately changing its fixture:
 
 ```bash
 uv run --directory execution-specs --quiet python3 ../scripts/spike/bal_producer_diff.py \
@@ -25,11 +34,22 @@ uv run --directory execution-specs --quiet python3 ../scripts/spike/bal_producer
   --out-dir /tmp/bal-producer-diff
 ```
 
+Run the complete registered set with:
+
+```bash
+scripts/spike/bal_producer_set.sh \
+  gen-out/regionmap/stateless_guest.elf \
+  /var/tmp/fc668/manifest.tsv \
+  /tmp/bal-producer-diff-set
+```
+
 The run supplies `SPIKE_DUMP_RANGES` from the ELF's `nm` symbols and the row
-sizes/capacities from `BlockAccessListBuilder.lean`. It reports attempted,
-decoded, skipped, undecodable, overflow, and final row counts. Any skipped or
-undecodable row is a hard failure. It also requires the final rebuilt BAL hash
-to equal the supplied BAL hash. `SPIKE_COMMITLOG` remains a separate
+sizes/capacities from `BlockAccessListBuilder.lean`, plus the code-effect and
+EIP-7702 code arenas. It reports attempted, decoded, skipped, undecodable,
+overflow, and final row counts. Any skipped or undecodable row is a hard
+failure. The rebuilt/supplied serializer hash equality is retained as a
+secondary cross-check; it is already shadow-verified inside the guest and is
+not the differential's headline claim. `SPIKE_COMMITLOG` remains a separate
 attempted-write audit and is not used as the producer extraction.
 
 The tracked `fixtures/kat` JSONs are intentionally mutated reject-side KATs;

--- a/scripts/spike/README.md
+++ b/scripts/spike/README.md
@@ -110,6 +110,25 @@ pre-tooling path (`cmp` matched the prior 256-byte output on the same fixture).
 | `SPIKE_BREAK_PC` | one-shot reg dump at a PC, then continue | step-1 until hit, then batch |
 | `SPIKE_COMMITLOG` | "what writes happened?" archaeology | huge files (~0.5 GB/fixture) |
 
+### Final-memory BAL producer dump
+
+For the tooling-only BAL producer differential, set both
+`SPIKE_DUMP_RANGES=addr:length,addr:length,...` and
+`SPIKE_DUMP_FILE=<file>`. The runner writes a self-describing `SPKDMP01`
+version-1 file after the guest halts. Ranges are explicit and checked for
+mapped memory; a missing variable or an unmapped byte is an error. The BAL
+probe derives these ranges from `nm` symbols and keeps `SPIKE_COMMITLOG` as a
+separate attempted-write audit.
+
+```bash
+SPIKE_DUMP_RANGES=0xb9d84948:0xb8,0xb9d84a00:3360000 \
+SPIKE_DUMP_FILE=/tmp/bal-final-memory.bin \
+scripts/spike/spike_run <guest.elf> <input> /tmp/output
+```
+
+Use `scripts/spike/bal_producer_diff.py` for the complete pre-registered
+fixture comparison; see `docs/bal-producer-differential.md`.
+
 ### 0. Resolve addresses
 
 ```bash

--- a/scripts/spike/README.md
+++ b/scripts/spike/README.md
@@ -126,8 +126,9 @@ SPIKE_DUMP_FILE=/tmp/bal-final-memory.bin \
 scripts/spike/spike_run <guest.elf> <input> /tmp/output
 ```
 
-Use `scripts/spike/bal_producer_diff.py` for the complete pre-registered
-fixture comparison; see `docs/bal-producer-differential.md`.
+Use `scripts/spike/bal_producer_set.sh` for the complete pre-registered
+fixture comparison; it checks exact row contents before the secondary hash
+cross-check. See `docs/bal-producer-differential.md`.
 
 ### 0. Resolve addresses
 

--- a/scripts/spike/bal-all-transaction-types.expectation.json
+++ b/scripts/spike/bal-all-transaction-types.expectation.json
@@ -1,0 +1,167 @@
+{
+  "schema": 1,
+  "fixture_label": "00317_test_bal_all_transaction_types_fork_Amsterdam-blockchain_test__b0",
+  "fixture_relpath": "blockchain_tests/for_amsterdam/amsterdam/eip7928_block_level_access_lists/block_access_lists/bal_all_transaction_types.json",
+  "manifest_sha256": "b40b7e3f7d4b3bde03c7298c98d3b9117ea146f76c2a2a914f1cbafa78c3ad07",
+  "input_sha256": "23bcd10d261c73ef886e67022501387f510303d3e1095f70ea3ffbc9b58b2de4",
+  "execution_specs_commit": "e5a8caf1b8055e4d805c7fb169edfa710914b7da",
+  "reference": "execution-specs Amsterdam BlockAccessList decoded from fixture payload",
+  "payload_bal_sha256": "3cbce1dff94bdc14de7e69e831fc66b762e8bcddc790c405ef34882fdfa5f842",
+  "rows": {
+    "accounts": [
+      "00000961ef480eb55e80d19ad83579a64c007002",
+      "000064d678505ad48f8ccb093bc65613800e8282",
+      "0000bbddc7ce488642fb579f8b00f3a590007251",
+      "0000bff46984e3725691fa540a8c7589300d8282",
+      "0000f90827f1c53a10cb7a02335b175320002935",
+      "000f3df6d732807ef1319fb7b8bb8522d0beac02",
+      "01b21d91b88d2dcaaa7231c6f2566681b89807a6",
+      "19c053cc13903a26dfa9c22d64724112a6fda2a4",
+      "1cc4c16789df2018bfcd72c9b0a5136af279431a",
+      "2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+      "40453da9a9607b627b3202ae87edef86591bfe45",
+      "8d1010d9d0ecb443674d601ebb123b5ac7efbad7",
+      "94d37e3fa2381d19a38dc58f8e77344f84f0cb29",
+      "b0bd1179e5b9b1df82498b92bca957d8882712b7",
+      "c9b9a62963aa4aaef854f05195c12fb419cda45f",
+      "ccbcccb8575994e288e5bd021cc371dd8a8ff1eb",
+      "f6c3a9edc1afa0ad5b720e4d42e1437c43d3b3ff",
+      "f705653af205a2c003d7b8011637684f0ba4c97e"
+    ],
+    "storage": [
+      {
+        "address": "0000f90827f1c53a10cb7a02335b175320002935",
+        "bai": 0,
+        "slot": 0,
+        "value": 87776279436343418067752407780281175652954332305329429635823042920810585315649
+      },
+      {
+        "address": "000f3df6d732807ef1319fb7b8bb8522d0beac02",
+        "bai": 0,
+        "slot": 12,
+        "value": 12
+      },
+      {
+        "address": "01b21d91b88d2dcaaa7231c6f2566681b89807a6",
+        "bai": 2,
+        "slot": 1,
+        "value": 2
+      },
+      {
+        "address": "1cc4c16789df2018bfcd72c9b0a5136af279431a",
+        "bai": 3,
+        "slot": 1,
+        "value": 3
+      },
+      {
+        "address": "8d1010d9d0ecb443674d601ebb123b5ac7efbad7",
+        "bai": 5,
+        "slot": 1,
+        "value": 5
+      },
+      {
+        "address": "b0bd1179e5b9b1df82498b92bca957d8882712b7",
+        "bai": 1,
+        "slot": 1,
+        "value": 1
+      },
+      {
+        "address": "f705653af205a2c003d7b8011637684f0ba4c97e",
+        "bai": 4,
+        "slot": 1,
+        "value": 4
+      }
+    ],
+    "balance": [
+      {
+        "address": "19c053cc13903a26dfa9c22d64724112a6fda2a4",
+        "bai": 3,
+        "post": 999999999999999999998487172
+      },
+      {
+        "address": "2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+        "bai": 1,
+        "post": 378207
+      },
+      {
+        "address": "2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+        "bai": 2,
+        "post": 769254
+      },
+      {
+        "address": "2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+        "bai": 3,
+        "post": 1399599
+      },
+      {
+        "address": "2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+        "bai": 4,
+        "post": 2029944
+      },
+      {
+        "address": "2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+        "bai": 5,
+        "post": 2929604
+      },
+      {
+        "address": "40453da9a9607b627b3202ae87edef86591bfe45",
+        "bai": 4,
+        "post": 999999999999999999998356100
+      },
+      {
+        "address": "c9b9a62963aa4aaef854f05195c12fb419cda45f",
+        "bai": 5,
+        "post": 999999999999999999997840816
+      },
+      {
+        "address": "ccbcccb8575994e288e5bd021cc371dd8a8ff1eb",
+        "bai": 2,
+        "post": 999999999999999999998696510
+      },
+      {
+        "address": "f6c3a9edc1afa0ad5b720e4d42e1437c43d3b3ff",
+        "bai": 1,
+        "post": 999999999999999999998739310
+      }
+    ],
+    "nonce": [
+      {
+        "address": "19c053cc13903a26dfa9c22d64724112a6fda2a4",
+        "bai": 3,
+        "nonce": 1
+      },
+      {
+        "address": "40453da9a9607b627b3202ae87edef86591bfe45",
+        "bai": 4,
+        "nonce": 1
+      },
+      {
+        "address": "8d1010d9d0ecb443674d601ebb123b5ac7efbad7",
+        "bai": 5,
+        "nonce": 1
+      },
+      {
+        "address": "c9b9a62963aa4aaef854f05195c12fb419cda45f",
+        "bai": 5,
+        "nonce": 1
+      },
+      {
+        "address": "ccbcccb8575994e288e5bd021cc371dd8a8ff1eb",
+        "bai": 2,
+        "nonce": 1
+      },
+      {
+        "address": "f6c3a9edc1afa0ad5b720e4d42e1437c43d3b3ff",
+        "bai": 1,
+        "nonce": 1
+      }
+    ],
+    "code": [
+      {
+        "address": "8d1010d9d0ecb443674d601ebb123b5ac7efbad7",
+        "bai": 5,
+        "code": "ef010094d37e3fa2381d19a38dc58f8e77344f84f0cb29"
+      }
+    ]
+  }
+}

--- a/scripts/spike/bal-balance-changes.expectation.json
+++ b/scripts/spike/bal-balance-changes.expectation.json
@@ -1,0 +1,62 @@
+{
+  "schema": 1,
+  "fixture_label": "00318_test_bal_balance_changes_fork_Amsterdam-blockchain_test__b0",
+  "fixture_relpath": "blockchain_tests/for_amsterdam/amsterdam/eip7928_block_level_access_lists/block_access_lists/bal_balance_changes.json",
+  "manifest_sha256": "b40b7e3f7d4b3bde03c7298c98d3b9117ea146f76c2a2a914f1cbafa78c3ad07",
+  "input_sha256": "14735ade5cff45a1c2171d7f6e6be712d5f03df62001b6810874deb6efa82abd",
+  "execution_specs_commit": "e5a8caf1b8055e4d805c7fb169edfa710914b7da",
+  "reference": "execution-specs Amsterdam BlockAccessList decoded from fixture payload",
+  "payload_bal_sha256": "a0ce1ac83ecd87e03a4e26c442ee4ebb443f7e8aac063de113afc555f2db266b",
+  "rows": {
+    "accounts": [
+      "00000961ef480eb55e80d19ad83579a64c007002",
+      "000064d678505ad48f8ccb093bc65613800e8282",
+      "0000bbddc7ce488642fb579f8b00f3a590007251",
+      "0000bff46984e3725691fa540a8c7589300d8282",
+      "0000f90827f1c53a10cb7a02335b175320002935",
+      "000f3df6d732807ef1319fb7b8bb8522d0beac02",
+      "2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+      "c0f6dc9e5836f54caadbf59cc69346c508e1992b",
+      "f6c3a9edc1afa0ad5b720e4d42e1437c43d3b3ff"
+    ],
+    "storage": [
+      {
+        "address": "0000f90827f1c53a10cb7a02335b175320002935",
+        "bai": 0,
+        "slot": 0,
+        "value": 52299183798028654046165148584144631363093432215379852176862615166358228418957
+      },
+      {
+        "address": "000f3df6d732807ef1319fb7b8bb8522d0beac02",
+        "bai": 0,
+        "slot": 12,
+        "value": 12
+      }
+    ],
+    "balance": [
+      {
+        "address": "2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+        "bai": 1,
+        "post": 204599998567800
+      },
+      {
+        "address": "c0f6dc9e5836f54caadbf59cc69346c508e1992b",
+        "bai": 1,
+        "post": 100
+      },
+      {
+        "address": "f6c3a9edc1afa0ad5b720e4d42e1437c43d3b3ff",
+        "bai": 1,
+        "post": 999999999999795399999999900
+      }
+    ],
+    "nonce": [
+      {
+        "address": "f6c3a9edc1afa0ad5b720e4d42e1437c43d3b3ff",
+        "bai": 1,
+        "nonce": 1
+      }
+    ],
+    "code": []
+  }
+}

--- a/scripts/spike/bal-code-changes.expectation.json
+++ b/scripts/spike/bal-code-changes.expectation.json
@@ -1,0 +1,74 @@
+{
+  "schema": 1,
+  "fixture_label": "00321_test_bal_code_changes_fork_Amsterdam-blockchain_test__b0",
+  "fixture_relpath": "blockchain_tests/for_amsterdam/amsterdam/eip7928_block_level_access_lists/block_access_lists/bal_code_changes.json",
+  "manifest_sha256": "b40b7e3f7d4b3bde03c7298c98d3b9117ea146f76c2a2a914f1cbafa78c3ad07",
+  "input_sha256": "1285200e26967fcfb333b34c21c8f7cf8a290dc225d5f5e6fcbc4350ef6d52f3",
+  "execution_specs_commit": "e5a8caf1b8055e4d805c7fb169edfa710914b7da",
+  "reference": "execution-specs Amsterdam BlockAccessList decoded from fixture payload",
+  "payload_bal_sha256": "e23ec0db1bccb9f0aea4ea32b1b49c4b315564adfbf9725223c95c163e9dd75a",
+  "rows": {
+    "accounts": [
+      "00000961ef480eb55e80d19ad83579a64c007002",
+      "000064d678505ad48f8ccb093bc65613800e8282",
+      "0000bbddc7ce488642fb579f8b00f3a590007251",
+      "0000bff46984e3725691fa540a8c7589300d8282",
+      "0000f90827f1c53a10cb7a02335b175320002935",
+      "000f3df6d732807ef1319fb7b8bb8522d0beac02",
+      "2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+      "ca5f5dc38fb090e840c55d0518d300e78ca58bf9",
+      "f6c3a9edc1afa0ad5b720e4d42e1437c43d3b3ff",
+      "f9e6021ec1a54b4226275c9842fdfe0f849a7cf4"
+    ],
+    "storage": [
+      {
+        "address": "0000f90827f1c53a10cb7a02335b175320002935",
+        "bai": 0,
+        "slot": 0,
+        "value": 67008441874175360922646158352325780355322351308527758674525692165582453820571
+      },
+      {
+        "address": "000f3df6d732807ef1319fb7b8bb8522d0beac02",
+        "bai": 0,
+        "slot": 12,
+        "value": 12
+      }
+    ],
+    "balance": [
+      {
+        "address": "2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+        "bai": 1,
+        "post": 633549
+      },
+      {
+        "address": "f6c3a9edc1afa0ad5b720e4d42e1437c43d3b3ff",
+        "bai": 1,
+        "post": 999999999999999999997888170
+      }
+    ],
+    "nonce": [
+      {
+        "address": "ca5f5dc38fb090e840c55d0518d300e78ca58bf9",
+        "bai": 1,
+        "nonce": 2
+      },
+      {
+        "address": "f6c3a9edc1afa0ad5b720e4d42e1437c43d3b3ff",
+        "bai": 1,
+        "nonce": 1
+      },
+      {
+        "address": "f9e6021ec1a54b4226275c9842fdfe0f849a7cf4",
+        "bai": 1,
+        "nonce": 1
+      }
+    ],
+    "code": [
+      {
+        "address": "f9e6021ec1a54b4226275c9842fdfe0f849a7cf4",
+        "bai": 1,
+        "code": "00"
+      }
+    ]
+  }
+}

--- a/scripts/spike/bal-storage-writes.expectation.json
+++ b/scripts/spike/bal-storage-writes.expectation.json
@@ -1,0 +1,69 @@
+{
+  "schema": 1,
+  "fixture_label": "00289_test_bal_2930_slot_listed_and_unlisted_writes_fork_Amsterdam-blockchain_test__b0",
+  "fixture_relpath": "blockchain_tests/for_amsterdam/amsterdam/eip7928_block_level_access_lists/block_access_lists/bal_2930_slot_listed_and_unlisted_writes.json",
+  "manifest_sha256": "b40b7e3f7d4b3bde03c7298c98d3b9117ea146f76c2a2a914f1cbafa78c3ad07",
+  "input_sha256": "392472a4b1f7ead83c255826f81faebd79c760d5e512aab43242700f94653267",
+  "execution_specs_commit": "e5a8caf1b8055e4d805c7fb169edfa710914b7da",
+  "reference": "execution-specs Amsterdam BlockAccessList decoded from fixture payload",
+  "payload_bal_sha256": "d945213ad5f31c0682860ea8a96d55cf1951914d34131a3d99c592f2c0126641",
+  "rows": {
+    "accounts": [
+      "00000961ef480eb55e80d19ad83579a64c007002",
+      "000064d678505ad48f8ccb093bc65613800e8282",
+      "0000bbddc7ce488642fb579f8b00f3a590007251",
+      "0000bff46984e3725691fa540a8c7589300d8282",
+      "0000f90827f1c53a10cb7a02335b175320002935",
+      "000f3df6d732807ef1319fb7b8bb8522d0beac02",
+      "2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+      "aff4e5a04d8e86c00c78dd2902d535ab43b95731",
+      "f6c3a9edc1afa0ad5b720e4d42e1437c43d3b3ff"
+    ],
+    "storage": [
+      {
+        "address": "0000f90827f1c53a10cb7a02335b175320002935",
+        "bai": 0,
+        "slot": 0,
+        "value": 44028032499357224129162206276553519449566763264442798287145076815371865495517
+      },
+      {
+        "address": "000f3df6d732807ef1319fb7b8bb8522d0beac02",
+        "bai": 0,
+        "slot": 12,
+        "value": 12
+      },
+      {
+        "address": "aff4e5a04d8e86c00c78dd2902d535ab43b95731",
+        "bai": 1,
+        "slot": 1,
+        "value": 66
+      },
+      {
+        "address": "aff4e5a04d8e86c00c78dd2902d535ab43b95731",
+        "bai": 1,
+        "slot": 2,
+        "value": 67
+      }
+    ],
+    "balance": [
+      {
+        "address": "2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+        "bai": 1,
+        "post": 729840
+      },
+      {
+        "address": "f6c3a9edc1afa0ad5b720e4d42e1437c43d3b3ff",
+        "bai": 1,
+        "post": 999999999999999999997567200
+      }
+    ],
+    "nonce": [
+      {
+        "address": "f6c3a9edc1afa0ad5b720e4d42e1437c43d3b3ff",
+        "bai": 1,
+        "nonce": 1
+      }
+    ],
+    "code": []
+  }
+}

--- a/scripts/spike/bal_producer_diff.py
+++ b/scripts/spike/bal_producer_diff.py
@@ -191,11 +191,17 @@ def lean_nat(source: Path, name: str) -> int:
     text = source.read_text()
     match = re.search(rf"def {re.escape(name)} : Nat := (\d+)", text)
     if not match:
+        # Some capacity definitions are intentionally expressed as a formula;
+        # their kernel-checked #guard still records the concrete value.
+        match = re.search(rf"#guard {re.escape(name)} = (\d+)", text)
+    if not match:
         fail(f"cannot find {name} in {source}")
     return int(match.group(1))
 
 
-def dump_ranges(elf: Path, program_source: Path) -> tuple[str, dict[str, int], dict[str, int]]:
+def dump_ranges(
+    elf: Path, program_source: Path, code_source: Path, params_source: Path
+) -> tuple[str, dict[str, int], dict[str, int]]:
     symbols = nm_symbols(elf)
     required = [
         "bal_builder_current_bai",
@@ -214,6 +220,8 @@ def dump_ranges(elf: Path, program_source: Path) -> tuple[str, dict[str, int], d
         "bal_builder_balance_changes",
         "bal_builder_nonce_changes",
         "bal_builder_code_changes",
+        "exec_code_effect_log",
+        "eip7702_auth_code_slots",
         "bal_serializer_surviving_read_count",
         "bal_serializer_sort_status",
         "bal_serializer_rebuilt_hash",
@@ -237,6 +245,10 @@ def dump_ranges(elf: Path, program_source: Path) -> tuple[str, dict[str, int], d
         "nonce": lean_nat(program_source, "balBuilderNonceRowBytes"),
         "code": lean_nat(program_source, "balBuilderCodeRowBytes"),
     }
+    code_effect_log_bytes = lean_nat(code_source, "execCodeEffectLogCap")
+    eip7702_auth_code_bytes = (
+        lean_nat(params_source, "bvEip7702AuthEntryCapacity") * 24
+    )
     arrays = {
         "accounts": "bal_builder_accounts",
         "storage": "bal_builder_storage_changes",
@@ -250,13 +262,20 @@ def dump_ranges(elf: Path, program_source: Path) -> tuple[str, dict[str, int], d
     for name in ("accounts", "storage", "balance", "nonce", "code"):
         ranges.append((symbols[arrays[name]], capacities[name] * strides[name]))
     ranges += [
+        (symbols["exec_code_effect_log"], code_effect_log_bytes),
+        (symbols["eip7702_auth_code_slots"], eip7702_auth_code_bytes),
         (symbols["bal_serializer_surviving_read_count"], 8),
         (symbols["bal_serializer_sort_status"], 8),
         (symbols["bal_serializer_rebuilt_hash"], 32),
         (symbols["bal_serializer_supplied_hash"], 32),
     ]
     dump = ",".join(f"0x{address:x}:{length}" for address, length in ranges)
-    return dump, symbols, {**capacities, **{f"{name}_stride": value for name, value in strides.items()}}
+    return dump, symbols, {
+        **capacities,
+        **{f"{name}_stride": value for name, value in strides.items()},
+        "code_effect_log_bytes": code_effect_log_bytes,
+        "eip7702_auth_code_bytes": eip7702_auth_code_bytes,
+    }
 
 
 def read_dump(path: Path) -> dict[int, bytes]:
@@ -292,6 +311,14 @@ def read_at(ranges: dict[int, bytes], address: int, length: int) -> bytes:
     fail(f"dump does not cover 0x{address:x}+{length}")
 
 
+def maybe_read_at(ranges: dict[int, bytes], address: int, length: int) -> bytes | None:
+    for base, data in ranges.items():
+        if base <= address and address + length <= base + len(data):
+            offset = address - base
+            return data[offset : offset + length]
+    return None
+
+
 def u64_at(ranges: dict[int, bytes], address: int) -> int:
     return int.from_bytes(read_at(ranges, address, 8), "little")
 
@@ -321,6 +348,7 @@ def decode_rows(
         }.items()
     }
     rows: dict[str, list[Any]] = {name: [] for name in count_symbols}
+    undecodable = 0
     bases = {
         "accounts": "bal_builder_accounts",
         "storage": "bal_builder_storage_changes",
@@ -357,12 +385,19 @@ def decode_rows(
                     {"address": address, "bai": bai, "nonce": int.from_bytes(row[32:40], "little")}
                 )
             else:
+                code_ptr = int.from_bytes(row[32:40], "little")
+                code_len = int.from_bytes(row[40:48], "little")
+                code = maybe_read_at(ranges, code_ptr, code_len)
+                if code is None:
+                    undecodable += 1
+                    code_hex = None
+                else:
+                    code_hex = code.hex()
                 rows[name].append(
                     {
                         "address": address,
                         "bai": bai,
-                        "code_ptr": int.from_bytes(row[32:40], "little"),
-                        "code_len": int.from_bytes(row[40:48], "little"),
+                        "code": code_hex,
                     }
                 )
     hashes = {
@@ -373,7 +408,7 @@ def decode_rows(
         "sort_status": u64_at(ranges, symbols["bal_serializer_sort_status"]),
         "surviving_reads": u64_at(ranges, symbols["bal_serializer_surviving_read_count"]),
     }
-    return rows, counts, {"overflows": overflows, "hashes": hashes}
+    return rows, counts, {"overflows": overflows, "hashes": hashes, "undecodable": undecodable}
 
 
 def main() -> int:
@@ -391,6 +426,18 @@ def main() -> int:
         help="BlockAccessListBuilder.lean (defaults to the checkout source)",
     )
     parser.add_argument(
+        "--code-source",
+        type=Path,
+        default=None,
+        help="CreateCodeEffectLog.lean (defaults to the checkout source)",
+    )
+    parser.add_argument(
+        "--params-source",
+        type=Path,
+        default=None,
+        help="BlockVerdictParams.lean (defaults to the checkout source)",
+    )
+    parser.add_argument(
         "--register-expectation",
         action="store_true",
         help="derive and write the expectation before executing the guest",
@@ -401,6 +448,8 @@ def main() -> int:
     root = Path(__file__).resolve().parents[2]
     specs_dir = args.execution_specs or root / "execution-specs"
     source = args.program_source or root / "EvmAsm/Codegen/Programs/BlockAccessListBuilder.lean"
+    code_source = args.code_source or root / "EvmAsm/Codegen/Programs/CreateCodeEffectLog.lean"
+    params_source = args.params_source or root / "EvmAsm/Codegen/Programs/BlockVerdictParams.lean"
     row = load_manifest(args.manifest, args.label)
     input_file = input_path(args.manifest, row)
     if not input_file.is_file():
@@ -427,7 +476,7 @@ def main() -> int:
         fail("pre-registered rows differ from the pinned execution-specs reference")
     expected_rows = expectation["rows"]
 
-    dump, symbols, layout = dump_ranges(args.guest_elf, source)
+    dump, symbols, layout = dump_ranges(args.guest_elf, source, code_source, params_source)
     args.out_dir.mkdir(parents=True, exist_ok=True)
     dump_file = args.out_dir / "bal-final-memory.bin"
     output_file = args.out_dir / "guest-output.bin"
@@ -446,8 +495,8 @@ def main() -> int:
 
     actual_rows, counts, diagnostics = decode_rows(read_dump(dump_file), symbols, layout)
     attempted = sum(counts.values())
-    skipped = counts["code"] if counts["code"] else 0
-    undecodable = 0
+    skipped = 0
+    undecodable = diagnostics["undecodable"]
     decoded = attempted - skipped
     mismatches = [name for name in actual_rows if actual_rows[name] != expected_rows.get(name, [])]
     overflowed = {name: value for name, value in diagnostics["overflows"].items() if value}

--- a/scripts/spike/bal_producer_diff.py
+++ b/scripts/spike/bal_producer_diff.py
@@ -1,0 +1,484 @@
+#!/usr/bin/env python3
+"""Compare final guest BAL-builder rows with a pre-registered EEST fixture.
+
+This is a tooling-only probe.  The guest is executed unchanged; SPIKE dumps
+the nm-derived builder ranges after halt, and this script decodes those rows.
+The reference side is the pinned execution-specs BAL carried by the fixture,
+not guest output fed back into SpecRef.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import struct
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, NoReturn
+
+
+MAGIC = b"SPKDMP01"
+U64 = struct.Struct("<Q")
+U32 = struct.Struct("<I")
+
+
+def fail(message: str) -> NoReturn:
+    raise SystemExit(f"FAIL: {message}")
+
+
+def sha256(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(1024 * 1024), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def load_manifest(path: Path, label: str) -> dict[str, str]:
+    for raw in path.read_text().splitlines():
+        if not raw.strip():
+            continue
+        fields = raw.split("\t")
+        if len(fields) not in (7, 8):
+            fail(f"bad manifest row with {len(fields)} fields: {raw!r}")
+        if fields[0] != label:
+            continue
+        return {
+            "label": fields[0],
+            "input": fields[1],
+            "expected": fields[2],
+            "fixture_relpath": fields[-2] if len(fields) == 8 else fields[-1],
+            "case_id": fields[-1] if len(fields) == 8 else "",
+        }
+    fail(f"manifest label not found: {label}")
+
+
+def input_path(manifest: Path, row: dict[str, str]) -> Path:
+    path = Path(row["input"])
+    return path if path.is_absolute() else manifest.parent / path
+
+
+def load_spec(input_file: Path, specs_dir: Path) -> dict[str, Any]:
+    src = specs_dir / "src"
+    if not src.is_dir():
+        fail(f"execution-specs source directory not found: {src}")
+    sys.path.insert(0, str(src))
+    try:
+        from ethereum.forks.amsterdam.block_access_lists import BlockAccessList
+        from ethereum.forks.amsterdam.stateless_guest import deserialize_stateless_input
+        from ethereum_rlp import rlp
+    except ImportError as exc:
+        fail(f"pinned execution-specs dependencies are unavailable: {exc}")
+
+    raw = input_file.read_bytes()
+    if len(raw) < 8:
+        fail(f"input shorter than zisk length prefix: {input_file}")
+    length = int.from_bytes(raw[:8], "little")
+    blob = raw[8 : 8 + length]
+    if len(blob) != length:
+        fail(f"truncated input: want {length} bytes, have {len(blob)}")
+    stateless_input = deserialize_stateless_input(blob)
+    payload = stateless_input.new_payload_request.execution_payload
+    bal = rlp.decode_to(BlockAccessList, payload.block_access_list)
+
+    rows: dict[str, list[Any]] = {
+        "accounts": [],
+        "storage": [],
+        "balance": [],
+        "nonce": [],
+        "code": [],
+    }
+    for account in bal:
+        address = bytes(account.address).hex()
+        rows["accounts"].append(address)
+        for group in account.storage_changes:
+            for change in group.changes:
+                rows["storage"].append(
+                    {
+                        "address": address,
+                        "bai": int(change.block_access_index),
+                        "slot": int(group.slot),
+                        "value": int(change.new_value),
+                    }
+                )
+        for change in account.balance_changes:
+            rows["balance"].append(
+                {
+                    "address": address,
+                    "bai": int(change.block_access_index),
+                    "post": int(change.post_balance),
+                }
+            )
+        for change in account.nonce_changes:
+            rows["nonce"].append(
+                {
+                    "address": address,
+                    "bai": int(change.block_access_index),
+                    "nonce": int(change.new_nonce),
+                }
+            )
+        for change in account.code_changes:
+            rows["code"].append(
+                {
+                    "address": address,
+                    "bai": int(change.block_access_index),
+                    "code": bytes(change.new_code).hex(),
+                }
+            )
+
+    # Make the reference canonical independently of the order in which the
+    # decoder happens to expose each list.
+    rows["accounts"].sort()
+    rows["storage"].sort(key=lambda row: (row["address"], row["slot"], row["bai"]))
+    for name in ("balance", "nonce", "code"):
+        rows[name].sort(key=lambda row: (row["address"], row["bai"]))
+    return {
+        "rows": rows,
+        "input_len": length,
+        "payload_bal_sha256": hashlib.sha256(payload.block_access_list).hexdigest(),
+    }
+
+
+def write_expectation(path: Path, manifest: Path, row: dict[str, str], spec: dict[str, Any], specs_dir: Path) -> None:
+    pin = subprocess.run(
+        ["git", "-C", str(specs_dir), "rev-parse", "HEAD"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    value = {
+        "schema": 1,
+        "fixture_label": row["label"],
+        "fixture_relpath": row["fixture_relpath"],
+        "manifest_sha256": sha256(manifest),
+        "input_sha256": sha256(input_path(manifest, row)),
+        "execution_specs_commit": pin,
+        "reference": "execution-specs Amsterdam BlockAccessList decoded from fixture payload",
+        "payload_bal_sha256": spec["payload_bal_sha256"],
+        "rows": spec["rows"],
+    }
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(value, indent=2) + "\n")
+    print(f"pre-registered expectation: {path}")
+
+
+def nm_symbols(elf: Path) -> dict[str, int]:
+    try:
+        proc = subprocess.run(
+            ["riscv64-unknown-elf-nm", "-n", str(elf)],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except (OSError, subprocess.CalledProcessError) as exc:
+        fail(f"nm failed for {elf}: {exc}")
+    result: dict[str, int] = {}
+    for raw in proc.stdout.splitlines():
+        fields = raw.split()
+        if len(fields) == 3:
+            try:
+                result[fields[2]] = int(fields[0], 16)
+            except ValueError:
+                pass
+    return result
+
+
+def lean_nat(source: Path, name: str) -> int:
+    text = source.read_text()
+    match = re.search(rf"def {re.escape(name)} : Nat := (\d+)", text)
+    if not match:
+        fail(f"cannot find {name} in {source}")
+    return int(match.group(1))
+
+
+def dump_ranges(elf: Path, program_source: Path) -> tuple[str, dict[str, int], dict[str, int]]:
+    symbols = nm_symbols(elf)
+    required = [
+        "bal_builder_current_bai",
+        "bal_builder_account_count",
+        "bal_builder_storage_change_count",
+        "bal_builder_balance_count",
+        "bal_builder_nonce_count",
+        "bal_builder_code_count",
+        "bal_builder_overflow",
+        "bal_builder_storage_change_overflow",
+        "bal_builder_balance_overflow",
+        "bal_builder_nonce_overflow",
+        "bal_builder_code_overflow",
+        "bal_builder_accounts",
+        "bal_builder_storage_changes",
+        "bal_builder_balance_changes",
+        "bal_builder_nonce_changes",
+        "bal_builder_code_changes",
+        "bal_serializer_surviving_read_count",
+        "bal_serializer_sort_status",
+        "bal_serializer_rebuilt_hash",
+        "bal_serializer_supplied_hash",
+    ]
+    missing = [name for name in required if name not in symbols]
+    if missing:
+        fail(f"guest ELF is missing required BAL symbols: {', '.join(missing)}")
+
+    capacities = {
+        "accounts": lean_nat(program_source, "balBuilderAccountCapacity"),
+        "storage": lean_nat(program_source, "balBuilderStorageChangeCapacity"),
+        "balance": lean_nat(program_source, "balBuilderBalanceCapacity"),
+        "nonce": lean_nat(program_source, "balBuilderNonceCapacity"),
+        "code": lean_nat(program_source, "balBuilderCodeCapacity"),
+    }
+    strides = {
+        "accounts": lean_nat(program_source, "balBuilderAccountRowBytes"),
+        "storage": lean_nat(program_source, "balBuilderStorageChangeRowBytes"),
+        "balance": lean_nat(program_source, "balBuilderBalanceRowBytes"),
+        "nonce": lean_nat(program_source, "balBuilderNonceRowBytes"),
+        "code": lean_nat(program_source, "balBuilderCodeRowBytes"),
+    }
+    arrays = {
+        "accounts": "bal_builder_accounts",
+        "storage": "bal_builder_storage_changes",
+        "balance": "bal_builder_balance_changes",
+        "nonce": "bal_builder_nonce_changes",
+        "code": "bal_builder_code_changes",
+    }
+    current = symbols["bal_builder_current_bai"]
+    overflow_end = symbols["bal_builder_code_overflow"] + 8
+    ranges: list[tuple[int, int]] = [(current, overflow_end - current)]
+    for name in ("accounts", "storage", "balance", "nonce", "code"):
+        ranges.append((symbols[arrays[name]], capacities[name] * strides[name]))
+    ranges += [
+        (symbols["bal_serializer_surviving_read_count"], 8),
+        (symbols["bal_serializer_sort_status"], 8),
+        (symbols["bal_serializer_rebuilt_hash"], 32),
+        (symbols["bal_serializer_supplied_hash"], 32),
+    ]
+    dump = ",".join(f"0x{address:x}:{length}" for address, length in ranges)
+    return dump, symbols, {**capacities, **{f"{name}_stride": value for name, value in strides.items()}}
+
+
+def read_dump(path: Path) -> dict[int, bytes]:
+    data = path.read_bytes()
+    if len(data) < 16 or data[:8] != MAGIC:
+        fail(f"bad SPIKE dump header: {path}")
+    version = U32.unpack_from(data, 8)[0]
+    count = U32.unpack_from(data, 12)[0]
+    if version != 1:
+        fail(f"unsupported SPIKE dump version {version}")
+    pos = 16
+    result: dict[int, bytes] = {}
+    for _ in range(count):
+        if pos + 16 > len(data):
+            fail("truncated SPIKE dump record header")
+        address = U64.unpack_from(data, pos)[0]
+        length = U64.unpack_from(data, pos + 8)[0]
+        pos += 16
+        if length > len(data) - pos:
+            fail("truncated SPIKE dump record payload")
+        result[address] = data[pos : pos + length]
+        pos += length
+    if pos != len(data):
+        fail("trailing bytes in SPIKE dump")
+    return result
+
+
+def read_at(ranges: dict[int, bytes], address: int, length: int) -> bytes:
+    for base, data in ranges.items():
+        if base <= address and address + length <= base + len(data):
+            offset = address - base
+            return data[offset : offset + length]
+    fail(f"dump does not cover 0x{address:x}+{length}")
+
+
+def u64_at(ranges: dict[int, bytes], address: int) -> int:
+    return int.from_bytes(read_at(ranges, address, 8), "little")
+
+
+def decode_rows(
+    ranges: dict[int, bytes], symbols: dict[str, int], layout: dict[str, int]
+) -> tuple[dict[str, list[Any]], dict[str, int], dict[str, Any]]:
+    global_base = symbols["bal_builder_current_bai"]
+    global_len = symbols["bal_builder_code_overflow"] + 8 - global_base
+    read_at(ranges, global_base, global_len)
+    count_symbols = {
+        "accounts": "bal_builder_account_count",
+        "storage": "bal_builder_storage_change_count",
+        "balance": "bal_builder_balance_count",
+        "nonce": "bal_builder_nonce_count",
+        "code": "bal_builder_code_count",
+    }
+    counts = {name: u64_at(ranges, symbols[symbol]) for name, symbol in count_symbols.items()}
+    overflows = {
+        name: u64_at(ranges, symbols[symbol])
+        for name, symbol in {
+            "shared": "bal_builder_overflow",
+            "storage": "bal_builder_storage_change_overflow",
+            "balance": "bal_builder_balance_overflow",
+            "nonce": "bal_builder_nonce_overflow",
+            "code": "bal_builder_code_overflow",
+        }.items()
+    }
+    rows: dict[str, list[Any]] = {name: [] for name in count_symbols}
+    bases = {
+        "accounts": "bal_builder_accounts",
+        "storage": "bal_builder_storage_changes",
+        "balance": "bal_builder_balance_changes",
+        "nonce": "bal_builder_nonce_changes",
+        "code": "bal_builder_code_changes",
+    }
+    for name, base_symbol in bases.items():
+        if counts[name] > layout[name]:
+            fail(f"{name} count {counts[name]} exceeds capacity {layout[name]}")
+        base = symbols[base_symbol]
+        stride = layout[f"{name}_stride"]
+        for index in range(counts[name]):
+            row = read_at(ranges, base + index * stride, stride)
+            address = row[:20].hex()
+            bai = int.from_bytes(row[24:32], "little")
+            if name == "accounts":
+                rows[name].append(address)
+            elif name == "storage":
+                rows[name].append(
+                    {
+                        "address": address,
+                        "bai": bai,
+                        "slot": int.from_bytes(row[32:64], "big"),
+                        "value": int.from_bytes(row[64:96], "little"),
+                    }
+                )
+            elif name == "balance":
+                rows[name].append(
+                    {"address": address, "bai": bai, "post": int.from_bytes(row[32:64], "big")}
+                )
+            elif name == "nonce":
+                rows[name].append(
+                    {"address": address, "bai": bai, "nonce": int.from_bytes(row[32:40], "little")}
+                )
+            else:
+                rows[name].append(
+                    {
+                        "address": address,
+                        "bai": bai,
+                        "code_ptr": int.from_bytes(row[32:40], "little"),
+                        "code_len": int.from_bytes(row[40:48], "little"),
+                    }
+                )
+    hashes = {
+        "rebuilt": read_at(ranges, symbols["bal_serializer_rebuilt_hash"], 32).hex(),
+        "supplied": read_at(ranges, symbols["bal_serializer_supplied_hash"], 32).hex(),
+        "equal": read_at(ranges, symbols["bal_serializer_rebuilt_hash"], 32)
+        == read_at(ranges, symbols["bal_serializer_supplied_hash"], 32),
+        "sort_status": u64_at(ranges, symbols["bal_serializer_sort_status"]),
+        "surviving_reads": u64_at(ranges, symbols["bal_serializer_surviving_read_count"]),
+    }
+    return rows, counts, {"overflows": overflows, "hashes": hashes}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--spike", type=Path, required=True)
+    parser.add_argument("--guest-elf", type=Path, required=True)
+    parser.add_argument("--manifest", type=Path, required=True)
+    parser.add_argument("--label", required=True)
+    parser.add_argument("--expectation", type=Path, required=True)
+    parser.add_argument("--execution-specs", type=Path, default=None)
+    parser.add_argument(
+        "--program-source",
+        type=Path,
+        default=None,
+        help="BlockAccessListBuilder.lean (defaults to the checkout source)",
+    )
+    parser.add_argument(
+        "--register-expectation",
+        action="store_true",
+        help="derive and write the expectation before executing the guest",
+    )
+    parser.add_argument("--out-dir", type=Path, required=True)
+    args = parser.parse_args()
+
+    root = Path(__file__).resolve().parents[2]
+    specs_dir = args.execution_specs or root / "execution-specs"
+    source = args.program_source or root / "EvmAsm/Codegen/Programs/BlockAccessListBuilder.lean"
+    row = load_manifest(args.manifest, args.label)
+    input_file = input_path(args.manifest, row)
+    if not input_file.is_file():
+        fail(f"fixture input not found: {input_file}")
+
+    if args.register_expectation:
+        spec = load_spec(input_file, specs_dir)
+        write_expectation(args.expectation, args.manifest, row, spec, specs_dir)
+    if not args.expectation.is_file():
+        fail(f"pre-registered expectation not found: {args.expectation}")
+    expectation = json.loads(args.expectation.read_text())
+    if expectation.get("fixture_label") != args.label:
+        fail("expectation fixture label does not match --label")
+    actual_input_sha = sha256(input_file)
+    if expectation.get("input_sha256") != actual_input_sha:
+        fail("expectation input sha256 does not match the manifest fixture")
+    actual_manifest_sha = sha256(args.manifest)
+    if expectation.get("manifest_sha256") != actual_manifest_sha:
+        fail("expectation manifest sha256 does not match --manifest")
+    spec = load_spec(input_file, specs_dir)
+    if expectation.get("payload_bal_sha256") != spec["payload_bal_sha256"]:
+        fail("expectation payload BAL sha256 does not match the fixture")
+    if expectation.get("rows") != spec["rows"]:
+        fail("pre-registered rows differ from the pinned execution-specs reference")
+    expected_rows = expectation["rows"]
+
+    dump, symbols, layout = dump_ranges(args.guest_elf, source)
+    args.out_dir.mkdir(parents=True, exist_ok=True)
+    dump_file = args.out_dir / "bal-final-memory.bin"
+    output_file = args.out_dir / "guest-output.bin"
+    env = os.environ.copy()
+    env["SPIKE_DUMP_RANGES"] = dump
+    env["SPIKE_DUMP_FILE"] = str(dump_file)
+    proc = subprocess.run(
+        [str(args.spike), str(args.guest_elf), str(input_file), str(output_file)],
+        env=env,
+        check=False,
+    )
+    if proc.returncode != 0:
+        fail(f"guest execution returned {proc.returncode}")
+    if not dump_file.is_file():
+        fail("guest succeeded without a final-memory dump")
+
+    actual_rows, counts, diagnostics = decode_rows(read_dump(dump_file), symbols, layout)
+    attempted = sum(counts.values())
+    skipped = counts["code"] if counts["code"] else 0
+    undecodable = 0
+    decoded = attempted - skipped
+    mismatches = [name for name in actual_rows if actual_rows[name] != expected_rows.get(name, [])]
+    overflowed = {name: value for name, value in diagnostics["overflows"].items() if value}
+    if mismatches:
+        fail(f"row mismatch in {', '.join(mismatches)}")
+    if skipped or undecodable:
+        fail(f"rows silently skipped or undecodable: skipped={skipped} undecodable={undecodable}")
+    if overflowed:
+        fail(f"builder overflow flags set: {overflowed}")
+    if diagnostics["hashes"]["sort_status"]:
+        fail(f"BAL serializer sort status is {diagnostics['hashes']['sort_status']}")
+    if not diagnostics["hashes"]["equal"]:
+        fail("rebuilt BAL hash differs from supplied BAL hash")
+
+    report = {
+        "fixture": args.label,
+        "input_sha256": actual_input_sha,
+        "guest_elf_sha256": sha256(args.guest_elf),
+        "attempted": attempted,
+        "decoded": decoded,
+        "skipped": skipped,
+        "undecodable": undecodable,
+        "overflow": overflowed,
+        "final_counts": counts,
+        "serializer_hash": diagnostics["hashes"],
+        "dump_file": str(dump_file),
+    }
+    print(json.dumps(report, sort_keys=True))
+    print("PASS: final BAL-builder rows and serialized BAL hash match the pre-registered fixture")
+    return 0
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/spike/bal_producer_set.sh
+++ b/scripts/spike/bal_producer_set.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -lt 2 || $# -gt 3 ]]; then
+  echo "usage: $0 <guest.elf> <manifest.tsv> [out-dir]" >&2
+  exit 2
+fi
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+GUEST_ELF=$(realpath "$1")
+MANIFEST=$(realpath "$2")
+OUT_DIR=${3:-/tmp/bal-producer-diff-set}
+OUT_DIR=$(realpath -m "$OUT_DIR")
+mkdir -p "$OUT_DIR"
+SPIKE=${SPIKE:-$ROOT/scripts/spike/spike_run}
+EXECUTION_SPECS=${EXECUTION_SPECS:-$ROOT/execution-specs}
+PROGRAM_SOURCE=$ROOT/EvmAsm/Codegen/Programs/BlockAccessListBuilder.lean
+CODE_SOURCE=$ROOT/EvmAsm/Codegen/Programs/CreateCodeEffectLog.lean
+PARAMS_SOURCE=$ROOT/EvmAsm/Codegen/Programs/BlockVerdictParams.lean
+
+run_case() {
+  local label=$1 expectation=$2
+  uv run --directory "$EXECUTION_SPECS" --quiet python3 \
+    "$ROOT/scripts/spike/bal_producer_diff.py" \
+    --spike "$SPIKE" \
+    --guest-elf "$GUEST_ELF" \
+    --manifest "$MANIFEST" \
+    --label "$label" \
+    --expectation "$ROOT/scripts/spike/$expectation" \
+    --execution-specs "$EXECUTION_SPECS" \
+    --program-source "$PROGRAM_SOURCE" \
+    --code-source "$CODE_SOURCE" \
+    --params-source "$PARAMS_SOURCE" \
+    --out-dir "$OUT_DIR/${label%%_*}"
+}
+
+run_case \
+  00318_test_bal_balance_changes_fork_Amsterdam-blockchain_test__b0 \
+  bal-balance-changes.expectation.json
+run_case \
+  00289_test_bal_2930_slot_listed_and_unlisted_writes_fork_Amsterdam-blockchain_test__b0 \
+  bal-storage-writes.expectation.json
+run_case \
+  00321_test_bal_code_changes_fork_Amsterdam-blockchain_test__b0 \
+  bal-code-changes.expectation.json
+run_case \
+  00317_test_bal_all_transaction_types_fork_Amsterdam-blockchain_test__b0 \
+  bal-all-transaction-types.expectation.json

--- a/scripts/spike/spike_run.cc
+++ b/scripts/spike/spike_run.cc
@@ -16,6 +16,8 @@
 //   SPIKE_WATCH_STOP=1       stop the run after the first watch hit (default: log+continue)
 //   SPIKE_BREAK_PC=<hex>     stop after executing the insn at this PC (logs once)
 //   SPIKE_RUN_DEBUG=1        existing: dump first 60 steps
+//   SPIKE_DUMP_RANGES=<addr:length,...> + SPIKE_DUMP_FILE=<file>
+//                            final-memory ranges for tooling-only inspection
 #include <sys/syscall.h>
 #include "sim.h"
 #include "cfg.h"
@@ -47,6 +49,11 @@ static const reg_t HANDLER_ADDR  = 0x60000000ULL;
 static const reg_t HALT_FLAG     = 0x60008000ULL;  // handler writes nonzero here on halt
 static const uint64_t STEP_CAP   = 20000000000ULL; // safety cap on total instructions
 static const size_t STEP_BATCH   = 2000000;
+
+struct DumpRange {
+  reg_t addr;
+  size_t len;
+};
 
 
 static size_t output_len() {
@@ -86,6 +93,95 @@ static unsigned long long parse_u64(const char* raw, const char* what) {
     exit(2);
   }
   return v;
+}
+
+static std::vector<DumpRange> parse_dump_ranges() {
+  const char* raw = getenv("SPIKE_DUMP_RANGES");
+  const char* path = getenv("SPIKE_DUMP_FILE");
+  if (!raw && !path) return {};
+  if (!raw || !*raw || !path || !*path) {
+    fprintf(stderr,
+            "spike_run: SPIKE_DUMP_RANGES and SPIKE_DUMP_FILE must be set together\n");
+    exit(2);
+  }
+
+  std::vector<DumpRange> ranges;
+  std::string specs(raw);
+  size_t begin = 0;
+  while (begin <= specs.size()) {
+    size_t end = specs.find(',', begin);
+    std::string spec = specs.substr(begin, end == std::string::npos
+                                             ? std::string::npos : end - begin);
+    size_t colon = spec.find(':');
+    if (spec.empty() || colon == std::string::npos ||
+        spec.find(':', colon + 1) != std::string::npos) {
+      fprintf(stderr, "spike_run: invalid SPIKE_DUMP_RANGES item '%s'\n",
+              spec.c_str());
+      exit(2);
+    }
+    std::string addr_s = spec.substr(0, colon);
+    std::string len_s = spec.substr(colon + 1);
+    unsigned long long addr = parse_u64(addr_s.c_str(), "SPIKE_DUMP_RANGES address");
+    unsigned long long len = parse_u64(len_s.c_str(), "SPIKE_DUMP_RANGES length");
+    if (len == 0 || len > static_cast<unsigned long long>(SIZE_MAX) ||
+        addr > UINT64_MAX - (len - 1)) {
+      fprintf(stderr, "spike_run: invalid SPIKE_DUMP_RANGES item '%s'\n",
+              spec.c_str());
+      exit(2);
+    }
+    ranges.push_back({(reg_t)addr, (size_t)len});
+    if (end == std::string::npos) break;
+    begin = end + 1;
+  }
+  if (ranges.empty()) {
+    fprintf(stderr, "spike_run: SPIKE_DUMP_RANGES has no ranges\n");
+    exit(2);
+  }
+  return ranges;
+}
+
+static void put_le_u32(std::ofstream& out, uint32_t value) {
+  uint8_t b[4] = {(uint8_t)value, (uint8_t)(value >> 8),
+                  (uint8_t)(value >> 16), (uint8_t)(value >> 24)};
+  out.write((const char*)b, sizeof(b));
+}
+
+static void put_le_u64(std::ofstream& out, uint64_t value) {
+  uint8_t b[8];
+  for (unsigned i = 0; i < sizeof(b); ++i) b[i] = (uint8_t)(value >> (8 * i));
+  out.write((const char*)b, sizeof(b));
+}
+
+static void dump_ranges(simif_t* memif, const std::vector<DumpRange>& ranges,
+                        const char* path) {
+  std::ofstream out(path, std::ios::binary | std::ios::trunc);
+  if (!out) {
+    fprintf(stderr, "spike_run: cannot open SPIKE_DUMP_FILE=%s\n", path);
+    exit(2);
+  }
+  const char magic[] = "SPKDMP01";
+  out.write(magic, sizeof(magic) - 1);
+  put_le_u32(out, 1);  // format version
+  put_le_u32(out, (uint32_t)ranges.size());
+  for (const DumpRange& range : ranges) {
+    put_le_u64(out, range.addr);
+    put_le_u64(out, range.len);
+    for (size_t i = 0; i < range.len; ++i) {
+      char* p = memif->addr_to_mem(range.addr + i);
+      if (!p) {
+        fprintf(stderr, "spike_run: unmapped dump read @0x%llx\n",
+                (unsigned long long)(range.addr + i));
+        exit(2);
+      }
+      out.put(*p);
+    }
+  }
+  if (!out) {
+    fprintf(stderr, "spike_run: write failed for SPIKE_DUMP_FILE=%s\n", path);
+    exit(2);
+  }
+  fprintf(stderr, "spike_run: dumped %zu final-memory range(s) to %s\n",
+          ranges.size(), path);
 }
 
 // ABI / numeric register name -> x-reg index. Returns -1 on failure.
@@ -333,7 +429,8 @@ int main(int argc, char** argv) {
     fprintf(stderr,
             "usage: %s <guest.elf> <input> <output>\n"
             "env: SPIKE_COMMITLOG SPIKE_DEBUG_CMD SPIKE_WATCH SPIKE_WATCH_STOP "
-            "SPIKE_BREAK_PC SPIKE_OUTPUT_LEN SPIKE_RUN_DEBUG\n",
+            "SPIKE_BREAK_PC SPIKE_OUTPUT_LEN SPIKE_RUN_DEBUG "
+            "SPIKE_DUMP_RANGES SPIKE_DUMP_FILE\n",
             argv[0]);
     return 2;
   }
@@ -347,6 +444,7 @@ int main(int argc, char** argv) {
     mem_cfg_t(0x60000000ULL, 0x00010000ULL),  // handler + tohost/fromhost
     mem_cfg_t(0x7ffff000ULL, 0x40001000ULL),  // headers+text+data+sszscratch+output -> 0xc0000000
   };
+  std::vector<DumpRange> dump_ranges_spec = parse_dump_ranges();
   std::vector<std::pair<reg_t, abstract_mem_t*>> mems;
   for (auto& m : cfg.mem_layout) mems.push_back({m.get_base(), new mem_t(m.get_size())});
 
@@ -490,6 +588,9 @@ int main(int argc, char** argv) {
   rd(&sim, OUTPUT_ADDR, out.data(), out_len);
   std::ofstream of(argv[3], std::ios::binary);
   of.write((const char*)out.data(), out_len);
+  if (!dump_ranges_spec.empty()) {
+    dump_ranges(&sim, dump_ranges_spec, getenv("SPIKE_DUMP_FILE"));
+  }
   for (auto& m : mems) delete m.second;
   return halted ? 0 : 3;
 }


### PR DESCRIPTION
## Summary

This is a tooling-only BAL producer differential probe. It does not change
guest assembly, the guest image, or layout-linked addresses.

- Adds an env-gated `SPIKE_DUMP_RANGES` / `SPIKE_DUMP_FILE` final-memory dump
  with a self-describing `SPKDMP01` format.
- Adds an `nm`-derived host decoder for BAL builder rows, including code bytes
  from the code-effect and EIP-7702 code arenas.
- Pre-registers four fixture expectations from the pinned execution-specs
  Amsterdam `BlockAccessList` reference.
- Reports attempted, decoded, skipped, undecodable, overflow, and final row
  counts, failing closed if any row is not decoded.

The primary assertion is exact element-by-element equality of every decoded
guest row stream (accounts, storage, balance, nonce, and code) against the
pre-registered spec-derived rows. This is not a count-only check. Rebuilt vs
supplied serializer hash equality is retained as a secondary cross-check; the
guest already shadow-verifies that condition internally, while the row
differential provides the per-entry visibility that a hash cannot provide.

## Validation

Candidate guest:

- commit `598c7fc4c`
- ELF SHA-256 `6a7242fc3049b5fec53bb3612fcf244f47e6693933d8712cf31efd7659a11c7e`
- SPIKE runner output remained byte-identical to the pre-dump binary;
  output SHA-256 `c47499b7b85e79125fe7f30cb330d8eaefe40ef6b82cba6dc3e3bd7345be7400`

The approved manifest is `/var/tmp/fc668/manifest.tsv` (SHA-256
`b40b7e3f7d4b3bde03c7298c98d3b9117ea146f76c2a2a914f1cbafa78c3ad07`), and the
reference pin is execution-specs `e5a8caf1b8055e4d805c7fb169edfa710914b7da`.
The four real fixtures all passed with zero skips, zero undecodable rows, and
zero overflow flags:

| fixture | attempted/decoded | final rows (accounts/storage/balance/nonce/code) |
| --- | ---: | ---: |
| `00318` balance changes | 15/15 | 9/2/3/1/0 |
| `00289` storage writes | 16/16 | 9/4/2/1/0 |
| `00321` code changes | 18/18 | 10/2/2/3/1 |
| `00317` all transaction types, five tx / multi-BAI | 42/42 | 18/7/10/6/1 |

The dump environment is fail-closed: setting only one of the two dump
variables returns `rc=2`. A deliberate same-count expectation mutation was
also rejected before execution because the pre-registered rows no longer
matched the pinned spec reference.

Run the set with:

```bash
EXECUTION_SPECS=/path/to/execution-specs \
  scripts/spike/bal_producer_set.sh \
  gen-out/regionmap/stateless_guest.elf \
  /var/tmp/fc668/manifest.tsv \
  /tmp/bal-producer-diff-set
```

`SPIKE_COMMITLOG` remains an independent attempted-write audit and is not used
for row extraction.
