### PR TITLE
fix(codegen): publish MTx sender refund map row

### DIFF
--- a/EvmAsm/Codegen/Programs/BlockVerdictMtxRuntime.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictMtxRuntime.lean
@@ -102,10 +102,17 @@ private def blockVerdictMtxRecordSenderRefund : String :=
   -- BAL row.  The BAL producer below deliberately re-reads this final state.
   "  la t0, sttc_nonce; ld a3, 0(t0); addi a4, a3, 1; la a0, bv_mtx_sender_addr; la a1, bv_pending_upfront_sender_pre; la a2, bv_pending_upfront_sender_post; jal ra, account_state_record_nonstorage\n" ++
   "  bnez a0, .Lbv_mtx_bail\n" ++
-  "  la a0, bv_mtx_sender_addr; la a1, bv_pending_upfront_sender_post; li a2, 19; jal ra, account_state_latest_balance\n" ++
-  "  beqz a0, .Lbv_mtx_bail  # the preceding AccountState credit must be observable\n" ++
+  -- Publish the post-body refund to the transaction map at the mutation point.
+  -- `create_ether` has already updated AccountState above; this companion records
+  -- the same settled pre/post pair without a second AccountState append.  The
+  -- publication must precede the post read below so a map-first reader observes
+  -- the refund instead of the pre-refund row.  It is deliberately after body
+  -- restoration and therefore survives an ordinary body revert, matching
+  -- `fork.py:1155-1169`.
   "  la t0, sttc_nonce; ld a3, 0(t0); addi a4, a3, 1; la a0, bv_mtx_sender_addr; la a1, bv_pending_upfront_sender_pre; la a2, bv_pending_upfront_sender_post; jal ra, record_nonstorage_effect_after_account_state\n" ++
   "  bnez a0, .Lbv_mtx_bail\n" ++
+  "  la a0, bv_mtx_sender_addr; la a1, bv_pending_upfront_sender_post; li a2, 19; jal ra, account_state_latest_balance\n" ++
+  "  beqz a0, .Lbv_mtx_bail  # the preceding AccountState credit must be observable\n" ++
 ".Lbv_mtx_sr_done:\n"
 
 /-! Gate the pre-user system-storage seed on the same code-presence predicate as


### PR DESCRIPTION
## Summary

The MTx sender-refund path now publishes the settled refund row to the transaction map immediately after the AccountState `create_ether`-equivalent update and before the map-first post-balance read. This matches the execution-spec ordering: `fork.py:1155-1169` applies the sender refund before the BAL-facing state is consumed. The existing caller tags (`a2=17/18/19`) are unchanged.

This is structural alignment, not a verdict change: AccountState remains the execution authority, so a lagging map row is currently verdict-neutral. The map must nevertheless agree before #11591 can make it authoritative.

## Evidence

- Base commit: `2e04928dd6fb2cde918c5469a9bf7a2d860f05de`
- Baseline ELF: `e7e3762e3a0e31a5f2a324030dce0784890de9734edcab6bc15f0844adf8da4e`
- Candidate ELF: `21b6d22c844ea479f2280f1ceafdfccca5dc554c4ec63ae882181bf385e498fe`
- Manifest: `/tmp/codex2-account-reader-ab-base-forward/manifest.tsv` (sha256 `43a41e1f321dc376698ab220711140b6551b8524a400433c43702e70de3c12ac`), 200 cases, seed `11586`
- Runner: `scripts/spike/spike_run` rebuilt from source at the base; binary sha256 `529504d986b06aa5b40c8e9fc351bd88831f4a30dc28b4ef92422d54ba9f2844`; source sha256 `757039f88382d7dac5fb7562fb6c61e48d454c4dccb445606e215cbce2e798cf`
- Enabled agreement harness: baseline mismatches `142` -> candidate `0`; all 142 baseline events were reader `19/tx`
- Balance probe invocations: `1090` -> `1090`; nonce probe invocations: `55` -> `55`
- `instrument_events`: `0` -> `0`
- Candidate/base output differences: `0`

The unchanged invocation counts show that the reader still executes; the mismatch count reaches exact zero rather than merely decreasing. The zero output-difference result is expected for this structural change on this corpus, not evidence that the publication is unnecessary.

During rebase validation, an intermediate candidate accidentally dropped the existing caller tags (`a2=17/18/19`). I caught it by comparing the emitted source before accepting the apparent zero; without those tags, reader attribution would have been silently invalid even though invocation counts remained unchanged. The final candidate preserves all three tags.
