### PR TITLE
ci: ratchet supplied BAL cursor debt

### DIFF
--- a/scripts/bal-class-a-baseline.tsv
+++ b/scripts/bal-class-a-baseline.tsv
@@ -1,4 +1,6 @@
-# bal-class-a-baseline.tsv — emitted paths touching bv_bal_start/bv_bal_len
+# bal-class-a-baseline.tsv — emitted paths touching supplied-BAL cursors
+# Predicate: bv_bal_*, bsr_bal_*, and c1_bal_* start/len cells
+# Debt count constant: EXPECTED_CLASS_A_DEBT in check-bal-class-a-ratchet.py
 # Columns: function  kind  jal_or_sink  return_status_tested  insn
 # Maintained by scripts/check-bal-class-a-ratchet.py
 # NEW path => fail; MISSING baselined path => fail (shrink baseline on purpose).
@@ -10,7 +12,15 @@
 # the finish line — not unfinished work. Retire CHECKs via EQUIVALENCE (spec
 # only hashes the BUILT list at fork.py:390; no supplied body), never via
 # "hash covers it" (needs collision-freedom; ruled out).
+.Lbsr_bal_replay	load	bal_account_record_array	yes	la t0, bsr_bal_start; ld a3, 0(t0); la t0, bsr_bal_len; ld a4, 0(t0); mv a5, t6
+.Lbsr_bal_replay	load	rlp_walk_init	no	la t0, bsr_bal_start; ld a0, 0(t0); la t0, bsr_bal_len; ld a1, 0(t0)
+.Lbsr_oao_2935_done	load	bal_section_info	yes	la t0, bsr_ssz_p; ld a0, 0(t0); la a1, bsr_bal_start; la a2, bsr_bal_len; la a3, bsr_bal_count
 .Lbv_after_tx_gate	load	bgv_u64le	no	la t2, bv_bal_start; ld t3, 0(t2); sub a1, a1, t3
 .Lbv_after_tx_gate	store	bgv_u32le	no	la t2, bv_bal_start; sd a0, 0(t2)
 .Lbv_after_tx_gate	store	bgv_u64le	no	la t2, bv_bal_len; sd a1, 0(t2)
 .Lbv_ret	store	bal_gas_valid_from_builder	yes	la t0, bv_bal_len; ld t1, 0(t0); la t0, bv_bal_shadow_supplied_len; sd t1, 0(t0)
+.Lc1_bd_same_block	load	bal_find_account_by_address	yes	la t0, c1_bal_start; ld a0, 0(t0); la t0, c1_bal_len; ld a1, 0(t0)
+.Lc1_be_same_block	load	bal_find_account_by_address	yes	la t0, c1_bal_start; ld a0, 0(t0); la t0, c1_bal_len; ld a1, 0(t0)
+.Lv2_input_hash	la	bal_section_info	yes	mv a0, s0; la a1, c1_bal_start; la a2, c1_bal_len; la a3, c1_bal_count; jal ra, bal_section_info
+block_state_root_pre_accounts	load	bal_account_record_array	yes	la t0, bsr_bal_start; ld a3, 0(t0); la t0, bsr_bal_len; ld a4, 0(t0); mv a5, t6
+block_state_root_pre_accounts	load	bal_section_info	yes	la t0, bsr_ssz_p; ld a0, 0(t0); la a1, bsr_bal_start; la a2, bsr_bal_len; la a3, bsr_bal_count

