### PR TITLE
fix(scripts): give SpecRef a distinct per-case result filename (#11746)

### DIFF
--- a/scripts/codegen-eest-stateless-check.sh
+++ b/scripts/codegen-eest-stateless-check.sh
@@ -1511,7 +1511,36 @@ classify_case_result() {
   fi
   classifiedLabels["$label"]=1
   total=$((total + 1))
-  IFS=$'\t' read -r status actual_hex oracle_hex < "$result"
+  # Result schema: TWO fields ("OK\t<hex>", "BUDGET\tsteps:N", "ERROR\t<reason>")
+  # on every write except the --specref-oracle path, which appends a third
+  # (oracle_hex).  Reading with three names is therefore correct: oracle_hex is
+  # empty whenever the oracle is off.
+  #
+  # ⛔ Why a distinct NAME rather than a field-count check: in the DEFAULT
+  # configuration the two schemas are IDENTICAL.  Every codegen-eest-stateless-check
+  # write is TWO fields ("OK\t<hex>", "BUDGET\tsteps:N", "ERROR\t<reason>") except
+  # the single --specref-oracle path, which writes three.  A collided file is
+  # therefore indistinguishable in shape from a legitimate one, in BOTH directions,
+  # so no arity or content check can detect it -- and the guest harness reading a
+  # SpecRef row would consume SpecRef's output AS THE GUEST'S with no anomaly at
+  # all: a silent wrong verdict.  Distinct filenames make that impossible instead.
+  #
+  # ⚠️ Reachability, measured rather than assumed: BOTH harnesses run an
+  # UNCONDITIONAL `rm -rf "$RUN_DIR"` at startup, including when the directory came
+  # from --run-dir or EEST_RUN_DIR.  So two SEQUENTIAL runs against one directory
+  # cannot mis-read each other -- the second deletes the first's outputs outright.
+  # The mis-read is reachable only when the two run CONCURRENTLY against one
+  # directory.  That `rm -rf` race is a separate and larger hazard, NOT addressed
+  # here.
+  #
+  # The _extra sink below catches only a file with MORE fields than this schema,
+  # i.e. a future intra-harness schema drift -- the GH #11308 class recurring.
+  IFS=$'\t' read -r status actual_hex oracle_hex _extra < "$result"
+  if [[ -n "$_extra" ]]; then
+    err=$((err + 1))
+    echo "  ERROR(schema)  $(case_identity "$label" "$relpath" "$case_id") (expected 3 fields in $result, found more: is another harness writing this directory?)"
+    return 0
+  fi
   if [[ "$status" == "BUDGET" ]]; then
     # Step-budget exhaustion: counted separately, NOT a correctness failure.
     budget=$((budget + 1))

--- a/scripts/eest-specref-check.sh
+++ b/scripts/eest-specref-check.sh
@@ -303,7 +303,29 @@ succ_allowlisted() {
 
 # Worker: invoke the exe and write a per-case result TSV so the dispatcher
 # can run many cases in parallel and the classifier can read them back in
-# manifest order. Result schema: "<STATUS>\t<actual_hex|reason>".
+# manifest order. Result schema: "<STATUS>\t<actual_hex|reason>" -- TWO fields.
+#
+# GH #11746: this file is named "<label>.specref-result.tsv", NOT
+# "<label>.result.tsv", which is what codegen-eest-stateless-check.sh writes.
+# Both harnesses honour EEST_RUN_DIR and --run-dir, so the two could otherwise
+# target one directory under one filename.
+#
+# ⛔ Why a distinct NAME rather than a field-count check: in the DEFAULT
+# configuration the two schemas are IDENTICAL.  Every codegen-eest-stateless-check
+# write is TWO fields ("OK\t<hex>", "BUDGET\tsteps:N", "ERROR\t<reason>") except
+# the single --specref-oracle path, which writes three.  A collided file is
+# therefore indistinguishable in shape from a legitimate one, in BOTH directions,
+# so no arity or content check can detect it -- and the guest harness reading a
+# SpecRef row would consume SpecRef's output AS THE GUEST'S with no anomaly at
+# all: a silent wrong verdict.  Distinct filenames make that impossible instead.
+#
+# ⚠️ Reachability, measured rather than assumed: BOTH harnesses run an
+# UNCONDITIONAL `rm -rf "$RUN_DIR"` at startup, including when the directory came
+# from --run-dir or EEST_RUN_DIR.  So two SEQUENTIAL runs against one directory
+# cannot mis-read each other -- the second deletes the first's outputs outright.
+# The mis-read is reachable only when the two run CONCURRENTLY against one
+# directory.  That `rm -rf` race is a separate and larger hazard, NOT addressed
+# here.
 run_worker() {
   local line="$1"
   local label input expected_hex succ_bit input_len gas_limit relpath case_id
@@ -320,7 +342,7 @@ run_worker() {
   IFS=$'\t' read -r label input expected_hex succ_bit input_len gas_limit relpath case_id _rest <<< "$line"
   local out="$RUN_DIR/$label.output"
   local log="$RUN_DIR/$label.log"
-  local result="$RUN_DIR/$label.result.tsv"
+  local result="$RUN_DIR/$label.specref-result.tsv"
 
   if ! lake exe specref-eest-check "$input" "$out" >"$log" 2>&1; then
     printf 'ERROR\tspec\n' > "$result"
@@ -332,7 +354,7 @@ run_worker() {
 }
 
 wait_for_one_worker() {
-  # Workers always write a per-case result.tsv; their exit code is irrelevant
+  # Workers always write a per-case specref-result.tsv; their exit code is irrelevant
   # (a lake-exe failure is recorded as an ERROR row, not a crash). Swallow it
   # so `set -e` in the dispatcher never aborts on a finished-but-nonzero job.
   wait -n 2>/dev/null || true
@@ -352,15 +374,24 @@ classify_case() {
   # as column 8 corrupted relpath.  _rest is never read.  (Python readers here use
   # positional fields[:7] slices and are already column-count tolerant.)
   IFS=$'\t' read -r label input expected_hex succ_bit input_len gas_limit relpath case_id _rest <<< "$line"
-  local result="$RUN_DIR/$label.result.tsv"
+  local result="$RUN_DIR/$label.specref-result.tsv"
   total=$((total + 1))
   if [[ ! -f "$result" ]]; then
     err=$((err + 1))
     echo "  ERROR(missing) $(case_identity "$label" "$relpath" "$case_id")"
     return 0
   fi
-  local status actual_hex
-  IFS=$'\t' read -r status actual_hex < "$result"
+  local status actual_hex _extra
+  # The _extra sink plus the emptiness check below is the arity half of GH
+  # #11746: it catches a file with MORE fields than this schema (which the
+  # length gate would report as a confusing FAIL[malformed]).  The FEWER-fields
+  # direction is closed by the distinct filename, not here.
+  IFS=$'\t' read -r status actual_hex _extra < "$result"
+  if [[ -n "$_extra" ]]; then
+    err=$((err + 1))
+    echo "  ERROR(schema)  $(case_identity "$label" "$relpath" "$case_id") (expected 2 fields in $result, found more: is another harness writing this directory?)"
+    return 0
+  fi
   if [[ "$status" != "OK" ]]; then
     err=$((err + 1))
     case "$actual_hex" in


### PR DESCRIPTION
Closes #11746.

`eest-specref-check.sh` wrote `<label>.result.tsv` — the same filename `codegen-eest-stateless-check.sh` writes. Both honour `EEST_RUN_DIR` and `--run-dir`, so the two could target one directory under one filename. **SpecRef now writes `<label>.specref-result.tsv`.**

## Two corrections to the issue as filed — both mine to make

I wrote the original latent-item report, so these correct my own characterisation.

**1. The schemas are identical in the default configuration, so no check could detect the collision.** The issue says SpecRef would fold `oracle_hex` into `actual_hex`. That is the *loud* direction and it only exists under `--specref-oracle`. Enumerating every write site:

| writer | rows |
|---|---|
| guest harness :1351 | `OK\t<hex>\t<oracle_hex>` — **3 fields**, `--specref-oracle` only |
| guest harness :1403, :1423 | `OK\t<hex>` — 2 |
| guest harness :1377, :1381, :1386, :1410, :1412, :1415, :1346 | `BUDGET\tsteps:N` / `ERROR\t<reason>` — 2 |
| SpecRef :344, :349 | `ERROR\tspec` / `OK\t<hex>` — 2 |

So by default **both harnesses write the same 2-field shape**. Measured on real artefacts from the run below: the guest's file and SpecRef's file are both 2 fields. A collided file is indistinguishable from a legitimate one **in both directions**, and the guest harness would consume SpecRef's output *as the guest's own* with no anomaly at all — a silent wrong verdict on a conformance harness.

⇒ **This settles the choice between the two candidate fixes.** A field-count assert cannot work here; only distinct names can. (I kept an arity guard anyway — see below — but it closes a different, lesser problem.)

**2. Reachability is narrower than the issue implies.** Both harnesses run an **unconditional** `rm -rf "$RUN_DIR"` at startup (`eest-specref-check.sh:207`, `codegen-eest-stateless-check.sh:741`), *including* when the directory came from `--run-dir` or `EEST_RUN_DIR`. So two **sequential** runs against one directory cannot mis-read each other — the second deletes the first's outputs outright. The mis-read is reachable only when the two run **concurrently**. I verified this rather than assuming it: after the paired run below, only SpecRef's file remains.

⚠️ **That `rm -rf` is a larger hazard than the one this issue names, and I have not touched it.** It is unconditional on a user-supplied directory, so pointing either harness at a directory containing anything else destroys it, and a concurrent run deletes the other harness's inputs mid-flight. That is a separate issue and a separate decision — flagging, not fixing.

## Caller audit

7 report scripts (`eest-succ-mismatch`, `eest-receipt-log-frontier`, `eest-ab-compare`, `eest-precompile-frontier`, `eest-bal-replay`, `eest-gas-parity`) plus `eest-run-monitor.sh` hardcode `<label>.result.tsv`. **All target the guest harness's directory** — the monitor defaults to `gen-out/eest-run/run-*` (:70). Nothing outside `eest-specref-check.sh` reads SpecRef's per-case files.

⇒ renaming the **SpecRef** side has **zero** external consumers; renaming the guest side would have broken all eight. That is why the rename went where it did.

## Also: an arity guard, for a different problem

Both readers gain an `_extra` sink and an `ERROR(schema)` line. This catches a file with **more** fields than the schema — a future intra-harness schema drift, the #11308 class recurring. It explicitly cannot catch the collision, for the reason in correction 1, and the comments say so.

## Verification

Base `377baad3d`, commit `e0bb9049e`, guest ELF `5a4e04d37ea711e8fdfc62da2b49551f926e5498c410c1feae874df02b5733ec`, backend spike.

- **Paired run into one shared `--run-dir`**, which is the condition the issue describes. Guest: **selected=1, ran=1, fail=0, full match=1**, exit 0. SpecRef, same directory: **total 1, ERROR/FAIL 0, full match 1**, exit 0.
- Both directions demonstrated on real artefacts before the fix: the 3-field-into-2-name fold yields a 277-char `actual_hex` and trips the 138-char gate (loud `FAIL[malformed]`); the 2-field-into-3-name read yields a clean 138-char hex with `oracle_hex` empty and **no gate firing** (silent).
- The arity guard fires on an over-wide file and — as documented — **accepts** the silent direction, which is the demonstration that the rename, not the guard, is what closes it.
- `bash -n` clean on both scripts.

No behaviour change to the guest harness's outputs or to any consumer of them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
