### PR TITLE
docs(codegen): fix false CREATE a0-a2 ABI comment (#11083)

### DIFF
--- a/EvmAsm/Codegen/Programs/ChildFrameCreateTail.lean
+++ b/EvmAsm/Codegen/Programs/ChildFrameCreateTail.lean
@@ -489,12 +489,22 @@ def createUnsupportedTail (netPopBytes : Nat) (hasSalt : Bool) : String :=
     -- CHILD env (switched by the descend). env+32 is LE; reverse to BE, u256_add_be the BE endowment
     -- (create_value_be, still valid — the initcode has not run yet), reverse back. create_creator_newbal
     -- is the BE scratch (free after the gate's creator-debit).
-    -- Save/restore x10/x12/x13 = dispatcher invariants (PC/stack/mem-base), NOT the a0-a2 write
-    -- set. RV ABI: a0=x10, a1=x11, a2=x12 — so setup clobbers x11 too, but x11 is dead across
-    -- this call (nothing reads it after restore; CREATE live set is x10/x12/x13 only). u256_add_be
-    -- itself does not touch x13; x13 is kept for the regional convention and callees that do.
-    -- (#11083: prior text claimed "a0-a2 alias x10/x12/x13", which is false and propagated the
-    -- mismatched CALL save set fixed in #11082.)
+    --
+    -- Save set around `u256_add_be` below is INTENTIONAL and is NOT meant to match the
+    -- helper's a0-a2 write set. This CREATE-tail region uses a regional convention:
+    -- preserve dispatcher invariants x10=PC, x12=stack-top, x13=mem-base across every
+    -- helper call (same pattern as L182/L258/L275 above). Those three are live; restore
+    -- them. RV ABI: a0=x10, a1=x11, a2=x12 — so the `la a0/a1/a2` setup also clobbers
+    -- x11. x11 is DEAD here (CREATE live set is only x10/x12/x13; nothing reads prior
+    -- x11 after restore; `create_frame_descend` already clobbered a0-a7). Do NOT "fix"
+    -- the save set to x10/x11/x12 to match the write set: that would drop x13 for no
+    -- gain, or add a dead x11 slot for hygiene-only churn (#11083). `u256_add_be` itself
+    -- touches x5-7,x10-12,x28-31 only (not x13); x13 stays in the save for the regional
+    -- convention and for callees that do clobber it. Prior text claimed "a0-a2 alias
+    -- x10/x12/x13" — false under RV ABI, and that false claim is what propagated the
+    -- mismatched CALL save set fixed in #11082. The mismatch that remains (save ≠ write
+    -- set) is deliberate invariant preservation, not an oversight.
+    --
     -- drj99.1 (initcode_calls_with_value bv_fail=44): FIRST capture the child's staged PRE-state
     -- balance (env+32 BEFORE the endowment credit, = block-pre balance: 0 for a fresh address) into
     -- nse_create_pre_bal (BE), so the created-account endowment-credit nonstorage record below carries

--- a/EvmAsm/Codegen/Programs/ChildFrameCreateTail.lean
+++ b/EvmAsm/Codegen/Programs/ChildFrameCreateTail.lean
@@ -309,9 +309,10 @@ def createUnsupportedTail (netPopBytes : Nat) (hasSalt : Bool) : String :=
     -- to_other receipt cumulativeGasUsed over-counted by exactly 2500 -> bv_fail=53). The warm
     -- table is a single global (evm_access_account_table, capacity 100000, reset only at tx setup),
     -- so the seed persists across create_frame_descend into the parent's subsequent CALL.
-    -- runtime_access_account_seed inserts WITHOUT charging gas and ignores duplicates; it clobbers
-    -- the a-regs that alias x10/x12/x13, so save/restore them. create_address_be is the canonical
-    -- 20-byte BE address (a0 expects exactly that).
+    -- runtime_access_account_seed inserts WITHOUT charging gas and ignores duplicates; it
+    -- clobbers a0-a3 (x10-x13). Save/restore the dispatcher invariants x10/x12/x13 (PC/stack/
+    -- mem-base); x11 is dead here. create_address_be is the canonical 20-byte BE address
+    -- (a0 expects exactly that).
     "  addi sp, sp, -32\n  sd x10, 0(sp)\n  sd x12, 8(sp)\n  sd x13, 16(sp)\n" ++
     "  la a0, create_address_be\n" ++
     "  la a1, " ++ runtimeAccessAccountTableLabel ++ "\n" ++
@@ -487,7 +488,13 @@ def createUnsupportedTail (netPopBytes : Nat) (hasSalt : Bool) : String :=
     -- address was pre-funded), so add the endowment on top = the EVM "new account balance". x20 = the
     -- CHILD env (switched by the descend). env+32 is LE; reverse to BE, u256_add_be the BE endowment
     -- (create_value_be, still valid — the initcode has not run yet), reverse back. create_creator_newbal
-    -- is the BE scratch (free after the gate's creator-debit). a0-a2 alias x10/x12/x13 -> save/restore.
+    -- is the BE scratch (free after the gate's creator-debit).
+    -- Save/restore x10/x12/x13 = dispatcher invariants (PC/stack/mem-base), NOT the a0-a2 write
+    -- set. RV ABI: a0=x10, a1=x11, a2=x12 — so setup clobbers x11 too, but x11 is dead across
+    -- this call (nothing reads it after restore; CREATE live set is x10/x12/x13 only). u256_add_be
+    -- itself does not touch x13; x13 is kept for the regional convention and callees that do.
+    -- (#11083: prior text claimed "a0-a2 alias x10/x12/x13", which is false and propagated the
+    -- mismatched CALL save set fixed in #11082.)
     -- drj99.1 (initcode_calls_with_value bv_fail=44): FIRST capture the child's staged PRE-state
     -- balance (env+32 BEFORE the endowment credit, = block-pre balance: 0 for a fresh address) into
     -- nse_create_pre_bal (BE), so the created-account endowment-credit nonstorage record below carries


### PR DESCRIPTION
## Summary

Closes #11083 (latent). **Comment-only** — no save-set / ELF change.

### Liveness (proved before push)

CREATE dispatcher live set is **x10=PC, x12=stack, x13=mem-base**. **x11 is dead** across all four sites (L182 / L258 / L275 / L511).

| site | call | save set | verdict |
|--|--|--|--|
| L182 | `latest_nonce_{tx,block}` | x10/x12/x13 | regional convention; x11 dead |
| L258 | `account_read_record` (a0 only) | x10/x12/x13 defensive | correct for context |
| L275 | `account_writes_lookup_current` (a0 only) | same | correct for context |
| L511 `.Lcr_sbc_rev_*` | `u256_add_be` child endowment | x10/x12/x13 | x11 dead; false ABI comment fixed |

Five independent arguments for x11 dead: CREATE live set is only x10/x12/x13; nothing reads prior x11 after restore; `create_frame_descend` clobbers a0–a7 before D; `u256_add_be` footprint is x5–7,x10–12,x28–31 only; #11082 CALL precedent (score-neutral).

### Finding (not just a typo)

Three of four sites are **not** copies of one ABI bug — they are a **regional convention** saving dispatcher invariants across helpers. Only D had the false `a0-a2 alias x10/x12/x13` claim (what propagated the CALL mismatch fixed in #11082).

### Write-set hygiene considered and declined

Aligning the save set to a0–a2 (`x10/x11/x12` as in #11082) was considered and **declined**:
- x11 is dead → adding it is pure churn
- dropping x13 would abandon the regional invariant convention for a helper that happens not to touch x13 today
- latent-issue emit change would buy four-artefact regen + full r200 for **zero correctness gain**

The remaining save≠write-set mismatch is **deliberate** (preserve x10/x12/x13) and is now documented in-source so it is not re-filed.

### Change

`ChildFrameCreateTail.lean` comments only (L312–313 seed path; L490+ child-credit WHY block).

### Test plan

- [x] Liveness re-derived from source + `u256_add_be` prog
- [ ] CI build (comment-only)