### PR TITLE
fix(selfdestruct): EIP-7708 log on status-3 origin (11617 receipts)

### DIFF
--- a/EvmAsm/Codegen/Programs/BlockVerdictCreationStage.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictCreationStage.lean
@@ -528,10 +528,13 @@ def blockVerdictCreationRuntimeFunction : String :=
   "  la t0, create_prebalance_acct; addi t0, t0, 8; la t1, bvcr_created_pre_bal; li t2, 32\n" ++
   ".Lbvcr_pre_bal_cp:\n" ++
   "  lbu t3, 0(t0); sb t3, 0(t1); addi t0, t0, 1; addi t1, t1, 1; addi t2, t2, -1; bnez t2, .Lbvcr_pre_bal_cp\n" ++
-  -- The endowment staging stays gated: a zero endowment means there is no transfer to
-  -- record, and the spec gates `move_ether`/`emit_transfer_log` together.
-  "  addi t0, s0, 96; ld t1, 0(t0); ld t2, 8(t0); or t1, t1, t2; ld t2, 16(t0); or t1, t1, t2; ld t2, 24(t0); or t1, t1, t2\n" ++
-  "  beqz t1, .Lbvcr_endow_done\n" ++
+  -- Always refresh `bvcr_endow_val_be` from ctx+96, including a zero endowment.
+  -- `dispatcher_seed_pending_value_transfer` (.Ldpub_create) consumes this buffer
+  -- whenever `create_prebalance_lookup_status == 0`; skipping the copy on value=0
+  -- left the prior-tx CREATE's endowment (e.g. initial_balance=1) in place, so a
+  -- later zero-value CREATE still `move_ether`d 1 wei into the new account
+  -- (sender −1 / entry +1) → #11547 on same_block_different_tx call_times_1
+  -- balance_1 (11737). `record_message_value_transfer` no-ops on a zero value.
   -- The context record holds the endowment as 32B BE at +96 (the EIP-7708 staging above
   -- reverses it DOWNWARD from +127 into the log's LE stack word, which fixes the direction).
   -- The recorder takes pointers to BE buffers, so copy it forward, unreversed.

--- a/EvmAsm/Codegen/Programs/Selfdestruct.lean
+++ b/EvmAsm/Codegen/Programs/Selfdestruct.lean
@@ -401,9 +401,18 @@ def selfdestructBalanceTransferRuntimeAsm : String :=
   -- just clear sdai_transfer_status to let selfdestructEip7708LogRuntimeAsm emit the
   -- log: it reads the transferred amount from the (valid) origin RLP and no-ops on a
   -- zero balance, so this is correct for both funded and empty new-beneficiary cases.
-  -- status 1/2/3 (no context / header / origin failure) keep skipping (status stays 1).
+  -- status 3 = origin MISS on block-pre MPT (CREATE in an earlier tx this block).
+  -- EIP-6780 still move_ethers the live balance; BeneficiaryNonstorage applies the
+  -- debit/credit, but 7708 log runs first and gates on transfer_status==0. Without
+  -- clearing here the log is skipped (log_status=1) → receipts_root mismatch bv53
+  -- (11617 dynamic_create2_selfdestruct_collision_multi_tx SD_first=False). 7708
+  -- non-created path then prefers account_state_latest_balance (still pre-debit).
+  -- status 1/2 (no context / header failure) keep skipping (status stays 1).
   "  li t2, 4\n" ++
+  "  beq t1, t2, .L_selfdestruct_transfer_log_only\n" ++
+  "  li t2, 3\n" ++
   "  bne t1, t2, .L_selfdestruct_transfer_done\n" ++
+  ".L_selfdestruct_transfer_log_only:\n" ++
   "  la t0, sdai_transfer_status\n" ++
   "  sd x0, 0(t0)\n" ++
   "  j .L_selfdestruct_transfer_done\n" ++

--- a/EvmAsm/Codegen/Programs/Selfdestruct.lean
+++ b/EvmAsm/Codegen/Programs/Selfdestruct.lean
@@ -789,18 +789,33 @@ def selfdestructBeneficiaryNonstorageAsm : String :=
   "  ld x10, 240(sp)\n  ld x12, 248(sp)\n  addi sp, sp, 256\n" ++
   "  j .L_sdbn_done\n" ++
   ".L_sdbn_chk_witness:\n" ++
+  -- status 0 = origin+beneficiary in block-pre; 4 = origin in pre, beneficiary new;
+  -- status 3 = origin MISS on block-pre MPT (e.g. CREATE in an earlier tx of this
+  -- block). EIP-6780 still `move_ether`s the live balance and does NOT delete
+  -- (originator ∉ created_accounts this tx). Bailing on status 3 left the CREATE
+  -- balance stranded and the beneficiary uncredited → #11547 root mismatch on
+  -- selfdestruct_created_same_block_different_tx (11737-39). Fall through and
+  -- resolve the origin balance from AccountState (prior-tx durable state).
   "  la t0, sdai_status; ld t0, 0(t0); beqz t0, .L_sdbn_origin_ok\n" ++
-  "  li t1, 4; bne t0, t1, .L_sdbn_done\n" ++
+  "  li t1, 4; beq t0, t1, .L_sdbn_origin_ok\n" ++
+  "  li t1, 3; bne t0, t1, .L_sdbn_done\n" ++
   ".L_sdbn_origin_ok:\n" ++
   "  addi sp, sp, -144\n" ++
   "  sd x10, 128(sp); sd x12, 136(sp)\n" ++
+  -- status 3: no origin RLP; start from 0 and let AccountState supply the live bal.
+  "  la t0, sdai_status; ld t0, 0(t0); li t1, 3; beq t0, t1, .L_sdbn_origin_bal_zero\n" ++
   "  la a0, sdai_origin_rlp; la t0, sdai_origin_len; ld a1, 0(t0); addi a2, sp, 64\n" ++
   "  jal ra, account_extract_balance\n" ++
+  "  j .L_sdbn_origin_bal_overlay\n" ++
+  ".L_sdbn_origin_bal_zero:\n" ++
+  "  sd zero, 64(sp); sd zero, 72(sp); sd zero, 80(sp); sd zero, 88(sp)\n" ++
+  ".L_sdbn_origin_bal_overlay:\n" ++
   -- The witness is block-pre state.  On a later transaction in the same block,
   -- a prior SELFDESTRUCT may already have recorded this origin's balance as
   -- zero; use that last committed effect before deciding whether there is a
   -- transfer.  Without this overlay, the stale witness balance is transferred
-  -- a second time (selfdestruct_then_transfer_same_block).
+  -- a second time (selfdestruct_then_transfer_same_block). Same overlay also
+  -- supplies the balance of a same-block prior-tx CREATE (status 3).
   "  sd zero, 96(sp); sd zero, 104(sp); sd zero, 112(sp); sd zero, 120(sp)\n" ++
   "  la t0, sdai_origin_address; addi t1, sp, 96; li t2, 20\n" ++
   ".L_sdbn_origin_key:\n" ++
@@ -844,20 +859,27 @@ def selfdestructBeneficiaryNonstorageAsm : String :=
   -- drj99.1 part 5c: record the ORIGIN's debit (balance -> 0, nonce preserved). SELFDESTRUCT moves the
   -- origin's whole balance to the (different) beneficiary, so the origin's final balance is 0; without a
   -- matching exec effect the BAL declares the origin's balance->0 with nothing to match -> bv_fail=44 (the
-  -- selfdestruct_* families). We are inside the witness-present (sdai_status 0/4) + origin!=beneficiary +
-  -- origin-balance!=0 path: the origin EXISTED at block-pre (created-in-THIS-tx accounts are absent from the
-  -- block-pre witness and never reach here), so EIP-6780 does NOT delete it -> nonce is PRESERVED. pre_bal =
-  -- origin balance (sp+64, extracted above); post_bal = 0 (sp+8..39); pre_nonce = post_nonce = origin nonce.
-  -- sp+0..63 is free scratch now (beneficiary pre/post already consumed). x10/x12 stay saved at sp+96/104.
+  -- selfdestruct_* families). Paths: status 0/4 (origin in block-pre) OR status 3 (origin from a
+  -- prior tx this block, live in AccountState only). EIP-6780 does NOT delete either → nonce PRESERVED.
+  -- pre_bal = origin balance (sp+64); post_bal = 0 (sp+8..39).
+  -- sp+0..63 is free scratch now (beneficiary pre/post already consumed). x10/x12 stay saved at sp+128/136.
+  "  sd zero, 8(sp); sd zero, 16(sp); sd zero, 24(sp); sd zero, 32(sp)\n" ++             -- post_balance = 0 (sp+8..39)
+  "  la t0, sdai_status; ld t0, 0(t0); li t1, 3; beq t0, t1, .L_sdbn_origin_nonce_as\n" ++
   "  la a0, sdai_origin_rlp; la t0, sdai_origin_len; ld a1, 0(t0); addi a2, sp, 0\n" ++   -- origin nonce -> sp+0
   "  jal ra, account_extract_nonce\n" ++
