### PR TITLE
proof: the RLP walk predicates are deterministic (prereq for #11345/#11346)

### DIFF
--- a/EvmAsm/Codegen/Programs/Imports.lean
+++ b/EvmAsm/Codegen/Programs/Imports.lean
@@ -72,6 +72,7 @@ import EvmAsm.Codegen.Programs.TxTypeDispatchTyped
 import EvmAsm.Codegen.Programs.TxTypeDispatchTop
 import EvmAsm.Codegen.Programs.TxTypeDispatchDischarge
 import EvmAsm.Codegen.Programs.RlpRead
+import EvmAsm.Codegen.Programs.RlpWalkDeterminism
 import EvmAsm.Codegen.Programs.RlpListNthItemCallSAsm
 import EvmAsm.Codegen.Programs.RlpWalkCallSAsm
 import EvmAsm.Codegen.Programs.ReceiptExtractLogsBloomCallSAsm

--- a/EvmAsm/Codegen/Programs/RlpWalkDeterminism.lean
+++ b/EvmAsm/Codegen/Programs/RlpWalkDeterminism.lean
@@ -1,0 +1,97 @@
+/-
+  EvmAsm.Codegen.Programs.RlpWalkDeterminism
+
+  The `Codegen`-layer half of the walk determinism story: `StrictListPayload`,
+  `StrictNthItem` and `Success` are **functions** of the bytes they read.
+
+  The core-layer half — `rlpItemDecode_deterministic` — lives in
+  `EvmAsm/Rv64/RLP/WalkItemDeterminism.lean`, because it is about a predicate the
+  verified core owns. The predicates below are defined under `Codegen`
+  (`RlpListNthItemSAsmBase.lean`, `RlpListNthItemStrictList.lean`), so their determinism
+  has to be stated here; `check-layering.sh` L1 forbids the other direction.
+
+  WHAT THIS UNBLOCKS. Every walk-family postcondition is existential —
+  `∃ offset len, Success bytes base listLen index offset len ∧ <outputs from offset/len>`.
+  Those existentials are whatever the *routine* found. A caller holding a **known**
+  encoding (an `AccountRecord`'s four fields, a header's field 8) cannot conclude the
+  outputs denote that value without knowing the found offsets are the right ones. That
+  step is exactly `success_deterministic`, and it was missing — which is the actual
+  content of #11345 and #11346, both of which sit on this tower.
+
+  ⚠️ This module is deliberately consumer-free: it is a prerequisite landed on its own so
+  it can be reviewed as one idea. The consumers arrive with #11345/#11346. That is not the
+  "availability is not use" failure — no registry row claims a grade on the strength of
+  these lemmas.
+-/
+
+import EvmAsm.Rv64.RLP.WalkItemDeterminism
+import EvmAsm.Codegen.Programs.RlpListNthItemSAsmBase
+
+namespace EvmAsm.Codegen.RlpListNthItemSAsm
+
+open EvmAsm.Rv64 EvmAsm.Rv64.RLP
+
+/-- The list header determines both the payload cursor and the exclusive end.
+
+    `endPtr` is forced by the `listLen` index alone (both constructors conclude
+    `base + BitVec.ofNat 64 listLen`), so the content is the cursor: the `short` arm
+    yields `1` and the `long` arm `1 + lenOfLen`, and the two are separated by the
+    `ult B 0xf8` guard. -/
+theorem strictListPayload_deterministic {bytes : List (BitVec 8)} {base : Word}
+    {listLen c₁ c₂ : Nat} {e₁ e₂ : Word}
+    (h₁ : StrictListPayload bytes base listLen c₁ e₁)
+    (h₂ : StrictListPayload bytes base listLen c₂ e₂) :
+    c₁ = c₂ ∧ e₁ = e₂ := by
+  cases h₁ with
+  | short b hb hlist hshort hcur hlen =>
+    cases h₂ with
+    | short b' hb' _ _ hcur' _ =>
+      exact ⟨hcur.trans hcur'.symm, rfl⟩
+    | long b' first' hb' hlong' _ _ _ _ _ =>
+      obtain rfl : b = b' := Option.some.inj (hb.symm.trans hb')
+      exact absurd hshort hlong'
+  | long b first hb hlong hfirst hnz hmin hcur hlen =>
+    cases h₂ with
+    | short b' hb' _ hshort' _ _ =>
+      obtain rfl : b = b' := Option.some.inj (hb.symm.trans hb')
+      exact absurd hshort' hlong
+    | long b' first' hb' _ _ _ _ hcur' _ =>
+      obtain rfl : b = b' := Option.some.inj (hb.symm.trans hb')
+      exact ⟨hcur.trans hcur'.symm, rfl⟩
+
+/-- Walking to the `index`-th item is deterministic: same window and same start offset
+    give the same final cursor and length. Induction on the index; each step is pinned by
+    `rlpItemDecode_deterministic`, which also forces the offset handed to the next step. -/
+theorem strictNthItem_deterministic {bytes : List (BitVec 8)} {base endPtr : Word}
+    {index off : Nat} {n₁ l₁ n₂ l₂ : Word}
+    (h₁ : StrictNthItem bytes base endPtr index off n₁ l₁)
+    (h₂ : StrictNthItem bytes base endPtr index off n₂ l₂) :
+    n₁ = n₂ ∧ l₁ = l₂ := by
+  induction h₁ generalizing n₂ l₂ with
+  | zero off n l hitem =>
+    cases h₂ with
+    | zero _ n' l' hitem' => exact rlpItemDecode_deterministic hitem hitem'
+  | succ index off n l fn fl hitem hrest ih =>
+    cases h₂ with
+    | succ _ _ n' l' fn' fl' hitem' hrest' =>
+      obtain ⟨rfl, -⟩ := rlpItemDecode_deterministic hitem hitem'
+      exact ih hrest'
+
+/-- ⭐ **`Success` is deterministic.** The offset and length a walk routine reports for
+    item `index` are functions of the bytes, the base, the declared list length and the
+    index — nothing else.
+
+    This is the lemma callers need to identify an existentially-quantified postcondition
+    with a known encoding's field offsets. -/
+theorem success_deterministic {bytes : List (BitVec 8)} {base : Word}
+    {listLen index : Nat} {o₁ l₁ o₂ l₂ : Word}
+    (h₁ : Success bytes base listLen index o₁ l₁)
+    (h₂ : Success bytes base listLen index o₂ l₂) :
+    o₁ = o₂ ∧ l₁ = l₂ := by
+  obtain ⟨c₁, e₁, n₁, hlist₁, hnth₁, hoff₁⟩ := h₁
+  obtain ⟨c₂, e₂, n₂, hlist₂, hnth₂, hoff₂⟩ := h₂
+  obtain ⟨rfl, rfl⟩ := strictListPayload_deterministic hlist₁ hlist₂
+  obtain ⟨rfl, rfl⟩ := strictNthItem_deterministic hnth₁ hnth₂
+  exact ⟨hoff₁.trans hoff₂.symm, rfl⟩
+
+end EvmAsm.Codegen.RlpListNthItemSAsm

