### PR TITLE
fix(codegen): record MTx coinbase fee account reads

### DIFF
--- a/EvmAsm/Codegen/Programs/BlockVerdictMtxCoinbase.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictMtxCoinbase.lean
@@ -33,13 +33,6 @@ def blockVerdictMtxCoinbaseFeeEffect : String :=
   "  la t0, sv_pre_rlp_ptr; ld a0, 0(t0); la t0, sv_pre_rlp_len; ld a1, 0(t0)\n" ++
   "  la t0, bv_exec_p; ld t0, 0(t0); addi a2, t0, 32\n" ++
   "  ld a3, 80(s0); ld a4, 88(s0); la a5, bv_mtx_cbfee_pre\n" ++
-  -- Amsterdam's `get_account` records the beneficiary read before resolving
-  -- tx writes, block writes, or the authenticated parent.  Keep this at the
-  -- execution producer callsite: `balance_at_header_state_root` is also used
-  -- by verification and ordinary BALANCE paths, where recording would add a
-  -- non-execution read to the BAL.  The recorder preserves t0-t6 and leaves
-  -- a1-a5 untouched; save only the header pointer held in a0.
-  "  mv t0, a0; mv a0, a2; jal ra, account_read_record; mv a0, t0\n" ++
   "  jal ra, balance_at_header_state_root\n" ++
   "  bnez a0, .Lbv_mtx_cbfee_done\n" ++
   "  la a0, bv_mtx_cbfee_pre; la a1, bv_mtx_cbfee_credit; la a2, bv_mtx_cbfee_post\n" ++

--- a/EvmAsm/Codegen/Programs/BlockVerdictMtxCoinbase.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictMtxCoinbase.lean
@@ -33,6 +33,13 @@ def blockVerdictMtxCoinbaseFeeEffect : String :=
   "  la t0, sv_pre_rlp_ptr; ld a0, 0(t0); la t0, sv_pre_rlp_len; ld a1, 0(t0)\n" ++
   "  la t0, bv_exec_p; ld t0, 0(t0); addi a2, t0, 32\n" ++
   "  ld a3, 80(s0); ld a4, 88(s0); la a5, bv_mtx_cbfee_pre\n" ++
+  -- Amsterdam's `get_account` records the beneficiary read before resolving
+  -- tx writes, block writes, or the authenticated parent.  Keep this at the
+  -- execution producer callsite: `balance_at_header_state_root` is also used
+  -- by verification and ordinary BALANCE paths, where recording would add a
+  -- non-execution read to the BAL.  The recorder preserves t0-t6 and leaves
+  -- a1-a5 untouched; save only the header pointer held in a0.
+  "  mv t0, a0; mv a0, a2; jal ra, account_read_record; mv a0, t0\n" ++
   "  jal ra, balance_at_header_state_root\n" ++
   "  bnez a0, .Lbv_mtx_cbfee_done\n" ++
   "  la a0, bv_mtx_cbfee_pre; la a1, bv_mtx_cbfee_credit; la a2, bv_mtx_cbfee_post\n" ++

--- a/EvmAsm/Codegen/Programs/BlockVerdictMtxRuntime.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictMtxRuntime.lean
@@ -732,9 +732,9 @@ def blockVerdictMtxRuntimeLoop : String :=
   -- storage, account, and code reads survive a failed transaction even when
   -- its AccountState commit is bypassed.  This join follows the spec order:
   -- sender refund, coinbase fee, then incorporation.  In particular the fee
-  -- helper's balance lookup records a coinbase account read even when its
-  -- priority-fee credit is zero; promote that final per-transaction read at
-  -- this transaction's incorporation boundary.
+  -- helper records a coinbase account read immediately before its balance
+  -- lookup, even when the priority-fee credit is zero; promote that final
+  -- per-transaction read at this transaction's incorporation boundary.
   -- The block-storage incorporation above is complete; retain the existing
   -- caller-save wrapper because this function still needs its outer `ra`.
   "  addi sp, sp, -32; sd ra, 0(sp); sd a1, 8(sp); sd a2, 16(sp); jal ra, read_sets_incorporate_tx; ld ra, 0(sp); ld a1, 8(sp); ld a2, 16(sp); addi sp, sp, 32\n" ++

--- a/EvmAsm/Codegen/Programs/BlockVerdictMtxRuntime.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictMtxRuntime.lean
@@ -731,10 +731,11 @@ def blockVerdictMtxRuntimeLoop : String :=
   -- `incorporate_tx_into_block` promotes all three read sets unconditionally:
   -- storage, account, and code reads survive a failed transaction even when
   -- its AccountState commit is bypassed.  This join follows the spec order:
