### PR TITLE
fix(codegen): raise EXTCODECOPY length cap to EIP-7907 MAX_CODE_SIZE

### DIFF
--- a/EvmAsm/Codegen/Programs/EvmExtcodecopy.lean
+++ b/EvmAsm/Codegen/Programs/EvmExtcodecopy.lean
@@ -53,8 +53,8 @@ private def extcodecopyWitnessTail : HandlerTail :=
     memDynamicU256RangeOogGuardAsm
       "extcodecopy" "x12" "x15" "x16" "x17" 32 96 ++
     -- eccob.1: both EXTCODECOPY copy paths consume only the low 64-bit code offset.
-    -- If any high limb is nonzero, or the low limb is at/above the deployed-code cap,
-    -- normalize to 32768 so the existing zero-padded copy loops cannot wrap the source index.
+    -- If any high limb is nonzero, or the low limb is at/above EIP-7907 MAX_CODE_SIZE
+    -- (65536), normalize to 65536 so zero-padded copy loops cannot wrap the source index.
     "  ld x16, 64(x12)
 " ++
     "  ld x17, 72(x12)
@@ -66,12 +66,12 @@ private def extcodecopyWitnessTail : HandlerTail :=
 " ++
     "  bnez x17, .Lrt_ecc_oob_offset
 " ++
-    "  li x18, 32768
+    "  li x18, 65536
   bltu x16, x18, .Lrt_ecc_offset_ok
 " ++
     ".Lrt_ecc_oob_offset:
 " ++
-    "  li x18, 32768
+    "  li x18, 65536
   sd x18, 64(x12)
 " ++
     ".Lrt_ecc_offset_ok:

--- a/EvmAsm/Codegen/Programs/EvmOpcodesExtcodecopy.lean
+++ b/EvmAsm/Codegen/Programs/EvmOpcodesExtcodecopy.lean
@@ -52,7 +52,7 @@ open EvmAsm.Rv64.Program
       a1 (input)  : header_rlp_len
       a2 (input)  : address ptr (20 bytes)
       a3 (input)  : code_offset (u64)
-      a4 (input)  : length (u64; must be <= 32768)
+      a4 (input)  : length (u64; must be <= MAX_CODE_SIZE = 65536 / EIP-7907)
       a5 (input)  : output buffer ptr (`length` bytes)
       a6 (input)  : witness.state ptr
       a7 (input)  : witness.state len
@@ -67,7 +67,7 @@ open EvmAsm.Rv64.Program
         4 = header parse / state_root size fail
         5 = code_hash != EMPTY but not in witness.codes
             (witness integrity violation)
-        6 = length > 32768 (deployed-code cap; not a spec issue)
+        6 = length > 65536 (EIP-7907 deployed-code cap)
 
       (Code 1 "account not in trie" is intentionally absent:
       missing accounts map to `status=0, output=all zeros` per
@@ -94,7 +94,10 @@ def extcodecopyAtHeaderStateRoot_prog : Program :=
     .MV .x21 .x15,
     .MV .x22 .x16,
     .MV .x23 .x17,
-    .LUI .x5 (8 : BitVec 20),
+    -- Cap = EIP-7907 MAX_CODE_SIZE 65536 (LUI 16 << 12). Was 32768 (LUI 8) —
+    -- half the raised limit; EXTCODECOPY of full max-code accounts returned
+    -- status 6 with a pre-zeroed window (keccak of zeros → #11547).
+    .LUI .x5 (16 : BitVec 20),
     .BLTU .x5 .x20 (344 : BitVec 13),
     .MV .x5 .x21,
     .MV .x6 .x20,
@@ -236,7 +239,7 @@ theorem extcodecopyAtHeaderStateRootFunction_eq_prog :
       bytes 16..24 : witness_state_len (u64 LE)
       bytes 24..32 : witness_codes_len (u64 LE)
       bytes 32..40 : code_offset (u64 LE)
-      bytes 40..48 : length (u64 LE; must be <= 32768)
+      bytes 40..48 : length (u64 LE; must be <= 65536)
       bytes 48..68 : address (20 bytes)
       bytes 68..68+H              : header_rlp
       bytes 68+H..68+H+WS         : witness.state

--- a/EvmAsm/Codegen/Programs/EvmOpcodesExtcodecopy.lean
+++ b/EvmAsm/Codegen/Programs/EvmOpcodesExtcodecopy.lean
@@ -94,9 +94,6 @@ def extcodecopyAtHeaderStateRoot_prog : Program :=
     .MV .x21 .x15,
     .MV .x22 .x16,
     .MV .x23 .x17,
-    -- Cap = EIP-7907 MAX_CODE_SIZE 65536 (LUI 16 << 12). Was 32768 (LUI 8) —
-    -- half the raised limit; EXTCODECOPY of full max-code accounts returned
-    -- status 6 with a pre-zeroed window (keccak of zeros → #11547).
     .LUI .x5 (16 : BitVec 20),
     .BLTU .x5 .x20 (344 : BitVec 13),
     .MV .x5 .x21,

--- a/scripts/asm-fixtures/extcodecopyAtHeaderStateRootFunction.s
+++ b/scripts/asm-fixtures/extcodecopyAtHeaderStateRootFunction.s
@@ -12,10 +12,10 @@ extcodecopy_at_header_state_root:
   mv s5, a5                  # output buffer ptr
   mv s6, a6                  # witness.state ptr
   mv s7, a7                  # witness.state len
-  # Reject length > 32768 (EIP-7907 deployed-code-size cap).
-  li t0, 32768
+  # Reject length > 65536 (EIP-7907 MAX_CODE_SIZE / deployed-code-size cap).
+  li t0, 65536
   bgtu s4, t0, .Lecc_too_long
-  # Pre-zero output[0..length] byte-by-byte (length <= 32768).
+  # Pre-zero output[0..length] byte-by-byte (length <= 65536).
   mv t0, s5
   mv t1, s4
 .Lecc_zero_loop:


### PR DESCRIPTION
## Summary
- `extcodecopy_at_header_state_root` rejected `length > 32768` (status 6) while EIP-7907 raised `MAX_CODE_SIZE` to **65536**.
- Full-size `EXTCODECOPY` left the pre-zeroed memory window → SHA3 of 64k zeros → wrong storage slot → **#11547** state-root mismatch.
- `EXTCODESIZE` / `EXTCODEHASH` had no such cap (worked on the same accounts).
- Runtime OOB code-offset normalize raised 32768 → 65536 to match.

Decoder class `nonce_mismatch` on these rows was a **false friend** (TOUCHED-only AW); applied account RLP already had correct nonce/code_hash.

## Spec
- Amsterdam EIP-7907 / `CreateDeployedCodeValid.maxDeployedCodeSize = 65536`
- EXTCODECOPY zero-pads past end; does not error on missing account

## Measure vs main `11fcab529`
| set | result |
|---|---|
| 01308 / 01315 max_code_size | **F→P** |
| r200 seed=20260806 | 0/0 |
| controls 01114/11619/00178/05814/11710/03736 | PASS |

ELF base `41877692…` cand `88e1f721…`. text size unchanged (LUI imm only) — no layout pin regen.

## Remain (not this PR)
- **12832/12833/12834** `precompile_absence`: high-key storage clear with baseline=0 (omit 0→0) — related to SLOAD original / #11604 baseline class
- **00026** guest_extra OOG rollback delegations — separate

## Pattern
Half-migrated constant: deployed-code cap lifted in CREATE validator, left at old half-limit on EXTCODECOPY length gate.

## Do not
- No merge from grok; await label