### PR TITLE
fix(evm64): update Amsterdam cold storage gas

### DIFF
--- a/EvmAsm/Evm64/StorageGas.lean
+++ b/EvmAsm/Evm64/StorageGas.lean
@@ -15,10 +15,11 @@ inductive StorageAccessStatus where
   | warm
   deriving DecidableEq, Repr
 
-/-- Cold SLOAD/storage-key access cost from EIP-2929. -/
-def coldSloadCost : Nat := 2100
+/-- Current Amsterdam cold SLOAD/storage-key access cost
+    (`GasCosts.COLD_STORAGE_ACCESS`). -/
+def coldSloadCost : Nat := 3000
 
-/-- Warm storage read/access cost from EIP-2929. -/
+/-- Current Amsterdam warm storage read/access cost (`GasCosts.WARM_ACCESS`). -/
 def warmStorageReadCost : Nat := 100
 
 /-- Dynamic gas charged for the storage-key access itself. -/
@@ -117,13 +118,13 @@ theorem sstoreDynamicCost_cold (current new : EvmWord) :
   cases status <;> rfl
 
 theorem storageAccessCost_cold_eq :
-    storageAccessCost .cold = 2100 := rfl
+    storageAccessCost .cold = 3000 := rfl
 
 theorem storageAccessCost_warm_eq :
     storageAccessCost .warm = 100 := rfl
 
 theorem sloadDynamicCost_cold_eq :
-    sloadDynamicCost .cold = 2100 := rfl
+    sloadDynamicCost .cold = 3000 := rfl
 
 theorem sloadDynamicCost_warm_eq :
     sloadDynamicCost .warm = 100 := rfl


### PR DESCRIPTION
## Summary

- Update `EvmAsm/Evm64/StorageGas.lean`'s cold storage access cost from 2100 to 3000.
- Restate `storageAccessCost_cold_eq` and `sloadDynamicCost_cold_eq` at 3000; both remain direct `rfl` theorems.
- `StorageAccess.lean` and `StorageAccessOutcome.lean` consume `coldSloadCost` symbolically and were left unchanged.

## Authority

The authority is the external `execution-specs` checkout at commit
`e5a8caf1b8055e4d805c7fb169edfa710914b7da`, not the repository's `SpecRef`
port:

`src/ethereum/forks/amsterdam/vm/gas.py:69` defines
`WARM_ACCESS: Final[Uint] = Uint(100)` and line 71 defines
`COLD_STORAGE_ACCESS: Final[Uint] = Uint(3000)`.

The previous 2100 value was the Shanghai constant, not a typo. This is a
fork-transition miss; other Shanghai-era constants in the same area may need
separate auditing.

The sweep found no remaining 2100-derived numeral in `StorageGas.lean`.
`sstoreColdSurcharge` references `coldSloadCost` symbolically, so it tracks the
updated value automatically. The remaining literals (warm/no-op 100, set
20000, reset 5000) are independent constants.

## Scope and validation

This changes Evm64 model code only; it does not change emitted guest assembly.
Therefore no guest regeneration or r200 was run or is owed.

Validation: full clean `lake build` passed all 4744 jobs, and `git diff --check`
passed.
