### PR TITLE
Parameterize BAAP probe arenas by gas bound

### DIFF
--- a/EvmAsm/Codegen/Programs/BalAccountApplyPostFields.lean
+++ b/EvmAsm/Codegen/Programs/BalAccountApplyPostFields.lean
@@ -893,9 +893,11 @@ def ziskMapAccountApplyPostFieldsDataSection : String :=
   "bsr_builder_result_len:\n  .zero 8\n" ++
   "bsr_builder_value_max:\n  .zero 8\n" ++
   "bsr_builder_witness_value_max:\n  .zero 8\n" ++
-  "baap_storage_desc:\n  .zero 2400000\n" ++
-  "baap_storage_paths:\n  .zero 3840000\n" ++
-  "baap_storage_values:\n  .zero 3840000\nbaap_storage_values_end:\n" ++
+  -- Keep the standalone probe's sibling arenas on the same gas-derived bound
+  -- as the production guest. A capacity raise must move all three together.
+  "baap_storage_desc:\n  .zero " ++ toString (bsrMaxBalItems * baapStorageDescBytes) ++ "\n" ++
+  "baap_storage_paths:\n  .zero " ++ toString (bsrMaxBalItems * bsrPathBytes) ++ "\n" ++
+  "baap_storage_values:\n  .zero " ++ toString (bsrMaxBalItems * bsrPathBytes) ++ "\nbaap_storage_values_end:\n" ++
   "baap_out_pad:\n  .zero 8"
 
 def ziskMapAccountApplyPostFieldsProbeUnit : BuildUnit := {

--- a/EvmAsm/Codegen/RegionPredicates.lean
+++ b/EvmAsm/Codegen/RegionPredicates.lean
@@ -51,8 +51,9 @@
 
   ## ⚠️ Every extent claim names its build unit
 
-  `baap_storage_values` is emitted at three sizes in three units (#11222) and
-  `evm_memory_pool` at two (guest 96 MiB vs a 1 MiB probe emit in
+  `baap_storage_values` is emitted by three units (#11222), with the guest and
+  BAAP probe sharing the gas-derived extent while the descriptor probe is
+  smaller, and `evm_memory_pool` at two (guest 96 MiB vs a 1 MiB probe emit in
   `CallFrameDescend.lean`). A predicate that does not name its unit is false in
   at least one of them. A symbol exists per *image*, not per repository.
 -/
@@ -626,12 +627,12 @@ theorem calleeSeedAbsentSymbols_length : calleeSeedAbsentSymbols.length = 3 := b
     anything beyond the byte range would be asserting something the code does
     not maintain.
 
-    ⛔ **And the extent is unit-dependent (#11222):** the same symbol name is
-    emitted at **three sizes in three units** — guest `6_400_000`
-    (`bsrMaxBalItems * bsrPathBytes`), the `BalAccountApplyPostFields` probe
-    `3_840_000`, and `BalAccountDescriptorArray` `32_768`. An `extent =`
-    theorem is therefore true in `stateless_guest` and **false** in the other
-    two. Closing #11222 (overload vs dead) is required before any single global
+    ⛔ **And the extent remains unit-dependent (#11222):** the same symbol name
+    is emitted by three units — guest and `BalAccountApplyPostFields` probe at
+    `bsrMaxBalItems * bsrPathBytes` (= `6_400_000` today), and
+    `BalAccountDescriptorArray` at `32_768`. An `extent =` theorem is therefore
+    true for the guest and BAAP probe but **false** for the descriptor probe.
+    Closing #11222 (overload vs dead) is required before any single global
     claim; until then the unit must be named at every use, which is why
     `statelessGuest` exists above. Its initialisation contract is
     **self-discharged** — the routine clears the cells in its own entry block
@@ -642,10 +643,11 @@ theorem calleeSeedAbsentSymbols_length : calleeSeedAbsentSymbols.length = 3 := b
 
 /-- The three build units that emit `baap_storage_values`, with the size each
     one uses. Recorded as data so the overload is checkable rather than prose:
-    a predicate naming no unit is wrong in two of these three. -/
+    the guest and BAAP probe are formula-matched; the descriptor probe remains
+    a smaller unit-local arena. -/
 def baapStorageValuesUnitSizes : List (String × Nat) :=
-  [ ("stateless_guest", 6400000),
-    ("BalAccountApplyPostFields probe", 3840000),
+  [ ("stateless_guest", bsrMaxBalItems * bsrPathBytes),
+    ("BalAccountApplyPostFields probe", bsrMaxBalItems * bsrPathBytes),
     ("BalAccountDescriptorArray", 32768) ]
 
 /-- The guest size is the layout formula's, not a literal — so if
@@ -655,10 +657,10 @@ theorem baapStorageValues_guest_size_eq_formula :
     (baapStorageValuesUnitSizes.head?.map (·.2)) = some (bsrMaxBalItems * bsrPathBytes) := by
   decide
 
-/-- ⚠️ The three sizes really are distinct — the overload is not a
-    documentation artifact of one number written three ways. -/
+/-- The guest and BAAP probe now share a size; the descriptor probe remains
+    the distinct small unit-local extent. -/
 theorem baapStorageValues_sizes_distinct :
-    (baapStorageValuesUnitSizes.map (·.2)).eraseDups.length = 3 := by decide
+    (baapStorageValuesUnitSizes.map (·.2)).eraseDups.length = 2 := by decide
 
 /-! ## `bal_canonical_sort` row arrays (GH #10817)
 

--- a/docs/4ch8f-predicate-shapes.md
+++ b/docs/4ch8f-predicate-shapes.md
@@ -89,7 +89,7 @@ Arena-relative (layout-invariant). From `RegionMap.dataUnionChildren`:
 | **Lifetime** | block-root / BAAP apply phase; not a per-tx journal |
 | **Disjointness** | **union child** of `call_frame_arena` — aliases frame slots by phase; aliases sibling baap_* by offset partition only |
 | **Init (slot 9)** | cursor set to base at apply entry (**self-discharged**); values content overwritten as encoded; do not require pre-zero of full 6.4 MiB for correctness of encoding |
-| **UNCLEAN / FINDING `#11222`** | same symbol name emitted at **three sizes in three units**: guest **6_400_000**; `BalAccountApplyPostFields.lean` probe **3_840_000**; `BalAccountDescriptorArray.lean` **32_768**. A predicate `extent = 100000×64` is true in `stateless_guest` and **false** in the other two. **Do not land a predicate without naming the build unit.** Closing `#11222` (overload vs dead) is required before a single global claim |
+| **UNIT-LOCAL EXTENT `#11222`** | same symbol name is emitted by three units: guest and `BalAccountApplyPostFields.lean` probe both use **`bsrMaxBalItems × bsrPathBytes` = 6_400_000**; `BalAccountDescriptorArray.lean` remains **32_768**. A predicate `extent = 100000×64` is true in the guest and BAAP probe and **false** in the descriptor probe. **Do not land a predicate without naming the build unit.** Closing `#11222` (overload vs dead) is required before a single global claim |
 
 ---
 


### PR DESCRIPTION
## Summary

- Parameterize all three standalone `zisk_map_account_apply_post_fields` arenas with the same gas-derived formulas as production:
  - descriptors: `bsrMaxBalItems * baapStorageDescBytes`
  - paths/values: `bsrMaxBalItems * bsrPathBytes`
- Update the unit-size ledger and predicate-shape documentation, retaining the distinct descriptor-probe size caveat.
- The old 60,001 tripwire is obsolete: the standalone probe no longer has a separate 60,000-row composite cap; its three arenas derive from the same `bsrMaxBalItems` bound as production, so a formula-bound change resizes both together.

## Expected layout direction

The probe's zero-initialized groups are routed to `.bss` by `Layout.moveZeroDataToBss`.

- Probe arena total: 10,080,000 -> 16,800,000 bytes (+6,720,000).
- Descriptor delta: +1,600,000 bytes.
- Path delta: +2,560,000 bytes.
- Value delta: +2,560,000 bytes.
- Probe `.data` remains `0x6000da`; probe `.bss` grows `0x1312b08 -> 0x197b508`.
- Production `stateless_guest` ELF is unchanged: baseline and candidate SHA-256 are both `15290f1257cb33543aa16a34b5410c9f3d5c4b010fa481aa652054cecd12c26b`, with identical linked `.text` and section bases/sizes. No production address-pinned `rfl` proof moves.

## Verification

- Four-artifact regeneration completed:
  - `python3 scripts/gen-symbol-addresses.py --build`
  - `python3 scripts/asm_to_program.py guest-addrs`
  - `python3 scripts/guest_image_coverage.py --emit-lean`
  - `python3 scripts/gen-region-map-link-pins.py`
  All generated artifacts were unchanged.
- `lake build`: PASS (4,730 jobs).
- `check-no-warnings.sh`: PASS (0 warnings under `EvmAsm/`).
- `check-asm-to-program.sh`, `check-region-map.sh`, stateless link check, layering, unimported-file, forbidden-tactics, heartbeat-approval, and round-trip coverage checks: PASS.
- Full requested r200: tag `tests-zkevm@v0.6.2`, random seed `4242`, 200 rows, Spike:
  - base: 200/200 full passes, FA=0, FR=0
  - candidate: 200/200 full passes, FA=0, FR=0
  - exact `base-PASS -> candidate-FR` set: `[]`
  - candidate output-difference set: `[]`

The repository A/B comparator intentionally rejects these runs at self-check 0 because this probe-only change produces the same production guest ELF. A byte-identical production ELF is the expected outcome for a probe-only change and is the strongest evidence that the change is confined. The direct paired run comparison above is therefore reported explicitly rather than presenting a vacuous same-artifact A/B verdict.