### PR TITLE
test(spike): cover BAL withdrawal and top-level CREATE stages

### DIFF
--- a/scripts/spike/bal-create-transaction-empty.expectation.json
+++ b/scripts/spike/bal-create-transaction-empty.expectation.json
@@ -1,0 +1,62 @@
+{
+  "schema": 1,
+  "fixture_label": "00323_test_bal_create_transaction_empty_code_fork_Amsterdam-blockchain_test__b0",
+  "fixture_relpath": "blockchain_tests/for_amsterdam/amsterdam/eip7928_block_level_access_lists/block_access_lists/bal_create_transaction_empty_code.json",
+  "manifest_sha256": "b40b7e3f7d4b3bde03c7298c98d3b9117ea146f76c2a2a914f1cbafa78c3ad07",
+  "input_sha256": "a55a09b2aa6b2d2aaf26d23b361b0ef37a2e836859af3f041e21f6685115b797",
+  "execution_specs_commit": "e5a8caf1b8055e4d805c7fb169edfa710914b7da",
+  "reference": "execution-specs Amsterdam BlockAccessList decoded from fixture payload",
+  "payload_bal_sha256": "7b2a67df751a508380f959e67f0a424adbe9e7d977997ff7b73e6057845b2137",
+  "rows": {
+    "accounts": [
+      "00000961ef480eb55e80d19ad83579a64c007002",
+      "000064d678505ad48f8ccb093bc65613800e8282",
+      "0000bbddc7ce488642fb579f8b00f3a590007251",
+      "0000bff46984e3725691fa540a8c7589300d8282",
+      "0000f90827f1c53a10cb7a02335b175320002935",
+      "000f3df6d732807ef1319fb7b8bb8522d0beac02",
+      "081f85bbb63f960f83724898686620b3e01a5542",
+      "2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+      "f6c3a9edc1afa0ad5b720e4d42e1437c43d3b3ff"
+    ],
+    "storage": [
+      {
+        "address": "0000f90827f1c53a10cb7a02335b175320002935",
+        "bai": 0,
+        "slot": 0,
+        "value": 52299183798028654046165148584144631363093432215379852176862615166358228418957
+      },
+      {
+        "address": "000f3df6d732807ef1319fb7b8bb8522d0beac02",
+        "bai": 0,
+        "slot": 12,
+        "value": 12
+      }
+    ],
+    "balance": [
+      {
+        "address": "2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+        "bai": 1,
+        "post": 619800
+      },
+      {
+        "address": "f6c3a9edc1afa0ad5b720e4d42e1437c43d3b3ff",
+        "bai": 1,
+        "post": 999999999999999999997934000
+      }
+    ],
+    "nonce": [
+      {
+        "address": "081f85bbb63f960f83724898686620b3e01a5542",
+        "bai": 1,
+        "nonce": 1
+      },
+      {
+        "address": "f6c3a9edc1afa0ad5b720e4d42e1437c43d3b3ff",
+        "bai": 1,
+        "nonce": 1
+      }
+    ],
+    "code": []
+  }
+}

