### PR TITLE
feat(evm64): split SSTORE set gas cost

### DIFF
--- a/EvmAsm/Evm64/StorageGas.lean
+++ b/EvmAsm/Evm64/StorageGas.lean
@@ -5,6 +5,7 @@
 -/
 
 import EvmAsm.Evm64.EvmWord
+import EvmAsm.Evm64.GasCost
 
 namespace EvmAsm.Evm64
 namespace StorageGas
@@ -34,8 +35,16 @@ def sloadDynamicCost (status : StorageAccessStatus) : Nat :=
 /-- Warm SSTORE no-op cost: writing the same value charges a warm storage read. -/
 def sstoreNoopCost : Nat := warmStorageReadCost
 
-/-- Warm SSTORE cost when a zero slot is set to a nonzero value. -/
-def sstoreSetCost : Nat := 20000
+/-- Warm SSTORE cost when a zero slot is set to a nonzero value.
+
+The regular component is `GasCosts.STORAGE_WRITE` from
+`execution-specs/src/ethereum/forks/amsterdam/vm/gas.py:73-75`; the state
+component is `StateGasCosts.STORAGE_SET` from
+`execution-specs/src/ethereum/forks/amsterdam/vm/gas.py:40-46`, namely 64
+state bytes at 1,530 gas per byte. -/
+def sstoreSetCost : GasCost :=
+  { regular := 10000
+    state := 64 * 1530 }
 
 /-- Warm SSTORE cost when a nonzero slot is written to a different value. -/
 def sstoreResetCost : Nat := 10000
@@ -50,7 +59,7 @@ def sstoreWriteCost (current new : EvmWord) : Nat :=
   if new = current then
     sstoreNoopCost
   else if current = 0 then
-    sstoreSetCost
+    sstoreSetCost.regular
   else
     sstoreResetCost
 
@@ -85,7 +94,7 @@ theorem sstoreWriteCost_noop (current : EvmWord) :
   simp [sstoreWriteCost]
 
 theorem sstoreWriteCost_set {new : EvmWord} (h_new : new ≠ 0) :
-    sstoreWriteCost 0 new = sstoreSetCost := by
+    sstoreWriteCost 0 new = sstoreSetCost.regular := by
   unfold sstoreWriteCost
   split
   · contradiction
@@ -132,8 +141,9 @@ theorem sloadDynamicCost_warm_eq :
 theorem sstoreNoopCost_eq :
     sstoreNoopCost = 100 := rfl
 
-theorem sstoreSetCost_eq :
-    sstoreSetCost = 20000 := rfl
+theorem sstoreSetCost_components :
+    sstoreSetCost.regular = 10000 ∧ sstoreSetCost.state = 97920 := by
+  constructor <;> rfl
 
 theorem sstoreResetCost_eq :
     sstoreResetCost = 10000 := rfl


### PR DESCRIPTION
## Summary

- Migrate `sstoreSetCost` to the paired `GasCost` model from #11860.
- Set the regular component to 10,000 (`GasCosts.STORAGE_WRITE`) and the
  state component to 97,920 (`64 * 1,530`, `StateGasCosts.STORAGE_SET`).
- Preserve the existing regular-gas API by taking `.regular` in
  `sstoreWriteCost`; `StorageAccess.lean` and `StorageAccessOutcome.lean`
  therefore continue to consume a `Nat` and do not propagate the pair.

The pinned Amsterdam sources provide the two dimensions independently:
`execution-specs/src/ethereum/forks/amsterdam/vm/gas.py:73-75` for the
regular component and `:40-46` for the state component.

## Theorem decision

The former `sstoreSetCost_eq : sstoreSetCost = 20000` theorem no longer
described surviving code: there is no single total. It is replaced by
`sstoreSetCost_components`, which pins both named dimensions (`regular =
10000` and `state = 97920`). The `sstoreWriteCost_set` theorem is likewise
restated against the regular projection used by its caller.

## Verification

- Base: `ab91aba16` (merged #11860).
- `lake build` — passed (4726 jobs).
- `scripts/check-unimported.sh` — 2756 modules, 2756 reachable, 0 orphans.
- `git diff --check` — clean.
- Model-only change: no Codegen regeneration and no random-200 run.

Refs #11859.
