### PR TITLE
proof(#11574): the EIP-2537 wire-pad relation, stated not commented

### DIFF
--- a/EvmAsm/EL/RLP/Properties.lean
+++ b/EvmAsm/EL/RLP/Properties.lean
@@ -166,6 +166,29 @@ theorem Nat.toBytesBE_fromBytesBE_of_canonical :
     have hmod : (Nat.fromBytesBE xs * 256 + b.toNat) % 256 = b.toNat := by omega
     rw [hdiv, hmod, ihxs, ofNat8_toNat]
 
+/-- Leading zero bytes do not change the big-endian value: each contributes
+    `0 * 256 ^ _`. This is the *non-canonical* companion to
+    `toBytesBE_fromBytesBE_of_canonical` — that lemma needs a non-zero head, this
+    one is about exactly the case it excludes.
+
+    Motivation (#11574): EIP-2537 transmits a BLS12-381 base-field element as a
+    **64-byte** wire felt whose first 16 bytes are zero, while the guest's
+    `blsg_lt_p` scan reads only the **48** compact bytes. Without this lemma the
+    two sides are different lists and any bridge between them would relate
+    different objects while typechecking cleanly. -/
+theorem Nat.fromBytesBE_zero_prefix :
+    ∀ (zs xs : List Byte), (∀ z ∈ zs, z = 0) →
+      Nat.fromBytesBE (zs ++ xs) = Nat.fromBytesBE xs
+  | [], _, _ => by simp
+  | z :: zs, xs, hz => by
+    have hz0 : z = 0 := hz z (List.mem_cons_self ..)
+    have he : Nat.fromBytesBE ((z :: zs) ++ xs)
+        = z.toNat * 256 ^ (zs ++ xs).length + Nat.fromBytesBE (zs ++ xs) := rfl
+    have hrec : Nat.fromBytesBE (zs ++ xs) = Nat.fromBytesBE xs :=
+      Nat.fromBytesBE_zero_prefix zs xs fun x hx => hz x (List.mem_cons_of_mem _ hx)
+    rw [he, hrec, hz0]
+    simp
+
 /-! ## takeBytes properties -/
 
 /-- Taking 0 bytes always succeeds with an empty prefix and the original list. -/

--- a/EvmAsm/Stateless/Crypto/FieldAssertions.lean
+++ b/EvmAsm/Stateless/Crypto/FieldAssertions.lean
@@ -39,6 +39,7 @@
 -/
 
 import EvmAsm.Crypto.BeBytesBridge
+import EvmAsm.EL.RLP.Properties
 import EvmAsm.Rv64.SAsm.AccelStep
 import EvmAsm.Stateless.SpecRef.PrecompilesBls
 import EvmAsm.Stateless.SpecRef.PrecompilesKzg
@@ -162,5 +163,73 @@ example : ¬ bnG1OnCurve 0 0 := by unfold bnG1OnCurve; decide
     the correction this module's header records. -/
 theorem blsP_ne_blsModulus : SpecRef.Bls12.blsP ≠ SpecRef.Kzg.BLS_MODULUS := by
   decide
+
+/-! ## The EIP-2537 wire pad — the relation that keeps the BLS bridge honest
+
+    ⚠️ **Without this, a BLS bridge would relate two different objects while
+    typechecking cleanly.** `bytes_to_fq` (`SpecRef/PrecompilesBls.lean:78`)
+    rejects anything whose length is not **64** and decodes the whole 64 bytes;
+    `blsg_lt_p` scans the **48** compact bytes and states its post over those.
+    Both sides are `List Byte → Nat`, so a bridge that simply juxtaposed them
+    would elaborate — and be about two different lists.
+
+    The pad is a real guest step, not a modelling convenience:
+    `scripts/asm-fixtures/bls12KzgG1WireFunction.s` (`blsk_g1_wire`) writes 16
+    zero bytes with `sb zero` and then copies 48 with `lbu`/`sb`, per coordinate,
+    at a 64-byte stride. So the wire felt is literally `16 zeros ++ 48 compact
+    bytes`, and this section says what that does to the value: nothing.
+
+    ⭐ **BN254 needs no counterpart, and the asymmetry is recorded rather than
+    papered over with a vacuous twin.** `Bn128.bytes_to_g1`
+    (`SpecRef/PrecompilesCurve.lean:83`) reads `bytesBEtoNat (data.take 32)`
+    directly, against a guest routine that scans the same 32 bytes — there is no
+    pad on that side, so there is nothing to relate. -/
+
+/-- **The pad is value-preserving.** If the first 16 of 64 wire bytes are zero,
+    the big-endian value of the wire felt is the big-endian value of its 48-byte
+    compact suffix.
+
+    Stated over `EL.RLP.Nat.fromBytesBE` on the left and `Crypto.beBytesToNat` on
+    the right *on purpose*: those are the two decoders the two sides actually use
+    (`bytesBEtoNat` is an abbrev for the former, `SpecRef/Crypto.lean:58`), so this
+    discharges both the pad and the decoder mismatch in one step, over
+    `beBytesToNat_eq_fromBytesBE` (#11677). -/
+theorem eip2537_wire_pad_value (w : List (BitVec 8)) (hlen : w.length = 64)
+    (hpad : ∀ i, i < 16 → w.getD i 0 = 0) :
+    EL.RLP.Nat.fromBytesBE w = beBytesToNat (w.drop 16) := by
+  have hz : ∀ z ∈ w.take 16, z = 0 := by
+    intro z hzmem
+    obtain ⟨i, hi, hget⟩ := List.getElem_of_mem hzmem
+    have hi16 : i < 16 := by
+      have hle : (w.take 16).length ≤ 16 := List.length_take_le ..
+      omega
+    have hwi : w.getD i 0 = z := by
+      rw [List.getElem_take] at hget
+      rw [List.getD_eq_getElem?_getD, List.getElem?_eq_getElem (by omega), hget]
+      rfl
+    exact (hwi ▸ hpad i hi16 : z = 0)
+  calc EL.RLP.Nat.fromBytesBE w
+      = EL.RLP.Nat.fromBytesBE (w.take 16 ++ w.drop 16) := by
+        rw [List.take_append_drop]
+    _ = EL.RLP.Nat.fromBytesBE (w.drop 16) :=
+        EL.RLP.Nat.fromBytesBE_zero_prefix _ _ hz
+    _ = beBytesToNat (w.drop 16) := (Crypto.beBytesToNat_eq_fromBytesBE _).symm
+
+/-- The compact suffix really is 48 bytes — the width `blsFpBeIs` and
+    `blsgLtP_spec` both fix. Trivial, but stated so the bridge can cite it rather
+    than re-derive `64 - 16` inline. -/
+theorem eip2537_wire_suffix_length (w : List (BitVec 8)) (hlen : w.length = 64) :
+    (w.drop 16).length = 48 := by
+  rw [List.length_drop, hlen]
+
+/-- The same statement at `bytesBEtoNat`, the name the SpecRef side is written
+    over. Definitionally the theorem above (`bytesBEtoNat` is an abbrev), stated
+    anyway so the connection is machine-checked rather than asserted in prose —
+    a reader of `bytes_to_fq` sees `bytesBEtoNat` and should not have to unfold an
+    abbrev to believe the bridge applies. -/
+theorem eip2537_wire_pad_specref (w : SpecRef.Bytes) (hlen : w.length = 64)
+    (hpad : ∀ i, i < 16 → w.getD i 0 = 0) :
+    SpecRef.bytesBEtoNat w = beBytesToNat (w.drop 16) :=
+  eip2537_wire_pad_value w hlen hpad
 
 end EvmAsm.Stateless.Crypto

--- a/EvmAsm/Stateless/Crypto/FieldAssertions.lean
+++ b/EvmAsm/Stateless/Crypto/FieldAssertions.lean
@@ -173,11 +173,35 @@ theorem blsP_ne_blsModulus : SpecRef.Bls12.blsP ≠ SpecRef.Kzg.BLS_MODULUS := b
     Both sides are `List Byte → Nat`, so a bridge that simply juxtaposed them
     would elaborate — and be about two different lists.
 
-    The pad is a real guest step, not a modelling convenience:
-    `scripts/asm-fixtures/bls12KzgG1WireFunction.s` (`blsk_g1_wire`) writes 16
-    zero bytes with `sb zero` and then copies 48 with `lbu`/`sb`, per coordinate,
-    at a 64-byte stride. So the wire felt is literally `16 zeros ++ 48 compact
-    bytes`, and this section says what that does to the value: nothing.
+    The pad is a real guest artifact, not a modelling convenience, and there are
+    two independent sightings of it:
+
+    * **Written** — `scripts/asm-fixtures/bls12KzgG1WireFunction.s`
+      (`blsk_g1_wire`) emits 16 `sb zero` and then copies 48 with `lbu`/`sb`, per
+      coordinate, at a 64-byte stride. So the wire felt is literally
+      `16 zeros ++ 48 compact bytes`.
+    * **Checked** — every calldata reader calls `blsg_is_zero_n(ptr, 16)` and
+      rejects on nonzero before the 48-byte scan: `blsg_decode_g1`
+      (`Codegen/Programs/Bls12G1.lean:692-700`, both coordinates),
+      `blsg2_decode_g2` (`Bls12G2.lean:774-784`, all four felts),
+      `zkvm_bls12_map_fp_to_g1` (`Bls12MapG1Real.lean:23-29`),
+      `zkvm_bls12_map_fp2_to_g2` (`Bls12MapG2Real.lean:23-38`). All live via the
+      0x0b..0x11 dispatch table (`PrecompileSharedExecute.lean:136-142`).
+
+    ⚠️ The **checked** sighting is the load-bearing one, and an earlier draft of
+    this docstring gave only the written one. `blsk_g1_wire` never sees calldata,
+    so it establishes the wire *layout* but says nothing about whether an
+    attacker-supplied felt satisfies the hypothesis. Recorded rather than
+    silently swapped, because reaching for the first citation that fits is how
+    the wrong one ends up load-bearing.
+
+    ⚠️ What this section does **not** prove is the composition
+    (`blsg_is_zero_n(16) ∧ blsg_lt_p(48)` ⟹ `bytes_to_fq`'s verdict on the
+    64-byte felt), and it cannot yet: those decoders exist only as assembly
+    strings, with no `Program` and no drift guard, so nothing is statable over
+    them. Converting `blsg_decode_g1` is the prerequisite (#11574).
+
+    This section says what the pad does to the value: nothing.
 
     ⭐ **BN254 needs no counterpart, and the asymmetry is recorded rather than
     papered over with a vacuous twin.** `Bn128.bytes_to_g1`


### PR DESCRIPTION
Third increment on #11574, after #11677 (the `beBytesToNat ⟷ fromBytesBE` bridge) and #11679 (the assertion vocabulary). This one lands the relation that makes a BLS bridge *possible*; the bridges themselves follow in the next PR.

## Why this is a prerequisite and not a comment

@pirapira's reason, and it is the whole point: **left unstated, a BLS bridge relates two different objects while typechecking cleanly.**

- `Bls12.bytes_to_fq` (`EvmAsm/Stateless/SpecRef/PrecompilesBls.lean:78`) rejects any length other than **64** and decodes all 64 bytes.
- `blsgLtP_spec` (`EvmAsm/Codegen/Programs/Bls12G1LtPSAsm.lean:734`) holds `bytesRegion inPtr xs` with `xs.length = 48` and states its post over those 48.

Both sides have type `List Byte → Nat`. A bridge that simply juxtaposed them would elaborate — and be about two different lists.

**The pad is a real guest step, not a modelling convenience.** `scripts/asm-fixtures/bls12KzgG1WireFunction.s`, routine `blsk_g1_wire`:

```asm
  li t2, 16
.Lblsk_g1w_pad:
  sb zero, 0(t1)          # 16 zero bytes
  ...
  li t3, 48
.Lblsk_g1w_copy:
  lbu t4, 0(t2); sb t4, 0(t1)    # then 48 compact bytes
```

per coordinate, at a 64-byte stride. So the wire felt is literally `16 zeros ++ 48 big-endian bytes`, and this PR says what that does to the value: nothing.

## What landed

**1. `Nat.fromBytesBE_zero_prefix`** — `EvmAsm/EL/RLP/Properties.lean`

```lean
theorem Nat.fromBytesBE_zero_prefix :
    ∀ (zs xs : List Byte), (∀ z ∈ zs, z = 0) →
      Nat.fromBytesBE (zs ++ xs) = Nat.fromBytesBE xs
```

No such lemma existed. The file had `_nil`, `_lt`, `_snoc`, `_toBytesBE`, `_eq_zero_iff`, `_pos_of_head_ne_zero`, and nothing about a zero prefix — it is the **non-canonical companion** to `toBytesBE_fromBytesBE_of_canonical`, which needs a non-zero head and so excludes exactly this case. Homed with its siblings; `EL/RLP` is uncapped.

**2. `eip2537_wire_pad_value`** — `EvmAsm/Stateless/Crypto/FieldAssertions.lean`

```lean
theorem eip2537_wire_pad_value (w : List (BitVec 8)) (hlen : w.length = 64)
    (hpad : ∀ i, i < 16 → w.getD i 0 = 0) :
    EL.RLP.Nat.fromBytesBE w = beBytesToNat (w.drop 16)
```

Deliberately `fromBytesBE` on the left and `beBytesToNat` on the right: those are the two decoders the two sides actually use, so this discharges **the pad and the decoder mismatch in one step**, over `beBytesToNat_eq_fromBytesBE` from #11677. Plus `eip2537_wire_suffix_length` (the suffix really is 48) and `eip2537_wire_pad_specref`, the same statement at `bytesBEtoNat` — definitionally the first one, stated anyway so the connection is machine-checked rather than requiring a reader of `bytes_to_fq` to unfold an abbrev to believe the bridge applies.

## ⭐ BN254 gets no counterpart, and the asymmetry is recorded

`Bn128.bytes_to_g1` (`SpecRef/PrecompilesCurve.lean:83`) reads `bytesBEtoNat (data.take 32)` directly, against a guest routine scanning the same 32 bytes. No pad on that side, so **nothing to relate** — the module records the asymmetry rather than writing a vacuous BN254 twin to make the two families look symmetric.

## Placement

`FieldAssertions.lean` rather than `Crypto/BeBytesBridge.lean`: the pad relation is about the *wire encoding of a field element*, which is this module's subject, and it already imports SpecRef. Putting it in `BeBytesBridge` would have pushed the whole RLP `Properties` tower onto every future consumer of the decoder equality, for no gain.

## Verification

- `lake build` clean — 4736 jobs.
- `check-file-size` (2173 files, all within cap), `check-forbidden-tactics` (OK), `check-unimported` (2766 modules, 0 orphans), `check-layering` (invariants hold; the four `Rv64 → Evm64` advisories are pre-existing and untouched).
- `#print axioms`, fully qualified:

```
'EvmAsm.EL.RLP.Nat.fromBytesBE_zero_prefix' depends on axioms: [propext]
'EvmAsm.Stateless.Crypto.eip2537_wire_pad_value' depends on axioms: [propext, Quot.sound]
'EvmAsm.Stateless.Crypto.eip2537_wire_suffix_length' does not depend on any axioms
'EvmAsm.Stateless.Crypto.eip2537_wire_pad_specref' depends on axioms: [propext, Quot.sound]
```

Inside the classical three, and one better — no `Classical.choice`.

No registry movement: this PR adds no witnessed spec. The two absent `Progress/*` rows for `blsgLtP_spec` / `bnfLtP_spec` land with the bridges.

## Next on #11574

The two bridges (`blsgLtP_spec` → `bytes_to_fq`, `bnfLtP_spec` → `bytes_to_g1`) with the modulus constants as theorems rather than `#guard`s, then the registry rows plus `docs/crypto-spec-correspondence.md`.

⚠️ One thing I will not claim there: `lt_p` returns a boolean, not the field element, so **predicate agreement is all it can support**. Value agreement is not available from this routine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
