### PR TITLE
docs: clarify retired M25 ABI tombstone

### DIFF
--- a/CODEGEN.md
+++ b/CODEGEN.md
@@ -2094,10 +2094,11 @@ clean (`lake build EvmAsm.Codegen` exits 0).
 
 ### M25 — Post-state slot serializer — **RETIRED (#11556 / #11326)**
 
-Historically walked the Option-A persistent log and wrote
-deduped `(slotKey, current)` pairs at `OUTPUT[56..]`, with an
-`expectedPostStorage` opcode-test field and a
-`codegen-opcodes-runtime-check.sh` column assert.
+The retired implementation walked the Option-A persistent log and
+wrote deduped `(slotKey, current)` pairs at `OUTPUT[56..]`. Its
+`expectedPostStorage` opcode-test field and
+`codegen-opcodes-runtime-check.sh` column assertion were removed
+with M25; neither artifact exists now.
 
 **Why retired (not restored):**
 


### PR DESCRIPTION
## Summary

- Clarify the surviving M25 ABI reference in CODEGEN.md so it no longer promises the retired `expectedPostStorage` field or `scripts/codegen-opcodes-runtime-check.sh` column assertion.
- Keep the two deliberate retirement tombstones: CODEGEN.md:2119 is an ABI-removal note that cites issue 11556, and EvmAsm/Codegen/Cli.lean:145 records that the field was retired.

## Premise correction

The issue description overstates what remains in the current tree. At `df80b1efe`, `Cases.lean` is already clean: the `expectedPostStorage` field and the four `sstore_post_state` / `sstore_dup_keeps_latest` cases are gone. `scripts/codegen-opcodes-runtime-check.sh` is also absent from `git ls-tree`.

Only `CODEGEN.md:2099` described the field and runner column as though they still existed—the false promise this cleanup addresses. The other two surviving references are deliberate tombstones that inform the next reader, so they remain unchanged.

## Verification

- `git diff --check` passed.
- Docs-only change; no guest image moved and no `r200` is owed.
- No merge label is requested by this PR.