### PR TITLE
Widen BAL producer differential fixture set

### DIFF
--- a/docs/bal-producer-differential.md
+++ b/docs/bal-producer-differential.md
@@ -70,12 +70,18 @@ The balance mismatches have a gas-shaped signature rather than being arbitrary
 serializer values, but the two fixtures are not yet one defect class. In 01087,
 Tx2's sender is lower by `16,259,889 * 10` wei and the fee recipient is higher
 by `16,259,889 * 3` wei; this tracks the failed CREATE2 path that also leaves
-the factory's running nonce unadvanced. In 00612, each of Tx2 and Tx3 charges
+the factory's running nonce unadvanced (the nonce omission is tracked
+separately in [#11363](https://github.com/Verified-zkEVM/evm-asm/issues/11363)). In 00612, each of Tx2 and Tx3 charges
 its sender an extra `43,190 * 10` wei and credits the fee recipient an extra
 `43,190 * 3` wei. The pinned test shows that both are the same plain CALL into
 the delegated counter, while the sole authorization is in Tx1, so this is
 evidence for a repeated delegated-call gas discrepancy, not an AUTH_BASE charge
-on Tx2/Tx3. Keep these as separate follow-ups until their execution paths are
+on Tx2/Tx3. The reference post-balances imply gas-used values 129,032 for Tx2
+and 31,112 for Tx3; their 97,920 difference is the Amsterdam zero-to-nonzero
+storage-set state charge (`64 * 1530`). The guest records `35,190` state gas
+for each transaction (`AUTH_BASE = 23 * 1530`) and an additional `8,000`
+regular `ACCOUNT_WRITE`, exactly explaining the `43,190` excess on both later
+CALLs. Keep these as separate follow-ups until their execution paths are
 traced; issue [#11362](https://github.com/Verified-zkEVM/evm-asm/issues/11362)
 covers the 01087 collision case.
 

--- a/docs/bal-producer-differential.md
+++ b/docs/bal-producer-differential.md
@@ -40,10 +40,32 @@ rows, but the guest producer disagrees with the pinned reference:
 | `00612_test_bal_7702_cross_tx_delegation_then_call...` | EIP-7702 cross-transaction attribution | 12 / 4 / 5 / 4 / 1 | 12 / 4 / 5 / 4 / 1 |
 
 The second finding has mismatching balance payloads despite equal row counts;
-both findings also have unequal rebuilt/supplied serializer hashes. They are
-kept out of the green set so the set runner remains a pass/fail oracle, but are
-reported explicitly for follow-up rather than being hidden as unsupported
-fixtures. The findings had zero undecodable rows and zero overflow flags.
+both findings also have unequal rebuilt/supplied serializer hashes. A normal
+guest run rejects both fixtures (`successful_validation=0`, oracle `1`, and
+`bv_fail_code=1`). 01087 reports rebuilt/supplied lengths `460/494`; 00612
+reports `496/496`. They are kept out of the green set so the set runner remains
+a pass/fail oracle, but are reported explicitly for follow-up rather than being
+hidden as unsupported fixtures. The findings had zero undecodable rows and
+zero overflow flags.
+
+The row comparison is intentionally primary for a reason demonstrated by
+00612: every row count matches and the rebuilt/supplied serialized lengths are
+equal, but the balance payloads still differ. A hash or length-only check would
+miss that finding; element-wise comparison identifies the affected address,
+BAI, and post-balance. Conversely, 01087's length delta provides an additional
+byte-level ledger: the missing target-A nonce and code rows account for 35
+bytes, a second missing nonce row accounts for 3, an extra storage row adds 3,
+and one guest balance scalar is one byte wider, yielding
+`-35 - 3 + 3 + 1 = -34 = 460 - 494`.
+
+The balance mismatches also share a gas-shaped signature rather than being
+arbitrary serializer values. In 01087, Tx2's sender is lower by
+`16,259,889 * 10` wei and the fee recipient is higher by
+`16,259,889 * 3` wei. In 00612, each of Tx2 and Tx3 charges its sender an extra
+`43,190 * 10` wei and credits the fee recipient an extra `43,190 * 3` wei.
+These are candidate cross-transaction gas/account-write-stage defects, and
+are kept as field-level evidence for the shared investigation (see issue
+[#11362](https://github.com/Verified-zkEVM/evm-asm/issues/11362)).
 
 Each expectation records the execution-specs pin and input SHA-256. Regenerate
 one only when deliberately changing its fixture:

--- a/docs/bal-producer-differential.md
+++ b/docs/bal-producer-differential.md
@@ -66,14 +66,18 @@ bytes, a second missing nonce row accounts for 3, an extra storage row adds 3,
 and one guest balance scalar is one byte wider, yielding
 `-35 - 3 + 3 + 1 = -34 = 460 - 494`.
 
-The balance mismatches also share a gas-shaped signature rather than being
-arbitrary serializer values. In 01087, Tx2's sender is lower by
-`16,259,889 * 10` wei and the fee recipient is higher by
-`16,259,889 * 3` wei. In 00612, each of Tx2 and Tx3 charges its sender an extra
-`43,190 * 10` wei and credits the fee recipient an extra `43,190 * 3` wei.
-These are candidate cross-transaction gas/account-write-stage defects, and
-are kept as field-level evidence for the shared investigation (see issue
-[#11362](https://github.com/Verified-zkEVM/evm-asm/issues/11362)).
+The balance mismatches have a gas-shaped signature rather than being arbitrary
+serializer values, but the two fixtures are not yet one defect class. In 01087,
+Tx2's sender is lower by `16,259,889 * 10` wei and the fee recipient is higher
+by `16,259,889 * 3` wei; this tracks the failed CREATE2 path that also leaves
+the factory's running nonce unadvanced. In 00612, each of Tx2 and Tx3 charges
+its sender an extra `43,190 * 10` wei and credits the fee recipient an extra
+`43,190 * 3` wei. The pinned test shows that both are the same plain CALL into
+the delegated counter, while the sole authorization is in Tx1, so this is
+evidence for a repeated delegated-call gas discrepancy, not an AUTH_BASE charge
+on Tx2/Tx3. Keep these as separate follow-ups until their execution paths are
+traced; issue [#11362](https://github.com/Verified-zkEVM/evm-asm/issues/11362)
+covers the 01087 collision case.
 
 Each expectation records the execution-specs pin and input SHA-256. Regenerate
 one only when deliberately changing its fixture:

--- a/docs/bal-producer-differential.md
+++ b/docs/bal-producer-differential.md
@@ -32,11 +32,12 @@ classes. It keeps the first four controls and adds ten class-covering fixtures:
 
 Two additional class probes are recorded as findings rather than silently
 removed from the investigation. They have no skipped, undecodable, or overflow
-rows, but the guest producer disagrees with the pinned reference:
+rows, but the guest execution (as reflected by its producer rows) disagrees
+with the pinned reference:
 
 | fixture prefix | class | expected rows (accounts/storage/balance/nonce/code) | guest rows |
 | --- | --- | --- | --- |
-| `01087_test_bal_create2_selfdestruct_then_recreate_same_block...` | EIP-6780 deletion/recreation | 11 / 4 / 6 / 5 / 1 | 11 / 5 / 6 / 3 / 0 |
+| `01087_test_bal_create2_selfdestruct_then_recreate_same_block...` | EIP-6780 deletion/recreation / CREATE2 collision | 11 / 4 / 6 / 5 / 1 | 11 / 5 / 6 / 3 / 0 |
 | `00612_test_bal_7702_cross_tx_delegation_then_call...` | EIP-7702 cross-transaction attribution | 12 / 4 / 5 / 4 / 1 | 12 / 4 / 5 / 4 / 1 |
 
 The second finding has mismatching balance payloads despite equal row counts;
@@ -47,6 +48,13 @@ reports `496/496`. They are kept out of the green set so the set runner remains
 a pass/fail oracle, but are reported explicitly for follow-up rather than being
 hidden as unsupported fixtures. The findings had zero undecodable rows and
 zero overflow flags.
+
+01087's three row-shape differences have one execution-side explanation: the
+factory's Tx2 CREATE2 returns zero when the pinned spec recreates the
+SELFDESTRUCTed target. The resulting factory `slot=0, BAI=2, value=0` row,
+missing target nonce row, and missing target code row are therefore evidence
+for a collision/tombstone predicate defect, not an independent BAL-builder
+omission. See issue [#11362](https://github.com/Verified-zkEVM/evm-asm/issues/11362).
 
 The row comparison is intentionally primary for a reason demonstrated by
 00612: every row count matches and the rebuilt/supplied serialized lengths are

--- a/docs/bal-producer-differential.md
+++ b/docs/bal-producer-differential.md
@@ -11,7 +11,7 @@ fixture payload and are pre-registered in
 [`scripts/spike/bal-balance-changes.expectation.json`](../scripts/spike/bal-balance-changes.expectation.json).
 
 The registered fixture set is deliberately small but spans the producer
-classes:
+classes. It keeps the first four controls and adds ten class-covering fixtures:
 
 | expectation | fixture | final rows (accounts/storage/balance/nonce/code) |
 | --- | --- | --- |
@@ -19,6 +19,31 @@ classes:
 | `bal-storage-writes` | storage-write fixture | 9 / 4 / 2 / 1 / 0 |
 | `bal-code-changes` | code-change fixture | 10 / 2 / 2 / 3 / 1 |
 | `bal-all-transaction-types` | five-transaction, multi-BAI fixture | 18 / 7 / 10 / 6 / 1 |
+| `bal-cross-tx-balance-dependency` | multi-transaction BAI attribution | 11 / 3 / 6 / 2 / 0 |
+| `bal-selfdestruct-to-coinbase` | SELFDESTRUCT / EIP-6780 | 9 / 2 / 3 / 1 / 0 |
+| `bal-create-storage-selfdestruct` | CREATE storage then SELFDESTRUCT | 11 / 3 / 4 / 2 / 0 |
+| `bal-7702-delegated-storage` | EIP-7702 delegated storage access | 10 / 3 / 3 / 1 / 0 |
+| `bal-7702-delegation-create` | EIP-7702 delegation creation | 9 / 2 / 2 / 1 / 1 |
+| `bal-system-noop` | system-phase rows including BAI 0 | 9 / 2 / 3 / 1 / 0 |
+| `bal-system-dequeue-consolidations` | system-phase consolidation rows | 9 / 15 / 6 / 2 / 0 |
+| `bal-net-zero-storage-empty-pre` | net-zero storage, empty prestate | 9 / 2 / 2 / 1 / 0 |
+| `bal-net-zero-storage-nonzero-pre` | net-zero storage, nonzero prestate | 9 / 2 / 2 / 1 / 0 |
+| `bal-net-zero-nested-delegatecall` | net-zero nested delegatecall storage | 10 / 2 / 2 / 1 / 0 |
+
+Two additional class probes are recorded as findings rather than silently
+removed from the investigation. They have no skipped, undecodable, or overflow
+rows, but the guest producer disagrees with the pinned reference:
+
+| fixture prefix | class | expected rows (accounts/storage/balance/nonce/code) | guest rows |
+| --- | --- | --- | --- |
+| `01087_test_bal_create2_selfdestruct_then_recreate_same_block...` | EIP-6780 deletion/recreation | 11 / 4 / 6 / 5 / 1 | 11 / 5 / 6 / 3 / 0 |
+| `00612_test_bal_7702_cross_tx_delegation_then_call...` | EIP-7702 cross-transaction attribution | 12 / 4 / 5 / 4 / 1 | 12 / 4 / 5 / 4 / 1 |
+
+The second finding has mismatching balance payloads despite equal row counts;
+both findings also have unequal rebuilt/supplied serializer hashes. They are
+kept out of the green set so the set runner remains a pass/fail oracle, but are
+reported explicitly for follow-up rather than being hidden as unsupported
+fixtures. The findings had zero undecodable rows and zero overflow flags.
 
 Each expectation records the execution-specs pin and input SHA-256. Regenerate
 one only when deliberately changing its fixture:

--- a/docs/bal-producer-differential.md
+++ b/docs/bal-producer-differential.md
@@ -74,16 +74,25 @@ the factory's running nonce unadvanced (the nonce omission is tracked
 separately in [#11363](https://github.com/Verified-zkEVM/evm-asm/issues/11363)). In 00612, each of Tx2 and Tx3 charges
 its sender an extra `43,190 * 10` wei and credits the fee recipient an extra
 `43,190 * 3` wei. The pinned test shows that both are the same plain CALL into
-the delegated counter, while the sole authorization is in Tx1, so this is
-evidence for a repeated delegated-call gas discrepancy, not an AUTH_BASE charge
-on Tx2/Tx3. The reference post-balances imply gas-used values 129,032 for Tx2
-and 31,112 for Tx3; their 97,920 difference is the Amsterdam zero-to-nonzero
-storage-set state charge (`64 * 1530`). The guest records `35,190` state gas
-for each transaction (`AUTH_BASE = 23 * 1530`) and an additional `8,000`
-regular `ACCOUNT_WRITE`, exactly explaining the `43,190` excess on both later
-CALLs. Keep these as separate follow-ups until their execution paths are
-traced; issue [#11362](https://github.com/Verified-zkEVM/evm-asm/issues/11362)
-covers the 01087 collision case.
+the delegated counter, while the sole authorization is in Tx1. The reference
+post-balances imply gas-used values 129,032 for Tx2 and 31,112 for Tx3; their
+97,920 difference is the Amsterdam zero-to-nonzero storage-set state charge
+(`64 * 1530`). The reference Tx3 body is exactly `3,112` gas: cold `SLOAD`
+3,000, `ADD` 3, three `PUSH1`s 9, warm `SSTORE` 100, and regular
+`STORAGE_WRITE` 10,000. Adding the 12,000 transaction base, 3,000 cold
+recipient charge, and 3,000 cold delegated-code resolution gives 31,112;
+Tx2 adds only the 97,920 `STORAGE_SET` state charge.
+
+The guest-side excess is localized in the final gas cells: its
+`bvgr_tx_state_gas` lanes are `[35190, 35190, 35190]`, while
+`bvgr_tx_exec_state_gas` is `[0, 97920, 0]`. The fixed `43,190` therefore
+decomposes as an `AUTH_BASE` state charge of `23 * 1530 = 35,190` plus a
+regular `ACCOUNT_WRITE` charge of `8,000`; the latter is also present in the
+candidate's `runtime_tx_top_frame_regular_gas` cell. Both components are
+charged on the two later delegated calls despite Tx2/Tx3 having no
+authorization list. Keep this as a separate delegated-call gas follow-up;
+issue [#11362](https://github.com/Verified-zkEVM/evm-asm/issues/11362) covers
+the 01087 collision case.
 
 Each expectation records the execution-specs pin and input SHA-256. Regenerate
 one only when deliberately changing its fixture:

--- a/scripts/spike/bal-7702-delegated-storage.expectation.json
+++ b/scripts/spike/bal-7702-delegated-storage.expectation.json
@@ -1,0 +1,69 @@
+{
+  "schema": 1,
+  "fixture_label": "00613_test_bal_7702_delegated_storage_access_fork_Amsterdam-blockchain_test__b0",
+  "fixture_relpath": "blockchain_tests/for_amsterdam/amsterdam/eip7928_block_level_access_lists/block_access_lists_eip7702/bal_7702_delegated_storage_access.json",
+  "manifest_sha256": "b40b7e3f7d4b3bde03c7298c98d3b9117ea146f76c2a2a914f1cbafa78c3ad07",
+  "input_sha256": "bedd57f993dc0f612c40adfe7e405e306363b8d6b337aa418fc50a30e328199f",
+  "execution_specs_commit": "e5a8caf1b8055e4d805c7fb169edfa710914b7da",
+  "reference": "execution-specs Amsterdam BlockAccessList decoded from fixture payload",
+  "payload_bal_sha256": "a4a167dc6fc62e7ede3b00f1763160894231c6c794c2d91e721ae9a87bdd3def",
+  "rows": {
+    "accounts": [
+      "00000961ef480eb55e80d19ad83579a64c007002",
+      "000064d678505ad48f8ccb093bc65613800e8282",
+      "0000bbddc7ce488642fb579f8b00f3a590007251",
+      "0000bff46984e3725691fa540a8c7589300d8282",
+      "0000f90827f1c53a10cb7a02335b175320002935",
+      "000f3df6d732807ef1319fb7b8bb8522d0beac02",
+      "2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+      "56e2b6fb9cc939dc6c3eaab33d6ba2f0c3a02f73",
+      "baa47f5a87ec2501d9f0449f55dc8650991385d7",
+      "f6c3a9edc1afa0ad5b720e4d42e1437c43d3b3ff"
+    ],
+    "storage": [
+      {
+        "address": "0000f90827f1c53a10cb7a02335b175320002935",
+        "bai": 0,
+        "slot": 0,
+        "value": 102576144516095364636233502081131914642986631943216253214801181879084939025426
+      },
+      {
+        "address": "000f3df6d732807ef1319fb7b8bb8522d0beac02",
+        "bai": 0,
+        "slot": 12,
+        "value": 12
+      },
+      {
+        "address": "baa47f5a87ec2501d9f0449f55dc8650991385d7",
+        "bai": 1,
+        "slot": 2,
+        "value": 66
+      }
+    ],
+    "balance": [
+      {
+        "address": "2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+        "bai": 1,
+        "post": 413787
+      },
+      {
+        "address": "baa47f5a87ec2501d9f0449f55dc8650991385d7",
+        "bai": 1,
+        "post": 10
+      },
+      {
+        "address": "f6c3a9edc1afa0ad5b720e4d42e1437c43d3b3ff",
+        "bai": 1,
+        "post": 999999999999999999998620700
+      }
+    ],
+    "nonce": [
+      {
+        "address": "f6c3a9edc1afa0ad5b720e4d42e1437c43d3b3ff",
+        "bai": 1,
+        "nonce": 1
+      }
+    ],
+    "code": []
+  }
+}

--- a/scripts/spike/bal-7702-delegation-create.expectation.json
+++ b/scripts/spike/bal-7702-delegation-create.expectation.json
@@ -1,0 +1,63 @@
+{
+  "schema": 1,
+  "fixture_label": "00620_test_bal_7702_delegation_create_fork_Amsterdam-blockchain_test-self_funded__b0",
+  "fixture_relpath": "blockchain_tests/for_amsterdam/amsterdam/eip7928_block_level_access_lists/block_access_lists_eip7702/bal_7702_delegation_create.json",
+  "manifest_sha256": "b40b7e3f7d4b3bde03c7298c98d3b9117ea146f76c2a2a914f1cbafa78c3ad07",
+  "input_sha256": "e0ea7f202f43fea3146cbc386cc1219070e36772dcfb788602e27ea6559f844f",
+  "execution_specs_commit": "e5a8caf1b8055e4d805c7fb169edfa710914b7da",
+  "reference": "execution-specs Amsterdam BlockAccessList decoded from fixture payload",
+  "payload_bal_sha256": "e2fa6e9f8c2cce41d12ba7bb3256ccf52130919d70f493c963c86e9dd92c12a8",
+  "rows": {
+    "accounts": [
+      "00000961ef480eb55e80d19ad83579a64c007002",
+      "000064d678505ad48f8ccb093bc65613800e8282",
+      "0000bbddc7ce488642fb579f8b00f3a590007251",
+      "0000bff46984e3725691fa540a8c7589300d8282",
+      "0000f90827f1c53a10cb7a02335b175320002935",
+      "000f3df6d732807ef1319fb7b8bb8522d0beac02",
+      "2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+      "c0f6dc9e5836f54caadbf59cc69346c508e1992b",
+      "f6c3a9edc1afa0ad5b720e4d42e1437c43d3b3ff"
+    ],
+    "storage": [
+      {
+        "address": "0000f90827f1c53a10cb7a02335b175320002935",
+        "bai": 0,
+        "slot": 0,
+        "value": 97654168261609168111534742007851779117988270365976596797037426657087296399110
+      },
+      {
+        "address": "000f3df6d732807ef1319fb7b8bb8522d0beac02",
+        "bai": 0,
+        "slot": 12,
+        "value": 12
+      }
+    ],
+    "balance": [
+      {
+        "address": "c0f6dc9e5836f54caadbf59cc69346c508e1992b",
+        "bai": 1,
+        "post": 10
+      },
+      {
+        "address": "f6c3a9edc1afa0ad5b720e4d42e1437c43d3b3ff",
+        "bai": 1,
+        "post": 999999999999999999998266748
+      }
+    ],
+    "nonce": [
+      {
+        "address": "f6c3a9edc1afa0ad5b720e4d42e1437c43d3b3ff",
+        "bai": 1,
+        "nonce": 2
+      }
+    ],
+    "code": [
+      {
+        "address": "f6c3a9edc1afa0ad5b720e4d42e1437c43d3b3ff",
+        "bai": 1,
+        "code": "ef010037f536464af59c8d7358cae965f92cbeadd58dcb"
+      }
+    ]
+  }
+}

--- a/scripts/spike/bal-create-storage-selfdestruct.expectation.json
+++ b/scripts/spike/bal-create-storage-selfdestruct.expectation.json
@@ -1,0 +1,80 @@
+{
+  "schema": 1,
+  "fixture_label": "01114_test_bal_create_storage_op_then_selfdestruct_same_tx_fork_Amsterdam-create_opcode_CREATE-blockch",
+  "fixture_relpath": "blockchain_tests/for_amsterdam/amsterdam/eip7928_block_level_access_lists/block_access_lists_opcodes/bal_create_storage_op_then_selfdestruct_same_tx.json",
+  "manifest_sha256": "b40b7e3f7d4b3bde03c7298c98d3b9117ea146f76c2a2a914f1cbafa78c3ad07",
+  "input_sha256": "764dc316dbdd4a9d69fbb85fdfc54257d957446fe704d8b3477cf9f556f44fe9",
+  "execution_specs_commit": "e5a8caf1b8055e4d805c7fb169edfa710914b7da",
+  "reference": "execution-specs Amsterdam BlockAccessList decoded from fixture payload",
+  "payload_bal_sha256": "9b49e61bc2b02b4426d14fd5baed0fbc3ef4f675598d4274c868dccfda9f1bd3",
+  "rows": {
+    "accounts": [
+      "00000961ef480eb55e80d19ad83579a64c007002",
+      "000064d678505ad48f8ccb093bc65613800e8282",
+      "0000bbddc7ce488642fb579f8b00f3a590007251",
+      "0000bff46984e3725691fa540a8c7589300d8282",
+      "0000f90827f1c53a10cb7a02335b175320002935",
+      "000f3df6d732807ef1319fb7b8bb8522d0beac02",
+      "2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+      "c0f6dc9e5836f54caadbf59cc69346c508e1992b",
+      "f59cb9029e3e765e0dd79124f517545a2488953e",
+      "f6c3a9edc1afa0ad5b720e4d42e1437c43d3b3ff",
+      "fd184434582c1cae53df720d5da5e5374c6c64b9"
+    ],
+    "storage": [
+      {
+        "address": "0000f90827f1c53a10cb7a02335b175320002935",
+        "bai": 0,
+        "slot": 0,
+        "value": 46775774342948643318105020553784478352015222157787104218522098074716974988973
+      },
+      {
+        "address": "000f3df6d732807ef1319fb7b8bb8522d0beac02",
+        "bai": 0,
+        "slot": 12,
+        "value": 12
+      },
+      {
+        "address": "fd184434582c1cae53df720d5da5e5374c6c64b9",
+        "bai": 1,
+        "slot": 0,
+        "value": 1402197771766615916650016658532701838449522021694
+      }
+    ],
+    "balance": [
+      {
+        "address": "2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+        "bai": 1,
+        "post": 1019922
+      },
+      {
+        "address": "c0f6dc9e5836f54caadbf59cc69346c508e1992b",
+        "bai": 1,
+        "post": 100
+      },
+      {
+        "address": "f59cb9029e3e765e0dd79124f517545a2488953e",
+        "bai": 1,
+        "post": 0
+      },
+      {
+        "address": "f6c3a9edc1afa0ad5b720e4d42e1437c43d3b3ff",
+        "bai": 1,
+        "post": 999999999999999999996600260
+      }
+    ],
+    "nonce": [
+      {
+        "address": "f6c3a9edc1afa0ad5b720e4d42e1437c43d3b3ff",
+        "bai": 1,
+        "nonce": 1
+      },
+      {
+        "address": "fd184434582c1cae53df720d5da5e5374c6c64b9",
+        "bai": 1,
+        "nonce": 2
+      }
+    ],
+    "code": []
+  }
+}

--- a/scripts/spike/bal-cross-tx-balance-dependency.expectation.json
+++ b/scripts/spike/bal-cross-tx-balance-dependency.expectation.json
@@ -1,0 +1,90 @@
+{
+  "schema": 1,
+  "fixture_label": "00327_test_bal_cross_tx_balance_dependency_fork_Amsterdam-blockchain_test-funding_method_selfdestruct_",
+  "fixture_relpath": "blockchain_tests/for_amsterdam/amsterdam/eip7928_block_level_access_lists/block_access_lists/bal_cross_tx_balance_dependency.json",
+  "manifest_sha256": "b40b7e3f7d4b3bde03c7298c98d3b9117ea146f76c2a2a914f1cbafa78c3ad07",
+  "input_sha256": "fd8864504cfce4053946828dee3ce877fdc5a83ad1c847875c3830abaaddc190",
+  "execution_specs_commit": "e5a8caf1b8055e4d805c7fb169edfa710914b7da",
+  "reference": "execution-specs Amsterdam BlockAccessList decoded from fixture payload",
+  "payload_bal_sha256": "13ea88b72004996fbcf65fdc13ecd116d8238736aafe02510c593c6266700e64",
+  "rows": {
+    "accounts": [
+      "00000961ef480eb55e80d19ad83579a64c007002",
+      "000064d678505ad48f8ccb093bc65613800e8282",
+      "0000bbddc7ce488642fb579f8b00f3a590007251",
+      "0000bff46984e3725691fa540a8c7589300d8282",
+      "0000f90827f1c53a10cb7a02335b175320002935",
+      "000f3df6d732807ef1319fb7b8bb8522d0beac02",
+      "2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+      "a07a12b85d16542ca926629224946e717f632cbc",
+      "a7378c36a64dcfaff2e9def4eaf5b52d36a0b525",
+      "ccbcccb8575994e288e5bd021cc371dd8a8ff1eb",
+      "f6c3a9edc1afa0ad5b720e4d42e1437c43d3b3ff"
+    ],
+    "storage": [
+      {
+        "address": "0000f90827f1c53a10cb7a02335b175320002935",
+        "bai": 0,
+        "slot": 0,
+        "value": 61006514862669420177140136379880812693531883456454208455605057178604230297755
+      },
+      {
+        "address": "000f3df6d732807ef1319fb7b8bb8522d0beac02",
+        "bai": 0,
+        "slot": 12,
+        "value": 12
+      },
+      {
+        "address": "a7378c36a64dcfaff2e9def4eaf5b52d36a0b525",
+        "bai": 2,
+        "slot": 0,
+        "value": 1
+      }
+    ],
+    "balance": [
+      {
+        "address": "2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+        "bai": 1,
+        "post": 69009
+      },
+      {
+        "address": "2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+        "bai": 2,
+        "post": 446961
+      },
+      {
+        "address": "a07a12b85d16542ca926629224946e717f632cbc",
+        "bai": 1,
+        "post": 0
+      },
+      {
+        "address": "a7378c36a64dcfaff2e9def4eaf5b52d36a0b525",
+        "bai": 1,
+        "post": 1
+      },
+      {
+        "address": "ccbcccb8575994e288e5bd021cc371dd8a8ff1eb",
+        "bai": 2,
+        "post": 999999999999999999998740160
+      },
+      {
+        "address": "f6c3a9edc1afa0ad5b720e4d42e1437c43d3b3ff",
+        "bai": 1,
+        "post": 999999999999999999999769970
+      }
+    ],
+    "nonce": [
+      {
+        "address": "ccbcccb8575994e288e5bd021cc371dd8a8ff1eb",
+        "bai": 2,
+        "nonce": 1
+      },
+      {
+        "address": "f6c3a9edc1afa0ad5b720e4d42e1437c43d3b3ff",
+        "bai": 1,
+        "nonce": 1
+      }
+    ],
+    "code": []
+  }
+}

--- a/scripts/spike/bal-net-zero-nested-delegatecall.expectation.json
+++ b/scripts/spike/bal-net-zero-nested-delegatecall.expectation.json
@@ -1,0 +1,58 @@
+{
+  "schema": 1,
+  "fixture_label": "00364_test_bal_nested_delegatecall_storage_writes_net_zero_fork_Amsterdam-blockchain_test-depth_1__b0",
+  "fixture_relpath": "blockchain_tests/for_amsterdam/amsterdam/eip7928_block_level_access_lists/block_access_lists/bal_nested_delegatecall_storage_writes_net_zero.json",
+  "manifest_sha256": "b40b7e3f7d4b3bde03c7298c98d3b9117ea146f76c2a2a914f1cbafa78c3ad07",
+  "input_sha256": "0b29f3f6c7a8d32a3875fafffe58514fd31126bfc133ae4e81e743b30156765d",
+  "execution_specs_commit": "e5a8caf1b8055e4d805c7fb169edfa710914b7da",
+  "reference": "execution-specs Amsterdam BlockAccessList decoded from fixture payload",
+  "payload_bal_sha256": "562b9044e5b5afffa0f1967cdff44934b87ebb9336f51f81f4a63823ea15e115",
+  "rows": {
+    "accounts": [
+      "00000961ef480eb55e80d19ad83579a64c007002",
+      "000064d678505ad48f8ccb093bc65613800e8282",
+      "0000bbddc7ce488642fb579f8b00f3a590007251",
+      "0000bff46984e3725691fa540a8c7589300d8282",
+      "0000f90827f1c53a10cb7a02335b175320002935",
+      "000f3df6d732807ef1319fb7b8bb8522d0beac02",
+      "2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+      "2fc3743aa341c3a3d3362212c7d9ebfca0033c05",
+      "43e6f595ac8e8c6e584c7a2d9949a6bfae8c4287",
+      "f6c3a9edc1afa0ad5b720e4d42e1437c43d3b3ff"
+    ],
+    "storage": [
+      {
+        "address": "0000f90827f1c53a10cb7a02335b175320002935",
+        "bai": 0,
+        "slot": 0,
+        "value": 66958717232619209890080196528700423066513087568521907773519145639663042981441
+      },
+      {
+        "address": "000f3df6d732807ef1319fb7b8bb8522d0beac02",
+        "bai": 0,
+        "slot": 12,
+        "value": 12
+      }
+    ],
+    "balance": [
+      {
+        "address": "2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+        "bai": 1,
+        "post": 74712
+      },
+      {
+        "address": "f6c3a9edc1afa0ad5b720e4d42e1437c43d3b3ff",
+        "bai": 1,
+        "post": 999999999999999999999750960
+      }
+    ],
+    "nonce": [
+      {
+        "address": "f6c3a9edc1afa0ad5b720e4d42e1437c43d3b3ff",
+        "bai": 1,
+        "nonce": 1
+      }
+    ],
+    "code": []
+  }
+}

--- a/scripts/spike/bal-net-zero-storage-empty-pre.expectation.json
+++ b/scripts/spike/bal-net-zero-storage-empty-pre.expectation.json
@@ -1,0 +1,57 @@
+{
+  "schema": 1,
+  "fixture_label": "00356_test_bal_intra_tx_sstores_same_slot_net_zero_fork_Amsterdam-blockchain_test-empty_pre_ephemeral_",
+  "fixture_relpath": "blockchain_tests/for_amsterdam/amsterdam/eip7928_block_level_access_lists/block_access_lists/bal_intra_tx_sstores_same_slot_net_zero.json",
+  "manifest_sha256": "b40b7e3f7d4b3bde03c7298c98d3b9117ea146f76c2a2a914f1cbafa78c3ad07",
+  "input_sha256": "432c4979b06ba91bf764ae3a456988d9e7d8aa68c6b76e0fcba7b4a798f21be8",
+  "execution_specs_commit": "e5a8caf1b8055e4d805c7fb169edfa710914b7da",
+  "reference": "execution-specs Amsterdam BlockAccessList decoded from fixture payload",
+  "payload_bal_sha256": "af0499045808369f87901f8455a3fe4a23d3fa8bbcaeea37883dd2ebf29b6119",
+  "rows": {
+    "accounts": [
+      "00000961ef480eb55e80d19ad83579a64c007002",
+      "000064d678505ad48f8ccb093bc65613800e8282",
+      "0000bbddc7ce488642fb579f8b00f3a590007251",
+      "0000bff46984e3725691fa540a8c7589300d8282",
+      "0000f90827f1c53a10cb7a02335b175320002935",
+      "000f3df6d732807ef1319fb7b8bb8522d0beac02",
+      "2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+      "c272983b65e54b6b8648cb92d30647423c1deaf1",
+      "f6c3a9edc1afa0ad5b720e4d42e1437c43d3b3ff"
+    ],
+    "storage": [
+      {
+        "address": "0000f90827f1c53a10cb7a02335b175320002935",
+        "bai": 0,
+        "slot": 0,
+        "value": 110086398171348622355378589161335772936870700444259429770711317926518848303026
+      },
+      {
+        "address": "000f3df6d732807ef1319fb7b8bb8522d0beac02",
+        "bai": 0,
+        "slot": 12,
+        "value": 12
+      }
+    ],
+    "balance": [
+      {
+        "address": "2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+        "bai": 1,
+        "post": 67725
+      },
+      {
+        "address": "f6c3a9edc1afa0ad5b720e4d42e1437c43d3b3ff",
+        "bai": 1,
+        "post": 999999999999999999999774250
+      }
+    ],
+    "nonce": [
+      {
+        "address": "f6c3a9edc1afa0ad5b720e4d42e1437c43d3b3ff",
+        "bai": 1,
+        "nonce": 1
+      }
+    ],
+    "code": []
+  }
+}

--- a/scripts/spike/bal-net-zero-storage-nonzero-pre.expectation.json
+++ b/scripts/spike/bal-net-zero-storage-nonzero-pre.expectation.json
@@ -1,0 +1,57 @@
+{
+  "schema": 1,
+  "fixture_label": "00357_test_bal_intra_tx_sstores_same_slot_net_zero_fork_Amsterdam-blockchain_test-nonzero_pre_returns_",
+  "fixture_relpath": "blockchain_tests/for_amsterdam/amsterdam/eip7928_block_level_access_lists/block_access_lists/bal_intra_tx_sstores_same_slot_net_zero.json",
+  "manifest_sha256": "b40b7e3f7d4b3bde03c7298c98d3b9117ea146f76c2a2a914f1cbafa78c3ad07",
+  "input_sha256": "35df8a9715eba2956d103675881400b73a41112ac70ed698802774050c30fc69",
+  "execution_specs_commit": "e5a8caf1b8055e4d805c7fb169edfa710914b7da",
+  "reference": "execution-specs Amsterdam BlockAccessList decoded from fixture payload",
+  "payload_bal_sha256": "540bbabcf1c2c114aaf5594ff87d8bee300ab43da3dfa7ce0a9e97a12cc8133c",
+  "rows": {
+    "accounts": [
+      "00000961ef480eb55e80d19ad83579a64c007002",
+      "000064d678505ad48f8ccb093bc65613800e8282",
+      "0000bbddc7ce488642fb579f8b00f3a590007251",
+      "0000bff46984e3725691fa540a8c7589300d8282",
+      "0000f90827f1c53a10cb7a02335b175320002935",
+      "000f3df6d732807ef1319fb7b8bb8522d0beac02",
+      "2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+      "6b803753909d67ec3c6f1ad76bbfeb828842334f",
+      "f6c3a9edc1afa0ad5b720e4d42e1437c43d3b3ff"
+    ],
+    "storage": [
+      {
+        "address": "0000f90827f1c53a10cb7a02335b175320002935",
+        "bai": 0,
+        "slot": 0,
+        "value": 79646665363809413284103192317042525165460914949877799941522599415161642050340
+      },
+      {
+        "address": "000f3df6d732807ef1319fb7b8bb8522d0beac02",
+        "bai": 0,
+        "slot": 12,
+        "value": 12
+      }
+    ],
+    "balance": [
+      {
+        "address": "2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+        "bai": 1,
+        "post": 67725
+      },
+      {
+        "address": "f6c3a9edc1afa0ad5b720e4d42e1437c43d3b3ff",
+        "bai": 1,
+        "post": 999999999999999999999774250
+      }
+    ],
+    "nonce": [
+      {
+        "address": "f6c3a9edc1afa0ad5b720e4d42e1437c43d3b3ff",
+        "bai": 1,
+        "nonce": 1
+      }
+    ],
+    "code": []
+  }
+}

--- a/scripts/spike/bal-selfdestruct-to-coinbase.expectation.json
+++ b/scripts/spike/bal-selfdestruct-to-coinbase.expectation.json
@@ -1,0 +1,62 @@
+{
+  "schema": 1,
+  "fixture_label": "00505_test_bal_selfdestruct_to_coinbase_fork_Amsterdam-blockchain_test_from_state_test-pre_deploy__b0",
+  "fixture_relpath": "blockchain_tests/for_amsterdam/amsterdam/eip7928_block_level_access_lists/block_access_lists/bal_selfdestruct_to_coinbase.json",
+  "manifest_sha256": "b40b7e3f7d4b3bde03c7298c98d3b9117ea146f76c2a2a914f1cbafa78c3ad07",
+  "input_sha256": "dea5cf2de52a916665bf0c235df7908cf56c7bed21947265c6c7ab963464f503",
+  "execution_specs_commit": "e5a8caf1b8055e4d805c7fb169edfa710914b7da",
+  "reference": "execution-specs Amsterdam BlockAccessList decoded from fixture payload",
+  "payload_bal_sha256": "96ef28b5ba6bf218b19cc171baa662e4689d98dbc193dd0f53e6e29242cbb792",
+  "rows": {
+    "accounts": [
+      "00000961ef480eb55e80d19ad83579a64c007002",
+      "000064d678505ad48f8ccb093bc65613800e8282",
+      "0000bbddc7ce488642fb579f8b00f3a590007251",
+      "0000bff46984e3725691fa540a8c7589300d8282",
+      "0000f90827f1c53a10cb7a02335b175320002935",
+      "000f3df6d732807ef1319fb7b8bb8522d0beac02",
+      "b209edff1d046b3609baff761a6b4fa8ef7291c3",
+      "c0f6dc9e5836f54caadbf59cc69346c508e1992b",
+      "f6c3a9edc1afa0ad5b720e4d42e1437c43d3b3ff"
+    ],
+    "storage": [
+      {
+        "address": "0000f90827f1c53a10cb7a02335b175320002935",
+        "bai": 0,
+        "slot": 0,
+        "value": 32007146509643166719697810360903436155752526111482915413216367171119705440576
+      },
+      {
+        "address": "000f3df6d732807ef1319fb7b8bb8522d0beac02",
+        "bai": 0,
+        "slot": 1000,
+        "value": 1000
+      }
+    ],
+    "balance": [
+      {
+        "address": "b209edff1d046b3609baff761a6b4fa8ef7291c3",
+        "bai": 1,
+        "post": 0
+      },
+      {
+        "address": "c0f6dc9e5836f54caadbf59cc69346c508e1992b",
+        "bai": 1,
+        "post": 100
+      },
+      {
+        "address": "f6c3a9edc1afa0ad5b720e4d42e1437c43d3b3ff",
+        "bai": 1,
+        "post": 999999999999999999998518786
+      }
+    ],
+    "nonce": [
+      {
+        "address": "f6c3a9edc1afa0ad5b720e4d42e1437c43d3b3ff",
+        "bai": 1,
+        "nonce": 1
+      }
+    ],
+    "code": []
+  }
+}

--- a/scripts/spike/bal-system-dequeue-consolidations.expectation.json
+++ b/scripts/spike/bal-system-dequeue-consolidations.expectation.json
@@ -1,0 +1,160 @@
+{
+  "schema": 1,
+  "fixture_label": "00609_test_bal_system_dequeue_consolidations_eip7251_fork_Amsterdam-blockchain_test-single_block_max_c",
+  "fixture_relpath": "blockchain_tests/for_amsterdam/amsterdam/eip7928_block_level_access_lists/block_access_lists_eip7251/bal_system_dequeue_consolidations_eip7251.json",
+  "manifest_sha256": "b40b7e3f7d4b3bde03c7298c98d3b9117ea146f76c2a2a914f1cbafa78c3ad07",
+  "input_sha256": "87008f07b498a020b6126cad2c42ba6638b416982d64378331ce76822c66ce1e",
+  "execution_specs_commit": "e5a8caf1b8055e4d805c7fb169edfa710914b7da",
+  "reference": "execution-specs Amsterdam BlockAccessList decoded from fixture payload",
+  "payload_bal_sha256": "7ac8ab4fbe2b5a99b9b796d3bf4e2745788e845f3255753bc8fc7061a9a2c5b1",
+  "rows": {
+    "accounts": [
+      "00000961ef480eb55e80d19ad83579a64c007002",
+      "000064d678505ad48f8ccb093bc65613800e8282",
+      "0000bbddc7ce488642fb579f8b00f3a590007251",
+      "0000bff46984e3725691fa540a8c7589300d8282",
+      "0000f90827f1c53a10cb7a02335b175320002935",
+      "000f3df6d732807ef1319fb7b8bb8522d0beac02",
+      "2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+      "ccbcccb8575994e288e5bd021cc371dd8a8ff1eb",
+      "f6c3a9edc1afa0ad5b720e4d42e1437c43d3b3ff"
+    ],
+    "storage": [
+      {
+        "address": "0000bbddc7ce488642fb579f8b00f3a590007251",
+        "bai": 3,
+        "slot": 0,
+        "value": 1
+      },
+      {
+        "address": "0000bbddc7ce488642fb579f8b00f3a590007251",
+        "bai": 1,
+        "slot": 1,
+        "value": 1
+      },
+      {
+        "address": "0000bbddc7ce488642fb579f8b00f3a590007251",
+        "bai": 2,
+        "slot": 1,
+        "value": 2
+      },
+      {
+        "address": "0000bbddc7ce488642fb579f8b00f3a590007251",
+        "bai": 3,
+        "slot": 1,
+        "value": 0
+      },
+      {
+        "address": "0000bbddc7ce488642fb579f8b00f3a590007251",
+        "bai": 1,
+        "slot": 3,
+        "value": 1
+      },
+      {
+        "address": "0000bbddc7ce488642fb579f8b00f3a590007251",
+        "bai": 2,
+        "slot": 3,
+        "value": 2
+      },
+      {
+        "address": "0000bbddc7ce488642fb579f8b00f3a590007251",
+        "bai": 3,
+        "slot": 3,
+        "value": 0
+      },
+      {
+        "address": "0000bbddc7ce488642fb579f8b00f3a590007251",
+        "bai": 1,
+        "slot": 4,
+        "value": 1408775177817074336275094057776221098886080738303
+      },
+      {
+        "address": "0000bbddc7ce488642fb579f8b00f3a590007251",
+        "bai": 1,
+        "slot": 6,
+        "value": 340282366920938463463374607431768211456
+      },
+      {
+        "address": "0000bbddc7ce488642fb579f8b00f3a590007251",
+        "bai": 1,
+        "slot": 7,
+        "value": 2
+      },
+      {
+        "address": "0000bbddc7ce488642fb579f8b00f3a590007251",
+        "bai": 2,
+        "slot": 8,
+        "value": 1168844490979780582435414301829631731499474612715
+      },
+      {
+        "address": "0000bbddc7ce488642fb579f8b00f3a590007251",
+        "bai": 2,
+        "slot": 10,
+        "value": 1020847100762815390390123822295304634368
+      },
+      {
+        "address": "0000bbddc7ce488642fb579f8b00f3a590007251",
+        "bai": 2,
+        "slot": 11,
+        "value": 4
+      },
+      {
+        "address": "0000f90827f1c53a10cb7a02335b175320002935",
+        "bai": 0,
+        "slot": 0,
+        "value": 59846339687509731854281458693625976766161844079693254422053723680342406413004
+      },
+      {
+        "address": "000f3df6d732807ef1319fb7b8bb8522d0beac02",
+        "bai": 0,
+        "slot": 12,
+        "value": 12
+      }
+    ],
+    "balance": [
+      {
+        "address": "0000bbddc7ce488642fb579f8b00f3a590007251",
+        "bai": 1,
+        "post": 1
+      },
+      {
+        "address": "0000bbddc7ce488642fb579f8b00f3a590007251",
+        "bai": 2,
+        "post": 2
+      },
+      {
+        "address": "2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+        "bai": 1,
+        "post": 1751682
+      },
+      {
+        "address": "2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+        "bai": 2,
+        "post": 2915844
+      },
+      {
+        "address": "ccbcccb8575994e288e5bd021cc371dd8a8ff1eb",
+        "bai": 2,
+        "post": 999999999999999999996119459
+      },
+      {
+        "address": "f6c3a9edc1afa0ad5b720e4d42e1437c43d3b3ff",
+        "bai": 1,
+        "post": 999999999999999999994161059
+      }
+    ],
+    "nonce": [
+      {
+        "address": "ccbcccb8575994e288e5bd021cc371dd8a8ff1eb",
+        "bai": 2,
+        "nonce": 1
+      },
+      {
+        "address": "f6c3a9edc1afa0ad5b720e4d42e1437c43d3b3ff",
+        "bai": 1,
+        "nonce": 1
+      }
+    ],
+    "code": []
+  }
+}

--- a/scripts/spike/bal-system-noop.expectation.json
+++ b/scripts/spike/bal-system-noop.expectation.json
@@ -1,0 +1,62 @@
+{
+  "schema": 1,
+  "fixture_label": "00511_test_bal_system_contract_noop_filtering_fork_Amsterdam-blockchain_test__b0",
+  "fixture_relpath": "blockchain_tests/for_amsterdam/amsterdam/eip7928_block_level_access_lists/block_access_lists_cross_index/bal_system_contract_noop_filtering.json",
+  "manifest_sha256": "b40b7e3f7d4b3bde03c7298c98d3b9117ea146f76c2a2a914f1cbafa78c3ad07",
+  "input_sha256": "0ccc4204f80d42110c37b77cf3240e5f6b5a0838e459f295de0a6ec8a20ec5ed",
+  "execution_specs_commit": "e5a8caf1b8055e4d805c7fb169edfa710914b7da",
+  "reference": "execution-specs Amsterdam BlockAccessList decoded from fixture payload",
+  "payload_bal_sha256": "2aa5c0611be032fa7b9f5f512145d1eb1d58a49b316f3faedb8ce9a0640774eb",
+  "rows": {
+    "accounts": [
+      "00000961ef480eb55e80d19ad83579a64c007002",
+      "000064d678505ad48f8ccb093bc65613800e8282",
+      "0000bbddc7ce488642fb579f8b00f3a590007251",
+      "0000bff46984e3725691fa540a8c7589300d8282",
+      "0000f90827f1c53a10cb7a02335b175320002935",
+      "000f3df6d732807ef1319fb7b8bb8522d0beac02",
+      "2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+      "c0f6dc9e5836f54caadbf59cc69346c508e1992b",
+      "f6c3a9edc1afa0ad5b720e4d42e1437c43d3b3ff"
+    ],
+    "storage": [
+      {
+        "address": "0000f90827f1c53a10cb7a02335b175320002935",
+        "bai": 0,
+        "slot": 0,
+        "value": 52299183798028654046165148584144631363093432215379852176862615166358228418957
+      },
+      {
+        "address": "000f3df6d732807ef1319fb7b8bb8522d0beac02",
+        "bai": 0,
+        "slot": 12,
+        "value": 12
+      }
+    ],
+    "balance": [
+      {
+        "address": "2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+        "bai": 1,
+        "post": 613800
+      },
+      {
+        "address": "c0f6dc9e5836f54caadbf59cc69346c508e1992b",
+        "bai": 1,
+        "post": 100
+      },
+      {
+        "address": "f6c3a9edc1afa0ad5b720e4d42e1437c43d3b3ff",
+        "bai": 1,
+        "post": 999999999999999999997953900
+      }
+    ],
+    "nonce": [
+      {
+        "address": "f6c3a9edc1afa0ad5b720e4d42e1437c43d3b3ff",
+        "bai": 1,
+        "nonce": 1
+      }
+    ],
+    "code": []
+  }
+}

--- a/scripts/spike/bal_producer_set.sh
+++ b/scripts/spike/bal_producer_set.sh
@@ -46,3 +46,33 @@ run_case \
 run_case \
   00317_test_bal_all_transaction_types_fork_Amsterdam-blockchain_test__b0 \
   bal-all-transaction-types.expectation.json
+run_case \
+  00327_test_bal_cross_tx_balance_dependency_fork_Amsterdam-blockchain_test-funding_method_selfdestruct_ \
+  bal-cross-tx-balance-dependency.expectation.json
+run_case \
+  00505_test_bal_selfdestruct_to_coinbase_fork_Amsterdam-blockchain_test_from_state_test-pre_deploy__b0 \
+  bal-selfdestruct-to-coinbase.expectation.json
+run_case \
+  01114_test_bal_create_storage_op_then_selfdestruct_same_tx_fork_Amsterdam-create_opcode_CREATE-blockch \
+  bal-create-storage-selfdestruct.expectation.json
+run_case \
+  00613_test_bal_7702_delegated_storage_access_fork_Amsterdam-blockchain_test__b0 \
+  bal-7702-delegated-storage.expectation.json
+run_case \
+  00620_test_bal_7702_delegation_create_fork_Amsterdam-blockchain_test-self_funded__b0 \
+  bal-7702-delegation-create.expectation.json
+run_case \
+  00511_test_bal_system_contract_noop_filtering_fork_Amsterdam-blockchain_test__b0 \
+  bal-system-noop.expectation.json
+run_case \
+  00609_test_bal_system_dequeue_consolidations_eip7251_fork_Amsterdam-blockchain_test-single_block_max_c \
+  bal-system-dequeue-consolidations.expectation.json
+run_case \
+  00356_test_bal_intra_tx_sstores_same_slot_net_zero_fork_Amsterdam-blockchain_test-empty_pre_ephemeral_ \
+  bal-net-zero-storage-empty-pre.expectation.json
+run_case \
+  00357_test_bal_intra_tx_sstores_same_slot_net_zero_fork_Amsterdam-blockchain_test-nonzero_pre_returns_ \
+  bal-net-zero-storage-nonzero-pre.expectation.json
+run_case \
+  00364_test_bal_nested_delegatecall_storage_writes_net_zero_fork_Amsterdam-blockchain_test-depth_1__b0 \
+  bal-net-zero-nested-delegatecall.expectation.json


### PR DESCRIPTION
Attribution: codex2

## Summary

Widen the pre-registered BAL producer differential from four fixtures to 14,
covering multi-transaction BAI attribution, SELFDESTRUCT/EIP-6780, EIP-7702
delegation, system-phase BAI-0 rows, and net-zero storage writes.

The reference side remains pinned execution-specs Amsterdam `BlockAccessList`
decoded from each fixture payload. The probe still requires exact
element-by-element row equality, fails on skipped or undecodable rows, rejects
overflow, and retains serializer hash equality as a secondary check.

## Evidence

Using the candidate ELF built from guest commit `598c7fc4c`
(`6a7242fc3049b5fec53bb3612fcf244f47e6693933d8712cf31efd7659a11c7e`):

- 14/14 registered fixtures passed.
- 270/270 rows decoded and matched element-wise.
- skipped=0, undecodable=0, overflow=0 for every fixture.
- rebuilt/supplied serializer hashes matched for every fixture.
- a same-count expectation mutation was rejected by the pinned-reference lock.

The widened set found two explicit investigation findings, documented rather
than silently dropped: fixture `01087` (CREATE2 + SELFDESTRUCT + recreation)
has expected counts 11/4/6/5/1 versus guest 11/5/6/3/0, and fixture `00612`
(EIP-7702 cross-transaction delegation) has balance payload mismatches despite
equal counts. Both had zero undecodable rows and zero overflow flags.

## Validation command

```bash
SPIKE=/tmp/codex2-11355/scripts/spike/spike_run \
EXECUTION_SPECS=/home/yoichi-bkp/evm-asm-codex2/execution-specs \
scripts/spike/bal_producer_set.sh \
  /tmp/codex2-11104-rerun/gen-out/regionmap/stateless_guest.elf \
  /var/tmp/fc668/manifest.tsv \
  /tmp/bal-producer-diff-widen
```

No guest or layout artifacts are changed by this PR.
