### PR TITLE
Fix account lookup when exec flags are absent

### DIFF
--- a/EvmAsm/Codegen/Programs/AccountWriteMap.lean
+++ b/EvmAsm/Codegen/Programs/AccountWriteMap.lean
@@ -465,7 +465,7 @@ def accountWritesLookupCurrentFunction : String :=
   ".Lawlc_tx_next:\n" ++
   "  addi t3, t3, 1; j .Lawlc_tx_loop\n" ++
   ".Lawlc_tx_key:\n" ++
-  "  ld t0, 112(t5); andi t1, t0, 8; beqz t1, .Lawlc_tx_next; ld t1, 72(t5); beqz t1, .Lawlc_deleted; ld t1, 96(t5); andi t1, t1, 2; beqz t1, .Lawlc_deleted; andi t1, t0, 4; beqz t1, .Lawlc_empty; ld a1, 80(t5); ld a2, 88(t5); beqz a2, .Lawlc_empty; li a0, 1; j .Lawlc_ret\n" ++
+  "  ld t0, 112(t5); andi t1, t0, 8; beqz t1, .Lawlc_tx_next; ld t1, 72(t5); beqz t1, .Lawlc_deleted; andi t1, t0, 16; beqz t1, .Lawlc_empty; ld t1, 96(t5); andi t1, t1, 2; beqz t1, .Lawlc_deleted; andi t1, t0, 4; beqz t1, .Lawlc_empty; ld a1, 80(t5); ld a2, 88(t5); beqz a2, .Lawlc_empty; li a0, 1; j .Lawlc_ret\n" ++
   ".Lawlc_block_init:\n" ++
   "  la t0, account_writes_count; ld t1, 0(t0); li t2, 0xa28a0000; li t3, 0\n" ++
   ".Lawlc_block_loop:\n" ++
@@ -475,7 +475,7 @@ def accountWritesLookupCurrentFunction : String :=
   ".Lawlc_block_next:\n" ++
   "  addi t3, t3, 1; j .Lawlc_block_loop\n" ++
   ".Lawlc_block_key:\n" ++
-  "  ld t0, 112(t5); andi t1, t0, 8; beqz t1, .Lawlc_block_next; ld t1, 72(t5); beqz t1, .Lawlc_deleted; ld t1, 96(t5); andi t1, t1, 2; beqz t1, .Lawlc_deleted; andi t1, t0, 4; beqz t1, .Lawlc_empty; ld a1, 80(t5); ld a2, 88(t5); beqz a2, .Lawlc_empty; li a0, 1; j .Lawlc_ret\n" ++
+  "  ld t0, 112(t5); andi t1, t0, 8; beqz t1, .Lawlc_block_next; ld t1, 72(t5); beqz t1, .Lawlc_deleted; andi t1, t0, 16; beqz t1, .Lawlc_empty; ld t1, 96(t5); andi t1, t1, 2; beqz t1, .Lawlc_deleted; andi t1, t0, 4; beqz t1, .Lawlc_empty; ld a1, 80(t5); ld a2, 88(t5); beqz a2, .Lawlc_empty; li a0, 1; j .Lawlc_ret\n" ++
   ".Lawlc_empty:\n  li a0, 2; li a1, 0; li a2, 0; j .Lawlc_ret\n" ++
   ".Lawlc_deleted:\n  li a0, 3; li a1, 0; li a2, 0; j .Lawlc_ret\n" ++
   ".Lawlc_absent:\n  li a0, 0; li a1, 0; li a2, 0\n" ++


### PR DESCRIPTION
## Summary

Fixes #11306.

`account_writes_lookup_current` now checks the valid-mask `EXEC_FLAGS` bit (`16`) before reading `execFlags` at offset `+96` in both the transaction and block scans. When the bit is absent, the existing empty-account status path is returned.

This matches the surrounding readers in `EvmAsm/Codegen/Programs/AccountWriteMap.lean`:

- `AuthCurrent` transaction path at line 380 gates mask `16`.
- `AuthCurrent` block path at line 390 gates mask `16`.
- `AuthBlock` at line 415 gates mask `16` before reading `+96`.
- `CreatedContains` at line 440 gates mask `16` before reading `+96`.
- `lookup_current` was missing the same gate at lines 468 and 478.

## Causal chain

An unset `execFlags` field was read as data and caused a balance-only live row to be classified as deleted. `EXTCODEHASH` then returned zero instead of the keccak-empty value, the probe stored zero at key 1, and the storage root diverged. The observed `107920` gas follows because the zero operand makes the SSTORE state predicate false and skips both gated charges.

## Measurement

The A/B was isolated in the same worktree: only the two guards were temporarily removed to emit the base ELF, then the patch was restored to emit the candidate ELF. This is important because an older-checkout baseline made 17 blob-gas rows appear to regress; those were stale-baseline contamination, not regressions from this patch.

- Fixture tag: `tests-zkevm@v0.6.2`
- Backend: Spike via `scripts/spike/spike_run`
- Seed: `11306`
- Sample: 200 of 26104, with input parity enabled
- Jobs: 30
- Base ELF SHA-256: `81ac0530d7571ce489818a8d75926b6a852f8da99a3542a5681d4dfba4cdfe29`
- Candidate ELF SHA-256: `bcba0c875b3b427265c0559f29b9619d343c024a5fa4f9780f7fcd4c4ef17e1c`
- Both ELF files: 503224 bytes
- Base `.text`: `0x80000000`, size `0x54a0c`
- Candidate `.text`: `0x80000000`, size `0x54a1c`
- `.data` and `.bss` extents are identical
- 198 input-digest joins, 0 unmatched; self-check PASS
- Base: FA 0, FR 20
- Candidate: FA 0, FR 19
- New false rejections: 0
- Fixed false rejections: 1
- Status differences: 0
- Output-byte differences: 1
- Sole moved row: `00055_test_selfdestructing_initcode_preserves_balance_fork_Amsterdam-blockchain_test-success-precompil`, FR -> PASS

The four retained run artifacts are:

- Base ELF: `/tmp/codex2-11306-baseline-current/stateless_guest.elf`
- Candidate ELF: `/tmp/codex2-11306-candidate-empty/stateless_guest.elf`
- Base provenance: `/tmp/codex2-11306-r200-spike-base-current/run-provenance.tsv`
- Candidate provenance: `/tmp/codex2-11306-r200-spike-cand-empty/run-provenance.tsv`

## Verification

- `lake exe codegen --program stateless_guest --halt linux93 -o /tmp/codex2-11306-candidate-empty/stateless_guest`
- `git diff --check`
- `scripts/codegen-eest-stateless-check.sh --guest-elf ... --backend spike --jobs 30 --limit 200 --random --seed 11306 --quiet-passes --no-verdict-debug`
- `python3 scripts/eest-ab-compare.py ...`
