### PR TITLE
regionmap: derive .state_gas_diag's base instead of pinning it

### DIFF
--- a/EvmAsm/Codegen/Proofs/GuestImage.lean
+++ b/EvmAsm/Codegen/Proofs/GuestImage.lean
@@ -222,15 +222,24 @@ theorem guestScratch_sat : ∀ input : SpecRef.Bytes,
       (0xa3000000 + RegionMap.dataSizeBytes) (0xa3110000 + RegionMap.bssSizeBytes) :=
     t7.mono (by decide) (le_refl _)
   -- GH #11186: `.state_gas_diag` is linker-placed immediately after `.bss`, so
-  -- its base IS `t7`'s upper bound — this join needs no `mono` widening, unlike
-  -- the `t8` hop below. Both pins are `abbrev`, hence `decide` not `omega`;
-  -- alignment holds structurally (`.balign 8` in its emitter).
+  -- its base IS `t7`'s upper bound, and this join needs no `mono` widening —
+  -- but ONLY because the base is DERIVED as `0xa3110000 + bssSizeBytes` and the
+  -- two bounds are therefore the SAME TERM. While it was an independent pin the
+  -- join typechecked only because the two `abbrev`s reduced to the same numeral;
+  -- when `bssSizeBytes` moved, that coincidence ended and CI failed here with an
+  -- application type mismatch.
+  --
+  -- `t8.mono` below is a DIFFERENT case and stays: `.state_gas_diag` ends well
+  -- below `.sszscratch`'s base, so that hop crosses a genuine gap and must be
+  -- widened. Pins are `abbrev`, hence `decide` not `omega`; alignment holds
+  -- structurally (`.balign 8` in its emitter).
   have t7b : (regionScratch RegionMap.stateGasDiagRegion).SatWithin
-      RegionMap.stateGasDiagBase
-      (RegionMap.stateGasDiagBase + RegionMap.stateGasDiagSizeBytes) := by
+      (0xa3110000 + RegionMap.bssSizeBytes)
+      (0xa3110000 + RegionMap.bssSizeBytes + RegionMap.stateGasDiagSizeBytes) := by
     dsimp [regionScratch, RegionMap.stateGasDiagRegion,
       RegionMap.stateGasDiagBase, RegionMap.stateGasDiagSizeBytes,
-      RegionMapLinkPins.stateGasDiagBase, RegionMapLinkPins.stateGasDiagSizeBytes]
+      RegionMap.bssSizeBytes, RegionMapLinkPins.bssSizeBytes,
+      RegionMapLinkPins.stateGasDiagSizeBytes]
     apply satWithin_ramRegion <;> decide
   have t8 : (regionScratch RegionMap.sszScratchRegion).SatWithin
       0xbf980000 0xc0000000 :=

