### PR TITLE
Assert gen-symbol-addresses build output exists

### DIFF
--- a/scripts/gen-symbol-addresses.py
+++ b/scripts/gen-symbol-addresses.py
@@ -90,7 +90,12 @@ def build_elf(prog, elf_dir):
     subprocess.run(
         ["lake", "exe", "codegen", "--program", prog, "--halt", "linux93", "-o", prefix],
         cwd=REPO, check=True)
-    return prefix + ".elf"
+    elf = prefix + ".elf"
+    if not os.path.isfile(elf) or os.path.getsize(elf) == 0:
+        raise RuntimeError(
+            f"codegen exited successfully but did not produce a non-empty ELF: {elf}"
+        )
+    return elf
 
 
 def section_of(addr, headers):


### PR DESCRIPTION
Fixes #11004.

`gen-symbol-addresses.py --build` now verifies that the codegen command produced a non-empty `${elf_dir}/${prog}.elf` before invoking readelf. A successful driver command with no ELF now fails at the source with the missing artifact path instead of sending a downstream readelf/linker investigation.

Demonstrated detection:
- fake successful `lake` with no ELF: exits 1 with `did not produce a non-empty ELF`;
- fake successful `lake` with a valid ELF already present: passes the assertion and completes symbol extraction.
- `python3 -m py_compile scripts/gen-symbol-addresses.py`; `git diff --check`.

Scripts-only; no regen and no r200.