### PR TITLE
ci: diagnose read-only lake cache failures

### DIFF
--- a/scripts/check-build-units-link.sh
+++ b/scripts/check-build-units-link.sh
@@ -101,7 +101,8 @@ fail=0
 for u in $UNITS; do
   rm -f "$OUT/$u.elf"
   log="$OUT/$u.log"
-  lake exe codegen --program "$u" --halt linux93 -o "$OUT/$u" >"$log" 2>&1
+  scripts/lib/lake-cache-diagnostic.sh lake exe codegen --program "$u" \
+    --halt linux93 -o "$OUT/$u" >"$log"
 
   # The ELF's EXISTENCE is the check. codegen can exit 0 having written only the
   # .s/.o, which is the whole failure mode this script exists to catch -- so do not

--- a/scripts/check-guarded-handler-bytes.sh
+++ b/scripts/check-guarded-handler-bytes.sh
@@ -15,6 +15,7 @@ if ! command -v riscv64-unknown-elf-as >/dev/null 2>&1 \
 fi
 if [[ ! -f gen-out/regionmap/stateless_guest.elf ]]; then
   echo "==> gen-out/regionmap/stateless_guest.elf missing; emitting"
-  lake exe codegen --program stateless_guest --halt linux93 -o gen-out/regionmap/stateless_guest
+  scripts/lib/lake-cache-diagnostic.sh lake exe codegen --program stateless_guest \
+    --halt linux93 -o gen-out/regionmap/stateless_guest
 fi
 exec python3 scripts/check_guarded_handler_bytes.py

--- a/scripts/check-no-warnings.sh
+++ b/scripts/check-no-warnings.sh
@@ -61,7 +61,7 @@ if [[ -z "$log_file" ]]; then
   # exit code if it happened, since a failed build may produce spurious
   # or missing warning output.
   set +e
-  lake build 2>&1 | tee "$log_file"
+  scripts/lib/lake-cache-diagnostic.sh lake build 2>&1 | tee "$log_file"
   build_status=${PIPESTATUS[0]}
   set -e
   if (( build_status != 0 )); then

--- a/scripts/check-region-map.sh
+++ b/scripts/check-region-map.sh
@@ -76,7 +76,8 @@ ELF="$ELF_DIR/stateless_guest.elf"
 mkdir -p "$ELF_DIR"
 if [[ "${NO_BUILD:-0}" != "1" || ! -f "$ELF" ]]; then
   echo "==> emit stateless_guest ELF"
-  lake exe codegen --program stateless_guest --halt linux93 -o "$ELF_DIR/stateless_guest" >/dev/null
+  scripts/lib/lake-cache-diagnostic.sh lake exe codegen --program stateless_guest \
+    --halt linux93 -o "$ELF_DIR/stateless_guest" >/dev/null
 fi
 
 fail=0

--- a/scripts/codegen-eest-stateless-check.sh
+++ b/scripts/codegen-eest-stateless-check.sh
@@ -813,18 +813,20 @@ if [[ "$NO_BUILD" -eq 0 ]]; then
   build_targets=(codegen)
   [[ "$SPECREF_ORACLE" -eq 1 ]] && build_targets+=(specref-eest-check)
   echo "==> lake build ${build_targets[*]}"
-  lake build "${build_targets[@]}"
+  scripts/lib/lake-cache-diagnostic.sh lake build "${build_targets[@]}"
 
   if [[ -n "$BSR_WITNESS_CAP" || -n "$BSR_BAL_CAP" ]]; then
     cap_note=""
     [[ -n "$BSR_WITNESS_CAP" ]] && cap_note="bsr_witness_cap=$BSR_WITNESS_CAP"
     [[ -n "$BSR_BAL_CAP" ]] && cap_note="${cap_note:+$cap_note, }bsr_bal_cap=$BSR_BAL_CAP"
     echo "==> emit stateless_guest assembly (experimental $cap_note)"
