### PR TITLE
ci: report parallel gate coverage and skips

### DIFF
--- a/scripts/check-build-parallel.sh
+++ b/scripts/check-build-parallel.sh
@@ -57,36 +57,43 @@ report_checks() {
 }
 
 start codegen codegen_checks
-start guestaddrs-starts scripts/check-guestaddrs-starts.sh
-start asm-to-program scripts/check-asm-to-program.sh
+start guestaddrs-starts run_step scripts/check-guestaddrs-starts.sh
+start asm-to-program run_step scripts/check-asm-to-program.sh
 start reports report_checks
-start axioms scripts/check-axioms.sh
-start arithmetic-fuzz scripts/fuzz-arith-diff.sh
+start axioms run_step scripts/check-axioms.sh
+start arithmetic-fuzz run_step scripts/fuzz-arith-diff.sh
 
 status=0
 for i in "${!pids[@]}"; do
   name="${names[$i]}"
   lane_status=PASS
+  child_failed=0
   if ! wait "${pids[$i]}"; then
-    lane_status=FAIL
+    child_failed=1
     status=1
   fi
 
   log="$work/$name.log"
   steps="$(grep -c '^CHECK_BUILD_PARALLEL_STEP ' "$log" || true)"
-  skips="$(grep -Eic '(^|[^[:alpha:]])(skip|skipping)([^[:alpha:]]|$)' "$log" || true)"
+  # These are the deliberate, machine-readable skip lines emitted by the
+  # current child gates. Do not grep for the word "skip" anywhere: region-map
+  # also has prose about skipped sub-checks, and an unrelated filename or
+  # informational sentence must not turn a passing lane into a false failure.
+  skips="$(grep -Eic '^check-build-units-link: SKIP|^check-(guarded-handler-bytes|asm-to-program): .*skipping \(install to enable\)|^[[:space:]]+SKIP emitted-reality|^[[:space:]]+skip Class-A BAL ratchet' "$log" || true)"
   expected="${expected_steps[$name]}"
 
-  if [[ "$lane_status" == PASS && "$skips" -gt 0 ]]; then
+  if [[ "$steps" -ne "$expected" ]]; then
+    # set -e can stop a lane before its later children start. Report that loss
+    # of coverage explicitly even when the child that stopped it failed.
+    lane_status=INCOMPLETE
+    status=1
+  elif [[ "$child_failed" -eq 1 ]]; then
+    lane_status=FAIL
+  elif [[ "$skips" -gt 0 ]]; then
     # A child gate may intentionally return zero after deciding it cannot run.
     # That is not evidence for a green aggregate: make the third state visible
     # and fail the wrapper so CI cannot mistake it for a completed lane.
     lane_status=SKIP
-    status=1
-  elif [[ "$lane_status" == PASS && "$steps" -ne "$expected" ]]; then
-    # set -e can stop a lane before its later children start. Report that loss
-    # of coverage explicitly even when a future child changes its exit policy.
-    lane_status=INCOMPLETE
     status=1
   fi
 

--- a/scripts/check-build-parallel.sh
+++ b/scripts/check-build-parallel.sh
@@ -9,6 +9,14 @@ trap 'rm -rf "$work"' EXIT
 
 names=()
 pids=()
