### PR TITLE
fix(codegen): gate direct deposit fallback on receipt status

### DIFF
--- a/EvmAsm/Codegen/Programs/BlockVerdictDepositFallback.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictDepositFallback.lean
@@ -128,6 +128,12 @@ def blockVerdictDirectDepositFallback : String :=
   ".Lbv_deposit_direct_loop:\n" ++
   "  beq s3, s4, .Lbv_deposit_direct_done\n" ++
   "  la a0, bv_mtx_skip_ctx; mv a1, s3; jal ra, multi_tx_nth_context\n" ++
+  -- Direct request derivation is a fallback for missing runtime deposit logs,
+  -- not an independent transaction executor.  A reverted transaction can
+  -- retain the canonical calldata shape while its receipt status is zero;
+  -- execution-specs derives EIP-6110 requests from successful receipt logs,
+  -- so do not synthesize a request for that transaction.
+  "  slli t0, s3, 3; la t1, bv_tx_status_arr; add t1, t1, t0; ld t1, 0(t1); beqz t1, .Lbv_deposit_direct_noappend\n" ++
   "  la a0, bv_mtx_skip_ctx; mv a1, s2; mv a2, s5; jal ra, block_verdict_append_direct_deposit\n" ++
   "  mv s2, a1\n" ++
   "  beqz a0, .Lbv_deposit_direct_noappend\n" ++


### PR DESCRIPTION
Fix direct deposit fallback to honor reverted receipt status

## Summary

Route B derives EIP-6110 requests from canonical transaction calldata only
when captured receipt status is successful. A reverted canonical-shape call
must not synthesize a request merely because runtime dispatch status remains
zero; the receipt status is stored separately in `bv_tx_status_arr`.

Route B remains in place for blocks where runtime log capture is incomplete.
This change only gates its append helper on the per-transaction receipt status.

## Validation

- `lake build EvmAsm.Codegen.Programs.BlockVerdictDepositFallback`
- Candidate and origin stateless guests both link successfully.
- Constructed two-transaction Amsterdam witness: tx0 is a canonical deposit
  call with receipt status 0 due to the gas floor, tx1 is an ordinary successful
  call, and the honest header omits requests. Origin rejects and candidate
  accepts, matching the execution-specs reference.
- The companion header claims the request synthesized from tx0 calldata.
  Origin accepts and candidate rejects.

The trigger/reject distinction is intentional: `bv_dispatch_runtime_status`
stays zero on the reverted path, while `bv_tx_status_arr` records receipt
status. The fallback previously did not read the latter.
