### PR TITLE
fix(ci): distinguish axiom audit no-run from violations

### DIFF
--- a/scripts/check-axioms.sh
+++ b/scripts/check-axioms.sh
@@ -134,9 +134,11 @@ WITNESS_MODULE="EvmAsm.Progress.AxiomWitnesses"
 WITNESS_FILE="EvmAsm/Progress/AxiomWitnesses.lean"
 
 # GH #10601: the axiom audit is a checked-in witness module built by
-# `lake build`, so it works when LAKE_ARTIFACT_CACHE satisfies the graph
-# without materializing oleans (where `lake env lean` cannot resolve
-# cache-satisfied modules — issue #10537).  The module carries one
+# `lake build`.  A cache-satisfied graph does NOT replay the module's
+# `#print axioms` messages (and does not materialize its olean), so force a
+# cache-disabled build for this one target.  This is the same materialization
+# pattern used by `scripts/asm_to_program.py` before invoking `lake env lean`.
+# The module carries one
 # `#print axioms` line per registry witness and is generated from
 # EvmAsm/Progress.lean and EvmAsm/Progress/Routines.lean by
 # scripts/gen-axiom-witnesses.py; the registries are the single source of
@@ -153,11 +155,12 @@ if ! diff -q "$REGEN" "$WITNESS_FILE" >/dev/null; then
 fi
 
 # Capture both streams (do NOT suppress stderr — a real build failure
-# must surface).  `#print axioms` reports ride lake's message channel;
-# lake replays recorded messages even when the module is satisfied from
-# the artifact cache (measured on this checkout), so the reports are
-# present on cached rebuilds too.
-if ! lake build "$WITNESS_MODULE" > "$RAWOUT" 2>&1; then
+# must surface).  `#print axioms` reports ride lake's message channel; the
+# cache-disabled override above ensures the witness module is actually built
+# and its reports are emitted rather than fetched silently.
+# Keep the override local to this audit; the rest of the build may continue to
+# use the artifact cache.  Without it, a fetched module produces zero reports.
+if ! LAKE_ARTIFACT_CACHE=false lake build "$WITNESS_MODULE" > "$RAWOUT" 2>&1; then
   echo "check-axioms: 'lake build $WITNESS_MODULE' failed — output follows:" >&2
   cat "$RAWOUT" >&2
   exit 1

--- a/scripts/check-axioms.sh
+++ b/scripts/check-axioms.sh
@@ -163,6 +163,14 @@ if ! lake build "$WITNESS_MODULE" > "$RAWOUT" 2>&1; then
   exit 1
 fi
 
+# Keep a count of lines naming the witness module before filtering the lake
+# message stream.  A zero parsed report can mean either that lake emitted no
+# witness diagnostics at all or that its diagnostic format moved; both are a
+# harness failure, not evidence that all witnesses are axiom-clean.  The
+# count makes the failure actionable without dumping the (potentially large)
+# transitive build log.
+RAW_WITNESS_LINES="$(grep -cF "$WITNESS_FILE" "$RAWOUT" || true)"
+
 # `lake build` prints each report as `info: <file>:<line>:<col>: <text>`
 # (the axiom list may wrap onto space-indented continuation lines that carry
 # no prefix).  Strip the position prefix so records match the classic
@@ -213,6 +221,13 @@ mapfile -t REPORTED < <(
 )
 if (( ${#REPORTED[@]} != ${#NAMES[@]} )) \
   || ! diff -q <(printf '%s\n' "${NAMES[@]}") <(printf '%s\n' "${REPORTED[@]}") >/dev/null; then
+  if (( ${#REPORTED[@]} == 0 )); then
+    echo "check-axioms: ERROR: could not run #print axioms — parsed 0 reports for ${#NAMES[@]} registry witnesses" >&2
+    echo "check-axioms: this is a harness/diagnostic failure, not a clean axiom result" >&2
+    echo "check-axioms: raw lake output contained $RAW_WITNESS_LINES line(s) naming $WITNESS_FILE before parsing" >&2
+    echo "check-axioms: expected one report per witness; inspect lake output format or message routing" >&2
+    exit 2
+  fi
   echo "check-axioms: FAIL: parsed ${#REPORTED[@]} axiom report(s) for ${#NAMES[@]} registry witness(es)" >&2
   MISSING="$(comm -23 <(printf '%s\n' "${NAMES[@]}") <(printf '%s\n' "${REPORTED[@]}"))"
   if [[ -n "$MISSING" ]]; then


### PR DESCRIPTION
## Diagnosis

On `origin/main` `f3eac9e60885a9a1c0eb3521903341f1658791cc`, with the artifact cache enabled and the materialized `AxiomWitnesses` OLean absent, `lake build EvmAsm.Progress.AxiomWitnesses` fetches cached artifacts but emits no `#print axioms` diagnostics for `EvmAsm/Progress/AxiomWitnesses.lean`. The gate therefore parsed zero reports although the registry contains 146 witnesses. This is a could-not-run condition, not evidence that the witnesses are clean and not an axiom violation.

With `LAKE_ARTIFACT_CACHE=false`, the same checkout rebuilds the witness module and emits all 146 reports; the actual status is 146/146, only `propext`, `Classical.choice`, and `Quot.sound`, with zero forbidden/native-trust owners.

## Change

`check-axioms.sh` now forces `LAKE_ARTIFACT_CACHE=false` for the witness-module build, so a cache hit cannot silently fetch an OLean without replaying its `#print axioms` messages. If the parser still obtains zero witness reports, it reports an explicit `could not run #print axioms` harness error, explains that the result is not a clean axiom result, reports how many raw build-log lines named the witness module, and exits with status 2. A partial report set remains the existing status-1 completeness failure, and any parsed forbidden axiom remains the existing status-1 violation path.

## Verification

- CI wiring: `.github/workflows/build.yml:135` runs `scripts/check-build-parallel.sh`, whose `start axioms scripts/check-axioms.sh` entry is at `scripts/check-build-parallel.sh:46`; there is no cache override in that caller. The script-local `LAKE_ARTIFACT_CACHE=false` is therefore required for the indirect CI gate after the workflow restores `.lake`.
- Recent green CI confirmation: Build run `31253011947` on `f3eac9e60` contains exactly 146 `AxiomWitnesses.lean` report lines in the initial Lake-build log, followed by the indirect axioms gate passing 146 witnesses. CI did run the audit on that invocation; the defect is cache/invocation-dependent rather than a silently green CI gate on this run.
- Pre-fix cache-empty reproduction: with the materialized witness OLean removed, the old cache-enabled invocation produced exit 1 with `0` raw witness lines; this is the reproduced failure that motivated the fix.
- Actual audit with the cache-enabled caller: `LAKE_ARTIFACT_CACHE=true scripts/check-axioms.sh` → exit 0 after the script's local cache-disabled witness rebuild, 146 witnesses, only the three classical axioms.
- Explicit no-cache audit: `LAKE_ARTIFACT_CACHE=false scripts/check-axioms.sh` → exit 0, 146 witnesses, only the three classical axioms.
- `LAKE_ARTIFACT_CACHE=false scripts/check-axioms.sh --report` → no non-classical axioms and no native-trust owners.
- `bash -n scripts/check-axioms.sh` and `git diff --check` pass.