+declare -A expected_steps=(
+  [codegen]=5
+  [guestaddrs-starts]=1
+  [asm-to-program]=1
+  [reports]=3
+  [axioms]=1
+  [arithmetic-fuzz]=1
+)
 
 start() {
   local name="$1"
@@ -18,27 +26,34 @@ start() {
   pids+=("$!")
 }
 
+run_step() {
+  printf 'CHECK_BUILD_PARALLEL_STEP'
+  printf ' %q' "$@"
+  printf '\n'
+  "$@"
+}
+
 codegen_checks() {
-  scripts/codegen-stateless-link-check.sh --no-build
+  run_step scripts/codegen-stateless-link-check.sh --no-build
   # GH #10637: the line above links stateless_guest ONLY, so a unit that mirrors
   # guest handlers can reference an undefined symbol with every gate green.
-  scripts/check-build-units-link.sh
-  scripts/check-region-map.sh
+  run_step scripts/check-build-units-link.sh
+  run_step scripts/check-region-map.sh
   # check-region-map compares the DECLARED map against the ELF, so a region that
   # is not declared is not checked. Three in-use anchors were dropped from
   # RegionMap by a merge resolution with every gate green; this asserts the
   # missing invariant (declared anchor => has a region entry). Pure grep, instant.
-  scripts/check-memorylayout-region-coverage.sh
-  scripts/check-guarded-handler-bytes.sh
+  run_step scripts/check-memorylayout-region-coverage.sh
+  run_step scripts/check-guarded-handler-bytes.sh
 }
 
 report_checks() {
-  scripts/check-progress.sh
-  scripts/check-drift.sh
+  run_step scripts/check-progress.sh
+  run_step scripts/check-drift.sh
   # #11637: row EXISTENCE, which nothing gated before -- every other registry
   # invariant quantifies over rows that are already there, so a linked, proven
   # routine with no row at all tripped nothing. Pure source scan, instant.
-  scripts/check-registry-coverage.py
+  run_step scripts/check-registry-coverage.py
 }
 
 start codegen codegen_checks
@@ -51,13 +66,38 @@ start arithmetic-fuzz scripts/fuzz-arith-diff.sh
 status=0
 for i in "${!pids[@]}"; do
   name="${names[$i]}"
-  if wait "${pids[$i]}"; then
-    echo "==> $name: PASS"
-  else
-    echo "==> $name: FAIL" >&2
+  lane_status=PASS
+  if ! wait "${pids[$i]}"; then
+    lane_status=FAIL
     status=1
   fi
-  sed "s/^/[$name] /" "$work/$name.log"
+
+  log="$work/$name.log"
+  steps="$(grep -c '^CHECK_BUILD_PARALLEL_STEP ' "$log" || true)"
+  skips="$(grep -Eic '(^|[^[:alpha:]])(skip|skipping)([^[:alpha:]]|$)' "$log" || true)"
+  expected="${expected_steps[$name]}"
+
+  if [[ "$lane_status" == PASS && "$skips" -gt 0 ]]; then
+    # A child gate may intentionally return zero after deciding it cannot run.
+    # That is not evidence for a green aggregate: make the third state visible
+    # and fail the wrapper so CI cannot mistake it for a completed lane.
+    lane_status=SKIP
+    status=1
+  elif [[ "$lane_status" == PASS && "$steps" -ne "$expected" ]]; then
+    # set -e can stop a lane before its later children start. Report that loss
+    # of coverage explicitly even when a future child changes its exit policy.
+    lane_status=INCOMPLETE
+    status=1
+  fi
+
+  if [[ "$lane_status" == PASS ]]; then
+    echo "==> $name: PASS (steps=$steps/$expected, skips=$skips)"
+  elif [[ "$lane_status" == FAIL ]]; then
+    echo "==> $name: FAIL (steps=$steps/$expected, skips=$skips)" >&2
+  else
+    echo "==> $name: $lane_status (steps=$steps/$expected, skips=$skips)" >&2
+  fi
+  sed "s/^/[$name] /" "$log"
 done
 
 exit "$status"


### PR DESCRIPTION
Fixes #10959.

The parallel post-build wrapper now records every child gate start, reports each lane's completed/expected step count, and counts skip messages. A lane with a zero-exit skip is reported as SKIP and makes the aggregate fail; a lane that stops before its declared set is reported as INCOMPLETE. This prevents a green aggregate from being mistaken for full coverage.

Verification:
- bash -n scripts/check-build-parallel.sh
- git diff --check

Scripts-only; no regeneration and no r200.