### PR TITLE
docs(mpt): restate bounded-first live contract (#11613)

### DIFF
--- a/EvmAsm/Codegen/Programs/BalAccountApplyPostFields.lean
+++ b/EvmAsm/Codegen/Programs/BalAccountApplyPostFields.lean
@@ -600,8 +600,9 @@ def mapAccountApplyPostFieldsFunction : String :=
   "  addi t0, t0, 1; la t1, baap_sc_index; sd t0, 0(t1); j .Lbaap_multi_loop\n" ++
   -- #11385: `storage_root` is derived from the storage_writes rows at this
   -- use via `mpt_bounded_storage_root`; it is not a map field or mask bit.
-  -- The explicit legacy call below is only the conservative builder-failure
-  -- fallback and does not introduce a stored storage-root representation.
+  -- LIVE contract (#11613 framing): bounded-first always; legacy only when
+  -- bounded returns a0≠0 (fail-closed unsupported shape, e.g. LCP-prefixed
+  -- collapse after #11633). Not a disconnected/optional probe.
   ".Lbaap_multi_apply:\n" ++
   "  la t0, baap_sc_out_count; ld a4, 0(t0); beqz a4, .Lbaap_nonce\n" ++
   "  la t0, baap_storage_empty_flag; ld t0, 0(t0); bnez t0, .Lbaap_multi_apply_empty\n" ++
@@ -617,11 +618,12 @@ def mapAccountApplyPostFieldsFunction : String :=
   "  jal ra, mpt_bounded_storage_root\n" ++
   "  bnez a0, .Lbaap_multi_apply_legacy\n" ++
   "  j .Lbaap_multi_set_account\n" ++
-  "# Conservative bounded-builder bailout fallback: preserve the legacy exact\n" ++
-  "# storage replay instead of rejecting a valid BAL row. This is intentionally\n" ++
-  "# isolated so the normal route remains bounded and the unmasked behavior can\n" ++
-  "# be measured independently.\n" ++
+  "# Fail-closed fallback: bounded returned a0≠0 (unsupported/malformed).\n" ++
+  "# Legacy mpt_state_root_ins keeps the BAL/MPT row accepting when the shape\n" ++
+  "# is outside the bounded subset (measured: r200 fallback ~0%; 12832-class\n" ++
+  "# takes this arm after #11633 LCP gate). Not a second primary path.\n" ++
   ".Lbaap_multi_apply_legacy:\n" ++
+
   "  la t0, baap_storage_empty_flag; ld t0, 0(t0); bnez t0, .Lbaap_multi_legacy_empty\n" ++
   "  la t0, baap_storage_root_ptr; ld a0, 0(t0); la t0, aps_witness_ptr; ld a1, 0(t0); la t0, aps_witness_len; ld a2, 0(t0); j .Lbaap_multi_legacy_args\n" ++
   ".Lbaap_multi_legacy_empty:\n" ++

--- a/EvmAsm/Codegen/Programs/BalAccountApplyPostFields.lean
+++ b/EvmAsm/Codegen/Programs/BalAccountApplyPostFields.lean
@@ -620,8 +620,8 @@ def mapAccountApplyPostFieldsFunction : String :=
   "  j .Lbaap_multi_set_account\n" ++
   "# Fail-closed fallback: bounded returned a0≠0 (unsupported/malformed).\n" ++
   "# Legacy mpt_state_root_ins keeps the BAL/MPT row accepting when the shape\n" ++
-  "# is outside the bounded subset (measured: r200 fallback ~0%; 12832-class\n" ++
-  "# takes this arm after #11633 LCP gate). Not a second primary path.\n" ++
+  "# is outside the bounded subset (e.g. LCP-prefixed collapse after #11633).\n" ++
+  "# Not a second primary path. Fallback rate: see #11613 (dated measure).\n" ++
   ".Lbaap_multi_apply_legacy:\n" ++
 
   "  la t0, baap_storage_empty_flag; ld t0, 0(t0); bnez t0, .Lbaap_multi_legacy_empty\n" ++

--- a/EvmAsm/Codegen/Programs/MptBoundedSort.lean
+++ b/EvmAsm/Codegen/Programs/MptBoundedSort.lean
@@ -823,11 +823,12 @@ def mptBoundedEncodeExtensionFunction : String :=
     back to legacy `mpt_state_root_ins` — not a silent wrong-success path.
 
     Supported on the bounded path: unprefixed collapse, pure insert, pure
-    delete, small mixed (e.g. 21353/23274). Fail-closed: LCP-prefixed collapse
-    (`split_leaf_group` → collapse with `a6>0`; large mixed 12832-class).
-    Measured r200 fallback rate after #11633: ~0% (only named 12832-class
-    takes the legacy arm). Optional future work: implement LCP collapse so
-    that class stays on bounded (#11613 capability gap, not unsoundness).
+    delete, and small mixed insert+delete. Fail-closed: LCP-prefixed collapse
+    (`split_leaf_group` → collapse with `a6>0`), the large mixed
+    insert+delete class. Fallback is rare in practice; measured rate and date
+    live on #11613 (not here — numbers go stale). Optional future work:
+    implement LCP collapse so that class stays on bounded (#11613 capability
+    gap, not unsoundness).
 
     ABI: `a0 = old_root[32]`; `a1 = witness section`; `a2 = witness length`;
     `a3 = descriptors`; `a4 = descriptor count`; `a5 = out_root[32]`.

--- a/EvmAsm/Codegen/Programs/MptBoundedSort.lean
+++ b/EvmAsm/Codegen/Programs/MptBoundedSort.lean
@@ -732,15 +732,18 @@ def mptBoundedBuildMissingSubtreeFunction : String :=
   ".Lmbms_ret:\n" ++
   "  ld ra, 0(sp); ld s0, 8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp); ld s4, 40(sp); ld s5, 48(sp); ld s6, 56(sp); ld s7, 64(sp); addi sp, sp, 96; ret\n"
 
-/-- Depth-first bounded dispatcher for the already-supported exact-replacement
-    subset. It is deliberately a real recursive frontier walk, not a NodeDb
-    shim: branch children are opened only from their frame raw refs/witness,
+/-- Depth-first bounded dispatcher on the **live** baap storage-root path
+    (bounded-first; not a disconnected probe). Real recursive frontier walk,
+    not a NodeDb shim: branch children open only from frame raw refs/witness,
     and every completed child is copied to its parent before the shared result
-    slot is reused. Existing extension prefixes are preserved through the same
-    continuation; a one-descriptor insertion into an existing branch's empty
-    child is materialized as its bounded suffix leaf. Extension/leaf splits
-    and deletion collapse remain explicit conservative exits until their
-    canonical cases land. -/
+    slot is reused. Existing extension prefixes are preserved; a one-descriptor
+    insertion into an empty branch child becomes its bounded suffix leaf.
+
+    Unsupported shapes return `a0=1` (fail-closed) so baap can fall back to
+    legacy `mpt_state_root_ins`. Named unsupported today: LCP-prefixed collapse
+    (`mpt_bounded_collapse_branch_leaf` with `a6>0`, from `split_leaf_group`) —
+    #11613 / #11633. Unprefixed collapse and pure insert/delete stay on this
+    path. Do not read “exact-replacement subset” as “unwired”. -/
 def mptBoundedRebuildSubtreeFunction : String :=
   "  .globl mpt_bounded_rebuild_subtree\n" ++
   "  .type mpt_bounded_rebuild_subtree, @function\n" ++
@@ -811,11 +814,20 @@ def mptBoundedEncodeExtensionFunction : String :=
   ".Lmbee_ret:\n" ++
   "  ld ra, 0(sp); ld s0, 8(sp); ld s1, 16(sp); ld s2, 24(sp); ld s3, 32(sp); ld s4, 40(sp); ld s5, 48(sp); ld s6, 56(sp); addi sp, sp, 112; ret\n"
 
-/-- Bounded shared-root body for the supported exact-replacement subset.
-    The input descriptors have already been normalized to final, distinct
-    committed values.  LCP-prefixed collapse (split_leaf_group → collapse with
-    a6>0) is fail-closed (#11613); unprefixed collapse and pure insert/delete
-    remain on the bounded path. Legacy mpt_state_root_ins is the baap fallback.
+/-- Bounded shared-root body — **live** entry (`mpt_bounded_storage_root` /
+    `mpt_bounded_state_root`) wired from baap `.Lbaap_multi_apply_call`.
+
+    Contract (post-#11633): bounded-first on every multi-desc storage apply.
+    Descriptors are final distinct committed values. On success (`a0=0`) the
+    new root is authoritative. On unsupported/malformed (`a0≠0`) baap falls
+    back to legacy `mpt_state_root_ins` — not a silent wrong-success path.
+
+    Supported on the bounded path: unprefixed collapse, pure insert, pure
+    delete, small mixed (e.g. 21353/23274). Fail-closed: LCP-prefixed collapse
+    (`split_leaf_group` → collapse with `a6>0`; large mixed 12832-class).
+    Measured r200 fallback rate after #11633: ~0% (only named 12832-class
+    takes the legacy arm). Optional future work: implement LCP collapse so
+    that class stays on bounded (#11613 capability gap, not unsoundness).
 
     ABI: `a0 = old_root[32]`; `a1 = witness section`; `a2 = witness length`;
     `a3 = descriptors`; `a4 = descriptor count`; `a5 = out_root[32]`.


### PR DESCRIPTION
## Summary
Docstring-only close of the **stale-contract** half of #11613.

## Framing (measured, no collapse impl)
After #11633 (`bnez a6` LCP-prefixed collapse fail-closed):
| set | bounded calls | a0≠0 fallback |
|---|---|---|
| r200 seed=20260806 | 113 | **0 (0%)** |
| 12832/33/34 | 1 each | 1 each → legacy PASS |
| 21353/21354/23274 | 1 each | 0 (bounded ok) |

- **Unsound silent wrong-success:** closed by #11633
- **Stale docstring:** this PR — docs said disconnected/until-KATs while live is bounded-first + fail-closed fallback
- **Capability gap:** residual narrow (12832-class only); optional later; not this PR

## Changes
- `MptBoundedSort.lean`: rebuild + state-root docs state LIVE bounded-first, named unsupported (LCP a6>0), baap legacy on a0≠0
- `BalAccountApplyPostFields.lean`: multi_apply comments match (not optional probe)

## Non-goals
No collapse algorithm. No layout pins. No guest behavior change.

## Test plan
- [x] r200 + named MPT fallback instrument (pre-PR measure)
- [ ] CI docs-only green