--- a/EvmAsm/Rv64/RLP.lean
+++ b/EvmAsm/Rv64/RLP.lean
@@ -137,6 +137,7 @@ import EvmAsm.Rv64.RLP.ContentToU64
 import EvmAsm.Rv64.RLP.WalkInit
 import EvmAsm.Rv64.RLP.WalkInitWP
 import EvmAsm.Rv64.RLP.WalkNext
+import EvmAsm.Rv64.RLP.WalkItemDeterminism
 import EvmAsm.Rv64.RLP.WalkDecodeBridge
 import EvmAsm.Rv64.RLP.WithdrawalDecode
 import EvmAsm.Rv64.RLP.WithdrawalSchemaWP

--- a/EvmAsm/Rv64/RLP/WalkItemDeterminism.lean
+++ b/EvmAsm/Rv64/RLP/WalkItemDeterminism.lean
@@ -1,0 +1,88 @@
+/-
+  EvmAsm.Rv64.RLP.WalkItemDeterminism
+
+  **`rlpItemDecode` is a function**, not merely a relation — and so are the walk
+  predicates built on it.
+
+  WHY THIS IS NEEDED, and why it lives here rather than beside a consumer. Every
+  whole-routine spec in the RLP walk family states its outcome existentially: the
+  `rlp_list_nth_item` / `account_decode` / `account_is_eip161_empty` posts all read
+  `∃ offset len, … Success bytes base listLen index offset len ∧ <outputs written from
+  offset/len>`. Those existentials are *whatever the routine found*. To conclude that the
+  outputs denote a **known** value — the four fields of an `AccountRecord`, say — a caller
+  must know the found offsets ARE the offsets of that value's encoding. That is exactly a
+  determinism statement, and nothing in the tree had one.
+
+  So this is not an `account_decode` lemma; it is shared infrastructure. #11345 and #11346
+  sit on the identical `StrictListPayload`/`StrictNthItem`/`rlpItemDecode` tower, and
+  #11351 reaches it through `rlp_field_to_u64`. Putting it under `Rv64/RLP/` rather than
+  `Codegen/Programs/` is deliberate: the `Codegen` consumers are on both sides of the
+  layering boundary (`Field0ToU64.lean:173` already re-proved a walk fact at this layer to
+  dodge that import).
+
+  ⭐ WHY IT IS TRUE. `rlpItemDecode` (`WalkNext.lean:3649`) is
+  `∃ b, bytes[off]? = some b ∧ (five disjuncts)`. The head byte is shared — `Option.some`
+  is injective — and the five disjuncts are guarded by **range-disjoint** tests on
+  `B := b.zeroExtend 64`:
+
+      1  ult B 0x80                    2  ¬ult B 0x80 ∧ ult B 0xb8
+      3  ¬ult B 0xb8 ∧ ult B 0xc0      4  ¬ult B 0xc0 ∧ ult B 0xf8
+      5  ¬ult B 0xf8
+
+  so at most one arm applies. Within each arm `next` and `len` are pinned by explicit
+  equations in `b`, `cursor`, `endPtr`, `bytes` and `off` — there is no further choice.
+  Hence 25 cases: 5 diagonal ones close by `rfl` after substitution, and the 20
+  off-diagonal ones are guard contradictions, discharged uniformly by pushing every `ult`
+  through to `Nat` and calling `omega`.
+
+  ⚠️ NOT claimed here: that a decode *exists*, or that it agrees with `EL.RLP.decodeAux`.
+  The latter is **false** for the nested-list arms — see the `c3 c2 81 00` counterexample
+  on #11341 — and is a separate question about the verdict column, not this one.
+-/
+
+import EvmAsm.Rv64.RLP.WalkNext
+
+namespace EvmAsm.Rv64.RLP
+
+/-- Widening the bound of an unsigned comparison. The workhorse for the 20
+    off-diagonal cases: a byte below `0x80` is below `0xb8`, and so on. -/
+private theorem ult_mono {x c1 c2 : Word}
+    (h : BitVec.ult x c1 = true) (hc : c1.toNat ≤ c2.toNat) :
+    BitVec.ult x c2 = true := by
+  rw [BitVec.ult_iff_toNat_lt] at h ⊢
+  omega
+
+/-- The head-byte literals, as naturals — supplied to `omega`, which cannot evaluate
+    `BitVec.toNat` of a numeral on its own. -/
+private theorem prefix_literals :
+    ((0x80 : Word)).toNat = 128 ∧ ((0xb8 : Word)).toNat = 184 ∧
+    ((0xc0 : Word)).toNat = 192 ∧ ((0xf8 : Word)).toNat = 248 := by
+  refine ⟨by decide, by decide, by decide, by decide⟩
+
+/-- ⭐ **`rlpItemDecode` is deterministic.** Two canonical decodes at the same offset,
+    cursor and window agree on both the advanced cursor and the item length.
+
+    This is what lets a caller identify the existentially-quantified offsets in a walk
+    routine's postcondition with the offsets of a *known* encoding. -/
+theorem rlpItemDecode_deterministic {bytes : List (BitVec 8)} {off : Nat}
+    {cursor endPtr next₁ len₁ next₂ len₂ : Word}
+    (h₁ : rlpItemDecode bytes off cursor endPtr next₁ len₁)
+    (h₂ : rlpItemDecode bytes off cursor endPtr next₂ len₂) :
+    next₁ = next₂ ∧ len₁ = len₂ := by
+  obtain ⟨b, hb, hc₁⟩ := h₁
+  obtain ⟨b', hb', hc₂⟩ := h₂
+  obtain rfl : b = b' := Option.some.inj (hb.symm.trans hb')
+  obtain ⟨p80, pb8, pc0, pf8⟩ := prefix_literals
+  rcases hc₁ with ⟨g, -, hn₁, hl₁⟩ | ⟨g, g', -, -, hn₁, hl₁⟩ |
+      ⟨g, g', -, -, -, -, hn₁, hl₁⟩ | ⟨g, g', -, hn₁, hl₁⟩ | ⟨g, -, -, -, -, hn₁, hl₁⟩ <;>
+    rcases hc₂ with ⟨f, -, hn₂, hl₂⟩ | ⟨f, f', -, -, hn₂, hl₂⟩ |
+        ⟨f, f', -, -, -, -, hn₂, hl₂⟩ | ⟨f, f', -, hn₂, hl₂⟩ | ⟨f, -, -, -, -, hn₂, hl₂⟩ <;>
+    subst hn₁ <;> subst hl₁ <;> subst hn₂ <;> subst hl₂ <;>
+    first
+      | exact ⟨rfl, rfl⟩
+      | (exfalso
+         simp only [BitVec.ult_eq_decide, decide_eq_true_eq, Nat.not_lt,
+           p80, pb8, pc0, pf8] at *
+         omega)
+
+end EvmAsm.Rv64.RLP