--- a/scripts/spike/bal-create-transaction-success.expectation.json
+++ b/scripts/spike/bal-create-transaction-success.expectation.json
@@ -1,0 +1,68 @@
+{
+  "schema": 1,
+  "fixture_label": "21086_test_create_transaction_success_fork_Amsterdam-blockchain_test_from_state_test__b0",
+  "fixture_relpath": "blockchain_tests/for_amsterdam/ported_static/stTransactionTest/create_transaction_success/create_transaction_success.json",
+  "manifest_sha256": "b40b7e3f7d4b3bde03c7298c98d3b9117ea146f76c2a2a914f1cbafa78c3ad07",
+  "input_sha256": "2b9cfab376cfd31fbe236e9669127a4d4d8122588e3baadfa87076fd9ebbea44",
+  "execution_specs_commit": "e5a8caf1b8055e4d805c7fb169edfa710914b7da",
+  "reference": "execution-specs Amsterdam BlockAccessList decoded from fixture payload",
+  "payload_bal_sha256": "4e9f5169d53a85455057c32e357b8d22d01c9cb3392550aadc63944bdd8bbee0",
+  "rows": {
+    "accounts": [
+      "00000961ef480eb55e80d19ad83579a64c007002",
+      "000064d678505ad48f8ccb093bc65613800e8282",
+      "0000bbddc7ce488642fb579f8b00f3a590007251",
+      "0000bff46984e3725691fa540a8c7589300d8282",
+      "0000f90827f1c53a10cb7a02335b175320002935",
+      "000f3df6d732807ef1319fb7b8bb8522d0beac02",
+      "2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+      "9176f3d3132430f691489cfe2b701faee0892033",
+      "962aea7d0a0e077e3075514cae986ba883e67d22"
+    ],
+    "storage": [
+      {
+        "address": "0000f90827f1c53a10cb7a02335b175320002935",
+        "bai": 0,
+        "slot": 0,
+        "value": 90188496584938539333311624081300203808692964367472194165252983964460131354411
+      },
+      {
+        "address": "000f3df6d732807ef1319fb7b8bb8522d0beac02",
+        "bai": 0,
+        "slot": 1000,
+        "value": 1000
+      }
+    ],
+    "balance": [
+      {
+        "address": "9176f3d3132430f691489cfe2b701faee0892033",
+        "bai": 1,
+        "post": 100
+      },
+      {
+        "address": "962aea7d0a0e077e3075514cae986ba883e67d22",
+        "bai": 1,
+        "post": 97389160
+      }
+    ],
+    "nonce": [
+      {
+        "address": "9176f3d3132430f691489cfe2b701faee0892033",
+        "bai": 1,
+        "nonce": 1
+      },
+      {
+        "address": "962aea7d0a0e077e3075514cae986ba883e67d22",
+        "bai": 1,
+        "nonce": 1
+      }
+    ],
+    "code": [
+      {
+        "address": "9176f3d3132430f691489cfe2b701faee0892033",
+        "bai": 1,
+        "code": "60e060020a600035048063f8a8fd6d14601457005b601a6020565b60006000f35b56"
+      }
+    ]
+  }
+}

--- a/scripts/spike/bal-withdrawal-and-transaction.expectation.json
+++ b/scripts/spike/bal-withdrawal-and-transaction.expectation.json
@@ -1,0 +1,68 @@
+{
+  "schema": 1,
+  "fixture_label": "00564_test_bal_withdrawal_and_transaction_fork_Amsterdam-blockchain_test__b0",
+  "fixture_relpath": "blockchain_tests/for_amsterdam/amsterdam/eip7928_block_level_access_lists/block_access_lists_eip4895/bal_withdrawal_and_transaction.json",
+  "manifest_sha256": "b40b7e3f7d4b3bde03c7298c98d3b9117ea146f76c2a2a914f1cbafa78c3ad07",
+  "input_sha256": "e6dbda44adffd11f2443e185e148c24f2317cdd7ec57320a43601b2591de20e0",
+  "execution_specs_commit": "e5a8caf1b8055e4d805c7fb169edfa710914b7da",
+  "reference": "execution-specs Amsterdam BlockAccessList decoded from fixture payload",
+  "payload_bal_sha256": "b0c31b6b1ba00cbcdc8ed54b6a94a05355a8d26cd1e6f3761d7f6c974c837f4d",
+  "rows": {
+    "accounts": [
+      "00000961ef480eb55e80d19ad83579a64c007002",
+      "000064d678505ad48f8ccb093bc65613800e8282",
+      "0000bbddc7ce488642fb579f8b00f3a590007251",
+      "0000bff46984e3725691fa540a8c7589300d8282",
+      "0000f90827f1c53a10cb7a02335b175320002935",
+      "000f3df6d732807ef1319fb7b8bb8522d0beac02",
+      "2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+      "95d1be958d22adf294428c13cc71d89ff320bfd3",
+      "c0f6dc9e5836f54caadbf59cc69346c508e1992b",
+      "f6c3a9edc1afa0ad5b720e4d42e1437c43d3b3ff"
+    ],
+    "storage": [
+      {
+        "address": "0000f90827f1c53a10cb7a02335b175320002935",
+        "bai": 0,
+        "slot": 0,
+        "value": 52299183798028654046165148584144631363093432215379852176862615166358228418957
+      },
+      {
+        "address": "000f3df6d732807ef1319fb7b8bb8522d0beac02",
+        "bai": 0,
+        "slot": 12,
+        "value": 12
+      }
+    ],
+    "balance": [
+      {
+        "address": "2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+        "bai": 1,
+        "post": 1023000
+      },
+      {
+        "address": "95d1be958d22adf294428c13cc71d89ff320bfd3",
+        "bai": 2,
+        "post": 10000000000
+      },
+      {
+        "address": "c0f6dc9e5836f54caadbf59cc69346c508e1992b",
+        "bai": 1,
+        "post": 5
+      },
+      {
+        "address": "f6c3a9edc1afa0ad5b720e4d42e1437c43d3b3ff",
+        "bai": 1,
+        "post": 999999999999999999997544795
+      }
+    ],
+    "nonce": [
+      {
+        "address": "f6c3a9edc1afa0ad5b720e4d42e1437c43d3b3ff",
+        "bai": 1,
+        "nonce": 1
+      }
+    ],
+    "code": []
+  }
+}

