### PR TITLE
fix(scripts): fail the EEST run on fixture failures (#11737) and refuse wrong-shape verdict decodes (#11738)

### DIFF
--- a/scripts/codegen-eest-preflight-report-smoke.sh
+++ b/scripts/codegen-eest-preflight-report-smoke.sh
@@ -9,12 +9,19 @@ cd "$(dirname "$0")/.."
 JOBS="${EEST_PREFLIGHT_SMOKE_JOBS:-1}"
 STEPS="${EEST_PREFLIGHT_SMOKE_STEPS:-${EEST_STEPS:-200000000}}"
 
+# GH #11737: the harness now exits non-zero when a row FAILs. This smoke checks
+# that the PREFLIGHT REPORT renders, not that the selected row conforms -- its
+# header says the decoded dimensions must be visible "even when the guest halts
+# successfully", and equally when it does not. Under `set -e` a failing row would
+# otherwise abort this script and hide the very report it exists to smoke, so the
+# opt-out is deliberate here and must not be copied to conformance callers.
 scripts/codegen-eest-stateless-check.sh \
   --limit 1 \
   --jobs "$JOBS" \
   --quiet-passes \
   --max-failures 1 \
   --preflight-report always \
+  --exit-zero-on-failures \
   --steps "$STEPS" \
   "$@"
 

--- a/scripts/codegen-eest-stateless-check.sh
+++ b/scripts/codegen-eest-stateless-check.sh
@@ -203,6 +203,13 @@ BSR_BAL_CAP="${EEST_BSR_BAL_CAP:-}"
 MIN_SUCC=""
 MIN_FULL=""
 MIN_ROOT=""
+# GH #11737: a fixture failure must make the RUN fail.  Until this existed the
+# script exited 0 with any number of failing rows unless an opt-in --min-*
+# threshold happened to be passed, so `harness && echo ok` printed ok on a run
+# with 116 of 648 rows failing.  That is the dangerous direction: a tool that
+# errors loudly gets fixed, one that reports success gets trusted.  Callers that
+# genuinely want the summary regardless of the outcome must say so explicitly.
+EXIT_ZERO_ON_FAILURES="${EEST_EXIT_ZERO_ON_FAILURES:-0}"
 DEFAULT_TAG="$(tr -d '[:space:]' < scripts/eest-fixture-tag.txt 2>/dev/null || true)"
 DEFAULT_TAG="${DEFAULT_TAG:-$(cat scripts/eest-fixture-tag.txt)}"
 TAG="${EEST_FIXTURE_TAG:-$DEFAULT_TAG}"
@@ -248,6 +255,9 @@ Usage:
 
 Options:
   --all                    run every stateless block (slow); default: smoke subset
+  --exit-zero-on-failures  exit 0 even when rows FAIL or ERROR (GH #11737). Default is
+                           to exit non-zero, so a failing run cannot read as green.
+                           Use only when the summary is wanted regardless of outcome.
   --skip N                 skip first N selected stateless blocks after filtering
   --limit N                cap to N guest invocations (default 50)
   --filter SUBSTR          only fixtures whose relpath contains SUBSTR
@@ -307,6 +317,7 @@ require_arg() {
 while [[ $# -gt 0 ]]; do
   case "$1" in
     -h|--help) usage; exit 0 ;;
+    --exit-zero-on-failures) EXIT_ZERO_ON_FAILURES=1; shift ;;
     --all) ALL=1; shift ;;
     --backend) require_arg "$1" "${2:-}"; BACKEND="$2"; shift 2 ;;
     --skip) require_arg "$1" "${2:-}"; SKIP="$2"; shift 2 ;;
