### PR TITLE
fix(7702): AUTH_BASE skip when pre-delegated (asof bit16)

### DIFF
--- a/EvmAsm/Codegen/Programs/TxIntrinsicStateGas.lean
+++ b/EvmAsm/Codegen/Programs/TxIntrinsicStateGas.lean
@@ -130,10 +130,17 @@ def eip7702AuthorityAsOfFunction : String :=
   "  li t0, 1; bne a0, t0, .L77as_normal_nonce\n" ++
   "  ld s1, 56(sp)\n" ++
   -- a2 = delegated_before_tx: durable only (skip pending), else header code.
+  -- Durable is authoritative for code/delegation only when bit16 (execution-
+  -- known / code-known) is set — prior-tx auth/code commit.  Sender inclusion
+  -- (`publish_sender_inclusion` flags|=67 = occupied|exists|nonce-auth bit6)
+  -- must NOT mask pre-block header code: bit6 alone with a2=0 was charging
+  -- AUTH_BASE on already-delegated authorities (2ffdac 7702 pointer cluster,
+  -- over-debit = 35190 state gas).  Match record_code's bit4/bit16 contract
+  -- (CreateCodeEffectLog: balance-only must never mask authenticated code).
   "  mv a0, s0; la a1, account_state_durable; la t0, account_state_durable_count; ld a2, 0(t0); li a3, " ++ toString accountStateEntryCapacity ++ "; jal ra, account_state_find\n" ++
   "  beqz a0, .L77as_deleg_hdr\n" ++
   "  ld t0, 88(a0); andi t1, t0, 2; beqz t1, .L77as_deleg_empty\n" ++
-  "  andi t1, t0, 64; beqz t1, .L77as_deleg_hdr\n" ++
+  "  andi t1, t0, 16; beqz t1, .L77as_deleg_hdr\n" ++
   "  andi t0, t0, 8; snez a2, t0; mv a1, s1; li a0, 1; j .L77as_ret\n" ++
   ".L77as_deleg_empty:\n" ++
   "  mv a1, s1; li a2, 0; li a0, 1; j .L77as_ret\n" ++


### PR DESCRIPTION
## Summary

`eip7702_authority_asof` returned `delegated_before_tx=0` for already-delegated senders because durable sender-inclusion (`flags|=67`, bit6 only) was treated as authoritative for code/delegation. Spec (`eoa_delegation.py:273-279`) charges `AUTH_BASE` only for **net-new** delegation; guest charged 35190 state gas anyway → sender balance short by `35190 * baseFee` → terminal state-root mismatch ([#11547](https://github.com/Verified-zkEVM/evm-asm/issues/11547)).

**Fix:** durable path trusts bit8 (delegation) only when **bit16** (execution/code-known) is set — same contract as `account_state_record_code` / auth commit. Inclusion-only snapshots fall through to header code.

## Pattern

Fourth instance of **ZERO-AS-VALUE vs ZERO-AS-MISS / presence mask**: a nonce-only durable row must not answer “not delegated” when it simply does not know code.

## Measure

| set | result |
|---|---|
| 53-row 2ffdac balance (leaf-decoder rank) | **F→P=21 P→F=0** remain 32 |
| 24842 asof a2 | 0 → **1**; `bvgr_tx_state_gas` 35190 → **0**; charge watch hits=0 |
| controls 01114/11619/00178/05814/11710/03736/03737 | PASS |
| r200 seed=20260806 | F→P=0 P→F=0 |

ELF base `c3393ecd…` @ main `a590139b4`; cand `7699aae8…` @ this tip.

### Residual (not this PR)

32/53 still FR bv=1. 24842 paid gas 145338 vs spec 145238 (**+100**). Base was +35290 (=35190+100); this PR removes AUTH_BASE only. Follow-up: residual +100/+200 gas on remain cluster.

## Spec

- `amsterdam/vm/eoa_delegation.py:223-228,273-279` — AUTH_BASE iff `not delegated_before_tx and authority not in delegation_set_for`
- `get_pre_state_account` code, not current-tx inclusion nonce snapshot

## Test plan

- [x] 53-row 2ffdac named set
- [x] r200
- [x] SPIKE asof a0/a1/a2 + AUTH_BASE charge watch on 24842
- [ ] CI layout (text size unchanged — andi imm only)