### PR TITLE
fix(codegen): retarget EIP-8037 transaction loop

### DIFF
--- a/EvmAsm/Codegen/Programs/BlockVerdictGasGate.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictGasGate.lean
@@ -649,7 +649,7 @@ def eip8037TxGasGate_prog : Program :=
     .SUB .x29 .x19 .x28,
     .BLTU .x29 .x6 (20 : BitVec 13),
     .ADDI .x24 .x24 (1 : BitVec 12),
-    .JAL .x0 (-1916 : BitVec 21),
+    .JAL .x0 (-1892 : BitVec 21),
     .LI .x10 (1 : Word),
     .JAL .x0 (24 : BitVec 21),
     .LI .x10 (2 : Word),

--- a/scripts/asm-fixtures/eip8037TxGasGateFunction.s
+++ b/scripts/asm-fixtures/eip8037TxGasGateFunction.s
@@ -427,7 +427,7 @@ eip8037_tx_gas_gate:
   sub x29, x19, x28
   bltu x29, x6, .+20
   addi x24, x24, 1
-  jal x0, .-1916
+  jal x0, .-1892
   li x10, 1
   jal x0, .+24
   li x10, 2


### PR DESCRIPTION
Fixes #11530.

The EIP-8037 transaction re-entry jump was encoded as -1916, targeting 0x80028c2c. The transaction-loop header is 0x80028c44, so the correct displacement is -1892 (24 bytes forward). The six instructions in the skipped interval are: li t1,1; sd t1,0(t0); li s8,0; auipc t0,...; addi t0,t0,...; sd zero,0(t0). The latter four initialize the transaction index and blob-gas accumulator, so the stale target re-entered one-time setup, not merely a counter reset.

The correction is applied to both the checked-in Program and its canonical asm fixture; no converter/tooling changes are included.

Important gate evidence: after the Program was corrected, `check-asm-to-program` caught that canonical fixture line 430 still contained `jal x0, .-1916`. This prevented a superficially complete one-file fix from leaving the source-of-truth fixture stale. The fixture was then corrected to `.-1892` as part of this PR.

Validation:
- Fresh linked ELF: 7a7168522f486689a3ae931ed5adc6e62169542dcaedd9ec2c2beb1736fb3477.
- Previously hanging row 15788: pre-fix rc=3 (step cap), succ byte was 1 but stale/unusable; oracle=1. Post-fix rc=0, succ=1.
- All 314 formerly step-capped rows: post-fix rc=0 and OK for all 314; oracle=1 and guest_succ=1 for all 314; mismatches=0.
- Deterministic random-200 sample (seed 11530): pre-fix OK=197, FR=2, FAULT=1, FA=0; post-fix OK=198, FR=2, FAULT=0, FA=0. The only transition was 15899_test_staticcall_createfails... FAULT to OK; reverse OK-to-FAULT transitions: 0.
- Pre-fix step-cap rows span 17 fixture suites, including stRandom (91), stRandom2 (73), stMemoryStressTest (71), and ecrecover_weird_v (36).
- `scripts/codegen-stateless-link-check.sh` passed; `scripts/check-asm-to-program.sh` is clean (382 converted defs across 144 files).

The J-type naming follow-up is intentionally left to #11534; this PR is the main-compatible value correction.