### PR TITLE
feat(ci): #11520 code_at_header EMPTY_CODE_HASH guard

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,6 +54,8 @@ jobs:
           scripts/check-registry-crosscheck.sh
       - name: Layering invariants (verified core must not import Codegen / Progress)
         run: scripts/check-layering.sh
+      - name: "code_at_header empty-hash guard (#11520; raise→reject, not fallback)"
+        run: scripts/check-code-preimage-empty-hash.sh
       - name: Opcode-structure (AddrNorm pairing; advisory checklist for new complex dirs)
         run: scripts/check-opcode-structure.sh
       # Advisory naming nudge (camelCase hypotheses newly added in the PR);

--- a/scripts/check-code-preimage-empty-hash.py
+++ b/scripts/check-code-preimage-empty-hash.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env python3
+"""#11520 guard: code_at_header_state_root must not compile a missing preimage
+into empty code without an EMPTY_CODE_HASH identity check.
+
+Spec (pin e5a8caf1b witness_state.py:204-212):
+  * EMPTY_CODE_HASH → return b"" (legitimately empty)
+  * any other missing hash → raise KeyError → REJECTION
+A guest site that treats status-5 (code hash present on account, preimage
+absent from codes) as empty WITHOUT comparing cahsr_acct_struct.code_hash to
+EMPTY_CODE_HASH has compiled a raise into a fallback value.
+
+Two correct sites already exist (ChildFrameHandlers status-5 + cd_empty_code_hash;
+BlockVerdictDispatchTx materialize path + chahsr_empty_code_hash). This gate
+makes a regression uncompilable-to-CI rather than merely reviewable.
+
+Checks (Lean source of Codegen Programs / Dispatch — no guest emit required):
+
+  1. FUNCTION PAIRING: any non-probe `def` whose body contains
+     `jal ra, code_at_header_state_root` must also contain an
+     `*empty_code_hash` load (`la …, …empty_code_hash`). Missing → violator.
+  2. STATUS-5 ANTI-PATTERN: after a `jal ra, code_at_header_state_root`, a
+     `li r, 5` followed by `beq a0, r, …empty…` (or swap) WITHOUT an intervening
+     `*empty_code_hash` load → violator (even if the same function has a
+     correct site elsewhere — DispatchTx has both).
+
+Allow-list: scripts/code-preimage-empty-hash-allow.txt
+  lines: kind\\tfile\\tdef\\tordinal   kind in {pair, anti}
+EXPECTED_VIOLATOR_COUNT must match the allow-list length and ratchet DOWN only
+with an explicit edit in the same commit that fixes a site (same durability
+rule as EXPECTED_ANNOTATION_COUNT / #11505).
+
+OUT OF SCOPE (different family — do not count as covered by this gate):
+  account_exists_at_header_state_root / account_is_empty_at_header_state_root
+  callers that treat nonzero as "no charge" (ChildFrameHandlers:974-989,
+  BlockVerdictSimpleTransferGas, Selfdestruct, ChildFrameHandlerTailHelpers
+  exists/empty path). Tracked separately (#11526 FA-directional undercharge).
+
+Usage:
+  python3 scripts/check-code-preimage-empty-hash.py
+  python3 scripts/check-code-preimage-empty-hash.py --write-allowlist
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCAN_ROOTS = [
+    ROOT / "EvmAsm" / "Codegen" / "Programs",
+    ROOT / "EvmAsm" / "Codegen" / "Dispatch.lean",
+]
+ALLOW_PATH = ROOT / "scripts" / "code-preimage-empty-hash-allow.txt"
+# Durability: every allow-list line is one known violator. Drive to zero.
+EXPECTED_VIOLATOR_COUNT = 7
+
+JAL_CODE = re.compile(r"jal\s+ra,\s*code_at_header_state_root\b")
+EMPTY_LA = re.compile(r"la\s+\w+,\s*\w*empty_code_hash\b")
+DEF = re.compile(r"^def\s+(\w+)\b", re.M)
+PROBE_NAME = re.compile(
+    r"^(zisk|Zisk)|Prologue$|Probe|probe|Selftest|selftest|DataSection|Data$"
+)
+
+
+def _iter_files() -> list[Path]:
+    out: list[Path] = []
+    for root in SCAN_ROOTS:
+        if root.is_file():
+            out.append(root)
+        elif root.is_dir():
+            out.extend(sorted(root.rglob("*.lean")))
+    return out
+
+
+def _def_spans(text: str) -> list[tuple[str, int, int]]:
+    """Return (name, start, end) for each top-level def; end = next def or EOF."""
+    ms = list(DEF.finditer(text))
+    spans = []
+    for i, m in enumerate(ms):
+        end = ms[i + 1].start() if i + 1 < len(ms) else len(text)
+        spans.append((m.group(1), m.start(), end))
+    return spans
+
+
+def _is_probe(name: str) -> bool:
+    return bool(PROBE_NAME.search(name))
+
+
+def find_violators() -> list[tuple[str, str, str, int]]:
+    """Return list of (kind, relpath, def_name, ordinal)."""
+    viol: list[tuple[str, str, str, int]] = []
+    for path in _iter_files():
+        text = path.read_text(errors="replace")
+        if "code_at_header_state_root" not in text:
+            continue
+        rel = str(path.relative_to(ROOT))
+        spans = _def_spans(text)
+        # map byte offset -> owning def
+        def owner_at(pos: int) -> str:
+            for name, s, e in spans:
+                if s <= pos < e:
+                    return name
+            return "?"
+
+        # Per-def jal ordinals
+        jal_ord: dict[str, int] = defaultdict(int)
+        for m in JAL_CODE.finditer(text):
+            name = owner_at(m.start())
+            if _is_probe(name):
+                jal_ord[name] += 1
+                continue
+            ord_i = jal_ord[name]
+            jal_ord[name] += 1
+            # window after jal for anti-pattern (raw Lean with \n escapes)
+            win = text[m.end() : m.end() + 2500].replace("\\n", "\n")
+            # anti: li r,5 ; beq a0,r, …empty… without empty_code_hash before beq
+            anti = False
+            for sm in re.finditer(r"li\s+(\w+),\s*5\b", win):
+                reg = sm.group(1)
+                after = win[sm.end() : sm.end() + 350]
+                if re.search(
+                    rf"beq\s+(?:a0,\s*{reg}|{reg},\s*a0),\s*\S*[Ee]mpty", after
+                ):
+                    pre = win[: sm.start()]
+                    if not EMPTY_LA.search(pre) and "empty_code_hash" not in pre:
+                        anti = True
+                        break
+            if anti:
+                viol.append(("anti", rel, name, ord_i))
+
+        # function pairing: def has jal code_at and no empty_code_hash anywhere
+        for name, s, e in spans:
+            if _is_probe(name):
+                continue
+            body = text[s:e]
+            if not JAL_CODE.search(body):
+                continue
+            body_n = body.replace("\\n", "\n")
+            if EMPTY_LA.search(body_n) or "empty_code_hash" in body_n:
+                continue
+            # one pair entry per def (ordinal 0)
+            viol.append(("pair", rel, name, 0))
+    # stable order
+    viol.sort()
+    return viol
+
+
+def load_allow() -> set[tuple[str, str, str, int]]:
+    if not ALLOW_PATH.exists():
+        return set()
+    out: set[tuple[str, str, str, int]] = set()
+    for line in ALLOW_PATH.read_text().splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        parts = line.split("\t")
+        if len(parts) != 4:
+            raise SystemExit(f"bad allow line (want kind\\tfile\\tdef\\tord): {line!r}")
+        kind, f, d, o = parts
+        out.add((kind, f, d, int(o)))
+    return out
+
+
+def write_allow(viol: list[tuple[str, str, str, int]]) -> None:
+    lines = [
+        "# #11520 code_at_header_state_root empty-hash guard allow-list",
+        "# kind\\tfile\\tdef\\tordinal",
+        "# kind=pair: function has jal code_at_header without *empty_code_hash",
+        "# kind=anti: status-5 beq-to-empty without EMPTY_CODE_HASH compare",
+        "# EXPECTED_VIOLATOR_COUNT in check-code-preimage-empty-hash.py must match.",
+        "# Ratchet DOWN only with a same-commit site fix. Never raise without coord.",
+        "",
+    ]
+    for kind, f, d, o in viol:
+        lines.append(f"{kind}\t{f}\t{d}\t{o}")
+    ALLOW_PATH.write_text("\n".join(lines) + "\n")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument(
+        "--write-allowlist",
+        action="store_true",
+        help="rewrite allow-list to current violators (bootstrap / deliberate shrink)",
+    )
+    args = ap.parse_args()
+    viol = find_violators()
+    if args.write_allowlist:
+        write_allow(viol)
+        print(
+            f"wrote {ALLOW_PATH.relative_to(ROOT)}: {len(viol)} violators "
+            f"(set EXPECTED_VIOLATOR_COUNT = {len(viol)})"
+        )
+        return 0
+
+    allow = load_allow()
+    problems: list[str] = []
+
+    if len(allow) != EXPECTED_VIOLATOR_COUNT:
+        problems.append(
+            f"allow-list has {len(allow)} entries but EXPECTED_VIOLATOR_COUNT="
+            f"{EXPECTED_VIOLATOR_COUNT} — update both in the same commit"
+        )
+    if len(viol) != EXPECTED_VIOLATOR_COUNT:
+        problems.append(
+            f"found {len(viol)} violators but EXPECTED_VIOLATOR_COUNT="
+            f"{EXPECTED_VIOLATOR_COUNT} (allow {len(allow)})"
+        )
+
+    viol_set = set(viol)
+    new = sorted(viol_set - allow)
+    gone = sorted(allow - viol_set)
+    for kind, f, d, o in new:
+        problems.append(f"NEW violator not on allow-list: {kind} {f} {d} #{o}")
+    for kind, f, d, o in gone:
+        problems.append(
+            f"allow-list entry gone (fix landed? shrink EXPECTED + allow): "
+            f"{kind} {f} {d} #{o}"
+        )
+
+    if problems:
+        print("check-code-preimage-empty-hash: FAIL")
+        for p in problems:
+            print(f"  {p}")
+        print(
+            f"  (pairing+anti violators={len(viol)}; allow={len(allow)}; "
+            f"EXPECTED={EXPECTED_VIOLATOR_COUNT})"
+        )
+        print(
+            "  OUT OF SCOPE: account_exists/is_empty_at_header_state_root no-charge "
+            "family (#11526) — not covered by this gate."
+        )
+        return 1
+
+    print(
+        f"check-code-preimage-empty-hash: OK "
+        f"({len(viol)}/{EXPECTED_VIOLATOR_COUNT} allow-listed violators; "
+        f"0 new; pair+anti). OUT OF SCOPE: exists/is_empty no-charge family."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check-code-preimage-empty-hash.py
+++ b/scripts/check-code-preimage-empty-hash.py
@@ -17,11 +17,14 @@ Checks (Lean source of Codegen Programs / Dispatch — no guest emit required):
 
   1. FUNCTION PAIRING: any non-probe `def` whose body contains
      `jal ra, code_at_header_state_root` must also contain an
-     `*empty_code_hash` load (`la …, …empty_code_hash`). Missing → violator.
-  2. STATUS-5 ANTI-PATTERN: after a `jal ra, code_at_header_state_root`, a
-     `li r, 5` followed by `beq a0, r, …empty…` (or swap) WITHOUT an intervening
-     `*empty_code_hash` load → violator (even if the same function has a
-     correct site elsewhere — DispatchTx has both).
+     `*empty_code_hash` load. Missing → violator (kind=pair).
+  2. STATUS-5 ANTI-PATTERN: after that jal, `li r,5` + `beq a0,r,…empty…`
+     without a prior empty-hash load → violator (kind=anti).
+  3. GATING (not mere presence): after `la …empty_code_hash`, the limb
+     `bne` mismatch targets must not all equal the match fall-through `j`
+     target. Convergence = discarded comparison = false assurance
+     (kind=conv). SenderCounts:248 is the proof case — every bne and the
+     final j go to `.Leas_we_ok`.
 
 Allow-list: scripts/code-preimage-empty-hash-allow.txt
   lines: kind\\tfile\\tdef\\tordinal   kind in {pair, anti}
@@ -54,10 +57,13 @@ SCAN_ROOTS = [
 ]
 ALLOW_PATH = ROOT / "scripts" / "code-preimage-empty-hash-allow.txt"
 # Durability: every allow-list line is one known violator. Drive to zero.
-EXPECTED_VIOLATOR_COUNT = 7
+EXPECTED_VIOLATOR_COUNT = 8
 
 JAL_CODE = re.compile(r"jal\s+ra,\s*code_at_header_state_root\b")
 EMPTY_LA = re.compile(r"la\s+\w+,\s*\w*empty_code_hash\b")
+# bne rs1, rs2, .Ltarget  (labels may embed Lean ++ tag fragments)
+BNE_LAB = re.compile(r"\bbne\s+\w+,\s*\w+,\s*(\.[A-Za-z0-9_]+)")
+J_LAB = re.compile(r"\bj\s+(\.[A-Za-z0-9_]+)\b")
 DEF = re.compile(r"^def\s+(\w+)\b", re.M)
 PROBE_NAME = re.compile(
     r"^(zisk|Zisk)|Prologue$|Probe|probe|Selftest|selftest|DataSection|Data$"
@@ -88,8 +94,53 @@ def _is_probe(name: str) -> bool:
     return bool(PROBE_NAME.search(name))
 
 
+def _compare_gates(win: str) -> str | None:
+    """Classify an empty-hash compare window after a code_at jal.
+
+    Returns:
+      None  — no empty_code_hash load in window
+      "ok"  — at least one bne mismatch target differs from the match fall-through
+      "conv"— comparison present but every bne target equals the match j target
+              (discarded comparison — false assurance, #11520 SenderCounts)
+    """
+    la = EMPTY_LA.search(win)
+    if not la and "empty_code_hash" not in win:
+        return None
+    # Slice from first empty_code_hash load through a short limb-compare tail.
+    start = la.start() if la else win.find("empty_code_hash")
+    chunk = win[start : start + 900]
+    bnes = BNE_LAB.findall(chunk)
+    if not bnes:
+        return None
+    # Match path: first `j .L…` after the last bne in this chunk (fall-through
+    # after all limbs match). If absent, use the last bne as sole signal.
+    last_bne = list(BNE_LAB.finditer(chunk))[-1]
+    j_m = J_LAB.search(chunk[last_bne.end() : last_bne.end() + 200])
+    match_tgt = j_m.group(1) if j_m else None
+    # Strip trailing Lean string noise from labels (tag concat ends at word boundary)
+    def norm(lab: str) -> str:
+        return lab.rstrip('"').split('"')[0]
+
+    bnes_n = [norm(b) for b in bnes]
+    if match_tgt is None:
+        # no fall-through j: gating if any two bne targets differ, else unknown→ok
+        return "ok" if len(set(bnes_n)) > 1 else "conv"
+    match_n = norm(match_tgt)
+    # Gating iff some mismatch bne goes somewhere other than the match path.
+    if any(b != match_n for b in bnes_n):
+        return "ok"
+    return "conv"
+
+
 def find_violators() -> list[tuple[str, str, str, int]]:
-    """Return list of (kind, relpath, def_name, ordinal)."""
+    """Return list of (kind, relpath, def_name, ordinal).
+
+    kinds:
+      pair  — jal code_at_header with no *empty_code_hash in the owning def
+      anti  — status-5 beq-to-empty without a prior empty-hash load
+      conv  — empty-hash compare whose bne mismatch targets all equal the
+              match fall-through (comparison computed and discarded)
+    """
     viol: list[tuple[str, str, str, int]] = []
     for path in _iter_files():
         text = path.read_text(errors="replace")
@@ -97,15 +148,18 @@ def find_violators() -> list[tuple[str, str, str, int]]:
             continue
         rel = str(path.relative_to(ROOT))
         spans = _def_spans(text)
-        # map byte offset -> owning def
+
         def owner_at(pos: int) -> str:
             for name, s, e in spans:
                 if s <= pos < e:
                     return name
             return "?"
 
-        # Per-def jal ordinals
         jal_ord: dict[str, int] = defaultdict(int)
+        # Per-def: did any jal site have a gating (ok) compare?
+        def_has_gating: dict[str, bool] = defaultdict(bool)
+        def_has_any_empty: dict[str, bool] = defaultdict(bool)
+
         for m in JAL_CODE.finditer(text):
             name = owner_at(m.start())
             if _is_probe(name):
@@ -113,8 +167,10 @@ def find_violators() -> list[tuple[str, str, str, int]]:
                 continue
             ord_i = jal_ord[name]
             jal_ord[name] += 1
-            # window after jal for anti-pattern (raw Lean with \n escapes)
-            win = text[m.end() : m.end() + 2500].replace("\\n", "\n")
+            # Wide window: ChildFrameHandlers empty compare is ~5–9KB of Lean
+            # source after the jal (comments + intermediate arms).
+            win = text[m.end() : m.end() + 12000].replace("\\n", "\n")
+
             # anti: li r,5 ; beq a0,r, …empty… without empty_code_hash before beq
             anti = False
             for sm in re.finditer(r"li\s+(\w+),\s*5\b", win):
@@ -130,7 +186,19 @@ def find_violators() -> list[tuple[str, str, str, int]]:
             if anti:
                 viol.append(("anti", rel, name, ord_i))
 
-        # function pairing: def has jal code_at and no empty_code_hash anywhere
+            gate = _compare_gates(win)
+            if gate == "ok":
+                def_has_gating[name] = True
+                def_has_any_empty[name] = True
+            elif gate == "conv":
+                def_has_any_empty[name] = True
+                viol.append(("conv", rel, name, ord_i))
+            elif gate is None and (
+                EMPTY_LA.search(win) or "empty_code_hash" in win
+            ):
+                def_has_any_empty[name] = True
+
+        # function pairing: jal present, no empty_code_hash symbol in def body
         for name, s, e in spans:
             if _is_probe(name):
                 continue
@@ -139,10 +207,16 @@ def find_violators() -> list[tuple[str, str, str, int]]:
                 continue
             body_n = body.replace("\\n", "\n")
             if EMPTY_LA.search(body_n) or "empty_code_hash" in body_n:
+                # Has a symbol but never a gating compare → still a pair-class
+                # gap only if no conv was already recorded for this def.
+                if not def_has_gating[name] and not any(
+                    k == "conv" and d == name and f == rel
+                    for k, f, d, _ in viol
+                ):
+                    # convergent-only or non-gating empty ref: ensure conv caught
+                    pass
                 continue
-            # one pair entry per def (ordinal 0)
             viol.append(("pair", rel, name, 0))
-    # stable order
     viol.sort()
     return viol
 
@@ -169,6 +243,8 @@ def write_allow(viol: list[tuple[str, str, str, int]]) -> None:
         "# kind\\tfile\\tdef\\tordinal",
         "# kind=pair: function has jal code_at_header without *empty_code_hash",
         "# kind=anti: status-5 beq-to-empty without EMPTY_CODE_HASH compare",
+        "# kind=conv: empty-hash bne mismatch targets all equal match fall-through",
+        "#            (comparison discarded — false assurance; SenderCounts:248)",
         "# EXPECTED_VIOLATOR_COUNT in check-code-preimage-empty-hash.py must match.",
         "# Ratchet DOWN only with a same-commit site fix. Never raise without coord.",
         "",
@@ -237,7 +313,7 @@ def main() -> int:
     print(
         f"check-code-preimage-empty-hash: OK "
         f"({len(viol)}/{EXPECTED_VIOLATOR_COUNT} allow-listed violators; "
-        f"0 new; pair+anti). OUT OF SCOPE: exists/is_empty no-charge family."
+        f"0 new; pair+anti+conv). OUT OF SCOPE: exists/is_empty no-charge family."
     )
     return 0
 

--- a/scripts/check-code-preimage-empty-hash.sh
+++ b/scripts/check-code-preimage-empty-hash.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# #11520: code_at_header_state_root must pair with EMPTY_CODE_HASH check.
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+exec python3 "$ROOT/scripts/check-code-preimage-empty-hash.py" "$@"

--- a/scripts/code-preimage-empty-hash-allow.txt
+++ b/scripts/code-preimage-empty-hash-allow.txt
@@ -2,12 +2,15 @@
 # kind\tfile\tdef\tordinal
 # kind=pair: function has jal code_at_header without *empty_code_hash
 # kind=anti: status-5 beq-to-empty without EMPTY_CODE_HASH compare
+# kind=conv: empty-hash bne mismatch targets all equal match fall-through
+#            (comparison discarded — false assurance; SenderCounts:248)
 # EXPECTED_VIOLATOR_COUNT in check-code-preimage-empty-hash.py must match.
 # Ratchet DOWN only with a same-commit site fix. Never raise without coord.
 
 anti	EvmAsm/Codegen/Programs/BlockVerdictDispatchTx.lean	dispatchTxRuntimeCodeFunction	1
 anti	EvmAsm/Codegen/Programs/TxIntrinsicStateGas.lean	eip7702AuthorityAsOfFunction	0
 anti	EvmAsm/Codegen/Programs/TxIntrinsicStateGas.lean	eip7702AuthorityAsOfFunction	1
+conv	EvmAsm/Codegen/Programs/BlockVerdictSenderCounts.lean	eip7702AuthorityStateMaterializeFunction	0
 pair	EvmAsm/Codegen/Programs/BalCodePreimages.lean	accountStateDelegationCodeResolveFunction	0
 pair	EvmAsm/Codegen/Programs/BlockVerdictStateRoot.lean	statelessVerdictV2Function	0
 pair	EvmAsm/Codegen/Programs/ChildFrameHandlerTailHelpers.lean	callDelegationAccessChargeAsm	0

--- a/scripts/code-preimage-empty-hash-allow.txt
+++ b/scripts/code-preimage-empty-hash-allow.txt
@@ -1,0 +1,14 @@
+# #11520 code_at_header_state_root empty-hash guard allow-list
+# kind\tfile\tdef\tordinal
+# kind=pair: function has jal code_at_header without *empty_code_hash
+# kind=anti: status-5 beq-to-empty without EMPTY_CODE_HASH compare
+# EXPECTED_VIOLATOR_COUNT in check-code-preimage-empty-hash.py must match.
+# Ratchet DOWN only with a same-commit site fix. Never raise without coord.
+
+anti	EvmAsm/Codegen/Programs/BlockVerdictDispatchTx.lean	dispatchTxRuntimeCodeFunction	1
+anti	EvmAsm/Codegen/Programs/TxIntrinsicStateGas.lean	eip7702AuthorityAsOfFunction	0
+anti	EvmAsm/Codegen/Programs/TxIntrinsicStateGas.lean	eip7702AuthorityAsOfFunction	1
+pair	EvmAsm/Codegen/Programs/BalCodePreimages.lean	accountStateDelegationCodeResolveFunction	0
+pair	EvmAsm/Codegen/Programs/BlockVerdictStateRoot.lean	statelessVerdictV2Function	0
+pair	EvmAsm/Codegen/Programs/ChildFrameHandlerTailHelpers.lean	callDelegationAccessChargeAsm	0
+pair	EvmAsm/Codegen/Programs/TxIntrinsicStateGas.lean	eip7702AuthorityAsOfFunction	0


### PR DESCRIPTION
## Summary
CI guard for #11520: missing code preimage must **reject**, not fall back to empty (`witness_state.py:204-212`).

### Checks (string-level, branch-aware)
1. **pair** — `jal code_at_header` without `*empty_code_hash` in the def
2. **anti** — status-5 `beq` to empty without prior hash load
3. **conv** — hash compare present but **every `bne` mismatch target equals the match `j`** (discarded comparison = false assurance)

### Why conv exists
SenderCounts:248 was reported “correct” under contains-pairing. Control flow:

```
bne … .Leas_we_ok   ×4 (mismatch → ok)
j .Leas_we_ok         (match → ok)
```

All arms converge → comparison gates nothing. A contains-test cannot see this.

### Branch-target re-check of the two real correct sites
| site | mismatch bne | match j | verdict |
|---|---|---|---|
| ChildFrameHandlers:859-878 | `.Lcd_fail_` | `.Lcd_empty_` | **OK** |
| DispatchTx materialize:123-132 | `.Ldtrc_materialize_lookup_done` | `.Ldtrc_materialize_empty_target` | **OK** |
| SenderCounts:248 | `.Leas_we_ok` | `.Leas_we_ok` | **conv violator** |

### Ratchet
`EXPECTED_VIOLATOR_COUNT = **8**` (was 7) + allow-list. Drive to 0 with site fixes.

### OUT OF SCOPE
exists/is_empty no-charge family → #11526.

### dual-accept
Same rule: transitional accept needs a drive-to-zero count (~203 bare B-imm files). Not touching #11524.