### PR TITLE
feat(#11574): the field-element and point-record assertion vocabulary

### DIFF
--- a/EvmAsm.lean
+++ b/EvmAsm.lean
@@ -1,5 +1,6 @@
 import EvmAsm.Rv64
 import EvmAsm.Crypto.BeBytesBridge
+import EvmAsm.Stateless.Crypto.FieldAssertions
 import EvmAsm.Crypto.Fermat
 import EvmAsm.Crypto.PowLadder
 import EvmAsm.Crypto.ScalarMul

--- a/EvmAsm/Crypto/BeBytesBridge.lean
+++ b/EvmAsm/Crypto/BeBytesBridge.lean
@@ -21,9 +21,18 @@
   stand on** without this equality: the two sides would be talking about
   syntactically different functions that a reader assumes are the same.
 
-  `U256MinSAsm.beBytesToNat_foldl` proves the accumulator generalisation, but it
-  is `private`, lives under `Codegen`, and stops short of the equality — so it is
-  unavailable to a core-side bridge on both counts.
+  The accumulator generalisation already exists twice under `Codegen` —
+  `U256MinSAsm.beBytesToNat_foldl` (`private`) and
+  `U256MulU64Be/Basic.beBytesToNat_foldl_init` (public) — and **neither is usable
+  here, for one reason: layering.** `Codegen` is a pure sink, so a core-side
+  bridge cannot import either, whatever their visibility. Both also stop short of
+  the equality, generalising within `beBytesToNat` rather than over `fromBytesBE`.
+
+  ⚠️ An earlier draft of this docstring gave "it is `private`" as half the
+  justification. That is wrong about the public one and irrelevant to the private
+  one — visibility never entered into it. Recorded rather than silently corrected,
+  because "this is unavailable" is exactly the kind of claim that gets repeated
+  from a docstring without being re-measured.
 -/
 
 import EvmAsm.Crypto.PowLadder

--- a/EvmAsm/Stateless/Crypto/FieldAssertions.lean
+++ b/EvmAsm/Stateless/Crypto/FieldAssertions.lean
@@ -1,0 +1,166 @@
+/-
+  EvmAsm.Stateless.Crypto.FieldAssertions
+
+  Assertion vocabulary for the precompile field towers (GH #11574).
+
+  ## ⚠️ Read this before reaching for the LE form
+
+  #11574 asks for `fpLimbsIs`, *"a fixed-width little-endian limb buffer"*, and
+  names `blsg_lt_p` / `bnf_lt_p` as its first consumers. **Those two things are
+  inconsistent**, which is why this module leads with the big-endian form:
+  `scripts/asm-fixtures/bls12G1LtPFunction.s` is a byte-at-a-time MSB-first
+  `lbu`/`bltu` scan against `blsg_p_be` — no `ld`, no 8-byte stride, no alignment
+  requirement. Both `lt_p` triples state their post over `beBytesToNat`.
+
+  The LE 6×64 / 4×64 layout is real, but its consumers are the *converters*
+  (`blsg_be_to_le` writes limb `i` at `base + 8i`, LSB first) and the accelerator
+  point forms. So `fpLimbsIs` is here too, and is genuinely useful — but as the
+  companion to the BE form rather than as the prerequisite it was filed as.
+
+  ## Why this is core and not `Codegen/RegionPredicates.lean`
+
+  `check-layering` L1 makes `EvmAsm/Codegen` a **pure sink**: 19 files under
+  `Codegen/**` import `SpecRef`, and 0 files under `Stateless/**` or `EL/**`
+  import `Codegen`. A crypto field predicate has to be consumable by a
+  **core-side** bridge against `bytes_to_fq`, so it cannot live under `Codegen`.
+
+  ⭐ The same rule sends `balEntriesFrom` (#10817) the other way, and the pair is
+  consistent rather than contradictory: *same rule, opposite consequence*.
+  #10817's obligation is about the **emitted program**, so its predicate lives
+  Codegen-side and may cite SpecRef freely; this one must be visible from core.
+
+  ## The primes are the ones the routines actually compare against
+
+  ⚠️ `blsg_lt_p` compares against `blsg_p_be`, the **base field** prime
+  (`Bls12.blsP`, 381-bit). #11574 and `docs/leaf-routine-targets.md` both paired
+  it with `Kzg.bytes_to_bls_field` / `BLS_MODULUS`, which is the **scalar field
+  order** (255-bit) — a different prime, and a different guest routine
+  (`blsk_lt_be`).
+-/
+
+import EvmAsm.Crypto.BeBytesBridge
+import EvmAsm.Rv64.SAsm.AccelStep
+import EvmAsm.Stateless.SpecRef.PrecompilesBls
+import EvmAsm.Stateless.SpecRef.PrecompilesKzg
+
+namespace EvmAsm.Stateless.Crypto
+
+open EvmAsm.Rv64 EvmAsm.Rv64.SAsm
+open EvmAsm.Crypto (beBytesToNat)
+
+/-! ## The big-endian form — what the `lt_p` routines actually read -/
+
+/-- **A big-endian field element in memory.** `width` bytes at `base`, decoding
+    to `v`, with `v < p` carried as part of the resource.
+
+    Shape follows `accountRlpIs` (`Stateless/State/AccountAssertions.lean:118`):
+    a value-carrying `…Is` whose well-formedness sits beside the `bytesRegion`
+    rather than being left to the caller. `…Is` is the right name per
+    `RegionPredicates`' convention — this pins the *whole* region, so the name
+    stays true. -/
+def fpBeBytesIs (width p : Nat) (base : Word) (v : Nat) : Assertion :=
+  fun ps => ∃ bs : List (BitVec 8),
+    bs.length = width ∧ beBytesToNat bs = v ∧ v < p ∧ bytesRegion base bs ps
+
+theorem pcFree_fpBeBytesIs (width p : Nat) (base : Word) (v : Nat) :
+    (fpBeBytesIs width p base v).pcFree := by
+  intro ps h
+  obtain ⟨bs, -, -, -, hreg⟩ := h
+  exact bytesRegion_pcFree base bs ps hreg
+
+/-- BLS12-381 base field element: 48 big-endian bytes, `< blsP`. This is the
+    exact resource `blsgLtP_spec` holds as `bytesRegion inPtr xs` plus
+    `xs.length = 48`. -/
+def blsFpBeIs (base : Word) (v : Nat) : Assertion :=
+  fpBeBytesIs 48 SpecRef.Bls12.blsP base v
+
+/-- BN254 base field element: 32 big-endian bytes, `< fieldModulus`. -/
+def bnFpBeIs (base : Word) (v : Nat) : Assertion :=
+  fpBeBytesIs 32 SpecRef.Bn128.fieldModulus base v
+
+/-! ## The little-endian limb form — the converters' and accelerators' view
+
+    Defined over the **existing** `wsNat` / `leBytesN` (`Rv64/SAsm/AccelStep.lean`)
+    rather than a fresh limb decoder: `wsNat nl ws k` is already "the `nl` limbs
+    at byte offset `k` read little-endian", and `nl = 6` is already documented
+    there as the BLS12-381 view. -/
+
+/-- **A little-endian limb-buffer field element.** `nl` 64-bit limbs at `base`,
+    LSB limb first, decoding to `v < p`. -/
+def fpLimbsIs (nl p : Nat) (base : Word) (v : Nat) : Assertion :=
+  fun ps => v < p ∧ bytesRegion base (leBytesN nl v) ps
+
+theorem pcFree_fpLimbsIs (nl p : Nat) (base : Word) (v : Nat) :
+    (fpLimbsIs nl p base v).pcFree := by
+  intro ps h
+  exact bytesRegion_pcFree base (leBytesN nl v) ps h.2
+
+/-- BLS12-381 base field element as six LE limbs — the shape `blsg_be_to_le`
+    writes and `blsg_le_add` consumes. -/
+def blsFpLimbsIs (base : Word) (v : Nat) : Assertion :=
+  fpLimbsIs 6 SpecRef.Bls12.blsP base v
+
+/-- BN254 base field element as four LE limbs. -/
+def bnFpLimbsIs (base : Word) (v : Nat) : Assertion :=
+  fpLimbsIs 4 SpecRef.Bn128.fieldModulus base v
+
+/-! ## Point records
+
+    ⚠️ **The two families' contents types are genuinely different and are kept
+    so.** BLS G1 is `Bn128.Proj Nat` — a projective triple, with `z = 0` meaning
+    infinity (`PrecompilesBls.lean:98`). BN254 is `Weier.Pt = Option (Nat × Nat)`
+    — an affine option, with `none` meaning infinity
+    (`PrecompilesCurve.lean:35`, `:91`). Forcing a shared contents type would
+    only move the case split somewhere less honest. -/
+
+/-- On-curve for BLS12-381 G1, **stated, not proven** — `y² = x³ + 4 (mod p)`,
+    mirroring `PrecompilesBls.lean:100`. Per #11574 item 2 this is a
+    well-formedness proposition the vocabulary carries, not an obligation this
+    module discharges. -/
+def blsG1OnCurve (x y : Nat) : Prop :=
+  (y * y) % SpecRef.Bls12.blsP = (x * x * x + 4) % SpecRef.Bls12.blsP
+
+/-- On-curve for BN254 G1 — `y² = x³ + 3 (mod p)`, mirroring
+    `PrecompilesCurve.lean:92`. Stated, not proven. -/
+def bnG1OnCurve (x y : Nat) : Prop :=
+  (y * y) % SpecRef.Bn128.fieldModulus
+    = (x * x * x + 3) % SpecRef.Bn128.fieldModulus
+
+/-- **A BLS12-381 G1 affine point in the guest's compact BE layout**: `x` at
+    `base`, `y` at `base + 48`, both `< p`, with the on-curve side condition
+    carried as a proposition. -/
+def g1AffineIs (base : Word) (x y : Nat) : Assertion :=
+  fun ps => blsG1OnCurve x y ∧
+    (blsFpBeIs base x ** blsFpBeIs (base + BitVec.ofNat 64 48) y) ps
+
+/-- **A BN254 G1 point in the guest's compact BE layout**: `x` at `base`, `y` at
+    `base + 32`. -/
+def bnPointIs (base : Word) (x y : Nat) : Assertion :=
+  fun ps => bnG1OnCurve x y ∧
+    (bnFpBeIs base x ** bnFpBeIs (base + BitVec.ofNat 64 32) y) ps
+
+/-! ## Satisfiability witnesses
+
+    ⚠️ Required rather than decorative. `RegionPredicates.lean:518-522` records
+    the #10688 lesson: *a predicate no state can satisfy proves nothing about the
+    region, and a bundled hypothesis can make a theorem vacuous without saying
+    so.* `g1AffineIs` bundles an on-curve condition, which is exactly the shape
+    that can be accidentally unsatisfiable — so the generators below are checked
+    rather than assumed.
+
+    The BN254 generator `(1, 2)` is on-curve: `2² = 4 = 1³ + 3`. -/
+
+example : bnG1OnCurve 1 2 := by unfold bnG1OnCurve; decide
+
+/-- The point at infinity's coordinates are **not** on the curve, and the port
+    handles it by a separate `x == 0 && y == 0` branch rather than by the curve
+    equation (`PrecompilesCurve.lean:91`). Pinned so nobody folds the infinity
+    case into `bnG1OnCurve` and makes the predicate accept a non-point. -/
+example : ¬ bnG1OnCurve 0 0 := by unfold bnG1OnCurve; decide
+
+/-- Both moduli really are distinct from the scalar order that #11574 named —
+    the correction this module's header records. -/
+theorem blsP_ne_blsModulus : SpecRef.Bls12.blsP ≠ SpecRef.Kzg.BLS_MODULUS := by
+  decide
+
+end EvmAsm.Stateless.Crypto


### PR DESCRIPTION
Second piece of #11574. **Stacked on #11677** (the decoder bridge). Per the ruling: BE first, LE alongside as the companion rather than the prerequisite.

## ⚠️ Why BE leads

The issue asks for `fpLimbsIs`, *"a fixed-width little-endian limb buffer"*, and names `blsg_lt_p` / `bnf_lt_p` as its first consumers. Those two are inconsistent — the fixture is a byte-at-a-time MSB-first `lbu`/`bltu` scan against `blsg_p_be`, with no `ld`, no stride and no alignment requirement, and both `lt_p` triples state their post over `beBytesToNat`. The LE 6×64 / 4×64 layout is real, but its consumers are the **converters** (`blsg_be_to_le`) and the accelerator point forms.

Both are here. The module header says which is which, so the issue's own error isn't reproduced inside its fix — that was your point about framing LE as following the bridge rather than preceding it.

## What's here

- **`fpBeBytesIs width p base v`** — the form the live consumers use. Shape follows `accountRlpIs` (`State/AccountAssertions.lean:118`): a value-carrying `…Is` whose well-formedness sits beside the `bytesRegion` rather than being left to the caller. `…Is` passes `RegionPredicates`' naming test, since a fixed-width element pins the *whole* region. Specialised as `blsFpBeIs` (48, `blsP`) and `bnFpBeIs` (32, `fieldModulus`).
- **`fpLimbsIs nl p base v`** over the **existing** `leBytesN` / `wsNat` (`Rv64/SAsm/AccelStep.lean:635`, `:623`) rather than a fresh limb decoder — `nl = 6` is already documented there as the BLS12-381 view.
- **`g1AffineIs` / `bnPointIs`** over the compact BE layouts, with on-curve **stated** as a `Prop` per item 2.

⚠️ **Contents types kept distinct**, as you asked: BLS G1 is projective with `z = 0` meaning infinity (`PrecompilesBls.lean:98`); BN254 is `Weier.Pt = Option (Nat × Nat)` with `none` meaning infinity (`PrecompilesCurve.lean:35`). Forcing a shared type would only move the case split somewhere less honest.

## Placement — and why it does not contradict #10817

The module is in **core**, not `Codegen/RegionPredicates.lean`, because a crypto predicate must be visible to a core-side bridge against `bytes_to_fq`, and L1 makes `Codegen` a pure sink.

I've recorded your framing from #11676 in the header rather than leaving a reviewer to reconstruct it:

> Same rule, opposite consequence.

#10817's obligation is about the **emitted program**, so its predicate lives Codegen-side and may cite SpecRef freely (19 files under `Codegen/**` already do); this one must be visible from core (0 files under `Stateless/**` or `EL/**` import `Codegen`). The pair is consistent by construction.

## Satisfiability witnesses — required, not decorative

`g1AffineIs` bundles an on-curve condition, which is exactly the shape that can be accidentally unsatisfiable — the #10688 lesson `RegionPredicates.lean:518-522` records. So:

- the BN254 generator `(1, 2)` is **checked** on-curve (`2² = 4 = 1³ + 3`);
- `(0, 0)` is **checked not** on-curve. The port handles infinity by a separate `x == 0 && y == 0` branch (`PrecompilesCurve.lean:91`), so folding it into the predicate would make the predicate accept a non-point. Pinned so nobody "simplifies" it later.

`blsP_ne_blsModulus` pins the correction this issue needed — the base field prime and the scalar order really are different numbers. It depends on **no axioms at all**.

## Verification

`lake build` clean (4735 jobs), no `sorry`. `check-layering` (core→core only), `check-unimported` (2765/2765, 0 orphans), `check-forbidden-tactics`, `check-file-size`.

```
'EvmAsm.Stateless.Crypto.pcFree_fpBeBytesIs' depends on axioms: [propext, Quot.sound]
'EvmAsm.Stateless.Crypto.pcFree_fpLimbsIs'   depends on axioms: [propext, Quot.sound]
'EvmAsm.Stateless.Crypto.blsP_ne_blsModulus' does not depend on any axioms
```

No registry rows yet — these are predicates, not routine specs, so `Routines`/`Correspondence`/`AxiomWitnesses` are untouched.

## Next

The 16-byte EIP-2537 wire-pad relation **in the statement**, then the bridges against `bytes_to_fq` / `bytes_to_g1` restating `blsgLtP_spec` / `bnfLtP_spec` in this vocabulary, then the two absent registry rows and the `4ch8f-crypto-kernel-inventory.md:53` correction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
