### PR TITLE
proof(#11351): Success excludes Failure for rlp_list_nth_item

### DIFF
--- a/EvmAsm/Codegen/Programs/RlpWalkDeterminism.lean
+++ b/EvmAsm/Codegen/Programs/RlpWalkDeterminism.lean
@@ -25,6 +25,7 @@
 -/
 
 import EvmAsm.Rv64.RLP.WalkItemDeterminism
+import EvmAsm.Rv64.RLP.ItemDecodeForward
 import EvmAsm.Codegen.Programs.RlpListNthItemSAsmBase
 
 namespace EvmAsm.Codegen.RlpListNthItemSAsm
@@ -93,5 +94,85 @@ theorem success_deterministic {bytes : List (BitVec 8)} {base : Word}
   obtain ⟨rfl, rfl⟩ := strictListPayload_deterministic hlist₁ hlist₂
   obtain ⟨rfl, rfl⟩ := strictNthItem_deterministic hnth₁ hnth₂
   exact ⟨hoff₁.trans hoff₂.symm, rfl⟩
+
+
+/-! ## Success excludes Failure
+
+`rlp_list_nth_item` reports exactly one of `Success` and `Failure`, but nothing
+in the tree said so; every existing use *constructs* a `Failure`. The model →
+guest direction needs the exclusion, in order to rule out `Result.listFailure`
+once the model has already established `Success`. -/
+
+/-- Any chain, of any arity, starts with a decode at its own cursor. -/
+theorem strictNthItem_head {bytes : List (BitVec 8)} {base endPtr : Word}
+    {index off : Nat} {next len : Word}
+    (h : StrictNthItem bytes base endPtr index off next len) :
+    ∃ n l, rlpItemDecode bytes off (base + BitVec.ofNat 64 off) endPtr n l := by
+  cases h
+  · exact ⟨_, _, by assumption⟩
+  · exact ⟨_, _, by assumption⟩
+
+/-- A walked prefix of `count ≤ index` steps lands on the `StrictNthItem`
+    chain: what remains at that cursor is a chain of arity `index - count`.
+
+    Induction is on the `StrictPrefix` derivation, identifying the prefix's
+    decode with the chain's at each cursor via `rlpItemDecode_deterministic`. -/
+theorem strictNthItem_extends_prefix {bytes : List (BitVec 8)} {base endPtr : Word}
+    {cursorOff : Nat} {index : Nat} {next len : Word}
+    (hnth : StrictNthItem bytes base endPtr index cursorOff next len) :
+    ∀ {count off : Nat}, StrictPrefix bytes base endPtr cursorOff count off →
+      count ≤ index →
+      ∃ next' len', StrictNthItem bytes base endPtr (index - count) off next' len' := by
+  intro count off hprefix
+  induction hprefix with
+  | zero => intro _; exact ⟨next, len, by simpa using hnth⟩
+  | succ count off0 n0 l0 hprefix hitem ih =>
+      intro hle
+      obtain ⟨n', l', hrest⟩ := ih (by omega)
+      obtain ⟨k, hk⟩ : ∃ k, index - count = k + 1 := ⟨index - count - 1, by omega⟩
+      rw [hk] at hrest
+      cases hrest
+      rename_i nn ll hitem' hrec
+      obtain ⟨rfl, -⟩ := rlpItemDecode_deterministic hitem hitem'
+      exact ⟨n', l', by rw [show index - (count + 1) = k from by omega]; exact hrec⟩
+
+/-- A walked prefix never runs past the list's declared end. -/
+theorem strictPrefix_le {bytes : List (BitVec 8)} {base : Word} {endOff cursorOff : Nat}
+    (hover : base.toNat + endOff + 9 < 2 ^ 64) (hstart : cursorOff ≤ endOff) :
+    ∀ {count off : Nat},
+      StrictPrefix bytes base (base + BitVec.ofNat 64 endOff) cursorOff count off →
+      off ≤ endOff := by
+  intro count off h
+  induction h with
+  | zero => exact hstart
+  | succ count off0 n0 l0 hprefix hitem ih =>
+      exact (BalAccountNonstorageFinalsSpec.rlpItemDecode_advance hitem ih hover).2.2
+
+/-- `Success` and `Failure` are mutually exclusive. -/
+theorem success_not_failure {bytes : List (BitVec 8)} {base : Word}
+    {listLen index : Nat} {offset len : Word}
+    (hover : base.toNat + listLen + 9 < 2 ^ 64)
+    (hsucc : Success bytes base listLen index offset len)
+    (hfail : Failure bytes base listLen index) : False := by
+  obtain ⟨cursorOff, ep, nxt, hlist, hnth, -⟩ := hsucc
+  cases hfail with
+  | init hno => exact hno ⟨cursorOff, ep, hlist⟩
+  | walk cursorOff' count off ep' hlist' hcount hprefix hfail =>
+      obtain ⟨rfl, rfl⟩ := strictListPayload_deterministic hlist' hlist
+      obtain ⟨n', l', hrest⟩ := strictNthItem_extends_prefix hnth hprefix hcount
+      obtain ⟨n, l, hdec⟩ := strictNthItem_head hrest
+      have hend : ep' = base + BitVec.ofNat 64 listLen := hlist'.end_eq
+      rw [hend] at hdec hfail
+      -- a decode exists at `off`, which refutes the "no item decodes" disjunct
+      -- outright and, via the advance bound, the "cursor past end" one too
+      have hstart : cursorOff' ≤ listLen := hlist'.cursor_le
+      rw [hend] at hprefix
+      have hoffle : off ≤ listLen := strictPrefix_le (by omega) hstart hprefix
+      obtain ⟨-, hlt, hle⟩ :=
+        BalAccountNonstorageFinalsSpec.rlpItemDecode_advance hdec hoffle (by omega)
+      rcases hfail with hbound | hnodec
+      · exact hbound ((ult_base_add_ofNat (bound := listLen) hoffle (le_refl _)
+          (by omega)).mpr (by omega))
+      · exact hnodec ⟨n, l, hdec⟩
 
 end EvmAsm.Codegen.RlpListNthItemSAsm


### PR DESCRIPTION
**Stacked on #11457.** This is the lemma I asked about there — built, since the search settled the only part that needed your knowledge (it genuinely does not exist), and the placement question is cheap to reverse.

`rlp_list_nth_item` reports exactly one of `Success` and `Failure`, but nothing in the tree said so. Every existing use *constructs* a `Failure` (`AccountDecodeClose*`, via `DecodeFailure.field{1,2,3}List`); none excludes one. The model → guest direction needs it, to rule out `Result.listFailure` once the model has already established `Success`.

## Contents

| lemma | role |
|---|---|
| `strictNthItem_head` | any chain, any arity, starts with a decode at its own cursor |
| `strictPrefix_le` | a walked prefix never runs past the list's declared end |
| `strictNthItem_extends_prefix` | a prefix of `count ≤ index` steps lands **on** the chain — what remains is a chain of arity `index - count` |
| `success_not_failure` | the exclusion |

`strictNthItem_extends_prefix` is the substance: induction over the prefix, identifying the prefix's decode with the chain's at each cursor via `rlpItemDecode_deterministic`. `success_not_failure` then refutes `Failure.init` from `Success`'s `StrictListPayload`, and `Failure.walk` by aligning the payloads with `strictListPayload_deterministic` and showing a decode *does* exist at the allegedly-failing cursor.

## ⭐ Correction to what I asked on #11457

**`rlpItemDecode_dichotomy` does not need to be made public.** I was wrong. `rlpItemDecode_advance` (`BalAccountNonstorageFinalsWalk.lean:71`) is already public and yields

```lean
off < (next - base).toNat ∧ (next - base).toNat ≤ endOff
```

which refutes **both** `WalkFailure` disjuncts — the cursor-past-end one as well as no-item-decodes. Please disregard that part of the ask; nothing needs to change in `WalkNext.lean`.

## One thing worth a reviewer's eye

The bound on the failing cursor **cannot** be derived from that cursor itself — attempting it is circular, and my first version was (it tried to get `off ≤ listLen` by contradiction from the very `ult` fact it was trying to refute). It has to be threaded from the list's start offset (`StrictListPayload.cursor_le`) *forward* through the prefix. That is what `strictPrefix_le` exists for, and it is the only reason that lemma is separate.

## Placement

`RlpWalkDeterminism.lean`, beside the determinism lemmas from #11408 that these extend, since #11345 and #11346 will want them too. Say the word if you'd prefer elsewhere — moving is trivial.

## Gates

`lake build` warning-free · `port-check` **PASS** (12 theorems, classical axioms only) · forbidden-tactics / layering / file-size **PASS**.

## Next

With this, the #11351 model tie has all its pieces: compose `headerExtractNumber_spec_within` (#11457) with `success_of_decodeFully_list` at index 8, discharge `Result`'s five constructors, and add the registry rows graded `.domainRestricted`.

Refs #11351, #11345, #11346

🤖 Generated with [Claude Code](https://claude.com/claude-code)