### PR TITLE
docs: record derived storage root

### DIFF
--- a/EvmAsm/Codegen/Programs/BalAccountApplyPostFields.lean
+++ b/EvmAsm/Codegen/Programs/BalAccountApplyPostFields.lean
@@ -587,6 +587,10 @@ def mapAccountApplyPostFieldsFunction : String :=
   ".Lbaap_multi_skip_zero:\n" ++
   "  la t0, baap_sc_index; ld t0, 0(t0)\n" ++
   "  addi t0, t0, 1; la t1, baap_sc_index; sd t0, 0(t1); j .Lbaap_multi_loop\n" ++
+  -- #11385: `storage_root` is derived from the storage_writes rows at this
+  -- use via `mpt_bounded_storage_root`; it is not a map field or mask bit.
+  -- The explicit legacy call below is only the conservative builder-failure
+  -- fallback and does not introduce a stored storage-root representation.
   ".Lbaap_multi_apply:\n" ++
   "  la t0, baap_sc_out_count; ld a4, 0(t0); beqz a4, .Lbaap_nonce\n" ++
   "  la t0, baap_storage_empty_flag; ld t0, 0(t0); bnez t0, .Lbaap_multi_apply_empty\n" ++

--- a/EvmAsm/Codegen/Programs/StorageWriteMap.lean
+++ b/EvmAsm/Codegen/Programs/StorageWriteMap.lean
@@ -47,6 +47,11 @@
   Base and stride are both 8-aligned, so every `ld`/`sd` below is 8-aligned as
   the RV64 operational semantics require.
 
+  `storage_root` is deliberately not another row field or mask bit.  Consumers
+  derive the account's new root from these storage slots through
+  `mpt_bounded_storage_root` at the point where the storage trie is rebuilt;
+  there is no stored map cell whose value could be read instead.
+
   ## It is a MAP, so the recorder upserts
 
   `set_storage` (`:489`) assigns `storage_writes[address][key] = value`, so the


### PR DESCRIPTION
## Summary\n\n- document that storage_root is derived from storage_writes through mpt_bounded_storage_root\n- record that the storage map has no storage_root field or mask bit\n- distinguish the explicit mpt_state_root_ins path as the conservative bounded-builder failure fallback\n\nThe source comments do not change emitted assembly or layout.\n\nCloses #11385