### PR TITLE
fix(codegen): resolve original for seeded system storage rows

### DIFF
--- a/EvmAsm/Codegen/Programs/BlockVerdictSystemStorageCapture.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictSystemStorageCapture.lean
@@ -198,6 +198,10 @@ def appendModeledSystemStorageTupleRowsFunction : String :=
   "  # the already materialized descriptor post-value for the comparison.\n" ++
   "  sd zero, 64(s2); sd zero, 72(s2); sd zero, 80(s2); sd zero, 88(s2)\n" ++
   ".Lamsr_original_ready:\n" ++
+  "  # The seed-only caller shares the authenticated-original lookup, but it\n" ++
+  "  # must not publish a duplicate side-log/BAL row.  Keep this dispatch here\n" ++
+  "  # so the resolver's zero-on-miss result is also the map baseline.\n" ++
+  "  la t0, bv_system_storage_map_seed_only; ld t0, 0(t0); bnez t0, .Lamsr_seed_original_ready\n" ++
   "  # Match the ordinary storage emitter's pre!=post rule.  Equal parent/current\n" ++
   "  # values still update the execution map, but publish no BAI-0 change row.\n" ++
   "  ld t0, 64(s2); ld t1, 96(s2); bne t0, t1, .Lamsr_emit_change\n" ++
@@ -225,20 +229,23 @@ def appendModeledSystemStorageTupleRowsFunction : String :=
   "  ld ra, 56(sp)\n" ++
   "  addi s1, s1, 1; sd s1, 0(s0)\n" ++
   "  j .Lamsr_one_ok\n" ++
-  ".Lamsr_finish_one:\n" ++
-  "  la t0, bv_system_storage_map_seed_only; ld t0, 0(t0); bnez t0, .Lamsr_seed_prepare\n" ++
-  "  j .Lamsr_original_resolve\n" ++
-  ".Lamsr_seed_prepare:\n" ++
-  "  sd ra, 56(sp)\n" ++
-  ".Lamsr_seed_map:\n" ++
-  "  # Pre-user mode publishes only the canonical map row; the terminal call\n" ++
-  "  # remains responsible for the side log and BAI-0 BAL builder event.\n" ++
-  "  # Seed has no resolved original here → a3=0 (baseline zero).\n" ++
-  "  mv a0, s2; addi a1, s2, 32; addi a2, s2, 96; li a3, 0\n" ++
+  ".Lamsr_seed_original_ready:\n" ++
+  "  # Seed-only mode updates the canonical map with the authenticated parent\n" ++
+  "  # baseline, without emitting the terminal BAI-0 side log or BAL row.\n" ++
+  "  mv a0, s2; addi a1, s2, 32; addi a2, s2, 96; addi a3, s2, 64\n" ++
   "  jal ra, storage_writes_block_upsert\n" ++
   "  la t0, storage_writes_overflow; ld t0, 0(t0); bnez t0, .Lamsr_map_overflow\n" ++
   "  ld ra, 56(sp)\n" ++
   "  j .Lamsr_one_ok\n" ++
+  ".Lamsr_finish_one:\n" ++
+  "  la t0, bv_system_storage_map_seed_only; ld t0, 0(t0); bnez t0, .Lamsr_seed_prepare\n" ++
+  "  j .Lamsr_original_resolve\n" ++
+  ".Lamsr_seed_prepare:\n" ++
+  "  # Resolve the real authenticated parent value before the seed upsert.\n" ++
+  "  # The raw resolver does not record a read, so this path cannot grow the\n" ++
+  "  # account/storage read sets or publish a side-log row as a lookup effect.\n" ++
+  "  addi s5, s2, 32\n" ++
+  "  j .Lamsr_original_resolve\n" ++
   ".Lamsr_one_ok:\n" ++
   "  li a0, 0; ret\n" ++
   ".Lamsr_one_overflow:\n" ++


### PR DESCRIPTION
## Summary

The pre-user modeled-system seed path used a sentinel `a3=0` baseline when calling `storage_writes_block_upsert`. On a seeded address/slot hit, the upsert preserves the existing row baseline, so the later state-root comparison can treat a nonzero authenticated-parent value as zero and omit a real change.

This change routes seed-only rows through the existing authenticated `slot_at_header_state_root` lookup, then upserts the resolved original at descriptor +64. It keeps seed-only behavior side-log/BAI-free. The resolver body (StateCompose.lean:565-625) has no `account_read_record` or `storage_read_record` call, so this route cannot add a read-set/BAL side effect.

This is a latent-defect removal and spec-alignment change, not a current-main FR repair. The old 157-row `post_unusable_multiblock` bucket was measured on stale artifact `a6c634e95`; all 157 rows already pass on current main `3ce5f22bd`.

## Evidence

Prediction before measurement: the random-200 and named controls have empty flip sets, because this path only changes seeded system-storage baselines and current main has no remaining failures in the historical bucket.

- Shared manifest: `/tmp/11582-selected.manifest.tsv` (157 historical rows plus five controls) and `/tmp/11582-r200-controls.manifest.tsv` (random-200 plus those controls).
- Base commit `3ce5f22bd`; base ELF SHA256 `8dd2c14e6d97b62de02f4a4875f97cc03cb4b019eaf730f9afe862c1716f7ab1`.
- Candidate commit `441ba5a0a`; candidate ELF SHA256 `a3f24ddd5704b9e9f8f8f780cbf6bfc945b8e6c716f1b2ac64172ae382691bab`.
- On the shared 162-row manifest, the stale reference ELF `26016e2ca3a41ba54ca7f7a1dca9f48aaf9bd199ed96a129039e185d8383c51d` gives 158 FR / 4 OK; freshly rebuilt current-main base gives 162/162 OK. The historical bucket is therefore genuinely retired by intervening merges, not a manifest mismatch.
- Historical 157 rows + five named controls: 162/162 OK on both current-main legs, FA=0, FR=0, no flips.
- Deterministic random-200 + five named controls: 205/205 OK on both legs, FA=0, FR=0, no flips.
- Named controls: 03736, 03737, 11734, 21353, 23274.
- Seeded-row BAL length identity (output +128 rebuilt, +136 supplied; 256-byte captures), both legs: 04457 263/263, 23094 815/815, 23206 824/824.
- `.text` moved `0x56910 -> 0x56924` (+0x14); `.data` and `.bss` are unchanged.

The change fixes no currently-failing row on current main; the evidence establishes no deterioration while making the seed path spec-shaped.
