### PR TITLE
fix(codegen): preserve EIP-7702 AccountState across dispatcher reset

### DIFF
--- a/EvmAsm/Codegen/Dispatch.lean
+++ b/EvmAsm/Codegen/Dispatch.lean
@@ -3078,10 +3078,25 @@ def emitRuntimeDispatcherCallableSetup : String :=
   "  la x5, exec_code_effect_next; sd x0, 0(x5)\n" ++
   "  la x5, exec_code_effect_overflow; sd x0, 0(x5)\n" ++
   ".Lrtdc_code_log_kept:\n" ++
+  -- EIP-7702 preparation publishes accepted authorizations into the
+  -- transaction-local AccountState overlay before entering this dispatcher.
+  -- That overlay is the live execution state consumed by delegation
+  -- resolution; clearing it here would erase the just-published rows before
+  -- the first delegated target is resolved.  Ordinary transactions still
+  -- take the reset path, while an auth-prepared transaction keeps its whole
+  -- AccountState journal across the dispatcher entry.  Keep pending, created,
+  -- and deleted counts together: account_state_commit_pending consumes these
+  -- as one coherent journal, so preserving only pending would desynchronize
+  -- the created/delete sets from their shared cursor state.
+  -- Preserve the overflow latch with them deliberately: clearing an
+  -- authorization-arena overflow at this boundary would turn a required
+  -- rejection into a later execution attempt.
+  "  la x5, runtime_tx_auth_prepared; ld x6, 0(x5); bnez x6, .Lrtdc_account_state_kept\n" ++
   "  la x5, account_state_pending_count; sd x0, 0(x5)\n" ++
   "  la x5, account_state_created_count; sd x0, 0(x5)\n" ++
   "  la x5, account_state_delete_count; sd x0, 0(x5)\n" ++
   "  la x5, account_state_overflow; sd x0, 0(x5)\n" ++
+  ".Lrtdc_account_state_kept:\n" ++
   "  la x5, evm_log_data_used; sd x0, 0(x5)\n" ++
   "  la x5, evm_log_data_overflow; sd x0, 0(x5)\n" ++
   emitRuntimeDispatcherSetupWithInputAsm


### PR DESCRIPTION
## Summary

On a same-block type-4 transaction, accepted EIP-7702 authorizations are published into the transaction-local AccountState pending journal before entering the callable runtime dispatcher. The dispatcher setup then cleared `account_state_pending_count`, `account_state_created_count`, and `account_state_delete_count` before delegation resolution consumed that state. This made the producer correct but unfed.

The fix keeps the three AccountState journal counters coherent when `runtime_tx_auth_prepared` is set; ordinary callable entries retain the existing bulk reset. Preserving only pending would desynchronize the created/delete sets from the shared journal consumed by `account_state_commit_pending`.

## Evidence

- Fixture: `00002_test_call_into_chain_delegating_set_code...`
- Input SHA: `3ed90ea176f7b9726e34f55c6374e5afe302026173ac0d2af20e5ead3703803a`
- Pre-fix probe ELF SHA: `1ec20df974c92930ba6770752a1042a9a4a9e26d88ae99ddf11d4726bf7fcc47`
- `account_state_pending_count`: 0→1→2 at `account_state_append_pending` PC `0x8003724c`
- The callable setup reset then changed it 2→0 at PC `0x8003526c` (`Dispatch.lean` around line 3088), before the resolver read.
- Candidate commit: `99fbcf6f1`
- Candidate ELF SHA: `dd8f2f0d4c9f3d018e1a55577ed40d11532acca96c27e30fb798a5c48cf71762`
- Candidate build timestamp: `2026-08-04T16:25Z`
- Targeted rerun: `scripts/codegen-eest-stateless-check.sh --filter call_into_chain_delegating_set_code --limit 1 --backend spike --jobs 1 --guest-elf gen-out/11406-accountstate-reset.elf --run-dir gen-out/eest-run-11406-reset-call --show-passes --no-verdict-debug`
- Result: `PASS(full)` 256/256, `succ=1`, `fail=0`, root and tail exact.

The execution-specs ordering is `set_delegation` followed by `prepare_dispatch` against the same transaction state (`interpreter.py:356-365`, pinned `e5a8caf1b`). The MTx loop already resets the journal at the transaction boundary before authorization preparation; the late callable reset is the ordering defect exposed by 11427.

This is intentionally separate from the 11406 consumer switch: the reset is independently wrong once authorization preparation is moved earlier, and the switch only made the erased producer observable. The convergent shape is a future auth-only preparation seam that runs after callable setup; this cut keeps the minimal conditional reset while preserving current ordinary-dispatch isolation.