### PR TITLE
docs(readme): call for an external Lean spec of the stateless guest

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,38 @@ followed by `~/.zisk/bin/ziskup --nokey -y` to skip the proving-key
 download (we only need the emulator). Codegen also has an `--asm-only`
 mode for CI hosts without the cross toolchain.
 
+### Wanted: an external Lean specification of the stateless guest
+
+evm-asm currently uses an **internal, untrusted** Lean specification of the
+stateless guest, under
+[`EvmAsm/Stateless/SpecRef/`](EvmAsm/Stateless/SpecRef). Because it is our own
+port, using it to justify spec alignment is circular — it can drift from
+upstream, and a defect in the port would be invisible to any proof that cites
+it.
+
+**We are looking for an external Lean specification of the stateless guest.**
+It should:
+
+1. Specify the **Amsterdam** stateless guest, tracking the
+   [`zkevm-tests` branch of `execution-specs`](https://github.com/ethereum/execution-specs/tree/zkevm-tests)
+   and updated regularly as that branch moves.
+2. For any input, specify a **set of allowed outputs** that a stateless guest
+   may produce — not a single output, since the guest is permitted latitude the
+   spec does not fix.
+3. For every test case in
+   [EEST](https://github.com/ethereum/execution-spec-tests), make that allowed
+   set a **singleton**, coinciding with the output EEST expects.
+4. For **any** byte string as input, make the allowed set contain the output of
+   `run_stateless_guest` as implemented in
+   [`execution-specs`](https://github.com/ethereum/execution-specs).
+
+Conditions 3 and 4 pull in opposite directions on purpose: 3 pins the spec to
+observed consensus behaviour where tests exist, while 4 keeps it honest on the
+inputs no test covers — which is where a stateless guest is most likely to be
+wrong.
+
+If you are interested in producing such a specification, please open an issue.
+
 ### Stateless-guest scaffold (currently **unproved**)
 
 `EvmAsm/Codegen/Programs.lean` (and the submodules under

--- a/README.md
+++ b/README.md
@@ -295,8 +295,6 @@ that imports your specification and `SpecRef`, and seeks to prove that
 `SpecRef`'s output is one of the allowed outputs according to your
 specification.
 
-If you are interested in producing such a specification, please open an issue.
-
 ### Stateless-guest scaffold (currently **unproved**)
 
 `EvmAsm/Codegen/Programs.lean` (and the submodules under

--- a/README.md
+++ b/README.md
@@ -275,8 +275,9 @@ It should:
    [`zkevm-tests` branch of `execution-specs`](https://github.com/ethereum/execution-specs/tree/zkevm-tests)
    and updated regularly as that branch moves.
 2. For any input, specify a **set of allowed outputs** that a stateless guest
-   may produce — not a single output, since the guest is permitted latitude the
-   spec does not fix.
+   may produce — not necessarily a single output, since existing stateless
+   guests perform differently on non-canonical inputs (e.g. an MPT containing
+   more than 64 nibbles in a path).
 3. For every test case in
    [EEST](https://github.com/ethereum/execution-spec-tests), make that allowed
    set a **singleton**, coinciding with the output EEST expects.
@@ -288,6 +289,11 @@ Conditions 3 and 4 pull in opposite directions on purpose: 3 pins the spec to
 observed consensus behaviour where tests exist, while 4 keeps it honest on the
 inputs no test covers — which is where a stateless guest is most likely to be
 wrong.
+
+If you have such a specification, we are interested in creating another repo
+that imports your specification and `SpecRef`, and seeks to prove that
+`SpecRef`'s output is one of the allowed outputs according to your
+specification.
 
 If you are interested in producing such a specification, please open an issue.
 


### PR DESCRIPTION
Adds a section to `README.md` stating that evm-asm is looking for an **external** Lean specification of the stateless guest.

## Why

We currently rely on an internal, untrusted Lean specification under `EvmAsm/Stateless/SpecRef/`. It is our own port, so **citing it to justify spec alignment is circular** — it can drift from upstream, and a defect in the port is invisible to any proof that cites it.

## What the section asks for

1. Specifies the **Amsterdam** stateless guest, tracking the `zkevm-tests` branch of `execution-specs`, updated as that branch moves.
2. For any input, specifies a **set** of allowed outputs rather than a single output.
3. For every EEST test case, that set is a **singleton** coinciding with EEST's output.
4. For **any** byte string, the set **contains** the output of `run_stateless_guest`.

Conditions 3 and 4 pull in opposite directions on purpose: 3 pins the spec to observed consensus behaviour where tests exist, 4 keeps it honest on the inputs no test covers — which is where a stateless guest is most likely to be wrong.

Docs only: no Lean, no emitted assembly, no regeneration and no r200 owed.