-  "  sd zero, 8(sp); sd zero, 16(sp); sd zero, 24(sp); sd zero, 32(sp)\n" ++             -- post_balance = 0 (sp+8..39)
   -- SELFDESTRUCT preserves the origin nonce, but a successful CREATE earlier
   -- in this transaction may already have advanced it.  Keep the witness nonce
   -- as the block-pre value and take the latest recorded nonce as the final.
   "  ld t0, 0(sp); sd t0, 40(sp)\n" ++
   "  la a0, sdai_origin_address; addi a1, sp, 40; jal ra, account_state_latest_nonce\n" ++
   "  ld a3, 0(sp); ld a4, 40(sp)\n" ++
+  "  j .L_sdbn_origin_debit\n" ++
+  ".L_sdbn_origin_nonce_as:\n" ++
+  -- status 3: no pre RLP. Nonce is whatever AccountState holds (CREATE deposited 1);
+  -- EIP-6780 preserves it, so pre_nonce = post_nonce = AS latest.
+  "  sd zero, 0(sp); la a0, sdai_origin_address; addi a1, sp, 0; jal ra, account_state_latest_nonce\n" ++
+  "  ld a3, 0(sp); mv a4, a3\n" ++
+  ".L_sdbn_origin_debit:\n" ++
   "  la a0, sdai_origin_address; addi a1, sp, 64; addi a2, sp, 8\n" ++                    -- a1 = pre_bal (origin), a2 = post_bal (0)
   "  jal ra, record_nonstorage_effect\n" ++
   ".L_sdbn_restore:\n" ++


