### PR TITLE
fix(codegen): raise EXTCODECOPY length cap to EIP-7907 MAX_CODE_SIZE

### DIFF
--- a/EvmAsm/Codegen/Programs/EvmExtcodecopy.lean
+++ b/EvmAsm/Codegen/Programs/EvmExtcodecopy.lean
@@ -53,8 +53,8 @@ private def extcodecopyWitnessTail : HandlerTail :=
     memDynamicU256RangeOogGuardAsm
       "extcodecopy" "x12" "x15" "x16" "x17" 32 96 ++
     -- eccob.1: both EXTCODECOPY copy paths consume only the low 64-bit code offset.
-    -- If any high limb is nonzero, or the low limb is at/above the deployed-code cap,
-    -- normalize to 32768 so the existing zero-padded copy loops cannot wrap the source index.
+    -- If any high limb is nonzero, or the low limb is at/above EIP-7907 MAX_CODE_SIZE
+    -- (65536), normalize to 65536 so zero-padded copy loops cannot wrap the source index.
     "  ld x16, 64(x12)
 " ++
     "  ld x17, 72(x12)
@@ -66,12 +66,12 @@ private def extcodecopyWitnessTail : HandlerTail :=
 " ++
     "  bnez x17, .Lrt_ecc_oob_offset
 " ++
-    "  li x18, 32768
+    "  li x18, 65536
   bltu x16, x18, .Lrt_ecc_offset_ok
 " ++
     ".Lrt_ecc_oob_offset:
 " ++
-    "  li x18, 32768
+    "  li x18, 65536
   sd x18, 64(x12)
 " ++
     ".Lrt_ecc_offset_ok:

--- a/EvmAsm/Codegen/Programs/EvmOpcodesExtcodecopy.lean
+++ b/EvmAsm/Codegen/Programs/EvmOpcodesExtcodecopy.lean
@@ -52,7 +52,7 @@ open EvmAsm.Rv64.Program
       a1 (input)  : header_rlp_len
       a2 (input)  : address ptr (20 bytes)
       a3 (input)  : code_offset (u64)
-      a4 (input)  : length (u64; must be <= 32768)
+      a4 (input)  : length (u64; must be <= MAX_CODE_SIZE = 65536 / EIP-7907)
       a5 (input)  : output buffer ptr (`length` bytes)
       a6 (input)  : witness.state ptr
       a7 (input)  : witness.state len
@@ -67,7 +67,7 @@ open EvmAsm.Rv64.Program
         4 = header parse / state_root size fail
         5 = code_hash != EMPTY but not in witness.codes
             (witness integrity violation)
