### PR TITLE
ci: serialize concurrent build and regen drivers

### DIFF
--- a/scripts/check-axioms.sh
+++ b/scripts/check-axioms.sh
@@ -70,6 +70,10 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$ROOT"
 
+if [[ "${EVMASM_BUILD_LOCK_HELD:-0}" != 1 ]]; then
+  exec scripts/lib/worktree-build-lock.sh "$0" "$@"
+fi
+
 PROGRESS_LEAN="EvmAsm/Progress.lean"
 ROUTINES_LEAN="EvmAsm/Progress/Routines.lean"
 CORRESPOND_LEAN="EvmAsm/Progress/Correspondence.lean"

--- a/scripts/check-build-parallel.sh
+++ b/scripts/check-build-parallel.sh
@@ -4,6 +4,10 @@ set -euo pipefail
 
 cd "$(dirname "$0")/.."
 
+if [[ "${EVMASM_BUILD_LOCK_HELD:-0}" != 1 ]]; then
+  exec scripts/lib/worktree-build-lock.sh "$0" "$@"
+fi
+
 work="$(mktemp -d)"
 trap 'rm -rf "$work"' EXIT
 

--- a/scripts/check-guarded-handler-bytes.sh
+++ b/scripts/check-guarded-handler-bytes.sh
@@ -8,6 +8,11 @@
 # project (the render runs the real Lean elaborator).
 set -euo pipefail
 cd "$(dirname "$0")/.."
+
+if [[ "${EVMASM_BUILD_LOCK_HELD:-0}" != 1 ]]; then
+  exec scripts/lib/worktree-build-lock.sh "$0" "$@"
+fi
+
 if ! command -v riscv64-unknown-elf-as >/dev/null 2>&1 \
    && ! command -v riscv64-elf-as >/dev/null 2>&1; then
   echo "check-guarded-handler-bytes: no riscv64-{unknown-,}elf-as found; skipping (install to enable)"

--- a/scripts/check-region-map.sh
+++ b/scripts/check-region-map.sh
@@ -38,6 +38,10 @@
 set -euo pipefail
 cd "$(dirname "$0")/.."
 
