### PR TITLE
fix(scripts): refuse to delete a run directory the harness does not own (#11748)

### DIFF
--- a/docs/eest-stateless-testing.md
+++ b/docs/eest-stateless-testing.md
@@ -753,6 +753,15 @@ gen-out/eest-run/run-<timestamp>-<pid>/
 Set `EEST_RUN_DIR=/path/to/dir` to force a stable directory for a single
 reproducible run; that directory is recreated at the start of the invocation.
 
+The harness only recreates a directory it owns. On first use it drops an
+`.eest-run-dir` marker recording the harness name and pid; on a later run it
+recreates the directory if that marker names the same harness and the recorded
+run has exited. Otherwise it **refuses and deletes nothing** (GH #11748) — a
+non-empty directory with no marker, a directory created by the other EEST
+harness, or one whose recorded run is still live. Point `--run-dir` at a new or
+empty directory, or remove the old one yourself. Reusing one directory per A/B
+leg still works exactly as before.
+
 Important files:
 
 - `manifest.tsv`: one row per selected guest invocation.

--- a/scripts/codegen-eest-stateless-check.sh
+++ b/scripts/codegen-eest-stateless-check.sh
@@ -738,8 +738,14 @@ elif [[ -n "${EEST_RUN_DIR:-}" ]]; then
 else
   RUN_DIR="$REPO_ROOT/gen-out/eest-run/run-$(date -u +%Y%m%dT%H%M%SZ)-$$"
 fi
-rm -rf "$RUN_DIR"
-mkdir -p "$RUN_DIR"
+# GH #11748: this used to be an unconditional `rm -rf "$RUN_DIR"`, which would
+# destroy a user-supplied directory and could delete a concurrent run's inputs
+# mid-flight. The guard recreates a directory this harness owns (the documented
+# behaviour) and refuses to delete anything else.
+source "$REPO_ROOT/scripts/lib/eest-run-dir.sh"
+if ! eest_prepare_run_dir "$RUN_DIR" "codegen-eest-stateless-check.sh"; then
+  exit 1
+fi
 GUEST_PREFIX="$RUN_DIR/stateless_guest"
 RESOLVED_GUEST_ELF="$GUEST_PREFIX.elf"
 

--- a/scripts/eest-specref-check.sh
+++ b/scripts/eest-specref-check.sh
@@ -204,8 +204,14 @@ elif [[ -n "${EEST_RUN_DIR:-}" ]]; then
 else
   RUN_DIR="$REPO_ROOT/gen-out/eest-specref-run/run-$(date -u +%Y%m%dT%H%M%SZ)-$$"
 fi
-rm -rf "$RUN_DIR"
-mkdir -p "$RUN_DIR"
+# GH #11748: this used to be an unconditional `rm -rf "$RUN_DIR"`, which would
+# destroy a user-supplied directory and could delete a concurrent run's inputs
+# mid-flight. The guard recreates a directory this harness owns (the documented
+# behaviour) and refuses to delete anything else.
+source "$REPO_ROOT/scripts/lib/eest-run-dir.sh"
+if ! eest_prepare_run_dir "$RUN_DIR" "eest-specref-check.sh"; then
+  exit 1
+fi
 
 # --- convert fixtures -> inputs + manifest (same selection as the guest) -----
 conv_args=(--fixtures-dir "$FX" --out-dir "$RUN_DIR")

--- a/scripts/lib/eest-run-dir.sh
+++ b/scripts/lib/eest-run-dir.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# Shared ownership guard for EEST harness run directories -- GH #11748.
+#
+# Both EEST harnesses used to run an UNCONDITIONAL `rm -rf "$RUN_DIR"` at
+# startup, including when the directory came from --run-dir or EEST_RUN_DIR.
+# Two consequences, both silent in the way that matters -- the deleting run
+# proceeds normally and reports its own results, while the damage lands
+# somewhere else:
+#
+#   * pointing a harness at a directory containing anything else destroys it;
+#   * a concurrent run deletes the other run's inputs mid-flight.
+#
+# The category is the one this repo keeps meeting: SAFE BY CONVENTION, NOT BY
+# CONSTRUCTION.  Nothing in the code prevented either case; only the current
+# call pattern did.
+#
+# The guard here converts that to safe-by-construction by recording ownership in
+# a marker file and refusing to delete anything this harness did not create.
+#
+# ⚠️ The clean-slate semantics are PRESERVED deliberately and must stay.
+# docs/eest-stateless-testing.md documents that an EEST_RUN_DIR "is recreated at
+# the start of the invocation", and the A/B workflow in docs/sasm-howto.md
+# reuses one directory per leg across runs.  Partial cleaning would be worse
+# than either extreme: leftover `<label>.result.tsv` files from an earlier,
+# larger selection are counted by eest-run-monitor.sh (which globs
+# `*.result.tsv`) and joined by the report scripts, so a half-cleaned directory
+# turns a loud destructive bug into a silent measurement one.
+
+EEST_RUN_DIR_MARKER=".eest-run-dir"
+
+# eest_prepare_run_dir <dir> <owner>
+#
+# Ensures <dir> exists and is a clean, owned run directory, or fails without
+# deleting anything.  <owner> is a stable harness identifier, e.g. the script
+# basename.  Returns non-zero (and prints to stderr) rather than exiting, so the
+# caller decides how to fail.
+eest_prepare_run_dir() {
+  local dir="$1"
+  local owner="$2"
+  local marker="$dir/$EEST_RUN_DIR_MARKER"
+
+  if [[ -z "$dir" || -z "$owner" ]]; then
+    echo "eest_prepare_run_dir: internal error: dir and owner are required" >&2
+    return 1
+  fi
+
+  # Never created, nothing to destroy: make it and claim it.
+  if [[ ! -e "$dir" ]]; then
+    mkdir -p "$dir" || return 1
+    _eest_write_marker "$marker" "$owner"
+    return 0
+  fi
+
+  if [[ ! -d "$dir" ]]; then
+    echo "run directory exists and is not a directory: $dir" >&2
+    return 1
+  fi
+
+  if [[ -f "$marker" ]]; then
+    local prev_owner prev_pid
+    read -r prev_owner prev_pid _ < "$marker"
+
+    if [[ "$prev_owner" != "$owner" ]]; then
+      echo "refusing to delete a run directory created by a different harness:" >&2
+      echo "  directory:   $dir" >&2
+      echo "  created by:  $prev_owner" >&2
+      echo "  this run is: $owner" >&2
+      echo "  Two harnesses must not share a run directory (GH #11746, GH #11748)." >&2
+      echo "  Use a separate --run-dir, or delete that directory yourself." >&2
+      return 1
+    fi
+
+    # Same harness, but a run may still be live in there. PID reuse can make
+    # this a false refusal; refusing is the safe direction and the message says
+    # how to proceed.
+    if [[ -n "$prev_pid" ]] && kill -0 "$prev_pid" 2>/dev/null; then
+      echo "refusing to delete a run directory that is still in use:" >&2
+      echo "  directory: $dir" >&2
+      echo "  owned by:  $prev_owner (pid $prev_pid, still running)" >&2
+      echo "  Use a separate --run-dir, or wait for that run to finish." >&2
+      return 1
+    fi
+
+    # Ours, and idle: recreate it, which is the documented behaviour.
+    rm -rf "$dir" || return 1
+    mkdir -p "$dir" || return 1
+    _eest_write_marker "$marker" "$owner"
+    return 0
+  fi
+
+  # Exists, no marker: adopt it only if it is empty, so we delete nothing.
+  if [[ -n "$(ls -A "$dir" 2>/dev/null)" ]]; then
+    echo "refusing to delete a non-empty directory this harness did not create:" >&2
+    echo "  directory: $dir" >&2
+    echo "  It has no $EEST_RUN_DIR_MARKER marker, so its contents are not ours" >&2
+    echo "  to remove (GH #11748). Point --run-dir at a new or empty directory," >&2
+    echo "  or delete this one yourself if it is disposable." >&2
+    return 1
+  fi
+
+  _eest_write_marker "$marker" "$owner"
+  return 0
+}
+
+_eest_write_marker() {
+  local marker="$1"
+  local owner="$2"
+  # owner, pid, and a human timestamp. Read back positionally by field.
+  printf '%s %s %s\n' "$owner" "$$" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" > "$marker"
+}


### PR DESCRIPTION
Closes #11748.

Both EEST harnesses ran an **unconditional** `rm -rf "$RUN_DIR"` at startup — including when the directory came from `--run-dir` or `EEST_RUN_DIR`. Safe by convention, not by construction: nothing in the code prevented either consequence, only the current call pattern did.

## Chosen shape: refuse to delete what the harness did not create

Option 1, via an `.eest-run-dir` marker recording harness name and pid. A new `scripts/lib/eest-run-dir.sh` holds the guard and both harnesses source it — duplicating a destructive check in two places invites drift.

| directory state | behaviour |
|---|---|
| does not exist | create, claim it |
| marker names this harness, recorded run exited | **recreate** — the documented behaviour |
| marker names the *other* harness | refuse, delete nothing |
| marker names this harness, recorded pid still live | refuse, delete nothing |
| exists, non-empty, no marker | refuse, delete nothing |
| exists, empty, no marker | adopt (deletes nothing) |

**Why not "delete only what we write" (option 2).** It would be *worse than either extreme here*. Leftover `<label>.result.tsv` files from an earlier, larger selection are globbed by `eest-run-monitor.sh` and joined by the report scripts, so a half-cleaned directory turns a loud destructive bug into a **silent measurement** one.

**Why not a force flag alone (option 3).** It narrows rather than removes, and a flag required for the *documented* stable-directory workflow becomes habitual — passed reflexively, which is how force flags stop protecting anything. The escape hatch is deleting the directory yourself: explicit and visible. Option 3's check survives as the refusal message.

The pid check also covers **same-harness** concurrency, the other half of the second consequence. PID reuse can make it a false refusal; refusing is the safe direction and the message says how to proceed.

## Clean slate is preserved, deliberately

`docs/eest-stateless-testing.md` documents that an `EEST_RUN_DIR` *"is recreated at the start of the invocation"*, and the A/B workflow in `docs/sasm-howto.md` reuses one directory per leg across runs. Both still work — verified below, not assumed. The doc is updated to state when the harness refuses.

## Caller audit

The only programmatic caller passing `--run-dir` is `codegen-eest-gas-parity-report.sh`, and it creates only the **parent** (`mkdir -p "$(dirname "$RUN_DIR")"`), letting the harness create the run dir — so it takes the owned path unchanged. Every other `--run-dir`/`EEST_RUN_DIR` reference is documentation. The marker is a dotfile, so it matches none of the `*.result.tsv` / `manifest.tsv` globs any consumer uses.

## Verification

Base `377baad3d`, commit `759eac5e2`, backend spike.

**Guard unit matrix** — every refusal checked for *survival of the data*, not just for the message:

| case | result |
|---|---|
| fresh directory | allowed, marker written |
| same owner, previous run exited | allowed, **stale file removed — clean slate intact** |
| different owner | refused, data intact |
| non-empty, no marker | refused, data intact |
| empty, no marker | adopted |
| same owner, live pid | refused, data intact |

**End-to-end, real harness:**

- **Foreign directory**: `--run-dir` at a directory holding `notes.txt` and `subdir/deep.txt` → exit 1, refusal printed, **both files survived including the nested one**. On `origin/main` this path is `rm -rf "$RUN_DIR"` with no condition, so the whole tree would be gone.
- **Documented reuse**: two consecutive runs into one `--run-dir`, each **selected=1, ran=1, fail=0, full match=1**, exit 0; a stale file planted between them was removed, so clean slate still holds.
- **Cross-harness**: SpecRef pointed at a guest-owned directory → exit 1, refusal naming both harnesses, **all 11 files intact**.

⭐ The cross-harness refusal also closes #11746's shared-directory scenario at the *directory* level, so that hazard now has two independent barriers: distinct filenames (#11747) and directory ownership (here).

`bash -n` clean on all three scripts. No CI shell-lint gate exists, so the new file needs no registration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
