### PR TITLE
fix(ci): restore the arithmetic differential fuzz oracle — 40 consecutive nightly failures, no operand compared in 40 days

### DIFF
--- a/scripts/fuzz_arith_oracle.py
+++ b/scripts/fuzz_arith_oracle.py
@@ -46,8 +46,18 @@ def evm_op(op: str, a: int, b: int, n: int) -> int:
         stack = [U256(b), U256(a)]
     else:
         stack = [U256(n), U256(b), U256(a)]
-    # Duck-typed frame: the handlers only touch .stack, .gas_left, .pc.
-    evm = SimpleNamespace(stack=stack, gas_left=Uint(10**9), pc=Uint(0))
+    # Duck-typed frame.  The handlers touch .stack, .gas_left and .pc, and --
+    # since Amsterdam split gas into regular and state dimensions -- charge_gas
+    # also accumulates .regular_gas_used (amsterdam/vm/gas.py:311).  Omitting a
+    # field the spec reads raises AttributeError *after* the operand rows and
+    # the evm-asm side are already produced, so the failure looks like a broken
+    # pipeline rather than a stale stub; see #11368.
+    evm = SimpleNamespace(
+        stack=stack,
+        gas_left=Uint(10**9),
+        pc=Uint(0),
+        regular_gas_used=Uint(0),
+    )
     fn(evm)
     return int(evm.stack[-1])
 


### PR DESCRIPTION
Closes #11368.

## What was broken

The nightly `Fuzz (arithmetic differential)` job on `main` has failed **40 consecutive runs**
(2026-06-26 → 2026-08-04), **zero successes in the last 40**. Not flaky, and not caused by any recent
PR — the oracle harness dies before comparing a single operand.

`scripts/fuzz_arith_oracle.py:50` duck-types an EVM frame:

```python
# Duck-typed frame: the handlers only touch .stack, .gas_left, .pc.
evm = SimpleNamespace(stack=stack, gas_left=Uint(10**9), pc=Uint(0))
```

Amsterdam split gas into regular and state dimensions, and `charge_gas` now ends with
`evm.regular_gas_used += amount` (`forks/amsterdam/vm/gas.py:311`), so every arithmetic handler raises
`AttributeError: 'types.SimpleNamespace' object has no attribute 'regular_gas_used'`.

The comment on the line above is the tell: it records an assumption about an **external** dependency that
the spec has since invalidated.

## Why it went unnoticed for 40 days

It fails *after* appearing to do the work:

```
==> lake build arith-diff-check        Build completed successfully (2344 jobs).
==> generating boundary-biased operands (5000 random + 2000 boundary)
    44646 operand rows
==> evm-asm side (lake exe arith-diff-check emit)
==> execution-specs oracle (uv run, amsterdam fork)     <-- dies here
```

Build green, 44,646 operands generated, evm-asm side emitted — only the last step fails, so the log reads
like a pipeline that stumbled at the end rather than a stale stub. **No operand has been differentially
compared in 40 days.**

## The fix

One field, plus a comment that names the dependency instead of denying it. Arithmetic opcodes only call
`charge_gas`, never `charge_state_gas`, so no state-gas fields are required.

Verified against the pinned spec `e5a8caf1b`:

```
{"op":"div","a":"0x64","b":"0x7","expected":"0xe"}                # 100/7 = 14
{"op":"sdiv","a":"0x1","b":"0x0","expected":"0x0"}                # EVM div-by-zero
{"op":"mulmod","a":"0x64","b":"0x7","n":"0xd","expected":"0xb"}   # 700 mod 13 = 11
{"op":"addmod","a":"0xff","b":"0x2","n":"0x10","expected":"0x1"}  # 257 mod 16 = 1
{"op":"mod","a":"0x0","b":"0x5","expected":"0x0"}
```

## Reviewer note

⚠️ **Expect the first green run to surface real diffs.** Forty days of drift means the comparison may fail
on *content* once it runs at all. That is the point of restoring it — triage those separately, and do not
silence them by loosening the harness.

Worth doing as a follow-up (not in this PR): a stub that duck-types an external dataclass will break again
on the next spec field. Either construct a real `Evm`, or assert up front that the stub satisfies the
attributes `charge_gas` touches, so the failure names the missing field instead of surfacing as a
mid-run `AttributeError`.

*Attribution: coord.*