-  -- sender refund, coinbase fee, then incorporation.  In particular the fee
-  -- helper records a coinbase account read immediately before its balance
-  -- lookup, even when the priority-fee credit is zero; promote that final
-  -- per-transaction read at this transaction's incorporation boundary.
+  -- sender refund, coinbase fee, then incorporation.  In particular the
+  -- existing `account_state_latest_balance` wrapper records the coinbase
+  -- account read immediately before its balance lookup, even when the
+  -- priority-fee credit is zero; promote that final per-transaction read at
+  -- this transaction's incorporation boundary.
   -- The block-storage incorporation above is complete; retain the existing
   -- caller-save wrapper because this function still needs its outer `ra`.
   "  addi sp, sp, -32; sd ra, 0(sp); sd a1, 8(sp); sd a2, 16(sp); jal ra, read_sets_incorporate_tx; ld ra, 0(sp); ld a1, 8(sp); ld a2, 16(sp); addi sp, sp, 32\n" ++


### PR DESCRIPTION
## Summary

Record the multi-transaction coinbase address at the execution fee-credit
producer, before the existing live-first/header balance lookup.

Amsterdam's `fork.py:1172` calls `create_ether(tx_state, block_env.coinbase,
transaction_fee)`. `state_tracker.py:680-696` implements `create_ether` through
`modify_state`, whose `get_account` call records `tx_state.account_reads` before
resolving the account (`state_tracker.py:199`). This is distinct from
`fork.py:1112`: `access_list_addresses.add(block_env.coinbase)` only warms the
transaction access-list/gas set; it is not the BAL `account_reads` set.

The guest had no other emitted `account_read_record` call for `bv_exec_p+32`
(the coinbase). This change adds that record at
`BlockVerdictMtxCoinbase.lean`, without changing the shared
`balance_at_header_state_root` helper or its verification/ordinary-BALANCE
callers. The existing MTx comment claiming that the fee helper records the
coinbase read is now true at the producer site; before this change it described
the intended behavior, not an emitted recorder.

## Predictions stated before measurement

There were three possible outcomes:

1. A large FR improvement if coinbase reads were missing and observable.
2. No flips if balance-change rows already create the account entry and the
   new read is deduplicated by `bal_builder_ensure_account`.
3. A regression (base-PASS -> candidate-FR) if the spec did not record this
   read and the new row were spurious; any such flip would block the change.

The measurement landed in outcome 2 on the available corpus. That does not
make the source change redundant: a zero-priority-fee credit can be a read-only
touch, while nonzero fee credits already have a balance-change row that masks
the read at the BAL builder.

## Evidence

Base and candidate were rebuilt from the same current-main commit
`5f23ef34fccf0eb71a0a8a6b0d06b12ae0237ce1`.

- Base ELF: `01826f5f1a6af12ffa028f239617eef69469638c605b330615eb6d10fb518c67`
- Candidate ELF: `b14f1529d6e4d93acc67ead1393538ed163168f60b68957dccebb313cae54ff8`
- Candidate build timestamp: `2026-08-05 20:03:08 +0200`
- Base `.text`: `0x55cc4`; candidate `.text`: `0x55cd4` (`+0x10`, four
  instructions); `.data`, `.bss`, and `.sszscratch` are unchanged.

Named controls, Spike backend:

- `exact_coinbase_fee_simple_sstore`: candidate 1/1 exact, base 1/1 exact.
- `bal_withdrawal_to_coinbase`: candidate 3/3 exact, base 3/3 exact.
- `call_with_value_to_coinbase_no_priority_fee_log`: candidate 1/1 exact,
  base 1/1 exact.
- `multi_block_observed_coinbase_balance`: candidate 2/2 exact, base 2/2
  exact.

Random-200, seed `11542`, 30 Spike jobs, same manifest and selection:

- Base: 200/200 ran, errors 0, FA 0, FR 3, full matches 197.
- Candidate: 200/200 ran, errors 0, FA 0, FR 3, full matches 197.
- Flip sets: base-PASS -> candidate-FR empty; base-FR -> candidate-PASS
  empty; candidate-PASS -> base-FR empty; candidate-FR -> base-PASS empty.
- `eest-ab-compare.py`: FR label sets identical, status differences 0, output
  byte differences 0, verdict byte-identical on all 199 joined cases.

The no-op result is corpus evidence, not a claim that zero-priority-fee
read-only coinbase touches are impossible: all observed nonzero fee credits
already have a balance-change account entry, and the named zero-tip controls
did not exercise a differing MTx BAL shape. The narrow case is specified by
construction: `create_ether` still calls `modify_state` at amount zero, but
`update_builder_from_tx` emits a balance change only when pre/post differ
(`block_access_lists.py:637-650`), while `account_reads` still ensures the
coinbase account at `block_access_lists.py:695-697`. Thus an MTx zero-fee row
needs the new read even though the available corpus has no such MTx witness.