-    lake exe codegen --program stateless_guest --halt linux93 -o "$GUEST_PREFIX" --asm-only
+    scripts/lib/lake-cache-diagnostic.sh lake exe codegen --program stateless_guest \
+      --halt linux93 -o "$GUEST_PREFIX" --asm-only
     patch_bsr_caps_and_relink
   else
     echo "==> emit stateless_guest ELF"
-    lake exe codegen --program stateless_guest --halt linux93 -o "$GUEST_PREFIX"
+    scripts/lib/lake-cache-diagnostic.sh lake exe codegen --program stateless_guest \
+      --halt linux93 -o "$GUEST_PREFIX"
   fi
 else
   echo "==> skipping build (--no-build)"
@@ -1208,7 +1210,8 @@ ensure_verdict_debug_probe() {
     [[ -n "$BSR_WITNESS_CAP" ]] && cap_note="bsr_witness_cap=$BSR_WITNESS_CAP"
     [[ -n "$BSR_BAL_CAP" ]] && cap_note="${cap_note:+$cap_note, }bsr_bal_cap=$BSR_BAL_CAP"
     echo "==> emit verdict debug probe (experimental $cap_note)" >&2
-    lake exe codegen --program zisk_stateless_verdict_v2 --halt linux93 -o "$prefix" --asm-only >/dev/null
+    scripts/lib/lake-cache-diagnostic.sh lake exe codegen \
+      --program zisk_stateless_verdict_v2 --halt linux93 -o "$prefix" --asm-only >/dev/null
     patch_bsr_caps_asm "$asm"
     as_tool="$(resolve_riscv_tool RISCV_AS riscv64-unknown-elf-as riscv64-elf-as)"
     ld_tool="$(resolve_riscv_tool RISCV_LD riscv64-unknown-elf-ld riscv64-elf-ld)"
@@ -1219,7 +1222,8 @@ ensure_verdict_debug_probe() {
       -nostdlib --no-relax -o "$VERDICT_DEBUG_ELF" "$obj"
   else
     echo "==> emit verdict debug probe" >&2
-    lake exe codegen --program zisk_stateless_verdict_v2 --halt linux93 -o "$prefix" >/dev/null
+    scripts/lib/lake-cache-diagnostic.sh lake exe codegen \
+      --program zisk_stateless_verdict_v2 --halt linux93 -o "$prefix" >/dev/null
   fi
 }
 

--- a/scripts/codegen-stateless-link-check.sh
+++ b/scripts/codegen-stateless-link-check.sh
@@ -49,11 +49,12 @@ mkdir -p "$(dirname "$OUT_PREFIX")"
 
 if [[ "$NO_BUILD" -eq 0 ]]; then
   echo "==> lake build codegen"
-  lake build codegen
+  scripts/lib/lake-cache-diagnostic.sh lake build codegen
 fi
 
 echo "==> emit and link stateless_guest ELF"
-lake exe codegen --program stateless_guest --halt linux93 -o "$OUT_PREFIX"
+scripts/lib/lake-cache-diagnostic.sh lake exe codegen --program stateless_guest \
+  --halt linux93 -o "$OUT_PREFIX"
 
 if [[ ! -s "${OUT_PREFIX}.elf" ]]; then
   echo "missing linked ELF: ${OUT_PREFIX}.elf" >&2

--- a/scripts/eest-specref-check.sh
+++ b/scripts/eest-specref-check.sh
@@ -207,7 +207,7 @@ echo "==> SpecRef EEST conformance check (reference model, no ziskemu, jobs=$JOB
 # --- build the Lean exe -----------------------------------------------------
 if [[ "$NO_BUILD" -eq 0 ]]; then
   echo "==> lake build specref-eest-check"
-  lake build specref-eest-check
+  scripts/lib/lake-cache-diagnostic.sh lake build specref-eest-check
 else
   echo "==> skipping build (--no-build)"
 fi

--- a/scripts/gen-symbol-addresses.py
+++ b/scripts/gen-symbol-addresses.py
@@ -38,6 +38,8 @@ REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 # every function entry + data arena base the .9.3 wave needs is a symbol here.
 DEFAULT_PROGS = ["stateless_guest"]
 OUT_TSV = os.path.join(REPO, "scripts", "asm-fixtures", "symbol-addresses.tsv")
+LAKE_CACHE_DIAGNOSTIC = os.path.join(
+    REPO, "scripts", "lib", "lake-cache-diagnostic.sh")
 
 # STABLE absolute bases, mirroring EvmAsm/Codegen/RegionMap.lean stableGuestBases.
 # (symbol -> address). Keep in sync with RegionMap.schemeAAnchors + section bases.
@@ -88,7 +90,8 @@ def which_readelf():
 def build_elf(prog, elf_dir):
     prefix = os.path.join(elf_dir, prog)
     subprocess.run(
-        ["lake", "exe", "codegen", "--program", prog, "--halt", "linux93", "-o", prefix],
+        [LAKE_CACHE_DIAGNOSTIC, "lake", "exe", "codegen", "--program", prog,
+         "--halt", "linux93", "-o", prefix],
         cwd=REPO, check=True)
     return prefix + ".elf"
 

--- a/scripts/lib/lake-cache-diagnostic.sh
+++ b/scripts/lib/lake-cache-diagnostic.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Run a command and explain cache-backed permission failures without changing
+# the command's output or exit status.
+set -uo pipefail
+
+if [[ $# -eq 0 ]]; then
+  echo "usage: $0 COMMAND [ARG ...]" >&2
+  exit 2
+fi
+
+log="$(mktemp -t evm-asm-lake.XXXXXX)"
+trap 'rm -f "$log"' EXIT
+
+set +e
+"$@" 2>&1 | tee "$log"
+status="${PIPESTATUS[0]}"
+set -e
+
+cache_enabled=0
+case "${LAKE_ARTIFACT_CACHE:-}" in
+  1|true|TRUE|yes|YES) cache_enabled=1 ;;
+esac
+build_dir="${EVMASM_LAKE_BUILD_DIR:-$PWD/.lake/build}"
+
+if (( status != 0 && cache_enabled )) \
+   && grep -qiE 'permission denied|error code: 13|EACCES' "$log"; then
+  readonly_count="$(find "$build_dir" -type f ! -perm -u+w -print 2>/dev/null | wc -l | tr -d ' ')"
+  if [[ "$readonly_count" -gt 0 ]]; then
+    echo "lake-cache-diagnostic: command failed with a permission error while" >&2
+    echo "  LAKE_ARTIFACT_CACHE is enabled and $readonly_count read-only artefact(s)" >&2
+    echo "  are present under $build_dir." >&2
+    echo "  Re-run with LAKE_ARTIFACT_CACHE=false to materialize private outputs." >&2
+    echo "  Do not chmod .lake/build: cache entries may be hardlinks into the shared cache." >&2
+  fi
+fi
+
+exit "$status"


### PR DESCRIPTION
Fixes #11028.

Build/codegen drivers now run Lake commands through a failure-preserving cache diagnostic. When LAKE_ARTIFACT_CACHE is enabled, the command reports a permission error, and read-only files are present under .lake/build, the diagnostic names cache materialization and gives the safe LAKE_ARTIFACT_CACHE=false retry. It explicitly warns not to chmod .lake/build because entries may be hardlinks into the shared cache. Unrelated failures and successful commands keep their original output and exit status.

Verification:
- synthetic permission-error case preserved exit 7 and emitted the cache diagnosis
- synthetic successful case preserved exit 0 without a false diagnostic
- bash -n on modified shell scripts
- python3 -m py_compile scripts/gen-symbol-addresses.py
- git diff --check

Scripts-only; no regeneration and no r200.