### PR TITLE
Fix Docker EEST fixture tag provenance

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ RUN mkdir -p /license-report \
 FROM ubuntu:24.04
 
 ARG DEBIAN_FRONTEND=noninteractive
-ARG EEST_TAG=zkevm@v0.4.0
+ARG EEST_TAG=tests-zkevm@v0.6.2
 ARG GIT_COMMIT=unknown
 ARG GIT_REF=unknown
 ARG BUILD_DATE=unknown
@@ -101,8 +101,15 @@ RUN curl -sSf \
 RUN lake exe codegen --program stateless_guest --halt linux93 \
     -o gen-out/stateless_guest
 
-# Fetch and bake in EEST fixtures (~221 MB, no gh CLI needed; uses curl fallback)
-RUN bash scripts/eest-fetch-fixtures.sh "${EEST_TAG}"
+# Fetch and bake in EEST fixtures (~221 MB, no gh CLI needed; uses curl fallback).
+# Keep the ARG so the resolved value remains visible in the image label, but
+# reject drift from the repository's canonical fixture-tag source.
+RUN canonical_tag="$(tr -d '[:space:]' < scripts/eest-fixture-tag.txt)" \
+    && if [ "${EEST_TAG}" != "${canonical_tag}" ]; then \
+         echo "EEST_TAG=${EEST_TAG} disagrees with scripts/eest-fixture-tag.txt=${canonical_tag}" >&2; \
+         exit 1; \
+       fi \
+    && bash scripts/eest-fetch-fixtures.sh "${EEST_TAG}"
 
 LABEL org.opencontainers.image.licenses="MIT"
 LABEL org.opencontainers.image.source="https://github.com/Verified-zkEVM/evm-asm"


### PR DESCRIPTION
## Summary

- Update the Dockerfile default from the stale `zkevm@v0.4.0` to the canonical `tests-zkevm@v0.6.2`.
- Keep `EEST_TAG` as an ARG so `LABEL eest.fixture.tag` records the resolved value.
- Add a build-time assertion that the ARG equals `scripts/eest-fixture-tag.txt`; a future release update now fails loudly instead of silently baking a stale tag.

The ARG-plus-assertion design preserves the image label as the provenance source while preventing the hardcoded copy from drifting from the canonical file.

## Verification

- Ran `bash scripts/eest-fetch-fixtures.sh tests-zkevm@v0.6.2` directly: downloaded the 497,764,775-byte tarball and extracted 6,334 JSON fixtures successfully.
- `git diff --check` and `bash -n scripts/eest-fetch-fixtures.sh` pass.
- No full Docker image build was run.
- Dockerfile/scripts only: no Lean, regeneration, or r200 work.