+if [[ "${EVMASM_BUILD_LOCK_HELD:-0}" != 1 ]]; then
+  exec scripts/lib/worktree-build-lock.sh "$0" "$@"
+fi
+
 die_missing() {
   echo "check-region-map: missing required command: $1" >&2
   exit 2

--- a/scripts/codegen-eest-stateless-check.sh
+++ b/scripts/codegen-eest-stateless-check.sh
@@ -145,6 +145,10 @@ INVOCATION_CWD="$PWD"
 cd "$(dirname "$0")/.."
 REPO_ROOT="$(pwd)"
 
+if [[ "${EVMASM_BUILD_LOCK_HELD:-0}" != 1 ]]; then
+  exec scripts/lib/worktree-build-lock.sh "$0" "$@"
+fi
+
 # ziskemu startup accelerator (options-only; no zisk/ziskemu change required).
 # Every `ziskemu --elf` re-runs the full RISC-V->ZisK transpile of the ~447MB
 # stateless_guest ELF (~56.7M instructions); that ELF->ROM build dominates

--- a/scripts/codegen-force-relink.sh
+++ b/scripts/codegen-force-relink.sh
@@ -4,6 +4,11 @@
 # content, while each probe ELF is emitted anew by `lake exe codegen`.
 set -euo pipefail
 cd "$(dirname "$0")/.."
+
+if [[ "${EVMASM_BUILD_LOCK_HELD:-0}" != 1 ]]; then
+  exec scripts/lib/worktree-build-lock.sh "$0" "$@"
+fi
+
 if [[ "${CODEGEN_RELINKED_SESSION:-}" == 1 ]]; then
   [[ -x .lake/build/bin/codegen ]] || {
     echo "codegen relink session has no executable" >&2

--- a/scripts/codegen-stateless-link-check.sh
+++ b/scripts/codegen-stateless-link-check.sh
@@ -9,6 +9,10 @@ set -euo pipefail
 
 cd "$(dirname "$0")/.."
 
+if [[ "${EVMASM_BUILD_LOCK_HELD:-0}" != 1 ]]; then
+  exec scripts/lib/worktree-build-lock.sh "$0" "$@"
+fi
+
 OUT_PREFIX="${CODEGEN_STATELESS_LINK_OUT:-gen-out/stateless-link-check/stateless_guest}"
 NO_BUILD=0
 

--- a/scripts/fuzz-arith-diff.sh
+++ b/scripts/fuzz-arith-diff.sh
@@ -38,6 +38,10 @@ set -euo pipefail
 
 cd "$(dirname "$0")/.."
 
+if [[ "${EVMASM_BUILD_LOCK_HELD:-0}" != 1 ]]; then
+  exec scripts/lib/worktree-build-lock.sh "$0" "$@"
+fi
+
 CORPUS="tests/fuzz-corpus/arith/corpus.jsonl"
 SPECS_DIR="execution-specs"
 ORACLE="$(pwd)/scripts/fuzz_arith_oracle.py"

--- a/scripts/gen-symbol-addresses.py
+++ b/scripts/gen-symbol-addresses.py
@@ -32,6 +32,11 @@ import subprocess
 import sys
 
 REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+LOCK_HELPER = os.path.join(REPO, "scripts", "lib", "worktree-build-lock.sh")
+
+if os.environ.get("EVMASM_BUILD_LOCK_HELD") != "1":
+    os.execv(LOCK_HELPER, [LOCK_HELPER, sys.executable, __file__, *sys.argv[1:]])
+
 # stateless_guest is the single fully-linked guest ELF. The runtime dispatcher
 # and the ~873 *Function routines are spliced INTO it (they are NOT independently
 # linkable: `runtime_dispatcher` alone has undefined cross-unit references), so

--- a/scripts/lib/worktree-build-lock.sh
+++ b/scripts/lib/worktree-build-lock.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Serialize build/codegen drivers that write a worktree's Lake artefacts.
+#
+# The lock lives outside the worktree: artifact-cache materialisation can make
+# .lake/build read-only, and a lock file there would turn that environmental
+# condition into a second failure mode. flock releases it automatically when
+# the driver exits, including on a crash.
+set -euo pipefail
+
+if [[ $# -eq 0 ]]; then
+  echo "usage: $0 COMMAND [ARG ...]" >&2
+  exit 2
+fi
+
+command -v flock >/dev/null 2>&1 || {
+  echo "worktree-build-lock: required command 'flock' is missing" >&2
+  exit 2
+}
+
+repo_root="$(cd "$(dirname "$0")/../.." && pwd -P)"
+lock_dir="${EVMASM_BUILD_LOCK_DIR:-${TMPDIR:-/tmp}}"
+lock_key="$(printf '%s' "$repo_root" | sha256sum | cut -c1-16)"
+lock_file="${EVMASM_BUILD_LOCK_FILE:-$lock_dir/evm-asm-build-$lock_key.lock}"
+mkdir -p "$(dirname "$lock_file")"
+
+exec 9>"$lock_file"
+if ! flock -n 9; then
+  echo "worktree-build-lock: another build/regen driver is already running" >&2
+  echo "  worktree: $repo_root" >&2
+  echo "  lock:     $lock_file" >&2
+  echo "  wait for it to finish before retrying" >&2
+  exit 75
+fi
+
+echo "==> acquired worktree build lock: $lock_file"
+EVMASM_BUILD_LOCK_HELD=1 "$@"


### PR DESCRIPTION
Fixes #11060.

Add a per-worktree advisory flock for build/codegen drivers. The lock file is keyed by the canonical worktree path and lives under /tmp (or EVMASM_BUILD_LOCK_FILE), so artifact-cache read-only .lake trees are not modified. A second driver exits 75 with the worktree and lock path instead of interleaving writes.

The parallel post-build wrapper acquires the lock once and propagates the held state to its lanes; direct codegen, layout, axiom, arithmetic, EEST, and relink drivers acquire it themselves.

Verification:
- contention test: second driver exits 75 with the diagnostic
- gen-symbol-addresses.py --help passes through the lock
- bash -n on all modified shell scripts
- python3 -m py_compile scripts/gen-symbol-addresses.py
- git diff --check

Scripts-only; no regeneration and no r200.