### PR TITLE
feat(progress): witness the RLP round-trip in the axiom gate

### DIFF
--- a/EvmAsm/Progress.lean
+++ b/EvmAsm/Progress.lean
@@ -675,6 +675,36 @@ private noncomputable abbrev _account_rlp_length_witness :=
 -- `bytesBEtoNat` is lenient about non-canonical zeros exactly as the guest is.
 private noncomputable abbrev _fromBytesBE_eq_zero_iff_witness :=
   @EvmAsm.EL.RLP.Nat.fromBytesBE_eq_zero_iff
+-- #11678: the RLP encode→decode round-trip was proven and `sorry`-free but
+-- reached NO gate — `decode_encode` appeared nowhere under `Progress/`, so a
+-- later edit could have introduced a `sorryAx` or a TCB-expanding tactic into it
+-- or its dependency chain with nothing to object. `Nat.fromBytesBE_eq_zero_iff`
+-- above was the only `EL.RLP` witness. Referencing a theorem does not gate it;
+-- the abbrev is what does (PLAN.md, #11671), which is why the residual survived
+-- #11661's sweep. No registry row is claimed here: a row asserts a tier, and
+-- these are pure-spec lemmas about the EL model with no RV64 routine behind
+-- them — same footing as the reference-side inversions witnessed just above.
+private noncomputable abbrev _rlp_decode_encode_witness :=
+  @EvmAsm.EL.RLP.decode_encode
+-- The fuel-parametric general form `decode_encode` specialises. Witnessed
+-- separately so a regression localises to the induction rather than only
+-- surfacing at the specialisation.
+private noncomputable abbrev _rlp_decode_encode_mutual_witness :=
+  @EvmAsm.EL.RLP.decode_encode_mutual
+-- The `decodeFully` lift. Deliberately `decodeFully_encode` and NOT
+-- `decodeFully_encode_of_decode_encode`, which #11678 named: that one *takes*
+-- `decode (encode item) = some (item, [])` as a hypothesis, so witnessing it
+-- alone certifies a re-wrapping whose interesting premise is supplied by the
+-- caller. `decodeFully_encode` is the composition with that premise discharged
+-- from the length bound, so it is the form whose axioms are worth auditing.
+private noncomputable abbrev _rlp_decodeFully_encode_witness :=
+  @EvmAsm.EL.RLP.decodeFully_encode
+-- Injectivity of `encode` over decoder-supported items: distinct items never
+-- share an encoding. Same dependency chain as the round-trip, and the
+-- soundness-relevant direction — a collision here would be a canonical-form
+-- confusion, the shape #11523's non-canonical leaves live in.
+private noncomputable abbrev _rlp_encode_injective_witness :=
+  @EvmAsm.EL.RLP.encode_injective
 private noncomputable abbrev _decode_account_from_leaf_inv_witness :=
   @EvmAsm.Stateless.SpecRef.decode_account_from_leaf_inv
 -- #11346: `account_exists_and_is_empty` split into the address lookup and the

--- a/EvmAsm/Progress/AxiomWitnesses.lean
+++ b/EvmAsm/Progress/AxiomWitnesses.lean
@@ -104,6 +104,14 @@ import EvmAsm.Progress.Correspondence
 
 #print axioms EvmAsm.EL.RLP.Nat.fromBytesBE_eq_zero_iff
 
+#print axioms EvmAsm.EL.RLP.decodeFully_encode
+
+#print axioms EvmAsm.EL.RLP.decode_encode
+
+#print axioms EvmAsm.EL.RLP.decode_encode_mutual
+
+#print axioms EvmAsm.EL.RLP.encode_injective
+
 #print axioms EvmAsm.Evm64.AddMod.Compose.evm_addmod_total_result_stack_spec_within
 
 #print axioms EvmAsm.Evm64.BlobBaseFee.evm_blobbasefee_stack_spec_within

--- a/PLAN.md
+++ b/PLAN.md
@@ -225,6 +225,21 @@ All deleted spec files have been recreated. See **Pending: Recreate Deleted Spec
   witness is always warranted for a named theorem; the row claims a *tier* and only
   if earned. Codegen-side specs are witnessed in `Routines.lean` (which imports those
   modules), never in `Correspondence.lean` (kept light on purpose).
+  - **Pure-spec lemmas are outside #11637's reach** (GH #11678). That gate closed row
+    *existence* for **routine-level** specs — a linked routine with a spec theorem and
+    no row fails the build. A lemma with no routine behind it has no symbol in the
+    image, so it is invisible to that gate *and* to the row-contents gates, which
+    quantify over rows that exist. `EL.RLP.decode_encode` sat in exactly that hole:
+    proven, `sorry`-free, and reaching no gate at all, with `decode_encode` appearing
+    nowhere under `Progress/`. Now witnessed, along with `decode_encode_mutual` (the
+    fuel-parametric general form), `decodeFully_encode` and `encode_injective` — all
+    four `[propext, Classical.choice, Quot.sound]`. No row: these are model-level
+    lemmas with no RV64 routine, same footing as the reference-side inversions
+    (`decode_account_from_leaf_inv`, `beq_EMPTY_ACCOUNT`) witnessed beside them.
+    ⚠️ Witness the **discharged** form, not a hypothesis-taking wrapper:
+    `decodeFully_encode_of_decode_encode` *assumes* the round-trip, so witnessing it
+    alone audits a re-wrapping whose one interesting premise the caller supplies —
+    the same near-vacuity trap as #10688's bundled existentials.
 
 - **Verified-Program insertion offsets** (`scripts/program-insert-offsets.py`,
   GH #10619): inserting one instruction into a `Program` literal moves **four**


### PR DESCRIPTION
Fixes #11678.

`EL/RLP/Properties.lean`'s `decode_encode` was proven and `sorry`-free but reached **no gate**: no `#print axioms` line in `Progress/AxiomWitnesses.lean`, and `decode_encode` appeared nowhere under `Progress/` at all. So `check-axioms.sh` did not cover the RLP round-trip, and a later edit could have introduced a `sorryAx` or a TCB-expanding tactic into it or its dependency chain with nothing to object.

**Why this residual survived #11661's sweep.** #11637's gate closed row *existence* for **routine-level** specs — a linked routine carrying a spec theorem with no registry row now fails the build. A pure-spec lemma has no symbol in the guest image, so it is invisible to that gate; and every row-*contents* gate (`gen-axiom-witnesses.py`, `verdict_requires_spec`, `crossVerdictOk`) quantifies over rows that already exist. Both halves existed, the join did not — one level up from where #11637 reaches.

## Witnessed

Four theorems, each reporting exactly `[propext, Classical.choice, Quot.sound]` — read back from the build log, not assumed:

| Theorem | Why |
|---|---|
| `decode_encode` | the named residual |
| `decode_encode_mutual` | the fuel-parametric general form it specialises; separate abbrev so a regression localises to the induction rather than only surfacing at the specialisation |
| `decodeFully_encode` | the `decodeFully` lift — see below |
| `encode_injective` | distinct items never share an encoding; same dependency chain, and the soundness-relevant direction (a collision is a canonical-form confusion, the shape #11523's non-canonical leaves live in) |

**One deviation from the issue, deliberate.** Item 2 named `decodeFully_encode_of_decode_encode` (`FullDecode.lean:106`). That theorem *takes* `decode (encode item) = some (item, [])` as a **hypothesis**:

```lean
theorem decodeFully_encode_of_decode_encode {item : RLPItem}
    (h_roundtrip : decode (encode item) = some (item, [])) :
    decodeFully (encode item) = some item
```

Witnessing it alone audits a re-wrapping whose one interesting premise the caller supplies — the near-vacuity trap of #10688's bundled existentials. I witnessed `decodeFully_encode` (`Properties.lean:2580`) instead, which is the same composition with the premise **discharged** from the length bound. Its axiom report transitively covers the wrapper anyway.

## No registry row, deliberately

A row asserts a *tier*, and these are model-level lemmas about the EL spec with no RV64 routine behind them — the same footing as the reference-side inversions (`decode_account_from_leaf_inv`, `beq_EMPTY_ACCOUNT`) witnessed immediately above them in `Progress.lean`. So the issue's item 3 (grading `.domainRestricted` for the `(encode item).length < 256 ^ 8` hypothesis) does not arise here; that grading note is recorded in PLAN.md for whenever a row *is* wanted.

Happy to add a `Correspondence` `.model`-layer row instead if you'd rather the round-trip be claimed as well as gated — say the word and I'll grade it `.domainRestricted` per item 3.

## Mechanics

`AxiomWitnesses.lean` is generated, so the four lines come from `python3 scripts/gen-axiom-witnesses.py --write` (**149 witnesses, up from 145**), not a hand edit — the gate regenerates and diffs, so a stale file fails CI. All four resolved with no new import to `Progress.lean`.

PLAN.md's "Witness ≠ row" note extended with the pure-spec-lemma hole and the discharged-vs-hypothesis-taking rule.

## Gates

`lake build` (4726 jobs, green) + check-progress, check-drift, check-forbidden-tactics, check-unimported, check-file-size, check-layering, check-heartbeats-approved, check-statement-tamper — **all pass**.

`check-axioms.sh` **cannot run in this checkout** and I am not claiming it: it exits 2 because `scripts/lib/worktree-build-lock.sh` requires `flock` (absent on macOS) and GNU `sha256sum`. CI's non-cache run is the authority. That said, the axiom reports this PR is *about* are visible directly in the `lake build` log and quoted above.

Out of scope per the issue: the round-trip proof itself (done), the encode-side guest↔EL link (#10780), nested/long-form list decode (#11711/#11341), per-context decode strictness (#11516/#11523).

Docs-and-registry only; no guest bytes, `.text` unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