--- a/scripts/spike/bal-withdrawal-no-evm.expectation.json
+++ b/scripts/spike/bal-withdrawal-no-evm.expectation.json
@@ -1,0 +1,44 @@
+{
+  "schema": 1,
+  "fixture_label": "00568_test_bal_withdrawal_no_evm_execution_fork_Amsterdam-blockchain_test__b0",
+  "fixture_relpath": "blockchain_tests/for_amsterdam/amsterdam/eip7928_block_level_access_lists/block_access_lists_eip4895/bal_withdrawal_no_evm_execution.json",
+  "manifest_sha256": "b40b7e3f7d4b3bde03c7298c98d3b9117ea146f76c2a2a914f1cbafa78c3ad07",
+  "input_sha256": "945d87d0d3962a38333a583c49f79dc7a43ae253c13ddf51e05927495bd67260",
+  "execution_specs_commit": "e5a8caf1b8055e4d805c7fb169edfa710914b7da",
+  "reference": "execution-specs Amsterdam BlockAccessList decoded from fixture payload",
+  "payload_bal_sha256": "b50ea48305dba031751dd0c460130991800bc96221856f06d5b3279527710b87",
+  "rows": {
+    "accounts": [
+      "00000961ef480eb55e80d19ad83579a64c007002",
+      "000064d678505ad48f8ccb093bc65613800e8282",
+      "0000bbddc7ce488642fb579f8b00f3a590007251",
+      "0000bff46984e3725691fa540a8c7589300d8282",
+      "0000f90827f1c53a10cb7a02335b175320002935",
+      "000f3df6d732807ef1319fb7b8bb8522d0beac02",
+      "3ed9f109b7188a178354f2cb30694a70b011d6eb"
+    ],
+    "storage": [
+      {
+        "address": "0000f90827f1c53a10cb7a02335b175320002935",
+        "bai": 0,
+        "slot": 0,
+        "value": 17869682084761246534850034050289559498577633917539310124817686149482629300477
+      },
+      {
+        "address": "000f3df6d732807ef1319fb7b8bb8522d0beac02",
+        "bai": 0,
+        "slot": 12,
+        "value": 12
+      }
+    ],
+    "balance": [
+      {
+        "address": "3ed9f109b7188a178354f2cb30694a70b011d6eb",
+        "bai": 1,
+        "post": 10000000000
+      }
+    ],
+    "nonce": [],
+    "code": []
+  }
+}

--- a/scripts/spike/bal_producer_set.sh
+++ b/scripts/spike/bal_producer_set.sh
@@ -68,6 +68,12 @@ run_case \
   00609_test_bal_system_dequeue_consolidations_eip7251_fork_Amsterdam-blockchain_test-single_block_max_c \
   bal-system-dequeue-consolidations.expectation.json
 run_case \
+  00568_test_bal_withdrawal_no_evm_execution_fork_Amsterdam-blockchain_test__b0 \
+  bal-withdrawal-no-evm.expectation.json
+run_case \
+  00323_test_bal_create_transaction_empty_code_fork_Amsterdam-blockchain_test__b0 \
+  bal-create-transaction-empty.expectation.json
+run_case \
   00356_test_bal_intra_tx_sstores_same_slot_net_zero_fork_Amsterdam-blockchain_test-empty_pre_ephemeral_ \
   bal-net-zero-storage-empty-pre.expectation.json
 run_case \

--- a/scripts/spike/bal_producer_set.sh
+++ b/scripts/spike/bal_producer_set.sh
@@ -67,12 +67,22 @@ run_case \
 run_case \
   00609_test_bal_system_dequeue_consolidations_eip7251_fork_Amsterdam-blockchain_test-single_block_max_c \
   bal-system-dequeue-consolidations.expectation.json
+# N=0 withdrawal: exact coverage only, not a discriminator for N+1.
 run_case \
   00568_test_bal_withdrawal_no_evm_execution_fork_Amsterdam-blockchain_test__b0 \
   bal-withdrawal-no-evm.expectation.json