--- a/EvmAsm/Codegen/RegionMap.lean
+++ b/EvmAsm/Codegen/RegionMap.lean
@@ -539,12 +539,30 @@ abbrev dataSizeBytes : Nat := RegionMapLinkPins.dataSizeBytes
     removal absorbs in the same direction (#10986, #10988). -/
 abbrev bssSizeBytes : Nat := RegionMapLinkPins.bssSizeBytes
 
-/-- ELF-measured base of `.state_gas_diag`. Unlike every other RAM section this
-    one carries **no `--section-start` flag**: the linker places it immediately
-    after `.bss`, so its base is a *consequence* of `bssSizeBytes` and moves on
-    every `.bss` growth. A hand-typed constant here would silently go stale, so
-    it is a class-A pin like the three BSS symbol bases. -/
-abbrev stateGasDiagBase : Nat := RegionMapLinkPins.stateGasDiagBase
+/-- Base of `.state_gas_diag`. Unlike every other RAM section this one carries
+    **no `--section-start` flag**: the linker places it immediately after
+    `.bss`, so its base is a *consequence* of `bssSizeBytes` — and it is
+    therefore **DERIVED here, not pinned**.
+
+    ⚠️ GH #11186 landed this as an independent class-A pin first, on the
+    reasoning that a hand-typed constant would go stale. Correct premise, wrong
+    conclusion: **the right conclusion from *it is a consequence* is to derive
+    it.** An independent pin for a derived quantity can contradict its own
+    premise the moment the two are regenerated at different times — and while
+    both were pins, `guestScratch_sat`'s `sepConj` join typechecked only because
+    the two `abbrev`s happened to *reduce to the same numeral*. That is
+    agreement by coincidence, not by construction: when `bssSizeBytes` moved
+    under a branch, CI failed with an application type mismatch at
+    `GuestImage.lean`, and a **clean** rebase (no conflict, no marker) produced a
+    `RegionMapLinkPins` whose `stateGasDiagBase` described the old image while
+    its `bssSizeBytes` described the new one.
+
+    Derived, the join holds because the two bounds are the SAME TERM, with no
+    reduction and no coincidence involved. `check-region-map.sh` then checks this
+    derivation against the linked ELF (`.state_gas_diag base == .bss end`),
+    which is also the only thing that can catch the one way it could break:
+    padding, if a future `.bss` size were not 8-aligned. -/
+abbrev stateGasDiagBase : Nat := 0xa3110000 + bssSizeBytes
 
 /-- ELF-measured `.state_gas_diag` size. -/
 abbrev stateGasDiagSizeBytes : Nat := RegionMapLinkPins.stateGasDiagSizeBytes

--- a/EvmAsm/Codegen/RegionMapLinkPins.lean
+++ b/EvmAsm/Codegen/RegionMapLinkPins.lean
@@ -5,9 +5,10 @@
   `python3 scripts/gen-region-map-link-pins.py` regenerates this from the
   linked stateless_guest ELF (issue #11230).
 
-  Link-layout-dependent pins only (class A): section sizes, three BSS
-  bases, and `.state_gas_diag`'s base — all move when the guest image
-  moves. Class B stable bases stay hand-typed in RegionMap.lean.
+  Link-layout-dependent pins only (class A): section sizes and three
+  BSS bases, which move when the guest image moves. Class B stable
+  bases stay hand-typed in RegionMap.lean; `.state_gas_diag`'s base is
+  neither — RegionMap DERIVES it from `bssSizeBytes` (GH #11186).
 
   Regenerated from: gen-out/regionmap/stateless_guest.elf
   Guard contract (check-region-map.sh): pins are this file (regen-time
@@ -22,7 +23,6 @@ abbrev textSizeBytes : Nat := 0x544b4
 abbrev dataSizeBytes : Nat := 0x5370
 abbrev bssSizeBytes : Nat := 0x18c03c00
 
-abbrev stateGasDiagBase : Nat := 0xbbd13c00
 abbrev stateGasDiagSizeBytes : Nat := 0x37cd0
 
 abbrev callFrameArenaBase : Nat := 0xabd38880

--- a/scripts/gen-region-map-link-pins.py
+++ b/scripts/gen-region-map-link-pins.py
@@ -38,10 +38,11 @@ def _find_tool(*names: str) -> str:
     sys.exit(f"missing required tool (tried {', '.join(names)})")
 
 
-# Sections whose (addr, size) this generator pins.  `.state_gas_diag` carries a
-# BASE as well as a size: it is placed by the linker immediately after `.bss`
-# rather than by a `--section-start` flag, so a hand-typed base in RegionMap
-# would go stale on every `.bss` growth.  It is emitted unconditionally by
+# Sections this generator reads.  `.state_gas_diag`'s SIZE is pinned; its BASE
+# deliberately is NOT.  The linker places that section immediately after `.bss`,
+# so RegionMap DERIVES the base as `0xa3110000 + bssSizeBytes` and the two can
+# never disagree -- pinning it independently let it contradict its own premise
+# (GH #11186).  Emitted unconditionally by
 # `dispatcherExecStateGasDifferentialData` (DispatcherExecStateGas.lean:158).
 SECTIONS = (".text", ".data", ".bss", ".state_gas_diag")
 
@@ -92,9 +93,10 @@ def render(elf: Path) -> str:
         "  `python3 scripts/gen-region-map-link-pins.py` regenerates this from the",
         "  linked stateless_guest ELF (issue #11230).",
         "",
-        "  Link-layout-dependent pins only (class A): section sizes, three BSS",
-        "  bases, and `.state_gas_diag`'s base — all move when the guest image",
-        "  moves. Class B stable bases stay hand-typed in RegionMap.lean.",
+        "  Link-layout-dependent pins only (class A): section sizes and three",
+        "  BSS bases, which move when the guest image moves. Class B stable",
+        "  bases stay hand-typed in RegionMap.lean; `.state_gas_diag`'s base is",
+        "  neither — RegionMap DERIVES it from `bssSizeBytes` (GH #11186).",
         "",
         f"  Regenerated from: {rel}",
         "  Guard contract (check-region-map.sh): pins are this file (regen-time",
@@ -110,9 +112,7 @@ def render(elf: Path) -> str:
         f"abbrev dataSizeBytes : Nat := {sec['.data'][1]:#x}",
         f"abbrev bssSizeBytes : Nat := {sec['.bss'][1]:#x}",
         "",
-        # `.state_gas_diag` is linker-placed after `.bss` (no --section-start), so
-        # its BASE is pinned here too rather than hand-typed in RegionMap.
-        f"abbrev stateGasDiagBase : Nat := {sec['.state_gas_diag'][0]:#x}",
+        # SIZE only -- the BASE is derived in RegionMap (see SECTIONS above).
         f"abbrev stateGasDiagSizeBytes : Nat := {sec['.state_gas_diag'][1]:#x}",
         "",
         f"abbrev callFrameArenaBase : Nat := {addrs['callFrameArenaBase']:#x}",


### PR DESCRIPTION
Follow-up to #11777 (merged), against current main `d29f5339f`. **Not a touch of the merged PR** — a fresh branch with the fix that PR's CI failure was pointing at.

## ⚠️ Main builds today by coincidence, and here is the coincidence

`RegionMapLinkPins.lean:25` pins `stateGasDiagBase := 0xbbd13c00`. `RegionMap`'s `.bss` base plus `:23`'s `bssSizeBytes` is `0xa3110000 + 0x18c03c00` = **`0xbbd13c00`**. The two `abbrev`s reduce to the same numeral, so `guestScratch_sat`'s `sepConj` join typechecks — **by reduction, not by construction**. (Checked against the merged tree, not inferred from the numbers I was handed.)

That ends the next time `.bss` moves and the two are regenerated at different moments.

## The reasoning error this corrects — mine

I made the base a generated pin *because* it is a consequence of `bssSizeBytes`: a hand-typed constant would go stale on every `.bss` growth. Correct premise, **wrong conclusion**. The right conclusion from *it is a consequence* is to **derive** it. An independent pin for a derived quantity can contradict its own premise.

## ⭐ The evidence, which proves it rather than arguing it

While preparing this fix, a rebase onto the then-new main **succeeded cleanly** and produced a `RegionMapLinkPins.lean` in which:

| line | value | describes |
|---|---|---|
| `stateGasDiagBase` | `0xbc139560` | my **old** image |
| `bssSizeBytes` | `0x18c03c00` | main's **new** image |

**Two lines of one generated file describing two different builds — no conflict marker, nothing objecting.** CI then failed at `GuestImage.lean:246` with an *application type mismatch*, not a `decide` that proved something false. No amount of care at the merge catches that; only removing the independent pin does.

## Changes

1. **`RegionMap.stateGasDiagBase := 0xa3110000 + bssSizeBytes`** — derived.
2. **`scripts/gen-region-map-link-pins.py` emits the SIZE only.** The size is a genuinely independent measurement; the base is not.
3. **`t7b`'s bounds restated in the derived term**, so `t7`'s upper bound and `t7b`'s lower bound are the *same term*, with no reduction and no coincidence involved.

## `t8.mono` stays — and I measured that rather than assuming it

The review question was whether the `mono` wrappers become unnecessary once the terms are identical by construction. **I removed `t8.mono` and rebuilt**: it fails with an application type mismatch at `:256`. So it is load-bearing, for a different reason than the `t7b` join:

- `t7'` → `t7b` is **adjacency** — `.state_gas_diag` begins exactly at `.bss`'s end — so that join needs no widening, and now needs none *by construction*.
- `t7b` → `t8` crosses a **real gap**: `.state_gas_diag` ends `0xbbd4b8d0`, `.sszscratch` begins `0xbf980000`. That hop must be widened and always will be.

## Evidence

- **`lake build`: 4737 jobs, exit 0** — zero errors, zero warnings, no `sorry`. Full build.
- **`scripts/check-region-map.sh`: PASS** — `region map matches the linked ELF`:
  ```
  OK   .state_gas_diag base 0xbbd13c00 == .bss end 0xbbd13c00
  OK   .state_gas_diag end 0xbbd4b8d0 < .sszscratch 0xbf980000
  ```
  This check is now worth more than it was: with the base derived, it stops being pin-versus-pin and becomes a genuine cross-check of the **derivation** against the linked ELF — and it is the only thing that can catch the one way the derivation could break, **padding if a future `.bss` size were not 8-aligned**.
- `scripts/check-forbidden-tactics.sh`: OK.
- Regenerated **to fixpoint** (2 passes, stable from the first).
- ⭐ **The pin diff against main is exactly one REMOVED line** (`stateGasDiagBase`); `textSizeBytes`, `dataSizeBytes` and `bssSizeBytes` are byte-identical to main. **No emitted guest code changes**, which is also why no r200 is owed here — there is no changed image to measure.

## Not in this PR

The arena relocation and capacity raise (#11770 derivations: undo journal → 163,840 rows, block map → 65,536, tx map unchanged at 16,384) is a separate change and owes the four-artefact regen plus a full r200. Context: #11186.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
