### PR TITLE
ci: guard retired storage-log predicates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,10 @@ jobs:
       - uses: actions/checkout@v4
       - name: Forbidden-tactic guard (no bv_decide / native_decide / TCB expanders)
         run: scripts/check-forbidden-tactics.sh
+      - name: Retired-predicate absence guard (#11596)
+        run: |
+          scripts/check-retired-predicates.sh --self-test
+          scripts/check-retired-predicates.sh
       - name: Sail pin guard (vendored model matches its provenance extraction)
         run: scripts/check-sail-pin.sh
       - name: Symbolic guest-PC guard (SAsm wrappers follow GuestAddrs)

--- a/scripts/check-retired-predicates.sh
+++ b/scripts/check-retired-predicates.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# check-retired-predicates.sh — keep retired proof vocabulary out of EvmAsm.
+#
+# The persistent append-only storage-log assertion was retired in #11601.  A
+# later reintroduction would compile cleanly but recreate the misleading
+# container vocabulary that the retirement removed, so this is intentionally a
+# source-level denylist rather than a registry or emitted-ELF check.
+#
+# Names may still be mentioned in documentation when wrapped in backticks;
+# the gate is about declarations and uses, not the historical record of why the
+# names were retired.  `--self-test` plants a declaration in a temporary Lean
+# file and verifies that the scanner rejects it, so a green scan is not merely
+# evidence that the name happens not to occur today.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+SCAN_DIR="EvmAsm"
+FORBIDDEN=(
+  storageLogIs
+  storageLogIs_nil
+  storageLogIs_cons
+  storageLogIs_congr
+  pcFree_storageLogIs
+  storageLogLenIs
+  PERSISTENT_STORAGE_LOG_BASE
+)
+
+mode="enforce"
+case "${1:-}" in
+  "")          mode="enforce" ;;
+  --report)    mode="report" ;;
+  --self-test) mode="self-test" ;;
+  *)
+    echo "usage: $0 [--report|--self-test]" >&2
+    exit 2
+    ;;
+esac
+
+alt="$(IFS='|'; echo "${FORBIDDEN[*]}")"
+
+scan_dir() {
+  local dir="$1"
+  # Bound tokens by non-identifier/non-backtick characters.  Backtick-wrapped
+  # prose is allowed, while line comments containing actual source tokens are
+  # still rejected so comments cannot hide a copy-paste reintroduction.
+  grep -rnE "(^|[^\`A-Za-z0-9_])(${alt})([^\`A-Za-z0-9_]|$)" \
+      --include="*.lean" "$dir" 2>/dev/null \
+    | grep -vE "\`(${alt})\`" \
+    || true
+}
+
+if [[ "$mode" == "self-test" ]]; then
+  tmp="$(mktemp -d)"
+  trap 'rm -rf "$tmp"' EXIT
+  mkdir -p "$tmp/planted" "$tmp/documented"
+  printf 'def storageLogIs := True\n' > "$tmp/planted/RetiredPredicate.lean"
+  planted="$(scan_dir "$tmp/planted")"
+  if [[ -z "$planted" ]]; then
+    echo "check-retired-predicates self-test FAILED: planted storageLogIs was not detected" >&2
+    exit 1
+  fi
+  printf -- '-- `storageLogIs`\n' > "$tmp/documented/Documentation.lean"
+  documented="$(scan_dir "$tmp/documented")"
+  if [[ -n "$documented" ]]; then
+    echo "check-retired-predicates self-test FAILED: backtick documentation was rejected" >&2
+    exit 1
+  fi
+  echo "check-retired-predicates self-test: planted declaration rejected; backtick documentation allowed."
+  exit 0
+fi
+
+hits="$(scan_dir "$SCAN_DIR")"
+
+if [[ "$mode" == "report" ]]; then
+  echo "== Retired-predicate scan over ${SCAN_DIR}/**.lean =="
+  echo "   forbidden: ${FORBIDDEN[*]}"
+  echo
+  if [[ -n "$hits" ]]; then echo "$hits"; else echo "  (none)"; fi
+  echo
+  echo "(report mode — exit 0)"
+  exit 0
+fi
+
+if [[ -n "$hits" ]]; then
+  echo "$hits" >&2
+  n="$(printf '%s\n' "$hits" | grep -c . || true)"
+  cat >&2 <<EOF
+
+==================================================================
+check-retired-predicates FAILED: $n retired storage-log token(s) found in
+${SCAN_DIR}/.
+
+The persistent append-only storage-log proof vocabulary was retired in #11601.
+Use the live map/transient vocabulary instead.  If this is historical prose,
+wrap the retired name in backticks; otherwise remove the declaration or use.
+==================================================================
+EOF
+  exit 1
+fi
+
+echo "check-retired-predicates: OK — no retired storage-log vocabulary in ${SCAN_DIR}/."


### PR DESCRIPTION
## Summary

Add a source-level absence gate for the persistent append-only storage-log proof vocabulary retired by #11601.

- `scripts/check-retired-predicates.sh` rejects `storageLogIs` and its retired companion vocabulary under `EvmAsm/**/*.lean`.
- Backtick-wrapped historical references remain allowed.
- The source-check workflow runs the gate and its negative-control self-test.

This is a source/CI guard only; it changes no Lean declarations, emitted strings, generated artifacts, or guest bytes.

## Negative control

The self-test plants a temporary `def storageLogIs := True` and verifies a nonzero exit, then checks that backtick documentation is allowed. I also manually reintroduced the same trivial declaration in `EvmAsm/Evm64/StorageAssertions.lean`; the real-tree scan rejected it, and the declaration was removed before this commit.

## Checks

- `scripts/check-retired-predicates.sh --self-test` ✅
- `scripts/check-retired-predicates.sh` ✅
- `bash -n scripts/check-retired-predicates.sh` ✅
- `git diff --check` ✅