--- a/scripts/check-bal-class-a-ratchet.py
+++ b/scripts/check-bal-class-a-ratchet.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
-"""Class-A provided-BAL ratchet (#11183).
+"""Class-A provided-BAL ratchet (#11183, #11796).
 
-Enumerate emitted paths that touch bv_bal_start / bv_bal_len (and, when the
-linked addresses are known, li/imm of those addresses). Compare to a checked-in
-baseline:
+Enumerate emitted paths that touch the supplied-BAL cursor cells
+(`bv_bal_*`, `bsr_bal_*`, and `c1_bal_*`; and, when the linked addresses are
+known, li/imm of those addresses). Compare to a checked-in baseline:
 
   * NEW path not in baseline  → fail (regression: new Class-A read)
   * BASELINE path disappeared → fail (force explicit baseline shrink on retirement)
@@ -36,6 +36,7 @@ Blind spots (CANNOT see) — documented for reviewers:
 
 Usage:
   scripts/check-bal-class-a-ratchet.py [--elf-dir DIR] [--write-baseline]
+  scripts/check-bal-class-a-ratchet.py --self-test
   scripts/check-bal-class-a-ratchet.py --baseline PATH   # default scripts/bal-class-a-baseline.tsv
 """
 from __future__ import annotations
@@ -45,13 +46,28 @@ from collections import Counter
 import re
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_BASELINE = ROOT / "scripts" / "bal-class-a-baseline.tsv"
 DEFAULT_NOTES = ROOT / "scripts" / "bal-class-a-notes.md"
 EXPECTED_ANNOTATION_COUNT = 1
-SEEDS = ("bv_bal_start", "bv_bal_len")
+# Class-A predicate: every emitted reference to a supplied-BAL cursor. Keep the
+# predicate here, beside the baseline/debt check, so the next reader can
+# re-derive the census instead of trusting the TSV row count (#11796).
+SEEDS = (
+    "bv_bal_start",
+    "bv_bal_len",
+    "bsr_bal_start",
+    "bsr_bal_len",
+    "c1_bal_start",
+    "c1_bal_len",
+)
+# One-way debt ratchet: this is the number of currently baselined emitted
+# paths in the predicate above. It is a debt figure, not a target; it may only
+# decrease, and a retirement plus this constant's decrease must land together.
+EXPECTED_CLASS_A_DEBT = 12
 # Direct jal whose a0 is commonly status-tested after BAL helpers.
 STATUS_JAL = re.compile(
     r"\bjal\s+ra,\s*([A-Za-z0-9_.]+)"
@@ -123,7 +139,11 @@ def analyze(s_path: Path) -> list[dict[str, str]]:
         if not seed_hit(line):
             continue
         # skip pure definitions
-        if re.match(r"^(bv_bal_start|bv_bal_len):\s*$", line.strip()):
+        if re.match(
+            r"^(bv_bal_start|bv_bal_len|bsr_bal_start|bsr_bal_len|"
+            r"c1_bal_start|c1_bal_len):\s*$",
+            line.strip(),
+        ):
             continue
         if line.strip().startswith("#"):
             continue
@@ -190,7 +210,9 @@ def row_key(r: dict[str, str]) -> str:
 
 
 HEADER = (
-    "# bal-class-a-baseline.tsv — emitted paths touching bv_bal_start/bv_bal_len\n"
+    "# bal-class-a-baseline.tsv — emitted paths touching supplied-BAL cursors\n"
+    "# Predicate: bv_bal_*, bsr_bal_*, and c1_bal_* start/len cells\n"
+    "# Debt count constant: EXPECTED_CLASS_A_DEBT in check-bal-class-a-ratchet.py\n"
     "# Columns: function  kind  jal_or_sink  return_status_tested  insn\n"
     "# Maintained by scripts/check-bal-class-a-ratchet.py\n"
     "# NEW path => fail; MISSING baselined path => fail (shrink baseline on purpose).\n"
@@ -217,6 +239,80 @@ def load_baseline(path: Path) -> set[str]:
             continue
         keys.add(line.rstrip("\n"))
     return keys
+
+
+def compare_rows(
+    rows: list[dict[str, str]], baseline: set[str]
+) -> tuple[list[str], list[str]]:
+    """Return new and disappeared paths for the Class-A set comparison."""
+    current = {row_key(r) for r in rows}
+    return sorted(current - baseline), sorted(baseline - current)
+
+
+def self_test() -> int:
+    """Prove a newly planted cursor read fails, then removal returns to OK."""
+    clean_asm = """\
+.text
+synthetic_bal_consumer:
+  la t0, bv_bal_start
+  ld a0, 0(t0)
+  ret
+bv_bal_start:
+  .zero 8
+c1_bal_start:
+  .zero 8
+"""
+    planted_asm = clean_asm.replace(
+        "  ret\n",
+        "  la t1, c1_bal_start\n"
+        "  ld a1, 0(t1)\n"
+        "  ret\n",
+        1,
+    )
+
+    with tempfile.TemporaryDirectory(prefix="bal-class-a-self-test-") as td:
+        root = Path(td)
+        clean_path = root / "clean.s"
+        planted_path = root / "planted.s"
+        clean_path.write_text(clean_asm)
+        planted_path.write_text(planted_asm)
+
+        clean_rows = analyze(clean_path)
+        baseline = {row_key(row) for row in clean_rows}
+        planted_rows = analyze(planted_path)
+        new, missing = compare_rows(planted_rows, baseline)
+        if len(new) != 1 or missing:
+            print(
+                "check-bal-class-a-ratchet --self-test: FAIL — planted "
+                "c1_bal_start read did not create exactly one new path",
+                file=sys.stderr,
+            )
+            return 1
+        print(
+            "check-bal-class-a-ratchet --self-test: planted synthetic "
+            "c1_bal_start read"
+        )
+        print(
+            "check-bal-class-a-ratchet: FAIL (expected; 1 new Class-A path)"
+        )
+        print(f"  + {new[0]}")
+
+        new, missing = compare_rows(clean_rows, baseline)
+        if new or missing:
+            print(
+                "check-bal-class-a-ratchet --self-test: FAIL — removing the "
+                "synthetic read did not restore the baseline",
+                file=sys.stderr,
+            )
+            return 1
+        print(
+            "check-bal-class-a-ratchet --self-test: synthetic read removed"
+        )
+        print(
+            f"check-bal-class-a-ratchet: OK (debt={len(clean_rows)} "
+            "synthetic baseline paths; no new Class-A edges)"
+        )
+    return 0
 
 
 ANNOTATION_COUNT_RE = re.compile(r"^\s*<!--\s*annotation-count:\s*(\d+)\s*-->\s*$")
@@ -352,7 +448,15 @@ def main() -> int:
         action="store_true",
         help="require existing .s under --elf-dir",
     )
+    ap.add_argument(
+        "--self-test",
+        action="store_true",
+        help="plant a synthetic cursor read, prove FAIL, then remove it and prove OK",
+    )
     args = ap.parse_args()
+
+    if args.self_test:
+        return self_test()
 
     if args.elf_dir:
         s_path = args.elf_dir / "stateless_guest.s"
@@ -368,7 +472,7 @@ def main() -> int:
     rows = analyze(s_path)
     if not rows:
         print(
-            "check-bal-class-a-ratchet: FAIL closed — zero bv_bal_start/len refs in emitted asm",
+            "check-bal-class-a-ratchet: FAIL closed — zero supplied-BAL cursor refs in emitted asm",
             file=sys.stderr,
         )
         return 1
@@ -378,7 +482,7 @@ def main() -> int:
     if args.write_baseline:
         write_baseline(args.baseline, rows)
         print(
-            f"wrote {args.baseline} ({len(rows)} paths; "
+            f"wrote {args.baseline} (debt={len(rows)} paths; "
             f"{annotation_count} annotations) from {s_path}"
         )
         return 0
@@ -388,12 +492,19 @@ def main() -> int:
         return 2
 
     base = load_baseline(args.baseline)
-    cur = {row_key(r) for r in rows}
-    new = sorted(cur - base)
-    missing = sorted(base - cur)
+    new, missing = compare_rows(rows, base)
+    debt_drift = len(rows) != EXPECTED_CLASS_A_DEBT
 
-    if new or missing:
+    if debt_drift or new or missing:
         print("check-bal-class-a-ratchet: FAIL", file=sys.stderr)
+        if debt_drift:
+            print(
+                "\nClass-A debt ratchet drift: "
+                f"expected exactly {EXPECTED_CLASS_A_DEBT} paths, found {len(rows)}; "
+                "update the committed debt only with the corresponding source "
+                "retirement.",
+                file=sys.stderr,
+            )
         if new:
             print(f"\nNEW paths not in baseline ({len(new)}):", file=sys.stderr)
             for k in new:
@@ -414,7 +525,7 @@ def main() -> int:
         return 1
 
     print(
-        f"check-bal-class-a-ratchet: OK ({len(rows)} baselined paths; "
+        f"check-bal-class-a-ratchet: OK (debt={len(rows)} baselined paths; "
         f"no new Class-A edges; no silent shrink; "
         f"{annotation_count} sidecar bullet annotations present)"
     )

--- a/scripts/check-region-map.sh
+++ b/scripts/check-region-map.sh
@@ -389,7 +389,7 @@ fi
 echo "check-region-map: region map matches the linked ELF"
 
 # --- Class-A provided-BAL ratchet (#11183) ---
-# Fail on NEW bv_bal_start/len edges or silent baseline shrink. See
+# Fail on NEW supplied-BAL cursor edges or silent baseline shrink. See
 # scripts/check-bal-class-a-ratchet.py and scripts/bal-class-a-baseline.tsv.
 # The ratchet also requires scripts/bal-class-a-notes.md and counts its explicit
 # rationale bullets.


### PR DESCRIPTION
## Summary

Closes #11796.

- Extend the Class-A predicate from `bv_bal_start`/`bv_bal_len` to the supplied-BAL cursor cells `bv_bal_*`, `bsr_bal_*`, and `c1_bal_*` start/len.
- Regenerate the exact-revision census: 4 old emitted paths become 12 baselined emitted paths (8 newly visible paths).
- Add `EXPECTED_CLASS_A_DEBT = 12` as a re-derivable debt ratchet. It records current debt, not a target: a retirement and the corresponding decrease land together; silent increase or shrink fails.
- Add `--self-test`: a planted synthetic `c1_bal_start` read produces the expected FAIL, and removing it returns to OK.
- No guest assembly or classification changes; #11806 remains the guest-assembly lane.

## Reconciling 12 ratchet paths with #11797's 9 live verdict-reaching reads

The counts are different units: the ratchet counts emitted rows, while the nine is the live body-consumer PC population. Seven ratchet rows represent those nine PCs because each `c1` row contains the cursor loads for both the `bal_find_account_by_address` and the following `bal_account_nonstorage_finals` call. The other five TSV rows are three logical non-verdict sites:

| ratchet rows | disposition | explanation |
|---|---|---|
| `.Lbsr_bal_replay` / `load` / `bal_account_record_array` | live | #11797 state-root parser; record status reaches the conservative verdict path |
| `.Lbsr_bal_replay` / `load` / `rlp_walk_init` | outside the 9 | dead/vestigial cursor walk; row values are discarded and only parse/capacity failure can reject |
| `.Lbsr_oao_2935_done` / `load` / `bal_section_info` | live | #11797 state-root parser; status reaches the conservative verdict path |
| `.Lbv_after_tx_gate` / `load` / `bgv_u64le` | outside the 9 | pointer/length binding into the later hash-only handoff; it does not field-read the supplied body |
| `.Lbv_after_tx_gate` / `store` / `bgv_u32le` | outside the 9 | same pointer/length binding/hash-only handoff site |
| `.Lbv_after_tx_gate` / `store` / `bgv_u64le` | outside the 9 | same pointer/length binding/hash-only handoff site |
| `.Lbv_ret` / `store` / `bal_gas_valid_from_builder` | outside the 9 | diagnostic `bv_bal_len` copy; it does not feed a verdict |
| `.Lc1_bd_same_block` / `load` / `bal_find_account_by_address` | live | #11797 builder-deposit fallback; the row also carries the following finals decode |
| `.Lc1_be_same_block` / `load` / `bal_find_account_by_address` | live | #11797 builder-exit fallback; the row also carries the following finals decode |
| `.Lv2_input_hash` / `la` / `bal_section_info` | live | #11797 `stateless_verdict_v2` body parse; failure reaches the verdict failure path |
| `block_state_root_pre_accounts` / `load` / `bal_account_record_array` | live | #11797 pre-accounts parser; record status reaches the conservative verdict path |
| `block_state_root_pre_accounts` / `load` / `bal_section_info` | live | #11797 pre-accounts parser; section status reaches the conservative verdict path |

Thus the 12 is not twelve unsafe body reads: it is 7 live emitted rows covering 9 live PCs plus 5 emitted rows from three explicitly identified non-verdict sites. The ratchet deliberately retains all 12 edges as debt so a future pointer/diagnostic/cursor retirement cannot silently disappear from the census.

## Evidence

Fresh `df80b1efe` guest build and gate:

```text
check-bal-class-a-ratchet: OK (debt=12 baselined paths; no new Class-A edges; no silent shrink; 1 sidecar bullet annotations present)
```

Synthetic gate self-test:

```text
check-bal-class-a-ratchet --self-test: planted synthetic c1_bal_start read
check-bal-class-a-ratchet: FAIL (expected; 1 new Class-A path)
  + synthetic_bal_consumer	la	-	no	la t1, c1_bal_start
check-bal-class-a-ratchet --self-test: synthetic read removed
check-bal-class-a-ratchet: OK (debt=1 synthetic baseline paths; no new Class-A edges)
```

Also passed:

- `python3 -m py_compile scripts/check-bal-class-a-ratchet.py`
- `git diff --check`
