### PR TITLE
proof(#11351): forward construction of rlp_list_nth_item's Success

### DIFF
--- a/EvmAsm/Codegen/Programs/Imports.lean
+++ b/EvmAsm/Codegen/Programs/Imports.lean
@@ -73,6 +73,7 @@ import EvmAsm.Codegen.Programs.TxTypeDispatchTop
 import EvmAsm.Codegen.Programs.TxTypeDispatchDischarge
 import EvmAsm.Codegen.Programs.RlpRead
 import EvmAsm.Codegen.Programs.BytesToNibblesBridge
+import EvmAsm.Codegen.Programs.RlpListNthItemForward
 import EvmAsm.Codegen.Programs.RlpWalkDeterminism
 import EvmAsm.Codegen.Programs.RlpListNthItemCallSAsm
 import EvmAsm.Codegen.Programs.RlpWalkCallSAsm

--- a/EvmAsm/Codegen/Programs/RlpListNthItemForward.lean
+++ b/EvmAsm/Codegen/Programs/RlpListNthItemForward.lean
@@ -1,0 +1,173 @@
+/-
+  EvmAsm.Codegen.Programs.RlpListNthItemForward
+
+  Forward (model → guest) construction of `rlp_list_nth_item`'s success
+  predicate.  `Success` / `StrictListPayload` / `StrictNthItem` previously had
+  **no constructor at all** driven by a model-side decode — every lemma about
+  them consumed one.  That gap is the shared prerequisite behind #11351,
+  #11345 and #11346.
+
+  Lives under `Codegen` rather than beside `Rv64/RLP/ItemDecodeForward.lean`
+  because `StrictNthItem` and friends are Codegen-layer definitions and
+  `scripts/check-layering.sh` L1 forbids core importing Codegen — the same
+  split used for the determinism prerequisite in #11408.
+
+  Scope is byte-string children, inherited from `ItemDecodeForward`: the
+  converse direction is false for nested lists (`c3 c2 81 00`), and every RLP
+  field of a block header is a byte string.
+-/
+
+import EvmAsm.Codegen.Programs.RlpListNthItemSAsmBase
+import EvmAsm.Rv64.RLP.ItemDecodeForward
+
+namespace EvmAsm.Codegen.RlpListNthItemSAsm
+
+open EvmAsm.Rv64 EvmAsm.Rv64.RLP EvmAsm.EL.RLP
+
+/-! ## The selected child -/
+
+/-- From a byte-string `DecodeChain` covering the list payload, the guest's
+    `StrictNthItem` holds for whichever child the model put at `index`.
+
+    Induction is on `index`, generalising the item list and the start offset:
+    the head decode supplies one `rlpItemDecode`, and the tail supplies the
+    rest of the chain re-entered at `(next - base).toNat`. -/
+theorem strictNthItem_of_chain
+    (bytes : List Byte) (base : Word) (endOff : Nat)
+    (hendOff : endOff ≤ bytes.length) (hover : base.toNat + bytes.length < 2 ^ 64) :
+    ∀ (index : Nat) (items : List RLPItem) (off offEnd : Nat) (p : List Byte),
+      DecodeChain bytes off items offEnd → offEnd ≤ endOff →
+      (∀ it ∈ items, ∃ q, it = RLPItem.bytes q) →
+      items[index]? = some (RLPItem.bytes p) →
+      ∃ next, StrictNthItem bytes base (base + BitVec.ofNat 64 endOff) index off next
+        (BitVec.ofNat 64 p.length) := by
+  intro index
+  induction index with
+  | zero =>
+      intro items off offEnd p hchain hle hbytes hidx
+      cases items with
+      | nil => simp at hidx
+      | cons item rest =>
+          simp only [List.getElem?_cons_zero, Option.some.injEq] at hidx
+          subst hidx
+          obtain ⟨off', hdec, hrest⟩ := hchain
+          have hoff'le : off' ≤ offEnd :=
+            DecodeChain.le_of_bytes rest off' offEnd hrest (by omega)
+              (fun it hit => hbytes it (List.mem_cons_of_mem _ hit))
+          refine ⟨base + BitVec.ofNat 64 off', ?_⟩
+          exact .zero off _ _
+            (rlpItemDecode_of_decodeAux_bytes bytes base off off' endOff 0 p
+              (hdec 0) (by omega) hendOff hover)
+  | succ index ih =>
+      intro items off offEnd p hchain hle hbytes hidx
+      cases items with
+      | nil => simp at hidx
+      | cons item rest =>
+          simp only [List.getElem?_cons_succ] at hidx
+          obtain ⟨off', hdec, hrest⟩ := hchain
+          obtain ⟨q, hq⟩ := hbytes item (List.mem_cons_self ..)
+          subst hq
+          have hoff'le : off' ≤ offEnd :=
+            DecodeChain.le_of_bytes rest off' offEnd hrest (by omega)
+              (fun it hit => hbytes it (List.mem_cons_of_mem _ hit))
+          have hhead := rlpItemDecode_of_decodeAux_bytes bytes base off off' endOff 0 q
+            (hdec 0) (by omega) hendOff hover
+          have hrec := ih rest off' offEnd p hrest hle
+            (fun it hit => hbytes it (List.mem_cons_of_mem _ hit)) hidx
+          have hback : ((base + BitVec.ofNat 64 off') - base).toNat = off' :=
+            sub_base_of_base_add (bound := bytes.length) (by omega) hover
+          obtain ⟨next, h⟩ := hrec
+          refine ⟨next, ?_⟩
+          exact .succ index off _ _ _ _ hhead (by rw [hback]; exact h)
+
+/-! ## The outer list header -/
+
+/-- Long-list header (`0xF8..0xFF`), forward.  This is the shape a block
+    header takes: ~500 bytes of payload means a `0xF9` prefix with two length
+    bytes. -/
+theorem strictListPayload_long_forward
+    (bytes : List Byte) (base : Word) (b : Byte) (lol payloadLen : Nat)
+    (hbyte : bytes[0]? = some b)
+    (hlong : 0xF8 ≤ b.toNat)
+    (hlolDef : lol = b.toNat - 0xF7)
+    (hfirst : ∃ first : Byte, bytes[1]? = some first ∧ first ≠ 0)
+    (hpayLen : Nat.fromBytesBE ((bytes.drop 1).take lol) = payloadLen)
+    (hminimal : 56 ≤ payloadLen) :
+    StrictListPayload bytes base (1 + lol + payloadLen) (1 + lol)
+      (base + BitVec.ofNat 64 (1 + lol + payloadLen)) := by
+  obtain ⟨first, hfirstGet, hfirstNz⟩ := hfirst
+  have hb256 : b.toNat < 256 := b.isLt
+  have hlolNat : (b.zeroExtend 64 - (0xf7 : Word)).toNat = lol := by
+    have hw : b.zeroExtend 64 - (0xf7 : Word) = BitVec.ofNat 64 lol := by
+      rw [show (0xf7 : Word) = BitVec.ofNat 64 0xf7 from by decide]
+      exact zeroExtend_sub_eq_ofNat (by omega) hlolDef (by norm_num)
+    rw [hw, BitVec.toNat_ofNat, Nat.mod_eq_of_lt (by omega)]
+  have hnotlt : ¬ BitVec.ult (b.zeroExtend 64) (0xf8 : Word) = true := by
+    rw [show (0xf8 : Word) = BitVec.ofNat 64 0xf8 from by decide]
+    exact fun hc => absurd ((ult_zeroExtend_iff (by norm_num)).mp hc) (by omega)
+  exact .long (1 + lol + payloadLen) (1 + lol) b first hbyte hnotlt hfirstGet hfirstNz
+    (by rw [hlolNat, hpayLen]; exact hminimal)
+    (by rw [hlolNat])
+    (by rw [hlolNat, hpayLen])
+
+/-- Short-list header (`0xC0..0xF7`), forward. -/
+theorem strictListPayload_short_forward
+    (bytes : List Byte) (base : Word) (b : Byte) (payloadLen : Nat)
+    (hbyte : bytes[0]? = some b)
+    (hlo : 0xC0 ≤ b.toNat) (hhi : b.toNat < 0xF8)
+    (hpay : payloadLen = b.toNat - 0xC0) :
+    StrictListPayload bytes base (payloadLen + 1) 1
+      (base + BitVec.ofNat 64 (payloadLen + 1)) := by
+  have hb256 : b.toNat < 256 := b.isLt
+  have hlenNat : (b.zeroExtend 64 - (0xc0 : Word)).toNat = payloadLen := by
+    have hw : b.zeroExtend 64 - (0xc0 : Word) = BitVec.ofNat 64 payloadLen := by
+      rw [show (0xc0 : Word) = BitVec.ofNat 64 0xc0 from by decide]
+      exact zeroExtend_sub_eq_ofNat (by omega) hpay (by norm_num)
+    rw [hw, BitVec.toNat_ofNat, Nat.mod_eq_of_lt (by omega)]
+  refine .short (payloadLen + 1) 1 b hbyte ?_ ?_ rfl (by rw [hlenNat])
+  · rw [show (0xc0 : Word) = BitVec.ofNat 64 0xc0 from by decide]
+    exact fun hc => absurd ((ult_zeroExtend_iff (by norm_num)).mp hc) (by omega)
+  · rw [show (0xf8 : Word) = BitVec.ofNat 64 0xf8 from by decide]
+    exact (ult_zeroExtend_iff (by norm_num)).mpr (by omega)
+
+/-! ## Assembling `Success` -/
+
+/-- The full forward construction: a model-side list decode whose children are
+    all byte strings yields the guest's `Success` for any child index the model
+    provides.  `listLen` is the **complete** encoded length (header + payload),
+    matching `StrictListPayload`'s index. -/
+theorem success_forward
+    (bytes : List Byte) (base : Word) (listLen cursorOff index : Nat)
+    (items : List RLPItem) (p : List Byte)
+    (hpayload : StrictListPayload bytes base listLen cursorOff
+      (base + BitVec.ofNat 64 listLen))
+    (hchain : DecodeChain bytes cursorOff items listLen)
+    (hbytes : ∀ it ∈ items, ∃ q, it = RLPItem.bytes q)
+    (hidx : items[index]? = some (RLPItem.bytes p))
+    (hlistLen : listLen ≤ bytes.length)
+    (hover : base.toNat + bytes.length < 2 ^ 64) :
+    ∃ offset, Success bytes base listLen index offset (BitVec.ofNat 64 p.length) := by
+  obtain ⟨next, h⟩ := strictNthItem_of_chain bytes base listLen hlistLen hover index items
+    cursorOff listLen p hchain (le_refl _) hbytes hidx
+  exact ⟨_, cursorOff, base + BitVec.ofNat 64 listLen, next, hpayload, h, rfl⟩
+
+/-! ## Non-vacuity
+
+End-to-end on a concrete buffer: `c4 83 01 02 03` is a four-byte-payload list
+holding one three-byte string.  Both the header lemma and the chain feed
+`success_forward`, so the whole composition is demonstrably instantiable — the
+hypothesis set is satisfiable, not merely consistent. -/
+
+set_option maxRecDepth 8000 in
+example :
+    ∃ offset, Success [0xc4, 0x83, 0x01, 0x02, 0x03] (0x1000 : Word) 5 0 offset
+      (BitVec.ofNat 64 3) := by
+  refine success_forward [0xc4, 0x83, 0x01, 0x02, 0x03] (0x1000 : Word) 5 1 0
+    [RLPItem.bytes [0x01, 0x02, 0x03]] [0x01, 0x02, 0x03]
+    (strictListPayload_short_forward _ _ 0xc4 4 rfl (by decide) (by decide) (by decide))
+    ⟨5, fun _ => rfl, rfl⟩ ?_ rfl (by norm_num) (by decide)
+  intro it hit
+  simp only [List.mem_singleton] at hit
+  exact ⟨[0x01, 0x02, 0x03], hit⟩
+
+end EvmAsm.Codegen.RlpListNthItemSAsm

--- a/EvmAsm/Rv64/RLP/ItemDecodeForward.lean
+++ b/EvmAsm/Rv64/RLP/ItemDecodeForward.lean
@@ -63,6 +63,16 @@ theorem sub_base_add_ofNat {base : Word} {i j bound : Nat}
       = 2 ^ 64 + (j - i) := by omega
   rw [hsplit, Nat.add_mod_left, Nat.mod_eq_of_lt hdlt]
 
+/-- Recovering an offset from its cursor — the form `StrictNthItem.succ` needs,
+    since it re-enters the chain at `(next - base).toNat`. -/
+theorem sub_base_of_base_add {base : Word} {k bound : Nat}
+    (hk : k ≤ bound) (hover : base.toNat + bound < 2 ^ 64) :
+    ((base + BitVec.ofNat 64 k) - base).toNat = k := by
+  have hklt : k < 2 ^ 64 := by omega
+  rw [BitVec.toNat_sub, toNat_base_add_ofNat hk hover]
+  have hsplit : 2 ^ 64 - base.toNat + (base.toNat + k) = 2 ^ 64 + k := by omega
+  rw [hsplit, Nat.add_mod_left, Nat.mod_eq_of_lt hklt]
+
 /-- `drop` is injective on offsets bounded by the length: the residues have
     different lengths otherwise.  This is what lets a `decodeAux` residue of the
     form `bytes.drop off'` pin `off'` itself. -/
@@ -489,6 +499,126 @@ theorem rlpItemDecode_of_decodeAux_bytes
                 | some ir =>
                     obtain ⟨items, leftover⟩ := ir
                     simp [hread, hshort, htake, hitems] at hdec
+
+/-! ## Offset advance
+
+Chaining items needs to know each decode *advances*.  There is no general
+"the `decodeAux` residue is a proper suffix" lemma in the tree, so this
+re-runs the prefix case split, but only to read off the offset — none of the
+`rlpItemDecode` construction is repeated.  It needs `off' ≤ bytes.length`
+alone, **not** the window bound, which is what keeps it usable as the
+termination fact in the chain induction (the window bound is what the
+induction is trying to establish). -/
+
+theorem decodeAux_bytes_advance
+    (bytes : List Byte) (off off' n : Nat) (p : List Byte)
+    (hdec : decodeAux (n + 1) (bytes.drop off) = some (.bytes p, bytes.drop off'))
+    (hoff'len : off' ≤ bytes.length) :
+    off < off' := by
+  obtain ⟨b, hget, hdrop⟩ := exists_prefix_of_decodeAux hdec
+  have hofflt : off < bytes.length := by
+    rw [List.getElem?_eq_some_iff] at hget; exact hget.1
+  rw [hdrop] at hdec
+  cases hclass : classifyPrefix b with
+  | singleByte =>
+      obtain ⟨_, hrest⟩ :=
+        (ByteStringDecodeBridge.decodeAux_cons_singleByte_eq_some_iff n b
+          (bytes.drop (off + 1)) hclass p (bytes.drop off')).mp hdec
+      have : off' = off + 1 := drop_inj_of_le hoff'len (by omega) hrest.symm
+      omega
+  | shortBytes =>
+      obtain ⟨payload, htake, hpay, _⟩ :=
+        (ByteStringDecodeBridge.decodeAux_cons_shortBytes_eq_some_iff n b
+          (bytes.drop (off + 1)) hclass p (bytes.drop off')).mp hdec
+      subst hpay
+      obtain ⟨hcat, _⟩ := takeBytes_eq_some_imp htake
+      have hfits : off + 1 + payload.length ≤ bytes.length := by
+        have := congrArg List.length hcat
+        rw [List.length_append, List.length_drop, List.length_drop] at this
+        omega
+      have hrest : bytes.drop off' = bytes.drop (off + 1 + payload.length) := by
+        have hdropEq : bytes.drop (off + 1 + payload.length)
+            = (bytes.drop (off + 1)).drop payload.length := by
+          rw [List.drop_drop]
+        rw [hdropEq, hcat, List.drop_left]
+      have : off' = off + 1 + payload.length := drop_inj_of_le hoff'len (by omega) hrest
+      omega
+  | longBytes =>
+      obtain ⟨hlo, hhi⟩ := (classifyPrefix_longBytes_iff b).mp hclass
+      obtain ⟨lenVal, restLen, hread, _, htake⟩ :=
+        (ByteStringDecodeBridge.decodeAux_cons_longBytes_eq_some_iff n b
+          (bytes.drop (off + 1)) hclass p (bytes.drop off')).mp hdec
+      have hlolEq : rlpPrefixLongBytesLenOfLen b = b.toNat - 0xB7 := rfl
+      rw [hlolEq] at hread
+      obtain ⟨hklen, _, hrestLen, _⟩ := readLength_inv (by omega) hread
+      obtain ⟨hcat, _⟩ := takeBytes_eq_some_imp htake
+      have hrestLenEq : restLen = bytes.drop (off + 1 + (b.toNat - 0xB7)) := by
+        rw [hrestLen, List.drop_drop]
+      have hfits : off + 1 + (b.toNat - 0xB7) + p.length ≤ bytes.length := by
+        have := congrArg List.length hcat
+        rw [List.length_append, hrestLenEq, List.length_drop] at this
+        rw [List.length_drop] at hklen
+        omega
+      have hrest : bytes.drop off'
+          = bytes.drop (off + 1 + (b.toNat - 0xB7) + p.length) := by
+        have hdropEq : bytes.drop (off + 1 + (b.toNat - 0xB7) + p.length)
+            = restLen.drop p.length := by
+          rw [hrestLenEq, List.drop_drop]
+        rw [hdropEq, hcat, List.drop_left]
+      have : off' = off + 1 + (b.toNat - 0xB7) + p.length :=
+        drop_inj_of_le hoff'len (by omega) hrest
+      omega
+  | shortList =>
+      exfalso
+      rw [decodeAux_cons_shortList_of_classifyPrefix n b (bytes.drop (off + 1)) hclass] at hdec
+      cases htake : takeBytes (bytes.drop (off + 1)) (rlpPrefixShortListPayloadLen b) with
+      | none => simp [htake] at hdec
+      | some pr =>
+          obtain ⟨payload, rest'⟩ := pr
+          cases hitems : decodeItems n payload with
+          | none => simp [htake, hitems] at hdec
+          | some ir =>
+              obtain ⟨items, leftover⟩ := ir
+              simp [htake, hitems] at hdec
+  | longList =>
+      exfalso
+      rw [decodeAux_cons_longList_of_classifyPrefix n b (bytes.drop (off + 1)) hclass] at hdec
+      cases hread : readLength (bytes.drop (off + 1)) (rlpPrefixLongListLenOfLen b) with
+      | none => simp [hread] at hdec
+      | some pr =>
+          obtain ⟨lenVal, rest'⟩ := pr
+          by_cases hshort : lenVal ≤ 55
+          · simp [hread, hshort] at hdec
+          · cases htake : takeBytes rest' lenVal with
+            | none => simp [hread, hshort, htake] at hdec
+            | some pr2 =>
+                obtain ⟨payload, rest''⟩ := pr2
+                cases hitems : decodeItems n payload with
+                | none => simp [hread, hshort, htake, hitems] at hdec
+                | some ir =>
+                    obtain ⟨items, leftover⟩ := ir
+                    simp [hread, hshort, htake, hitems] at hdec
+
+/-- A byte-string `DecodeChain` never runs past its own end offset.  Proved by
+    induction on the item list: the tail bounds `off'`, and `decodeAux_bytes_advance`
+    then bounds `off` below it. -/
+theorem DecodeChain.le_of_bytes {bytes : List Byte} :
+    ∀ (items : List RLPItem) (off offEnd : Nat),
+      DecodeChain bytes off items offEnd → offEnd ≤ bytes.length →
+      (∀ it ∈ items, ∃ q, it = RLPItem.bytes q) →
+      off ≤ offEnd := by
+  intro items
+  induction items with
+  | nil => intro off offEnd hchain _ _; exact le_of_eq hchain
+  | cons item rest ih =>
+      intro off offEnd hchain hend hbytes
+      obtain ⟨off', hdec, hrest⟩ := hchain
+      have hrestle : off' ≤ offEnd :=
+        ih off' offEnd hrest hend (fun it hit => hbytes it (List.mem_cons_of_mem _ hit))
+      obtain ⟨q, hq⟩ := hbytes item (List.mem_cons_self ..)
+      subst hq
+      have := decodeAux_bytes_advance bytes off off' 0 q (hdec 0) (by omega)
+      omega
 
 /-! ## Non-vacuity
 


### PR DESCRIPTION
**Stacked on #11434** (base branch is `proof-11351-header-number`, so the diff shows only this layer). #11434 built the per-item forward bridge; this composes it up to `Success` — the predicate that `rlp_field_to_u64`'s already-`.proven` triple consumes.

`Success` / `StrictListPayload` / `StrictNthItem` had **no constructor driven by a model-side decode**; every existing lemma consumed one. That is the shared prerequisite behind #11351, #11345 and #11346.

## Core side (`Rv64/RLP/ItemDecodeForward.lean`)

| lemma | role |
|---|---|
| `sub_base_of_base_add` | recovers an offset from its cursor — the form `StrictNthItem.succ` needs to re-enter the chain at `(next - base).toNat` |
| `decodeAux_bytes_advance` | each byte-string decode strictly advances |
| `DecodeChain.le_of_bytes` | a chain never runs past its own end offset |

⚠️ **One design point worth a reviewer's eye.** There is no general *"the `decodeAux` residue is a proper suffix"* lemma anywhere in the tree, so `decodeAux_bytes_advance` re-runs the prefix case split — but only to read the offset off, none of the `rlpItemDecode` construction is repeated. It deliberately requires `off' ≤ bytes.length` **alone**, not the window bound `off' ≤ endOff` that the main dispatcher takes. That is not an oversight: the window bound is precisely what the chain induction is trying to establish, so assuming it here would be circular. If a general suffix lemma is wanted instead, say so and I will add it to `EL/RLP/Properties.lean` and collapse this one.

## Codegen side (`Codegen/Programs/RlpListNthItemForward.lean`, new)

- `strictNthItem_of_chain` — induction on the index, generalising the item list and start offset: the head decode supplies one `rlpItemDecode`, the tail supplies the rest of the chain.
- `strictListPayload_long_forward` / `strictListPayload_short_forward` — the outer header. A block header is ~500 B, so the **long** form (`0xF9`, two length bytes) is what #11351 needs; the short form comes free and is what keeps the non-vacuity check small.
- `success_forward` — assembles all three.

**Layering.** The Codegen half cannot sit beside its core half: `check-layering.sh` L1 forbids core importing Codegen, and `StrictNthItem` is a Codegen-layer definition. Same split as the #11408 determinism prerequisite.

## Non-vacuity

An end-to-end `example` drives `c4 83 01 02 03` — a four-byte-payload list holding one three-byte string — through the header lemma, the chain, and `success_forward`. So the composition is demonstrably instantiable, not merely consistent.

## Registry

**No rows.** Pure lemma modules, to be cited and consumed by the triple itself, per "availability is not use".

## Gates

`lake build` warning-free · `port-check` **PASS** (12 theorems here, classical axioms only) · `check-axioms` OK (127 witnesses) · forbidden-tactics / layering / file-size **PASS**.

## What remains for #11351

Compose with `rlpFieldToU64_flat_spec_within` (already `.proven`) and the 8-instruction `headerExtractNumber_prog` wrapper, then registry rows. The **value** bridge is definitional: `Result.success` yields `BitVec.ofNat 64 (Nat.fromBytesBE …)` and `SpecRef.bytesBEtoNat` is an `abbrev` for `EL.RLP.Nat.fromBytesBE`, so there is no arithmetic lemma to invent. Grading will be `.domainRestricted`, not `.agrees`.

Refs #11351, #11345, #11346

🤖 Generated with [Claude Code](https://claude.com/claude-code)