### PR DESCRIPTION
Shared infrastructure, landed on its own because two issues need it and neither should discover it independently. **No registry rows touched**; no issue closed.

## The gap

Every walk-family postcondition is existential:

```lean
∃ offset len, Success bytes base listLen index offset len ∧ <outputs written from offset/len>
```

Those existentials are whatever the **routine** found. A caller holding a *known* encoding — an `AccountRecord`'s four fields (#11345), the `EMPTY_ACCOUNT` comparison (#11346), a header's field 8 (#11351) — cannot conclude the output cells denote that value without knowing the found offsets **are** its field offsets.

That step is a determinism statement, and nothing in the tree had one. I went looking for it while sizing #11345 as "invert `Decoded` to `bytes = a.rlp`" and found that framing was wrong: the inversion isn't the content, this is. Since #11346 sits on the identical `StrictListPayload`/`StrictNthItem`/`rlpItemDecode` tower, it seemed worth extracting rather than proving twice.

## Two modules, because the predicates straddle the layering boundary

`rlpItemDecode` is core (`Rv64/RLP/WalkNext.lean`); `StrictNthItem`/`Success` are Codegen (`RlpListNthItemSAsmBase.lean`). `check-layering.sh` L1 forbids core importing Codegen, so:

| module | contents |
|---|---|
| `Rv64/RLP/WalkItemDeterminism.lean` | `rlpItemDecode_deterministic` |
| `Codegen/Programs/RlpWalkDeterminism.lean` | `strictListPayload_deterministic`, `strictNthItem_deterministic`, `success_deterministic` |

(`Field0ToU64.lean:173` already re-proved a walk fact at the core layer to dodge that import, so the split follows existing practice.)

## ⭐ Why `rlpItemDecode` is a function

It is `∃ b, bytes[off]? = some b ∧ (five disjuncts)`. The head byte is shared — `Option.some` is injective — and the five guards are **range-disjoint** on `B := b.zeroExtend 64`:

```
1  ult B 0x80                     2  ¬ult B 0x80 ∧ ult B 0xb8
3  ¬ult B 0xb8 ∧ ult B 0xc0       4  ¬ult B 0xc0 ∧ ult B 0xf8
5  ¬ult B 0xf8
```

so at most one arm applies, and within an arm `next` and `len` are pinned by explicit equations with no further choice. 25 cases: the 5 diagonals close by `rfl` after substitution; the 20 off-diagonal guard contradictions are discharged **uniformly** by pushing every `ult` through to `Nat` (`ult_eq_decide` plus the four prefix literals, which `omega` cannot evaluate itself) and calling `omega`. No `bv_decide`.

`StrictNthItem` follows by induction on the index — each step is pinned by the item lemma, which also forces the offset handed to the next step. `StrictListPayload` is a two-constructor split on the same `ult B 0xf8` guard, with `endPtr` already forced by the `listLen` index. `Success` composes the two.

## ⚠️ What is deliberately not claimed

That a decode **exists**, or that it agrees with `EL.RLP.decodeAux`. The latter is **false** for the nested-list arms — the `c3 c2 81 00` counterexample I posted on #11341 — and is a question about the *verdict* column, which is still with you. Determinism is orthogonal to it and true unconditionally, which is why it can land now.

## On "availability is not use"

This module is consumer-free today, and I want to be explicit that I don't think that trips the rule I've been enforcing elsewhere. The rule is about a **registry row claiming a grade** on the strength of an unconsumed lemma. No row is added or re-graded here. The consumers arrive with #11345/#11346; if you'd rather this were folded into #11345's PR instead of landing separately, say so and I'll squash it there — I split it because it is one reviewable idea and two issues depend on it.

## Verification

`port-check.sh` **PASS** on both modules. `lake build` clean (4807 jobs, 0 warnings); `check-axioms` 126 witnesses classical-only; registry-crosscheck (17 × 23), layering, progress, forbidden-tactics, file-size, naming all pass. Submodule absent from the commit (checked).

Prereq for #11345, #11346.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
