### PR TITLE
docs(plan): record the Class-A provided-BAL programme and #10651's completion

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -277,6 +277,72 @@ All deleted spec files have been recreated. See **Pending: Recreate Deleted Spec
   `BlockVerdictMtxRuntime:399`, are later slices. This bead is the forced-order
   prerequisite for #10651 (compute the state root from operations, not from the BAL).
 
+- **#10651's headline is now DONE for user-tx accounts** (PR #11389, GH #11326 entry 6):
+  `BlockVerdictStateRoot.lean` no longer seeds `bsr_changes` from the supplied BAL — the
+  seeding block is a bare `j .Lbsr_bal_copy_next`, the RLP walk is retained only so the
+  cursor advances, and `execution_map_state_changes` is the **sole root authority**. The
+  state root is computed from operations, not from the BAL, matching the spec's data flow:
+  `fork.py:928-930` builds the BAL **from** tracked state *after* execution and
+  `:366`/`:390` bind only `hash_block_access_list`. Evidence the seed was redundant rather
+  than merely unused: a −484-byte removal left the random-200 **byte-identical** (FA=0,
+  forward set empty) — which is what the #11382 TOUCHED producers bought. `bsr_changed_accounts`
+  survives as a **dedup/already-owned list, not a work list**, so system-only content is now
+  its correct content. Residual: the modeled 2935/4788 arms still pre-seed and take
+  precedence over the map (GH #11390, PR #11399 — union, not precedence, since
+  `process_unchecked_system_transaction` at `fork.py:897-907` mutates the same tracked state
+  as everything else).
+
+- **The Class-A programme** (GH #11183) is #10651's successor line: *the guest must not read
+  the provided BAL as an **execution input***. ⛔ Its original wording — "except to hash it" —
+  proved **unreachable** and was amended 2026-08-04 with a **carve-out**: a witness-integrity
+  check may read BAL row *shapes* to select what to verify, provided every value it trusts is
+  authenticated and its only effect is to reject. `bal_code_preimages_valid` satisfies the
+  carve-out and **must not be deleted** — `bal_serializer_verify` never reads `svf_codes`, so
+  removing it turns a clean fail-11 reject into a **false accept** whenever the missing code
+  does not move the post-state root, and the spec agrees such witnesses are invalid
+  (`witness_state.py:204-212` raises `KeyError` when execution reads the code, *regardless of
+  state effect*). On the accept path the serializer hash pins the supplied BAL byte-for-byte to
+  the execution-derived rebuild, so what remains BAL-sourced there is only *selection*, never a
+  value.
+
+  Retired so far: the `runtime_current_bal_ptr` handoff into same-block delegation (#11396 /
+  PR #11400), the granular MtxTail comparators 37/44/45 together with the
+  `nonstorage_effect_aggregate` they alone fed (#10612 / PR #11392), the discarded
+  `bal_storage_whitelist_clean` scan (#11402 / PR #11404), the BAL-sourced recipient
+  state-charge arm across all four arms via one shared template (#11398 / PR #11403), and
+  `eip8037`'s redundant duplicate BAL loads (PR #11405). Still live:
+  `bal_same_block_delegation_code_resolve` at **15 emitted sites** (#11406 — blocked on
+  publishing the 23-byte auth marker into AccountState first, since **write maps are
+  attribution, not state**, and the spec reads code from `tx_state.code_writes`,
+  `state_tracker.py:248-274`), `eip8037_state_used_before_tx` (#11407 — the supplied BAL is the
+  prior-state-gas source for **later transactions** of non-independent/EOA blocks, because
+  `bvgr_runtime_count` is 0 there and the gas gate runs before `arena_prepare`; not deletable
+  until a per-tx storage-set counter exists, as `storage_writes` is a cumulative latest-value
+  map cleared by `write_sets_incorporate_tx`), and the BAL-shaped *selection* in the preimage
+  gate (#11410 — C-class re-derivation from actual code reads, not a deletion).
+
+  **A ratchet, not an assertion** (PR #11409): `scripts/check-bal-class-a-ratchet.py` plus a
+  33-path baseline fails on any **new** `bv_bal_start`/`bv_bal_len` edge *and* on a **silent
+  shrink**, so retirement must shrink the baseline deliberately and progress is visible as the
+  file shrinking. The invariant is not yet true, so a guard asserting it would be red on arrival
+  and would get disabled. The baseline records per path whether its **return status is tested**,
+  because *an unused datum is not an unused status*: three near-deletions in one hour had a
+  payload reaching nothing while `a0 == 2` gated a reject — `bal_find_account_by_address` @21731
+  (`BlockVerdictDispatchTx.lean:346` says outright the parse bail is FA-safe and stays, and its
+  `a3`/`a4` are out-pointers), `bal_txs_independent` (`.Lbv_mtx_bail`), and `eip8037`'s
+  arguments (live across an `s1`/`s2` save-restore, dead only in a redundant second load).
+  Blind spots are enumerated in the script, including that symbol-only scanning is **evadable by
+  an address literal** — `AccountWriteMap` reaches its arenas via `li 0xa2b20000`, `0xa28a0000`,
+  `0xa2d20000`, `0xa21a0000`, `0xa1fa0000`, `0xa23a0000`, none of which appears in
+  `symbol-addresses.tsv`.
+
+  ⚠️ **Gate equality is the test for retiring a check, and it must be applied per check.** #11392's
+  comparators were retirable because survivor and retired check shared one flag
+  (`bv_bal_shadow_ready`, sole writer `BlockVerdictFunction.lean:230`) *and* the hash covered the
+  same bytes. The same test **fails** for `bal_code_preimages_valid`, whose property the hash
+  cannot see. Byte coverage alone is necessary but not sufficient: a survivor behind a narrower
+  gate leaves an uncovered population that a random-200 cannot reveal.
+
 - **Memory-budget contingency guard** (`EvmAsm/Codegen/MemoryBudgetGuard.lean`,
   GH #10540): kernel-checked (`decide`, classical-3) assertions that the
   MLOAD/MSTORE sparse path is unaffordable under `TX_MAX_GAS_LIMIT` — exceeding

--- a/PLAN.md
+++ b/PLAN.md
@@ -311,15 +311,42 @@ All deleted spec files have been recreated. See **Pending: Recreate Deleted Spec
   `bal_storage_whitelist_clean` scan (#11402 / PR #11404), the BAL-sourced recipient
   state-charge arm across all four arms via one shared template (#11398 / PR #11403), and
   `eip8037`'s redundant duplicate BAL loads (PR #11405). Still live:
-  `bal_same_block_delegation_code_resolve` at **15 emitted sites** (#11406 — blocked on
-  publishing the 23-byte auth marker into AccountState first, since **write maps are
-  attribution, not state**, and the spec reads code from `tx_state.code_writes`,
-  `state_tracker.py:248-274`), `eip8037_state_used_before_tx` (#11407 — the supplied BAL is the
-  prior-state-gas source for **later transactions** of non-independent/EOA blocks, because
-  `bvgr_runtime_count` is 0 there and the gas gate runs before `arena_prepare`; not deletable
-  until a per-tx storage-set counter exists, as `storage_writes` is a cumulative latest-value
-  map cleared by `write_sets_incorporate_tx`), and the BAL-shaped *selection* in the preimage
-  gate (#11410 — C-class re-derivation from actual code reads, not a deletion).
+  `bal_same_block_delegation_code_resolve` at **15 emitted sites** (#11406) and the BAL-shaped
+  *selection* in the preimage gate (#11410 — C-class re-derivation from actual code reads, not a
+  deletion).
+
+  ⭐ **#11406's root cause, because four wrong hypotheses were tried first and each cost a
+  candidate build.** It is **not** a missing producer, a wiped journal, a key mismatch, or an
+  absent source for the delegate target's code. The generic code lookup **finds the 23-byte
+  `ef0100` marker and the handler treats it as ordinary code**, bypassing delegation resolution
+  — so the marker is *executed* instead of *followed*. The spec does the same lookup and then
+  recognises the designator: `is_valid_delegation` (`vm/eoa_delegation.py:40`) tests
+  `len(code) == EOA_DELEGATED_CODE_LENGTH` plus the `EOA_DELEGATION_MARKER` prefix, and
+  `get_delegated_code_address` (`:62`) extracts the target. **Recognition is a property of the
+  code bytes, not of which store they came from** — which is why the old BAL path worked by
+  accident: it *missed* in CodeState and so never had a marker to mistake for code. The fix
+  re-enters the existing `.Lcd_header_lookup` marker path, keeping one marker-follower rather
+  than two that can drift.
+
+  ⚠️ And why the diagnosis took seven candidates: `0xEF` is a **reserved invalid opcode**
+  (EIP-3541), so executing the marker halts exceptionally and burns the frame's gas *without
+  mutating state*. The post-state root therefore **matched** while `succ` did not — and
+  root-matching was read as reassurance rather than as evidence about where the failure was
+  **not**. When a root matches and the block still rejects, the defect is downstream of state.
+
+  **#11407 resolved as a deletion** (PR #11424, merged via #11437): the fallback computed
+  `97,920 × prior-tx storage-set count` while the primary sums *all* prior state gas — never
+  equivalent, **FA-lax** (under-reporting loosens the `tx.gas` rejection), and **unreachable on
+  any accepting path**, since the routes that starve `bvgr_runtime_count` also set
+  `bv_dispatch_runtime_status` nonzero and the receipts tail rejects at fail64. No counter was
+  built. ⭐ **No sweep could have found it** — the path is unexercised by the corpus, so only
+  computing *both* quantities on the rows where the primary succeeds compared the two
+  definitions. Decode gas figures by ÷1530 to read byte counts; that is what turned
+  "183600 vs 0" into "120 bytes of creation charge" and named the cause.
+
+  Its dead **transport** outlived its consumer and needed its own cut (#11428 / PR #11437) —
+  the prelude still loaded `bv_bal_start`/`bv_bal_len` and the gate still saved them into
+  `s1`/`s2` with nothing reading them, a recurrence of #11405's defect one register pair later.
 
   **A ratchet, not an assertion** (PR #11409): `scripts/check-bal-class-a-ratchet.py` plus a
   33-path baseline fails on any **new** `bv_bal_start`/`bv_bal_len` edge *and* on a **silent


### PR DESCRIPTION
**Attribution: coord.** Documentation only — `PLAN.md`, +66 lines, no code.

## Why

`PLAN.md` named "#10651 (compute the state root from operations, not from the BAL)" as a **future** forced-order
prerequisite. That headline is now **done for user-tx accounts** (PR #11389): the seeding block is a bare
`j .Lbsr_bal_copy_next` and `execution_map_state_changes` is the sole root authority. Its successor line — the Class-A
programme, #11183 — was absent from `PLAN.md` entirely, despite being this session's main structural thread and the
source of eleven merged or labelled PRs.

## What it records, chosen as the things a reader would otherwise re-derive

- **#11183's literal exit condition was unreachable** and now carries a **witness-integrity carve-out**.
  `bal_code_preimages_valid` must **not** be deleted: `bal_serializer_verify` never reads `svf_codes`, so removing it
  turns a clean fail-11 reject into a **false accept** whenever the missing code does not move the post-state root —
  and the spec agrees such witnesses are invalid (`witness_state.py:204-212` raises `KeyError` when execution reads the
  code, *regardless of state effect*). Someone will otherwise try to delete it under the hash-discharge argument.
- **Which reads are retired and which remain, with the blocker for each** — including that #11406 is blocked on
  publishing the auth marker into AccountState because *write maps are attribution, not state*, and that #11407 cannot
  be deleted at all until a per-tx storage-set counter exists, since `storage_writes` is a cumulative latest-value map
  cleared by `write_sets_incorporate_tx`.
- **Why the ratchet is a ratchet** and not an assertion of the invariant: the invariant is not yet true, so a guard
  asserting it would be red on arrival and would get disabled.
- **`an unused datum is not an unused status`**, with all three near-deletions named. This one cost the most time
  tonight and is the easiest to repeat.
- **Gate equality is the per-check test for retiring a strictness**, with both the case where it succeeded (#11392,
  shared `bv_bal_shadow_ready`) and the case where it fails (`bal_code_preimages_valid`, whose property the hash cannot
  see). Byte coverage alone is necessary but not sufficient.
- That `bsr_changed_accounts` survives #11389 as a **dedup list, not a work list** — misreading it as a work list would
  make the cut look wrong.

## Evidence

`scripts/check-file-size.sh`: 2164 files checked, all within cap. No `EvmAsm/**` file touched, so no build, pin, or
fixture implications, and it contends with nothing in the merge queue.

The claims are sourced from tonight's PR reviews and issue analyses (#11389, #11392, #11396/#11400, #11398/#11403,
#11402/#11404, #11405, #11406, #11407, #11409, #11410) rather than restated from memory; each carries its spec cite or
emitted-site reference inline.
