### PR TITLE
fix(codegen): record delegated code read before balance failure

### DIFF
--- a/EvmAsm/Codegen/Programs/ChildFrameHandlers.lean
+++ b/EvmAsm/Codegen/Programs/ChildFrameHandlers.lean
@@ -907,20 +907,30 @@ def callDescendFallThrough
   -- early. x12 is still the parent stack top; jump back to .Lcd_fail_ to pop+push 0.
   (if valueBearing then
      ".Lcd_insuffbal_" ++ tag ++ ":\n" ++
-     "  # GH #11410: spec reads the stack target's code BEFORE the balance\n" ++
-     "  # precheck (generic_call, system.py:461/584). Mirror: record the callee\n" ++
-     "  # code read through code_at_header_state_root (code_read_fetch) before\n" ++
-     "  # charging and failing, so precheck-failed CALL/CALLCODE still land in\n" ++
-     "  # the block code-read set the dynamic preimage gate iterates.\n" ++
-     "  la t0, cd_callee_be; sd zero, 0(t0); sd zero, 8(t0); sd zero, 16(t0); sd zero, 24(t0)\n" ++
-     "  addi t0, t0, 31; addi t1, x12, 32+19; li t2, 20\n" ++
-     ".Lcd_ib_addr_fill_" ++ tag ++ ":\n" ++
-     "  lbu t3, 0(t1); sb t3, 0(t0); addi t0, t0, -1; addi t1, t1, -1; addi t2, t2, -1; bnez t2, .Lcd_ib_addr_fill_" ++ tag ++ "\n" ++
+     "  # GH #11410: the shared delegation-access prelude has already read the\n" ++
+     "  # stack target through code_at_header_state_root before this balance\n" ++
+     "  # precheck (execution-specs system.py:460-461,486-494). Its cahsr\n" ++
+     "  # result remains live here. Do not repeat that lookup: the only new\n" ++
+     "  # read needed on a delegated target is the single-hop code_address\n" ++
+     "  # lookup below, which must reach code_read_fetch before the early fail.\n" ++
+     -- EIP-7702: the insufficient-balance path still follows the single-hop
+     -- target when the already-resolved callee code is a 23-byte marker. The
+     -- existing cahsr result is the original target; reuse it rather than
+     -- rebuilding the stack address (whose endian layout is not the code-table
+     -- address representation) or duplicating the original code read.
+     "  la t3, cahsr_code_length; ld t3, 0(t3); li t4, 23; bne t3, t4, .Lcd_ib_no_delegate_" ++ tag ++ "\n" ++
+     "  ld t3, 608(x20); la t4, cahsr_code_offset; ld t4, 0(t4); add t3, t3, t4\n" ++
+     "  lbu t4, 0(t3); li t5, 0xef; bne t4, t5, .Lcd_ib_no_delegate_" ++ tag ++ "\n" ++
+     "  lbu t4, 1(t3); li t5, 0x01; bne t4, t5, .Lcd_ib_no_delegate_" ++ tag ++ "\n" ++
+     "  lbu t4, 2(t3); bnez t4, .Lcd_ib_no_delegate_" ++ tag ++ "\n" ++
+     "  addi t3, t3, 3; la t4, cd_deleg_target; li t5, 20\n" ++
+     ".Lcd_ib_delegate_copy_" ++ tag ++ ":\n" ++
+     "  lbu t6, 0(t3); sb t6, 0(t4); addi t3, t3, 1; addi t4, t4, 1; addi t5, t5, -1; bnez t5, .Lcd_ib_delegate_copy_" ++ tag ++ "\n" ++
      "  addi sp, sp, -32; sd x10, 0(sp); sd x12, 8(sp); sd x13, 16(sp)\n" ++
-     "  la a0, cd_callee_be; addi a0, a0, 12\n" ++
-     "  ld a1, 576(x20); ld a2, 584(x20); ld a3, 592(x20); ld a4, 600(x20); ld a5, 608(x20); ld a6, 616(x20)\n" ++
+     "  ld a0, 576(x20); ld a1, 584(x20); la a2, cd_deleg_target; ld a3, 592(x20); ld a4, 600(x20); ld a5, 608(x20); ld a6, 616(x20)\n" ++
      "  jal ra, code_at_header_state_root\n" ++
      "  ld x10, 0(sp); ld x12, 8(sp); ld x13, 16(sp); addi sp, sp, 32\n" ++
+     ".Lcd_ib_no_delegate_" ++ tag ++ ":\n" ++
      "  li t0, 10300\n" ++
      "  ld t1, 568(x20)\n  bltu t1, t0, .exit_outofgas\n" ++
      "  sub t1, t1, t0\n  sd t1, 568(x20)\n" ++


### PR DESCRIPTION
## Summary

On the insufficient-balance path for value-bearing `CALL`/`CALLCODE`, record the
single-hop delegated target's code read before the early failure. The shared
delegation-access prelude already resolves and records the original stack target
before the balance precheck; this change reuses its live `cahsr` result, follows
an `EF0100` marker, and calls `code_at_header_state_root` for the delegated
target before charging/returning.

This follows the pinned Amsterdam execution-specs implementation at
`src/ethereum/forks/amsterdam/vm/instructions/system.py:460-461,486-494`:
`CALL` resolves `code_address` and reads its code before the sender-balance
precheck can fail. The missing guest step was the second code-address read for
an EIP-7702 delegated target on that failure path.

The first implementation attempt rebuilt the address from `cd_callee_be`.
That buffer's `+12` representation reverses the canonical address bytes; using
it would record a byte-reversed target and reject for the wrong reason. The
revised code copies the 20 marker payload bytes from the live `cahsr` code
bytes instead. It also avoids duplicating the original code lookup, which the
shared prelude already performs.

## Evidence

Candidate source was rebuilt from the stripped base `f56b516f5` plus this
change `f06fdca82`, before labelled PR #11528. Candidate ELF SHA256 is
`00de01bbfc0fc7801d2eb3f428cd3a7c6fd67f9b2b88b0f9204836c572946d99`, built
2026-08-05 14:36:39 +0200. Parent ELF SHA256 is
`fdea559bb5dd69cb22c1910c20237f3d289d3407cf27bb0a048f3b9096d0d4b4`.
The decode-scan work from the earlier contaminated branch was preserved for
its assigned owner and is not in this PR. The joint result against #11528 is
owed because #11528 changes the shared
delegation-access prelude; this PR was measured honestly on the pre-#11528
base and was not rebased onto the labelled branch.

The four named fixtures were run on this stripped candidate with
`scripts/spike/spike_run` (SHA256
`b4286c6e9100b83a0055e921fb4e4f96e8d852efe7f638c65a23a1a3af358349`). Each
row reports `rc / output[32] / bv_fail / code_reads_count`, with the count
shown as parent -> candidate:

| fixture | parent | candidate |
| --- | --- | --- |
| 02965 `validation_codes_missing_delegated_code_on_insufficient_balance_call` | `0 / 1 / 0 / 8` | `0 / 0 / 11 / 9` |
| 02967 `validation_codes_missing_implicit_system_contract_code` | `0 / 0 / 11 / 6` | `0 / 0 / 11 / 6` |
| 02970 `validation_codes_missing_sender_delegation_marker` | `0 / 1 / 0 / 6` | `0 / 1 / 0 / 6` |
| 02998 `validation_state_missing_failed_call_target_account_proof_node` | `0 / 1 / 0 / 7` | `0 / 1 / 0 / 7` |

The inserted call is live: a Spike PC probe stopped at `0x8004d478`, the
`code_at_header_state_root` call in `.Lcd_insuffbal_call_target`. The only
flip is 02965, and its new `bv_fail=11` is the dynamic preimage gate introduced
by #11426. 02967 is an unchanged reject control; 02970 and 02998 remain the
distinct residuals owned by the other investigations.

For a bounded random-200 check, parent and candidate used the same manifest
(`/tmp/eip7702-baseline-r200/manifest.tsv`, SHA256
`a228f3f6243d32e779d60183c98eac185d8c646df0bff302dbc666a3d5b014ef`) and 30
Spike workers. Both legs were `FA=0, FR=6, OK=193, FAULT=1`; the per-row TSVs
are byte-identical (SHA256
`6cab07f2016eaf77f8206e241e2e529ac056d8a9a30ffbb5908898a268eadabd`). Thus
the base-PASS -> candidate-REJECT set is empty on this sample, as is the
reverse transition set.

The arena format used for the read-count probes is `SPKDMP01`: each range has
a 16-byte header, so the second range's data begins after its header. The
earlier count of 8 was a real count from the pre-patch candidate; the current
02965 candidate count of 9 is from the correctly parsed second range, not a
header-offset correction.

No `merge!` label was applied by this PR author. The candidate must be
re-measured after #11528 lands because the shared prelude is part of this
change's input state.