+# N=1 plus withdrawal: distinguishes post-exec N+1 from per-tx BAI.
+run_case \
+  00564_test_bal_withdrawal_and_transaction_fork_Amsterdam-blockchain_test__b0 \
+  bal-withdrawal-and-transaction.expectation.json
+# Zero-value CREATE: exact coverage only; no created-account balance row.
 run_case \
   00323_test_bal_create_transaction_empty_code_fork_Amsterdam-blockchain_test__b0 \
   bal-create-transaction-empty.expectation.json
+# Nonzero-value top-level CREATE: created-account balance row is present.
+run_case \
+  21086_test_create_transaction_success_fork_Amsterdam-blockchain_test_from_state_test__b0 \
+  bal-create-transaction-success.expectation.json
 run_case \
   00356_test_bal_intra_tx_sstores_same_slot_net_zero_fork_Amsterdam-blockchain_test-empty_pre_ephemeral_ \
   bal-net-zero-storage-empty-pre.expectation.json


### PR DESCRIPTION
Attribution: evm-asm3-codex

## Summary

Registers exact BAL-builder producer-stage witnesses for #11329. The set now contains 18 fixtures and includes two discriminating stage witnesses:

- `00564` has one transaction plus one withdrawal; its withdrawal balance row is BAI 2, distinguishing the post-execution `N+1` producer from a per-transaction `index+1` formula.
- `21086` is a nonzero-value top-level CREATE; its created account has a balance row at BAI 1, exercising the depth-zero creation balance publisher.

Two earlier witnesses remain registered as exact coverage but are explicitly non-discriminating:

- `00568` has zero transactions plus one withdrawal, so BAI 1 cannot distinguish `N+1` from a per-transaction formula or a hardcoded one.
- `00323` is a zero-value top-level CREATE, so the created account has no balance-change row and does not exercise the CREATE balance publisher.

`00620` covers the zero-priority coinbase arm (`base_fee=7`, `max_priority_fee_per_gas=0`, `max_fee_per_gas=7`).

## Evidence

On repo `daa252da489e1fde504b4a820fd2074bdb72f35f`, guest ELF `9bd41dffc914b843279c4fd28626541a31a6ad44d4677bf7cc8155e1dd715adf`, runner `b4286c6e9100b83a0055e921fb4e4f96e8d852efe7f638c65a23a1a3af358349`, execution-specs `e5a8caf1b8055e4d805c7fb169edfa710914b7da`, and manifest SHA `b40b7e3f7d4b3bde03c7298c98d3b9117ea146f76c2a2a914f1cbafa78c3ad07`, all 18 fixtures pass exact element-wise comparison with no skipped, undecodable, or overflow rows and equal serializer hashes. The expanded run was executed on 2026-08-04 (Europe/Berlin); the per-fixture output directories contain the captured dump and hashes.

`00564` emits the withdrawal recipient at BAI 2 with post `10000000000`; the transaction-stage balance rows remain at BAI 1. `21086` emits the created address `9176f3d3132430f691489cfe2b701faee0892033` at BAI 1 with post `100`.

The BAI distinction follows `fork.py:916-921`: per-transaction production uses `index + 1`, while post-execution operations use `ulen(transactions) + 1`; BAI 0 remains the beacon-root/history default.

## Dynamic stage coverage

Measured emitted entrypoint probes on the same ELF/runner pair:

- sender-upfront `dispatcher_seed_pending_upfront_sender_balance` (`0x80039b7c`): all 16 original fixtures.
- shared account producer `account_write_record` (`0x80028058`): all 16 original fixtures.
- shared non-storage producer `record_nonstorage_effect` (`0x80043520`): all 16 original fixtures.
- nested CREATE runtime `block_verdict_creation_runtime` (`0x80021444`): `00323` and `21086`; the additional `00564` withdrawal fixture does not enter it.
- withdrawal helper `block_verdict_withdrawal_nonstorage_effects` (`0x8001c728`) is called at the block boundary; the helper's decoded `svf_wds_count` is `1` for `00564` and `00568`, and `0` for `21086`, `00323`, and `00609`.
- BAI-0 system-storage publisher `append_modeled_system_storage_tuple_rows` (`0x800102e4`) and `bsr_beacon_change` (`0x8000f8c8`) both hit `00609`.

The coinbase fee producer is an inlined block-verdict fragment rather than a standalone symbol; its source callsite is `BlockVerdictMtxCoinbase.lean:blockVerdictMtxCoinbaseFeeEffect`, so it is marked inferred at the entrypoint level while `00620` remains the registered zero-priority witness.
