### PR TITLE
fix(codegen): rename live runtime state labels

### DIFF
--- a/EvmAsm/Codegen/Dispatch.lean
+++ b/EvmAsm/Codegen/Dispatch.lean
@@ -690,9 +690,9 @@ def emitCreateChildFrameData : String :=
   -- create_child_code so it is defined in every closure whose CREATE tail deposits into it.
   createCodeEffectLogData ++ "\n" ++
   -- The code-effect log above remains BAL comparator evidence.  Execution reads
-  -- use this bounded, real-address keyed CodeState overlay instead, so CREATE /
-  -- SELFDESTRUCT / recreate follow current Ethereum state rather than an
-  -- append-only event history.
+  -- use the AccountState execution overlay instead, so CREATE / SELFDESTRUCT /
+  -- recreate follow current Ethereum state rather than an append-only event
+  -- history.
   codeStateData ++ "\n" ++
   -- .61.8c-1: per-creator running-nonce table (multi-CREATE address correctness), co-located
   -- so the CREATE tail's create_creator_nonce_use resolves in every closure.
@@ -1159,9 +1159,9 @@ def emitDispatcherPrologue : String :=
   "  la x5, create_nonce_table_overflow; sd x0, 0(x5)\n" ++
   "  la x5, create_nonce_undo_count; sd x0, 0(x5)\n" ++
   -- The comparator evidence heap is per dispatch in standalone mode, but is
-  -- block-lived while the MTx CodeState is active: retained code bytes are the
+  -- block-lived while the MTx runtime is active: retained code bytes are the
   -- backing store for cross-transaction execution reads.
-  "  la x5, code_state_mtx_active; ld x6, 0(x5); bnez x6, .Lrtd_code_log_kept\n" ++
+  "  la x5, runtime_mtx_active; ld x6, 0(x5); bnez x6, .Lrtd_code_log_kept\n" ++
   "  la x5, exec_code_effect_count; sd x0, 0(x5)\n" ++
   "  la x5, exec_code_effect_next; sd x0, 0(x5)\n" ++
   "  la x5, exec_code_effect_overflow; sd x0, 0(x5)\n" ++
@@ -1232,7 +1232,7 @@ def emitDispatcherPrologue : String :=
 
     Intentionally sticky — do NOT clear:
     `auth_phase_halted`, `prepare_prefix_status`, `auth_state_charged`,
-    `code_state_mtx_active`, `runtime_tx_oog_hook`. -/
+    `runtime_mtx_active`, `runtime_tx_oog_hook`. -/
 def emitExceptionalExitModeTeardown : String :=
   -- Access-list seed triple (set by dispatch_tx_runtime_code / MTx; consumed by
   -- emitTxAccessListSeedLoop). OOG during auth prepare leaves the triple live;
@@ -1349,7 +1349,7 @@ def emitExceptionalExit (label : String) (kind : Nat) : String :=
   -- Mode/continuation teardown already ran at entry (`emitExceptionalExitModeTeardown`,
   -- #11250) — covers prepare_only (#11249), auth_exec_fn (#11247), and the seed/warm
   -- function-pointer triples (candidate #3). Intentionally sticky flags (auth_phase_halted,
-  -- prepare_prefix_status, auth_state_charged, code_state_mtx_active, oog_hook) are NOT
+  -- prepare_prefix_status, auth_state_charged, runtime_mtx_active, oog_hook) are NOT
   -- cleared there; oog_hook is invoked next.
   -- A transaction-aware caller may stage a process_transaction debit before
   -- entering the callable dispatcher. An exceptional halt can occur in the