### PR DESCRIPTION
## Summary
Closes **11617** on #11564 residual list (masking hierarchy after #11565).

**Defect:** EIP-6780 same-block prior-tx CREATE → `sdai_status=3`. #11565 already move_ethers via `BeneficiaryNonstorage`, but `selfdestructBalanceTransferRuntimeAsm` left `sdai_transfer_status=1` for status≠0/4. `selfdestructEip7708LogRuntimeAsm` gates on `transfer_status==0` and skipped → `log_status=1`. Receipts missed both SD→beneficiary EIP-7708 Transfer logs → **bv_fail=53** (`.Lbv_receipts_root_mismatch`).

**Evidence (11617 before fix):** r0 logs=2 byte-identical; r1 logs=3 vs fixture 5 (741 vs 1055 B). Missing `1ffb→c0f6 amt=8` and `amt=11`. Gas increments already matched.

**Fix:** Clear `sdai_transfer_status` for status **3** the same way as status **4** (log-only path). 7708 non-created path then reads `account_state_latest_balance` (still pre-debit; log runs before BeneficiaryNonstorage).

**Commits:**
1. Cherry of #11565 (same-block transfer + endow refresh) — drop on rebase after 11565 merges
2. This log-status fix (Selfdestruct.lean only exclusive delta)

## Measure
| set | base (11565 cherry) | cand | F→P | P→F |
|---|---|---|---|---|
| sd-named (~1693) | FR=1 (11617 bv53) | FR=0 | **11617** | **0** |
| r200 seed=20260806 | FR=9 | FR=9 | 0 | 0 |
| 11618/11619/01114/11737-39/03736-37/11734/05814 | PASS | PASS | | |
| **11710** | FR bv1 | FR bv1 | still open #11564 last | |

ELF base `da2cadad52bd028b…` @ 2fe953509; cand `4818c71f9d25bba2…` @ dcb2b8ea7.

## Spec
- Amsterdam EIP-6780: prior-tx CREATE still `move_ether` + EIP-7708 Transfer log when beneficiary ≠ origin
- Receipts root compare (not #11547 state-root); state-root path already OK after #11565

## Test plan
- [x] 11617 PASS; log list matches fixture (5 Transfer logs on r1)
- [x] sd-named P→F=0; r200 P→F=0
- [ ] CI
- [ ] Rebase after #11565 merges (drop cherry commit 1)

Refs: #11564 #11565