### PR TITLE
docs(#11351): six of seven chain_validate_* have triples, not seven

### DIFF
--- a/docs/leaf-routine-targets.md
+++ b/docs/leaf-routine-targets.md
@@ -50,9 +50,15 @@ is exactly the "leaf means leaf in the TRANSITIVE call graph" trap.
 | 10 | `bgv_u32le` (leaf; 8 fixture in-edges; caller `EvmAsm/Codegen/Programs/BlockVerdictStateRoot.lean:681`) | the fixed-width LE reads of `deserialize_stateless_input` (`EvmAsm/Stateless/SpecRef/Guest.lean:29`) — the u32 accessor those reads reduce to | guest input blob (witness section offsets) | `bytesRegion`; proving this one leaf discharges a step in every one of its 8 callers |
 
 Row 9 is the representative of a **family**: `header_extract_logs_bloom`,
-`header_validate_extra_data_length`, and the seven `chain_validate_*` routines have the same
-shape (verified RLP callees only, one `_decode_header` field or one header rule each). Once
-row 9's pattern exists, the siblings are mechanical forks.
+`header_validate_extra_data_length`, and **six of the seven** `chain_validate_*` routines
+have the same shape (verified RLP callees only, one `_decode_header` field or one header
+rule each). Once row 9's pattern exists, those **eight** siblings are mechanical forks.
+
+⚠️ The seventh, `chain_validate_post_merge_full` (`GuestAddrs.lean:453`), is **not** a fork:
+it has no whole-routine triple at all — `ChainValidatePostMerge.lean` carries only the
+string↔`Program` byte-identity theorem (`:608`). It is an unproven routine, and counting it
+with the forks overstates what row 9's pattern buys. Measured on `origin/main`; an earlier
+revision of this paragraph said "seven".
 
 ## Runners-up (not in the ten, recorded so the cut is visible)
 


### PR DESCRIPTION
One-paragraph correction to `docs/leaf-routine-targets.md`.

## The claim, and the measurement

The table says row 9 (`header_extract_number`) is the representative of a family including *"the seven `chain_validate_*` routines"*, implying nine mechanical forks once its pattern lands.

Measured on `origin/main`: there are **seven** `chain_validate_*` symbols in `GuestAddrs.lean` but only **six** carry a whole-routine triple.

| routine | triple |
|---|---|
| `chain_validate_blob_gas_used_multiple` | `ChainValidateBlobGasMultipleLoopClose.lean:194` |
| `chain_validate_blob_gas_used_under_max` | `ChainValidateBlobGasUnderMaxLoopClose.lean:192` |
| `chain_validate_consecutive_numbers` | `ChainValidateConsecutiveNumbersLoopClose.lean:877` |
| `chain_validate_extra_data_length` | `ChainValidateExtraDataLengthLoopClose.lean:175` |
| `chain_validate_gas_used_under_limit` | `ChainValidateGasUsedUnderLimitLoopClose.lean:1283` |
| `chain_validate_increasing_timestamps` | `ChainValidateIncreasingTimestampsLoopClose.lean:873` |
| **`chain_validate_post_merge_full`** | **none** — `ChainValidatePostMerge.lean` has only the string↔`Program` byte-identity theorem (`:608`) |

## Why it is worth a PR rather than a silent edit

That count is the stated reason row 9 is the family representative and is ranked for leverage — so it feeds a prioritisation decision, not just prose. With `header_extract_logs_bloom` and `header_validate_extra_data_length`, the pattern unlocks **eight** forks, and the odd one out is an **unproven routine** rather than a fork awaiting a pattern. Grouping it with the others makes an unproven routine look like pending mechanical work.

Full table with file:line is on #11351, alongside the sizing for row 9 itself.

Docs only — no Lean touched. `check-drift.sh` passes.

Refs #11351.

🤖 Generated with [Claude Code](https://claude.com/claude-code)