-        6 = length > 32768 (deployed-code cap; not a spec issue)
+        6 = length > 65536 (EIP-7907 deployed-code cap)
 
       (Code 1 "account not in trie" is intentionally absent:
       missing accounts map to `status=0, output=all zeros` per
@@ -94,7 +94,10 @@ def extcodecopyAtHeaderStateRoot_prog : Program :=
     .MV .x21 .x15,
     .MV .x22 .x16,
     .MV .x23 .x17,
-    .LUI .x5 (8 : BitVec 20),
+    -- Cap = EIP-7907 MAX_CODE_SIZE 65536 (LUI 16 << 12). Was 32768 (LUI 8) —
+    -- half the raised limit; EXTCODECOPY of full max-code accounts returned
+    -- status 6 with a pre-zeroed window (keccak of zeros → #11547).
+    .LUI .x5 (16 : BitVec 20),
     .BLTU .x5 .x20 (344 : BitVec 13),
     .MV .x5 .x21,
     .MV .x6 .x20,
@@ -236,7 +239,7 @@ theorem extcodecopyAtHeaderStateRootFunction_eq_prog :
       bytes 16..24 : witness_state_len (u64 LE)
       bytes 24..32 : witness_codes_len (u64 LE)
       bytes 32..40 : code_offset (u64 LE)
-      bytes 40..48 : length (u64 LE; must be <= 32768)
+      bytes 40..48 : length (u64 LE; must be <= 65536)
       bytes 48..68 : address (20 bytes)
       bytes 68..68+H              : header_rlp
       bytes 68+H..68+H+WS         : witness.state

--- a/EvmAsm/Codegen/Programs/EvmOpcodesExtcodecopy.lean
+++ b/EvmAsm/Codegen/Programs/EvmOpcodesExtcodecopy.lean
@@ -94,9 +94,6 @@ def extcodecopyAtHeaderStateRoot_prog : Program :=
     .MV .x21 .x15,
     .MV .x22 .x16,
     .MV .x23 .x17,
-    -- Cap = EIP-7907 MAX_CODE_SIZE 65536 (LUI 16 << 12). Was 32768 (LUI 8) —
-    -- half the raised limit; EXTCODECOPY of full max-code accounts returned
-    -- status 6 with a pre-zeroed window (keccak of zeros → #11547).
     .LUI .x5 (16 : BitVec 20),
     .BLTU .x5 .x20 (344 : BitVec 13),
     .MV .x5 .x21,

--- a/scripts/asm-fixtures/extcodecopyAtHeaderStateRootFunction.s
+++ b/scripts/asm-fixtures/extcodecopyAtHeaderStateRootFunction.s
@@ -12,10 +12,10 @@ extcodecopy_at_header_state_root:
   mv s5, a5                  # output buffer ptr
   mv s6, a6                  # witness.state ptr
   mv s7, a7                  # witness.state len
-  # Reject length > 32768 (EIP-7907 deployed-code-size cap).
-  li t0, 32768
+  # Reject length > 65536 (EIP-7907 MAX_CODE_SIZE / deployed-code-size cap).
+  li t0, 65536
   bgtu s4, t0, .Lecc_too_long
-  # Pre-zero output[0..length] byte-by-byte (length <= 32768).
+  # Pre-zero output[0..length] byte-by-byte (length <= 65536).
   mv t0, s5
   mv t1, s4
 .Lecc_zero_loop:


### PR DESCRIPTION
## Summary

**Supersedes closed-without-merge #11608.** That PR was CLOSED at 10:58Z with `mergedAt=null` and never landed; main still had the half-cap. This PR re-lands the same verified fix on current `origin/main` `231b1195d` (post-#11610 prose sweep).

`extcodecopy_at_header_state_root` rejected `length > 32768` (status 6) while EIP-7907 raised `MAX_CODE_SIZE` to **65536**. Full-size `EXTCODECOPY` left the pre-zeroed memory window → SHA3 of 64k zeros → wrong storage slot → **#11547** state-root mismatch. `EXTCODESIZE` / `EXTCODEHASH` had no such cap (worked on the same accounts). Runtime OOB code-offset normalize raised 32768 → 65536 to match.

Decoder class `nonce_mismatch` on 01308/01315 was a **false friend** (TOUCHED-only AW); applied account RLP already had correct nonce/code_hash.

## Changes (same as #11608 tip `81c979fc9`)

1. **EvmOpcodesExtcodecopy.lean** — Program `.LUI .x5 (8)` → `(16)` (32768 → 65536); docs/status-6 comment updated.
2. **EvmExtcodecopy.lean** — runtime OOB normalize `li x18, 32768` → `65536` (two sites).
3. **scripts/asm-fixtures/extcodecopyAtHeaderStateRootFunction.s** — `li t0, 65536` so symbolic render is byte-identical to the Program (emitProgramR renders `lui x5, 0x10`).
4. Multi-line comment **removed from inside the Program list** (forms are comment-free; broke verbatim generated-block match). EIP-7907 rationale stays in doc comments outside the list.

## Bare local J site ratchet (parking comment on #11608)

Parking noted: `BARE LOCAL J SITE RATCHET expected exactly 176, found 171`.

**How resolved — 171 was an artefact of a mid-fix tree, not a ratchet change.**

- This PR does **not** touch `scripts/asm_to_program.py` / `EXPECTED_BARE_J_SITES`.
- Diff vs main is only the 3 files above (no ratchet edit).
- Local `python3 scripts/asm_to_program.py check-all` on this branch: **CLEAN** — `382 converted defs; bare local J report 49 files / 80 defs; blocking site ratchet 176 sites`.
- The 171 reading on the parked branch was from an incomplete intermediate state while the fixture/Program were still disagreeing; once fixture + Program agreed and the in-list comment was removed, the count returned to the committed equality **176**.

No silent ratchet adjustment.

## Spec

- Amsterdam EIP-7907 / `execution-specs` `amsterdam/vm/interpreter.py:77` `MAX_CODE_SIZE = 0x10000` (= 65536), enforced at :219.
- EXTCODECOPY zero-pads past end; does not error on missing account.
- `CreateDeployedCodeValid.maxDeployedCodeSize` already 65536 on main.

## Measure

Prior measure on #11608 vs then-main `11fcab529` (substance unchanged; LUI imm only):

| set | result |
|---|---|
| 01308 / 01315 max_code_size | **F→P** |
| r200 seed=20260806 | 0/0 |
| controls 01114/11619/00178/05814/11710/03736 | PASS |

ELF base `41877692…` cand `88e1f721…`. text size unchanged (LUI imm only) — no layout pin regen.

## Screening

No FA risk: value computation not control dependency; wrong copy → wrong root → reject (#11547).

## Remain (not this PR)

- **12832/12833/12834** `precompile_absence` / `mpt_bounded_storage_root` silent wrong-success (#11613) — separate
- **00026** guest_extra OOG rollback — separate
- #11610 prose-only constant sweep already on main

## Pattern

Half-migrated constant: deployed-code cap lifted in CREATE validator, left at old half-limit on EXTCODECOPY length gate.

## Do not

- No merge from grok; await label (do not self-label)
- Does not regenerate layout pins