@@ -2422,7 +2422,7 @@ private def emitTopLevelMessageD0Preparation : String :=
   -- auth-phase OOG re-applies rolled-back authority nonces into the block-lived
   -- nonstorage log (code44 NONCE_ONLY_AUTH / #11148 sibling shape).
   "  la x11, system_call_mode; ld x9, 0(x11); bnez x9, .runtime_tx_auth_state_used_done\n" ++
-  "  la x11, code_state_mtx_active; ld x9, 0(x11); beqz x9, .runtime_tx_auth_checkpoint_done\n" ++
+  "  la x11, runtime_mtx_active; ld x9, 0(x11); beqz x9, .runtime_tx_auth_checkpoint_done\n" ++
   "  la x11, exec_nonstorage_effect_count; ld x9, 0(x11); la x11, runtime_tx_auth_effect_count_checkpoint; sd x9, 0(x11)\n" ++
   "  la x11, exec_nonstorage_effect_overflow; ld x9, 0(x11); la x11, runtime_tx_auth_effect_overflow_checkpoint; sd x9, 0(x11)\n" ++
   "  la x11, exec_code_effect_count; ld x9, 0(x11); la x11, runtime_tx_auth_code_effect_count_checkpoint; sd x9, 0(x11)\n" ++
@@ -3073,7 +3073,7 @@ def emitRuntimeDispatcherCallableSetup : String :=
   "  la x5, create_nonce_table_count; sd x0, 0(x5)\n" ++
   "  la x5, create_nonce_table_overflow; sd x0, 0(x5)\n" ++
   "  la x5, create_nonce_undo_count; sd x0, 0(x5)\n" ++
-  "  la x5, code_state_mtx_active; ld x6, 0(x5); bnez x6, .Lrtdc_code_log_kept\n" ++
+  "  la x5, runtime_mtx_active; ld x6, 0(x5); bnez x6, .Lrtdc_code_log_kept\n" ++
   "  la x5, exec_code_effect_count; sd x0, 0(x5)\n" ++
   "  la x5, exec_code_effect_next; sd x0, 0(x5)\n" ++
   "  la x5, exec_code_effect_overflow; sd x0, 0(x5)\n" ++

--- a/EvmAsm/Codegen/Driver.lean
+++ b/EvmAsm/Codegen/Driver.lean
@@ -86,7 +86,7 @@ def assembleAndLink (asmPath : System.FilePath) (bssStart : String := "0xa311000
     -- present, so the flag is harmless for programs that do not emit it.
     #["-Ttext=0x80000000", "-Tdata=0xa3000000",
       s!"--section-start=.bss={bssStart}",
-      -- CodeState's fixed 1.5 MiB block-lifetime tables extend `.bss` through
+      -- The fixed block-lifetime AccountState arenas extend `.bss` through
       -- 0xbf910fdf.  Keep the 6.5 MiB SSZ work region below the 0xc0000000
       -- guest-RAM ceiling while leaving a fixed 0x6f020-byte gap after `.bss`.
       "--section-start=.sszscratch=0xbf980000",

--- a/EvmAsm/Codegen/Programs/BalCodePreimages.lean
+++ b/EvmAsm/Codegen/Programs/BalCodePreimages.lean
@@ -1234,7 +1234,7 @@ def balCodePreimagesValidFunction : String :=
   "  j .Lbsbd_ret\n" ++
   -- A delegation target created earlier in this transaction remains executable
   -- until transaction finalization.  Resolve it through the same layered
-  -- CodeState used by CALL and EXTCODE*, not through comparison evidence.
+  -- AccountState used by CALL and EXTCODE*, not through comparison evidence.
   ".Lbsbd_target_create_effect:\n" ++
   "  addi a0, s9, 3\n" ++
   "  jal ra, code_state_lookup_current\n" ++

--- a/EvmAsm/Codegen/Programs/BlockVerdictDispatchTx.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictDispatchTx.lean
@@ -108,7 +108,7 @@ def dispatchTxRuntimeCodeFunction : String :=
   "  ld a0, 576(x20); ld a1, 584(x20); la a2, dtrc_deleg_target\n" ++
   "  ld a3, 592(x20); ld a4, 600(x20); ld a5, 608(x20); ld a6, 616(x20)\n" ++
   -- A delegation target may itself have been successfully CREATEd by an
-  -- earlier transaction in this block.  CodeState is the current execution
+  -- earlier transaction in this block.  AccountState is the current execution
   -- state, so consult it before the immutable block-pre witness.
   "  la a0, dtrc_deleg_target; jal ra, account_state_lookup_current\n" ++
   "  li t0, 1; bne a0, t0, .Ldtrc_materialize_not_codestate\n" ++
@@ -243,7 +243,7 @@ def dispatchTxRuntimeCodeFunction : String :=
   "  beqz a0, .Ldtrc_same_block_delegation_code\n" ++
   "  li t0, 2; beq a0, t0, .Ldtrc_same_block_empty_code\n" ++
   -- The BAL resolver only owns EIP-7702 delegation designators.  For ordinary
-  -- code use the shared mutable CodeState first: a tx1 CREATE is visible to a
+  -- code use the shared mutable AccountState first: a tx1 CREATE is visible to a
   -- tx2 top-level call even though it is absent from the block-pre witness.
   "  addi sp, sp, -16; sd s2, 0(sp)\n" ++
   "  addi a0, s2, 72; jal ra, account_state_lookup_current\n" ++

--- a/EvmAsm/Codegen/Programs/BlockVerdictMtxRuntime.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictMtxRuntime.lean
@@ -317,17 +317,18 @@ def blockVerdictMtxRuntimeLoop : String :=
   "  la a0, nea_sort_b; la t0, bv_eip7702_authority_event_count; ld a1, 0(t0); la a2, bv_eip7702_authority_table; li a3, " ++ toString bvEip7702AuthorityEventCapacity ++ "; la a4, bv_eip7702_authority_count; jal ra, eip7702_authority_state_materialize; bnez a0, .Lbv_sender_nonce_fail\n" ++
   ".Lbv_mtx_state_init:\n" ++
   "  la t0, bv_mtx_i; sd zero, 0(t0)\n" ++
-  -- Execution CodeState is block-lived in the sequential lane. The callable
+  -- Execution AccountState is block-lived in the sequential lane. The callable
   -- dispatcher resets transaction-local pending overlays, including
   -- `account_state_pending_count`; it does not preserve that AccountState
   -- journal across dispatches. This reset is the live durability boundary in
   -- GH #10876: sender effects needed after dispatch must be materialized in
   -- durable state rather than left in the pending journal. Durable state and
   -- retained comparator bytes survive until this loop finishes.
-  -- CodeState is the sole execution code/existence model for every block,
-  -- including the one-transaction case.  The immutable witness is consulted
-  -- only after its pending and durable overlays miss.
-  "  la t0, code_state_mtx_active; li t1, 1; sd t1, 0(t0); la t0, runtime_tx_oog_hook; la t1, block_verdict_mtx_oog_materialize; sd t1, 0(t0); la t0, account_state_durable_count; sd zero, 0(t0); la t0, account_state_pending_count; sd zero, 0(t0); la t0, account_state_created_count; sd zero, 0(t0); la t0, account_state_delete_count; sd zero, 0(t0); la t0, account_state_overflow; sd zero, 0(t0)\n" ++
+  -- AccountState is the sole emitted execution code/existence model for every
+  -- block, including the one-transaction case.  The immutable witness is
+  -- consulted only after its pending and durable overlays miss; CodeState
+  -- names are compatibility aliases, not a separate table.
+  "  la t0, runtime_mtx_active; li t1, 1; sd t1, 0(t0); la t0, runtime_tx_oog_hook; la t1, block_verdict_mtx_oog_materialize; sd t1, 0(t0); la t0, account_state_durable_count; sd zero, 0(t0); la t0, account_state_pending_count; sd zero, 0(t0); la t0, account_state_created_count; sd zero, 0(t0); la t0, account_state_delete_count; sd zero, 0(t0); la t0, account_state_overflow; sd zero, 0(t0)\n" ++
   "  la t0, exec_code_effect_count; sd zero, 0(t0); la t0, exec_code_effect_next; sd zero, 0(t0); la t0, exec_code_effect_overflow; sd zero, 0(t0)\n" ++
   -- bmvmx.5 (fee-validity hoist, multi-tx): multi_tx_nth_context does NOT populate the
   -- record's base_fee_per_gas (record+32 is a per-call INPUT, BlockVerdictMultiTx.lean:44),
@@ -698,7 +699,7 @@ def blockVerdictMtxRuntimeLoop : String :=
   "  jal ra, capture_system_storage_exec_rows\n" ++
   "  bnez a0, .Lbv_mtx_bail\n" ++
   ".Lbv_mtx_capture_done:\n" ++
-  -- Commit the just-successful transaction's current CodeState overlay before
+  -- Commit the just-successful transaction's current AccountState overlay before
   -- the next callable dispatch.  A failed receipt commits no code/existence
   -- mutations, exactly like its effect-log rollback above.
   -- Match `process_message`'s two snapshots: a successful body commits all
@@ -871,7 +872,7 @@ def blockVerdictMtxRuntimeLoop : String :=
   -- for a different stored-post-nonce mechanism.
   "  la a0, bv_mtx_sender_addr; la t0, sttc_nonce; ld a1, 0(t0); la a2, bv_create_addr; jal ra, address_compute_create\n" ++
   -- EIP-684 observes the current block state before the immutable witness.
-  -- A durable CodeState entry is a prior-tx live account and collides; a
+  -- A durable AccountState entry is a prior-tx live account and collides; a
   -- durable tombstone is a same-tx-created account already deleted at an
   -- earlier transaction boundary, so it deliberately falls through to the
   -- pre-block predicate (where it is absent and may be recreated).

--- a/EvmAsm/Codegen/Programs/CallFrameDescend.lean
+++ b/EvmAsm/Codegen/Programs/CallFrameDescend.lean
@@ -500,7 +500,7 @@ def callFrameDescendFunction : String :=
   bodyStateCaptureScalarAsm "exec_code_effect_count" "t1" 16 "t4" "t0" ++
   bodyStateCaptureScalarAsm "exec_code_effect_next" "t1" 24 "t4" "t0" ++
   bodyStateCaptureScalarAsm "exec_code_effect_overflow" "t1" 32 "t4" "t0" ++
-  -- The mutable CodeState is a transaction overlay, so it needs the same
+  -- The mutable AccountState is a transaction overlay, so it needs the same
   -- per-frame high-water-mark discipline as the legacy comparison log.  Keep
   -- the checkpoints depth-indexed rather than extending the packed env ABI.
   bodyStateCaptureScalarAsm "account_state_pending_count" "t1" 72 "t4" "t0" ++

--- a/EvmAsm/Codegen/Programs/CallFrameReturn.lean
+++ b/EvmAsm/Codegen/Programs/CallFrameReturn.lean
@@ -204,7 +204,7 @@ def frameReturnFunction : String :=
   "  ld t2, 16(t0); la t1, exec_code_effect_count; sd t2, 0(t1)\n" ++
   "  ld t2, 24(t0); la t1, exec_code_effect_next; sd t2, 0(t1)\n" ++
   "  ld t2, 32(t0); la t1, exec_code_effect_overflow; sd t2, 0(t1)\n" ++
-  -- Restore this child's CodeState high-water marks on REVERT/exceptional
+  -- Restore this child's AccountState high-water marks on REVERT/exceptional
   -- return.  The current depth still names the child at this point.
   "  la t0, evm_call_depth; ld t2, 0(t0); " ++ bodyStateSlabStrideOps "t2" "t1" "t3" ++ "; la t0, body_state_snapshot_by_depth; add t0, t0, t1\n" ++
   "  ld t3, 72(t0); la t1, account_state_pending_count; sd t3, 0(t1)\n" ++

--- a/EvmAsm/Codegen/Programs/ChildFrameCreateTail.lean
+++ b/EvmAsm/Codegen/Programs/ChildFrameCreateTail.lean
@@ -255,7 +255,7 @@ def createUnsupportedTail (netPopBytes : Nat) (hasSalt : Bool) : String :=
     "  ld x10, 0(sp); ld x12, 8(sp); ld x13, 16(sp); addi sp, sp, 32\n" ++
      -- If an account-witness context is attached, apply the EIP-684
      -- code-or-nonce collision check to the derived target address.  The
-     -- mutable CodeState layer is checked first: a durable earlier-tx CREATE
+     -- mutable AccountState layer is checked first: a durable earlier-tx CREATE
      -- overrides a header miss, while a durable same-tx-delete mask permits a
      -- later recreate.  Only an overlay miss consults block-pre witness data.
      --
@@ -405,7 +405,7 @@ def createUnsupportedTail (netPopBytes : Nat) (hasSalt : Bool) : String :=
     -- spec is_account_alive(target) on mutable tx_state (state_tracker.py):
     -- LIVE balance via balance_at_header_state_root (live-first, #11019), not
     -- pure header. Code/nonce holders already took the collision branch; plus
-    -- the shared current CodeState overlay for prior same-tx creation.
+    -- the shared current AccountState overlay for prior same-tx creation.
     "  addi sp, sp, -32\n  sd x10, 0(sp)\n  sd x12, 8(sp)\n  sd x13, 16(sp)\n" ++
     "  ld a0, 576(x20)\n  ld a1, 584(x20)\n  la a2, create_address_be\n  ld a3, 592(x20)\n  ld a4, 600(x20)\n  la a5, cr_alive_bal\n" ++
     "  jal ra, balance_at_header_state_root\n" ++

--- a/EvmAsm/Codegen/Programs/ChildFrameHandlers.lean
+++ b/EvmAsm/Codegen/Programs/ChildFrameHandlers.lean
@@ -598,7 +598,7 @@ def callDescendFallThrough
     "  ld x10, 0(sp)\n  ld x12, 8(sp)\n  ld x13, 16(sp)\n  addi sp, sp, 32\n" ++
     "  li t5, 1; bne t6, t5, .Lcd_nacc_done_" ++ tag ++ "\n" ++
     -- A callee created earlier in the block is live even when absent from the
-    -- pre-block witness.  Ask the shared current CodeState rather than the
+    -- pre-block witness.  Ask the shared current AccountState rather than the
     -- append-only comparator log.
     -- is True -> no NEW_ACCOUNT state-gas charge. It is ABSENT from the block-pre witness, so
     -- account_exists_at_header_state_root below would falsely report "not exists" -> wrongly charge the
@@ -687,7 +687,7 @@ def callDescendFallThrough
   ".Lcd_code_addr_" ++ tag ++ ":\n" ++
   "  lbu t3, 0(t1)\n  sb t3, 0(t0)\n  addi t1, t1, -1\n  addi t0, t0, 1\n  addi t2, t2, -1\n" ++
   "  bnez t2, .Lcd_code_addr_" ++ tag ++ "\n" ++
-  -- Layered execution lookup: pending/durable CodeState is authoritative over
+  -- Layered execution lookup: pending/durable AccountState is authoritative over
   -- the block-pre witness.  In particular a durable tx1 CREATE must be seen by
   -- tx2 even though absent from the header, while a tx-end same-tx deletion
   -- masks stale header code.  Only an overlay miss may query the witness.
@@ -697,7 +697,7 @@ def callDescendFallThrough
   "  sd a0, 24(sp); sd a1, 32(sp); sd a2, 40(sp)\n" ++
   "  ld x10, 0(sp); ld x12, 8(sp); ld x13, 16(sp); ld t0, 24(sp); ld t1, 32(sp); ld t2, 40(sp); addi sp, sp, 64\n" ++
   "  bnez t0, .Lcd_acst_done_" ++ tag ++ "\n" ++
-  -- CodeState missed: a transaction-finalized EIP-6780 deletion (AccountState
+  -- AccountState missed: a transaction-finalized EIP-6780 deletion (AccountState
   -- delete-pending tombstone, written by account_state_commit_pending) makes
   -- the callee non-existent in every later transaction, so descend on empty
   -- code rather than stale witness bytes.  Within the destroying transaction
@@ -809,14 +809,14 @@ def callDescendFallThrough
   ".Lcd_resolve_not_precompile_" ++ tag ++ ":\n" ++
   "  beqz t3, .Lcd_descend_" ++ tag ++ "\n" ++
   -- CALL into a contract created earlier in this block.  Resolve the current
-  -- mutable CodeState before treating a header-witness miss as an empty EOA.
+  -- mutable AccountState before treating a header-witness miss as an empty EOA.
   -- ABSENT from the block-pre witness, so code_at_header_state_root returns status 1 (account
   -- not in state trie) and the delegation resolver also misses -> the call falsely routed to
   -- .Lcd_empty (empty EOA, push 1) and the child's runtime (e.g. its SELFDESTRUCT / outgoing
   -- value-CALLs) NEVER ran in re-execution -> its deletion / beneficiary credit were never
   -- recorded -> the exec-vs-BAL non-storage comparator false-rejects (bv_fail=44 on
   -- selfdestruct_same_tx_via_call + create-then-call families). The CREATE deposit already
-  -- published the child's deployed code into CodeState. On the code-lookup miss, resolve
+  -- published the child's deployed code into AccountState. On the code-lookup miss, resolve
   -- `cd_callee_be` from the shared overlay; on a hit, point the descend code/len at its retained
   -- byte arena (code pointer + length) by setting cahsr_code_offset/length so
   -- record+40) by setting cahsr_code_offset/length so 608(x20)+offset == record+48 (the existing
@@ -835,7 +835,7 @@ def callDescendFallThrough
   "  ld x10, 0(sp); ld x12, 8(sp); ld x13, 16(sp); ld t2, 24(sp)\n" ++
   "  addi sp, sp, 32\n" ++
   "  li t3, 1; bne t4, t3, .Lcd_callee_nocreate_" ++ tag ++ "\n" ++
-  "  la t3, cahsr_code_length; sd t6, 0(t3)\n" ++       -- CodeState code length
+  "  la t3, cahsr_code_length; sd t6, 0(t3)\n" ++       -- AccountState code length
   "  ld t3, 608(x20); sub t5, t5, t3\n" ++              -- code offset from codes base
   "  la t3, cahsr_code_offset; sd t5, 0(t3)\n" ++
   "  j .Lcd_descend_" ++ tag ++ "\n" ++
@@ -1012,7 +1012,7 @@ def callDescendFallThrough
    else "") ++
    -- An empty-code CALL still enters `process_message`: after its body snapshot,
    -- `move_ether` commits the paired debit and credit even though no child frame
-   -- is needed to execute bytecode.  Every arrival here (CodeState non-live,
+   -- is needed to execute bytecode.  Every arrival here (AccountState non-live,
    -- both delegation status-2 paths, absent header account, and EMPTY_CODE_HASH)
    -- bypasses `.Lcd_descend`, the only other balance-effect publisher.  Publish
    -- the already-resolved descriptors once before the successful empty-call return.

--- a/EvmAsm/Codegen/Programs/CreateCodeEffectLog.lean
+++ b/EvmAsm/Codegen/Programs/CreateCodeEffectLog.lean
@@ -32,8 +32,8 @@
   future retirement must first move the byte heap into its own retained code
   store, or preserve it verbatim; deleting/reusing this arena with live
   AccountState/BAL pointers is invalid.  This module deliberately does not
-  perform that layout split, because the current variable-stride cursor and all
-  CodeState readers use the packed record base.
+  perform that layout split, because the current variable-stride cursor and the
+  retained AccountState/code-byte readers use the packed record base.
 
   The CREATE-tail deposit call site (`create_record_code_effect(create_address_be,
   create_child_code, create_child_code_len)`) + EIP-3541 / MAX_CODE_SIZE / nonce
@@ -73,7 +73,7 @@ open EvmAsm.Rv64
     consumes that flag as a rejection. -/
 def execCodeEffectLogCap : Nat := 1048576
 
-/-! ## Bounded execution CodeState
+/-! ## Legacy CodeState source helpers (not emitted)
 
     `exec_code_effect_log` is an append-only comparison record: BAL's code
     comparator needs to see every execution-produced code change.  It is not a
@@ -81,33 +81,23 @@ def execCodeEffectLogCap : Nat := 1048576
     same address must replace an earlier one, and EIP-6780 deletion is scoped
     to the transaction which created the account).
 
-    The multi-transaction runtime therefore keeps its execution-facing code
-    state in fixed, real-address keyed tables.  A table entry is 64 bytes:
-
-      +0  address (20-byte BE, zero-padded to 32)
-      +32 code pointer
-      +40 code length
-      +48 flags (bit 0: occupied; bit 1: account exists; bit 2: code is available)
-      +56 reserved
-
-    There are separate pending and durable tables.  Pending entries are the
-    current transaction overlay; successful transaction finalization merges
-    them into durable state, while a failed transaction discards the pending
-    count.  The capacity is gas bounded: CREATE costs at least 32,000 gas, so
-    a 200M-gas block can create at most 6,250 accounts; 8,192 leaves margin
-    without scaling memory with untrusted input. -/
+    The historical `code_state_find`/`code_state_upsert` family below described
+    a separate fixed table.  Those source strings are retained only as
+    migration scaffolding; the emitted execution path uses AccountState, and
+    `code_state_lookup_current` is a compatibility jump to its resolver.  Do
+    not read these legacy constants as a live runtime container. -/
 def codeStateEntryBytes : Nat := 64
 def codeStateEntryCapacity : Nat := 8192
 def codeStateTableBytes : Nat := codeStateEntryBytes * codeStateEntryCapacity
 
 /-! ## Bounded execution AccountState
 
-    The old CodeState owns only code/existence while value and nonce readers
-    reconstruct their state from an append-only comparison log.  AccountState
-    is the replacement execution model: a complete account snapshot is written
-    for every execution mutation, so a later read has one layered source of
-    truth.  Pending entries form a per-transaction journal; durable entries
-    retain the latest successful block state.  Both are fixed arenas.
+    AccountState is the emitted execution model: a complete account snapshot
+    is written for every execution mutation, so a later read has one layered
+    source of truth.  Pending entries form a per-transaction journal; durable
+    entries retain the latest successful block state.  CodeState-named helpers
+    are compatibility aliases or source-only migration scaffolding, not a
+    second execution authority.  Both AccountState layers are fixed arenas.
 
     38,460 entries is the gas-derived bound.  The lowest-cost operation that
     changes two accounts is a value transfer; the existing 200M-gas bound is
@@ -706,10 +696,10 @@ def codeStateFinalBalanceNonzeroFunction : String :=
   -- pre-block balance/nonce.  This is normally an absent same-tx CREATE,
   -- therefore EIP-161-empty, but also handles a pre-funded CREATE target.
   ".Lcsfb_preblock:\n" ++
-  "  la t0, sv_pre_rlp_ptr; ld a0, 0(t0); la t0, sv_pre_rlp_len; ld a1, 0(t0); mv a2, s0; li a3, 20; la t0, bv_witness_state_ptr; ld a4, 0(t0); la t0, bv_witness_state_len; ld a5, 0(t0); la a6, code_state_pre_acct; jal ra, account_at_header_state_root\n" ++
+  "  la t0, sv_pre_rlp_ptr; ld a0, 0(t0); la t0, sv_pre_rlp_len; ld a1, 0(t0); mv a2, s0; li a3, 20; la t0, bv_witness_state_ptr; ld a4, 0(t0); la t0, bv_witness_state_len; ld a5, 0(t0); la a6, account_resolver_pre_acct; jal ra, account_at_header_state_root\n" ++
   "  beqz a0, .Lcsfb_pre_found; li t0, 1; bne a0, t0, .Lcsfb_unavailable; li a0, 0; j .Lcsfb_zero\n" ++
   ".Lcsfb_pre_found:\n" ++
-  "  la t0, code_state_pre_acct; ld t1, 8(t0); ld t2, 16(t0); or t1, t1, t2; ld t2, 24(t0); or t1, t1, t2; ld t2, 32(t0); or t1, t1, t2; bnez t1, .Lcsfb_nonzero; ld t1, 0(t0); bnez t1, .Lcsfb_nonzero; j .Lcsfb_zero\n" ++
+  "  la t0, account_resolver_pre_acct; ld t1, 8(t0); ld t2, 16(t0); or t1, t1, t2; ld t2, 24(t0); or t1, t1, t2; ld t2, 32(t0); or t1, t1, t2; bnez t1, .Lcsfb_nonzero; ld t1, 0(t0); bnez t1, .Lcsfb_nonzero; j .Lcsfb_zero\n" ++
   ".Lcsfb_unavailable:\n" ++
   "  li a0, 2\n" ++
   ".Lcsfb_ret:\n" ++
@@ -717,7 +707,9 @@ def codeStateFinalBalanceNonzeroFunction : String :=
 
 /-! ## code_state_lookup_current
 
-    Shared execution-read resolver for the CodeState layers.
+    Shared execution-read compatibility resolver.  The emitted body forwards
+    to the AccountState layers; the CodeState name remains only for callers
+    that have not yet been mechanically renamed.
 
     a0 = canonical 20-byte BE address pointer
     returns a0 = 0 absent from both overlays, 1 existing with code,
@@ -731,8 +723,8 @@ def codeStateFinalBalanceNonzeroFunction : String :=
 def codeStateLookupCurrentFunction : String :=
   "code_state_lookup_current:\n" ++
   -- Compatibility symbol for the atomic tqj1m source cutover.  Every legacy
-  -- caller now reaches the one AccountState layered resolver; the old table
-  -- remains comparison/migration evidence only and is no longer a read source.
+  -- caller now reaches the one AccountState layered resolver; the historical
+  -- table strings are migration evidence only and are no longer a read source.
   "  j account_state_lookup_current"
 
 /-! ## codeStateStatusIsLiveAsm
@@ -800,11 +792,11 @@ def codeStateAddressSetFlagFunction : String :=
   ".Lcsasf_miss:\n" ++
   "  li a0, 1; ld a3, 0(sp); addi sp, sp, 16; ret"
 
-/-- Fixed static data for the execution CodeState overlay.  `created` and
-    `delete` sets use the same 32-byte padded-address key representation. -/
+/-! Fixed static data for the AccountState execution overlay.  The `created`
+    and `delete` sets use the same 32-byte padded-address key representation. -/
 def codeStateData : String :=
   ".balign 8\n" ++
-  "code_state_mtx_active:\n  .zero 8\n" ++
+  "runtime_mtx_active:\n  .zero 8\n" ++
   -- tqj1m: AccountState is the sole execution-state source.  The old
   -- CodeState tables were retired after the atomic reader cutover; its small
   -- scalar names below remain only as compatibility guards for the retained
@@ -815,7 +807,7 @@ def codeStateData : String :=
   "account_state_delete_count:\n  .zero 8\n" ++
   "account_state_overflow:\n  .zero 8\n" ++
   -- BAL final-account scratch for the EIP-161 deferred-delete decision.
-  "code_state_pre_acct:\n  .zero 48\n" ++
+  "account_resolver_pre_acct:\n  .zero 48\n" ++
   ".balign 32\n" ++
   "account_state_scratch:\n  .zero 128\n" ++
   ".balign 32\n" ++

--- a/EvmAsm/Codegen/Programs/EvmAccountWitness.lean
+++ b/EvmAsm/Codegen/Programs/EvmAccountWitness.lean
@@ -155,7 +155,7 @@ private def extcodehashWitnessTail : HandlerTail :=
     "  jal ra, account_state_tombstone_balance_zero\n" ++
     "  bnez a0, .Lextcodehash_codestate_deleted\n" ++
     -- Execution code visibility is resolved from the layered mutable
-    -- CodeState, never from the append-only BAL comparison log.
+    -- AccountState, never from the append-only BAL comparison log.
     "  la a0, eahsr_address_scratch\n" ++
     "  jal ra, code_state_lookup_current\n" ++
     "  beqz a0, .Lextcodehash_witness_check\n" ++
@@ -178,7 +178,7 @@ private def extcodehashWitnessTail : HandlerTail :=
     "  addi sp, sp, 32\n" ++
     "  addi x10, x10, 1\n" ++
     dispatchContinueRet ++ "\n" ++
-    -- A durable CodeState tombstone is a transaction-finalized EIP-6780
+    -- A durable AccountState tombstone is a transaction-finalized EIP-6780
     -- deletion.  It masks stale pre-block code and is non-existent for
     -- EXTCODEHASH (zero, unlike an existing empty-code account's keccak("")).
     ".Lextcodehash_codestate_deleted:\n" ++
@@ -346,7 +346,7 @@ private def extcodesizeWitnessTail : HandlerTail :=
     "  jal ra, account_state_lookup_current\n" ++
     "  li t3, 2; beq a0, t3, .Lextcodesize_codestate_empty\n" ++
     "  li t3, 3; beq a0, t3, .Lextcodesize_codestate_empty\n" ++
-    -- Consult the shared CodeState before the authenticated witness fallback.
+    -- Consult the shared AccountState before the authenticated witness fallback.
     "  la a0, eahsr_address_scratch\n" ++
     "  jal ra, code_state_lookup_current\n" ++
     "  beqz a0, .Lextcodesize_witness_check\n" ++

--- a/EvmAsm/Codegen/Programs/EvmExtcodecopy.lean
+++ b/EvmAsm/Codegen/Programs/EvmExtcodecopy.lean
@@ -275,7 +275,7 @@ private def extcodecopyWitnessTail : HandlerTail :=
 " ++
     "  addi sp, sp, 64
 " ++
-    -- Current code comes from the shared mutable CodeState overlay before the
+    -- Current code comes from the shared mutable AccountState overlay before the
     -- authenticated pre-block witness.  The append-only effect log is BAL
     -- comparator evidence only and must not decide execution visibility.
     "  addi sp, sp, -64
@@ -320,10 +320,10 @@ private def extcodecopyWitnessTail : HandlerTail :=
 " ++
     "  bnez t0, .Lrt_ecc_codestate_empty
 " ++
-    -- CodeState missed: a transaction-finalized EIP-6780 deletion
+    -- AccountState missed: a transaction-finalized EIP-6780 deletion
     -- (AccountState delete-pending tombstone) makes the account non-existent
     -- in every later transaction, masking the witness exactly like an
-    -- explicit CodeState tombstone.  Within the destroying transaction no
+    -- explicit AccountState tombstone.  Within the destroying transaction no
     -- tombstone exists yet, so same-tx semantics are unchanged.
     "  addi sp, sp, -64
 " ++
@@ -377,7 +377,7 @@ private def extcodecopyWitnessTail : HandlerTail :=
 " ++
     "  j .Lrt_ecc_same_loop
 " ++
-    -- An explicit empty/deleted CodeState entry masks pre-block witness code.
+    -- An explicit empty/deleted AccountState entry masks pre-block witness code.
     -- EXTCODECOPY consequently writes zero bytes without touching the witness.
     ".Lrt_ecc_codestate_empty:
 " ++

--- a/EvmAsm/Codegen/Programs/NoopHalt.lean
+++ b/EvmAsm/Codegen/Programs/NoopHalt.lean
@@ -216,7 +216,7 @@ private def returnRevertTail (kind : Nat) (rollbackAsm : String := "")
       ".Lrr_csg_used_" ++ toString kind ++ ":\n" ++
       "  la t1, evm_state_gas_used\n  ld t2, 0(t1)\n  add t2, t2, t0\n  sd t2, 0(t1)\n" ++
       -- Capture execution-specs generic_create target_alive current-tx evidence
-      -- before publishing this CREATE.  This is a transaction-local CodeState
+      -- before publishing this CREATE.  This is a transaction-local AccountState
       -- membership query, not an append-only code-effect scan.
       "  la t0, create_target_alive_current_tx
   sd x0, 0(t0)
@@ -694,7 +694,7 @@ private def selfdestructTailAsm : String :=
   ".L_selfdestruct_ctit_codecheck:\n" ++
   -- AccountState's transaction-local created set follows the normal caller-saved ABI and
   -- clobbers a0-a3.  x13 is the live EVM stack cursor on this halt path, so
-  -- preserve it with the other runtime cursors before asking the CodeState.
+  -- preserve it with the other runtime cursors before asking the AccountState.
   "  addi sp, sp, -24\n  sd x10, 0(sp)\n  sd x12, 8(sp)\n  sd x13, 16(sp)\n" ++
   "  la a0, sdai_origin_address\n" ++
   "  jal ra, account_state_created_contains\n" ++

--- a/EvmAsm/Codegen/Programs/Selfdestruct.lean
+++ b/EvmAsm/Codegen/Programs/Selfdestruct.lean
@@ -40,7 +40,7 @@ def selfdestructNewAccountSurchargeAsm : String :=
   -- get_account(current_target).balance != 0). A zero-header-balance contract
   -- funded THIS tx (the tx value credit, or an earlier same-tx transfer) must
   -- still charge; prefer the journaled latest balance over the header value.
-  -- The layered CodeState lookup uses the standard caller-saved a0-a3
+  -- The layered AccountState lookup uses the standard caller-saved a0-a3
   -- registers.  Preserve the live EVM stack cursor (x13) as well as the
   -- runtime context registers across the lookup.
   "  addi sp, sp, -24\n  sd x10, 0(sp)\n  sd x12, 8(sp)\n  sd x13, 16(sp)\n" ++
@@ -185,9 +185,9 @@ def selfdestructNewAccountSurchargeAsm : String :=
   "  j .L_selfdestruct_surcharge_done\n" ++   -- beneficiary==self AND created-in-tx (alive) -> no NEW_ACCOUNT state gas
   ".L_selfdestruct_csg_not_ctit:\n" ++
   -- Mirror is_account_alive's created_accounts membership through the shared
-  -- current CodeState: a beneficiary created in this transaction is alive,
+  -- current AccountState: a beneficiary created in this transaction is alive,
   -- including an empty-code CREATE, so skip the charge.
-  -- The layered CodeState lookup uses the standard caller-saved a0-a3
+  -- The layered AccountState lookup uses the standard caller-saved a0-a3
   -- registers. Preserve the live EVM stack cursor (x13) with the runtime
   -- context registers across the lookup.
   "  addi sp, sp, -24\n  sd x10, 0(sp)\n  sd x12, 8(sp)\n  sd x13, 16(sp)\n" ++

--- a/scripts/asm-fixtures/symbol-addresses.tsv
+++ b/scripts/asm-fixtures/symbol-addresses.tsv
@@ -3008,13 +3008,13 @@ stateless_guest	exec_code_effect_count	0xba98bd00	.bss	LINK_DEPENDENT
 stateless_guest	exec_code_effect_next	0xba98bd08	.bss	LINK_DEPENDENT
 stateless_guest	exec_code_effect_overflow	0xba98bd10	.bss	LINK_DEPENDENT
 stateless_guest	exec_code_effect_log	0xba98bd18	.bss	LINK_DEPENDENT
-stateless_guest	code_state_mtx_active	0xbaa8bd18	.bss	LINK_DEPENDENT
+stateless_guest	runtime_mtx_active	0xbaa8bd18	.bss	LINK_DEPENDENT
 stateless_guest	account_state_pending_count	0xbaa8bd20	.bss	LINK_DEPENDENT
 stateless_guest	account_state_durable_count	0xbaa8bd28	.bss	LINK_DEPENDENT
 stateless_guest	account_state_created_count	0xbaa8bd30	.bss	LINK_DEPENDENT
 stateless_guest	account_state_delete_count	0xbaa8bd38	.bss	LINK_DEPENDENT
 stateless_guest	account_state_overflow	0xbaa8bd40	.bss	LINK_DEPENDENT
-stateless_guest	code_state_pre_acct	0xbaa8bd48	.bss	LINK_DEPENDENT
+stateless_guest	account_resolver_pre_acct	0xbaa8bd48	.bss	LINK_DEPENDENT
 stateless_guest	account_state_scratch	0xbaa8bd80	.bss	LINK_DEPENDENT
 stateless_guest	account_state_durable	0xbaa8be00	.bss	LINK_DEPENDENT
 stateless_guest	create_nonce_table_count	0xbaf3dc00	.bss	LINK_DEPENDENT


### PR DESCRIPTION
## Summary

Closes #11386. This is a names/comments-only cleanup for two live runtime values that remained under the obsolete CodeState prefix:

- `code_state_mtx_active` -> `runtime_mtx_active`: the live MTx/auth control latch.
- `code_state_pre_acct` -> `account_resolver_pre_acct`: the resolver scratch buffer written by `account_at_header_state_root` and read by the deferred-delete predicate.

The rename is in its own PR with no deletions mixed in. During the rebase, current main's dead source-string removals were retained; the branch's only source change is the live-label/comment rename. The former branch-only guards were dropped because they were behavior changes, not part of this names-only cleanup. Remaining table-oriented prose now identifies AccountState as the emitted execution authority; retained `code_state_*` compatibility helpers are explicitly documented as legacy/source-only or forwarding aliases.

## Structural prediction and evidence

Prediction before measurement: the emitted instruction and data bytes, verdict behavior, and section sizes are unchanged; only symbol/string metadata may change.

Parent `origin/main` `8adb23eeb558ab91f936de5ac23632c8a8fc19c3` versus candidate `c87590fa2eef174deaad067286e5898a79738da0`:

- `.text`: `0x58cd8` on both; extracted `.text` SHA256 identical (`e8c9c62451a97e2caad03365105562251c9539ec316fe32fae233bdcde6707b7`).
- `.data`: `0x5370` on both; extracted `.data` SHA256 identical (`d13b7ef9bfd3a42ead87a7c286e5a892aac569eece58b8591a24e52fb85f8c40`).
- `.bss`: `0x19295540` on both.
- Full ELF SHA differs only because the renamed symbols change ELF metadata: parent `845293ce5f540d7d8ca0ecb59c0d9ef2c410d343a018b29be7095c745b05a9b4`, candidate `023fcb622bc35f12d7e3571492f768c3eab2686f7e491836f6c4afe1b0ab16d6`.

## Checks

- `lake build codegen` — PASS, 4312 jobs (2026-08-04; `/tmp/11397-build.log`).
- `CODEGEN_STATELESS_LINK_OUT=gen-out/regionmap/stateless_guest scripts/codegen-stateless-link-check.sh --no-build` — PASS.
- `scripts/check-region-map.sh` — CLEAN; section pins and `symbol-addresses.tsv` match the linked ELF, including the Class-A ratchet.
- `scripts/check-asm-to-program.sh` — CLEAN (383 converted definitions across 145 files).
- `git diff --check` — CLEAN.

No EEST/random sweep was run: this rename is behavior-preserving by construction and the extracted instruction/data bytes are byte-identical. The named structural cases are the linked-ELF section sizes and extracted byte hashes above.