@@ -862,6 +873,18 @@ run_guest_elf() {
 format_verdict_debug() {
   local out="$1"
   local raw
+  # GH #11738: THESE OFFSETS DESCRIBE THE DIAGNOSTIC BUILD'S OUTPUT, NOT THE
+  # PRODUCTION GUEST'S.  The two layouts are different and neither is self-
+  # describing:
+  #   diagnostic : 21 u64 words from +0 -- verdict@+0, bv_fail@+8, ...,
+  #                tx_state0@+104, tx_state1@+112, then two 32-byte roots at
+  #                +168 (sv_recomputed) and +200 (payload state root).
+  #   production : bytes 0:32 are the new_payload_request_root, byte 32 is
+  #                successful_validation, and the rest is the SSZ tail.
+  # Decoding a PRODUCTION .out at the offsets below yields plausible garbage with
+  # no error -- a keccak digest read as `verdict` produced 1841024047515375962
+  # while investigating #11306.  The guard below refuses that rather than
+  # returning numbers that look like measurements.
   local -a labels=(
     verdict
     bv_fail
@@ -890,6 +913,14 @@ format_verdict_debug() {
 
   raw="$(od -An -v -tu8 -N 168 "$out" 2>/dev/null | xargs || true)"
   read -r -a words <<< "$raw"
+  # Shape gate (GH #11738).  In the diagnostic layout word[0] is the verdict BIT,
+  # so it is 0 or 1.  In a production artefact word[0] is the first 8 bytes of a
+  # keccak digest, which exceeds 1 with probability 1 - 2^-63.  Refuse loudly
+  # instead of emitting a decode of the wrong shape.
+  if [[ -n "${words[0]:-}" && "${words[0]}" =~ ^[0-9]+$ && "${words[0]}" -gt 1 ]]; then
+    echo "dbg=[UNDECODABLE: word0=${words[0]} is not a verdict bit (0|1) -- this looks like a PRODUCTION output, whose bytes 0:32 are the new_payload_request_root and byte 32 successful_validation. format_verdict_debug decodes the DIAGNOSTIC build only; see GH #11738]"
+    return 0
+  fi
   for i in "${!labels[@]}"; do
     value="${words[$i]:-?}"
     dbg="${dbg:+$dbg }${labels[$i]}=$value"
@@ -1700,5 +1731,19 @@ if [[ -n "$MIN_FULL" && "$full" -lt "$MIN_FULL" ]]; then
 fi
 if [[ -n "$MIN_ROOT" && "$root" -lt "$MIN_ROOT" ]]; then
   echo "==> REGRESSION: root match $root < --min-root $MIN_ROOT" >&2; rc=1
+fi
+# GH #11737: fixture failures and infrastructure errors now fail the run.  Both
+# counts are reported because they mean different things: `fail` is a guest/
+# fixture mismatch, `err` is the harness or emulator not completing a row.
+# `budget` is deliberately NOT included -- the summary already labels it "NOT a
+# correctness failure".
+if [[ "$fail" -gt 0 || "$err" -gt 0 ]]; then
+  if [[ "$EXIT_ZERO_ON_FAILURES" -eq 1 ]]; then
+    echo "==> $fail fixture failure(s) and $err error(s); exiting 0 because --exit-zero-on-failures was given" >&2
+  else
+    echo "==> FAILURES: fail=$fail errored=$err of selected=$selectedCount (ran=$ran, full match=$full)" >&2
+    echo "    read the summary block above for the verdict; pass --exit-zero-on-failures only if you need the summary regardless of outcome" >&2
+    rc=1
+  fi
 fi
 exit $rc


### PR DESCRIPTION
Closes #11737. Closes #11738.

Two instrument defects found while investigating #11306. Both produced confident, well-formed output that was wrong in a way the output itself could not reveal.

## #11737 — the harness exited 0 with failures

Measured on `2ed2c844d`: **selected 648, ran 648, fail 116, exit 0.** So `harness && echo ok` printed `ok` on a run where 116 rows failed, and an exit-code-only check reported all-green.

It now exits non-zero when `fail > 0` **or** `errored > 0`, printing both counts next to `selected` and `ran`. `budget` is deliberately excluded — the summary already labels it *"NOT a correctness failure"*.

⚠️ **The exit code was misleading in BOTH directions**, which is why the fix reports `selected` too: a filter on a run-scoped label index (`--filter 01087_test_...`) makes the harness print `no stateless blocks selected` and exit **1** having measured nothing. So `fail: 0` is **vacuously true when `selected: 0`** — the count alone is not a verdict.

### Callers audited before changing the default

| caller | invokes? | uses the status? | action |
|---|---|---|---|
| `Dockerfile:114` `ENTRYPOINT` (`CMD --all --jobs 2 ...`) | **yes** | becomes the container exit status | none — a conformance container *should* fail when fixtures fail |
| `scripts/check-guest-elf-override.sh` | **yes** | **requires non-zero** for misuse cases (`if [[ "$status" -eq 0 ]]; then fail "... was ACCEPTED (exit 0)"`) | none — this change only *adds* non-zero exits, so the guard is reinforced |
| `scripts/codegen-eest-preflight-report-smoke.sh` | **yes** | last command under `set -euo pipefail` | ⭐ **given `--exit-zero-on-failures`** |
| `check-statement-tamper.sh:110`, `progress-delta.sh:270` | no — path allowlist patterns | — | none |
| `eest-ab-compare.py`, `eest-succ-mismatch-report.py`, `eest-gas-parity-report.py`, `eest-specref-check.sh` | no — consume run dirs / mention it in prose | — | none |
| `codegen-zisk-stateless-verdict-debug-smoke.sh:65` | no — reads the harness's *text* to extract the formatter | — | none |
| `.github/workflows/**` | **no workflow invokes it at all** | — | none |

The preflight smoke is the one caller that genuinely needs the summary regardless of outcome: its own header says the decoded dimensions must be visible *"even when the guest halts successfully"*, and equally when it does not — under `set -e` a failing row would abort it and hide the very report it exists to smoke. Its opt-out carries a comment saying not to copy it to conformance callers.

## #11738 — the offset table described a different build, silently

`format_verdict_debug` reads the first 168 bytes as 21 `u64` words (`verdict@+0`, `bv_fail@+8`, … `tx_state0@+104`). Those offsets describe the **diagnostic** build (`zisk_stateless_verdict_v2`, via `verdict_debug_for_case` → `$label.verdict-debug.output`) — the only artefact it is ever called with. Nothing said so.

The **production** output is a different shape: bytes `0:32` are the `new_payload_request_root` and byte 32 is `successful_validation`. Decoding one at these offsets yields plausible garbage with **no error** — a keccak digest read as `verdict` gave `1841024047515375962` during #11306, and the two files are byte-identical apart from which ELF produced them, so nothing in the artefact distinguishes them.

Added a **shape gate**: `word[0]` is the verdict *bit* in the diagnostic layout, so a value above 1 means the artefact is a production output. The decode is refused with both layouts named and the issue cited, instead of returning numbers that look like measurements. The offset table now documents which build it describes, with the production layout beside it.

## Verification — controls in both directions, on real artefacts

| check | result |
|---|---|
| failing selection (`--skip 440 --limit 2`) | **exit 1**, `fail=2 of selected=2` |
| passing selection (`bal_create2_selfdestruct_then_recreate_same_block`) | **exit 0**, `fail=0`, `full match=2` |
| opt-out on the failing selection | **exit 0** + `exiting 0 because --exit-zero-on-failures was given` |
| real `.verdict-debug.output` | `word0=0`, `word1=1` ⇒ gate silent, `dbg=[verdict=0 bv_fail=1 …]` still decodes |
| production `.output` | `word0=1841024047515375962` ⇒ gate fires |
| `bash -n` on both scripts | clean |

Zero false `UNDECODABLE` on the end-to-end failing run, so the gate does not cost the diagnostics it protects.

Guest-neutral: no Lean or guest source touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
