### PR TITLE
fix(ci): allow fork PR head checkout in PR Summary (#10703)

### DIFF
--- a/.github/workflows/summary.yml
+++ b/.github/workflows/summary.yml
@@ -27,6 +27,12 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
+          # Required by actions/checkout when pull_request_target checks out a
+          # fork PR head (GH #10703). This workflow already refuses to execute
+          # PR-head scripts: progress-delta.sh is overwritten from the trusted
+          # base blob before run (see security note in the next step). Opt-in
+          # restores fork-PR summaries; it does not widen script execution.
+          allow-unsafe-pr-checkout: true
 
       - name: Compute deterministic progress delta
         id: progress_delta


### PR DESCRIPTION
## Summary
- Set `allow-unsafe-pr-checkout: true` on the PR Summary checkout step so fork PRs are not refused by modern `actions/checkout`.
- Existing hardening kept: `progress-delta.sh` is overwritten from the trusted **base** blob before execution (no PR-head script run with the privileged token).

Closes #10703

## Test plan
- [ ] Open/sync a fork PR and confirm summarize job passes checkout
- [x] Diff-only change; no guest impact