### PR TITLE
proof(rlp): fuel-sensitive per-item bridge, and name the residual list-interior gap

### DIFF
--- a/EvmAsm/Codegen/Programs/RlpListCountItemsBridge.lean
+++ b/EvmAsm/Codegen/Programs/RlpListCountItemsBridge.lean
@@ -287,4 +287,157 @@ theorem StrictPrefix.decodeChain_of_itemBridge
     refine ⟨items ++ [item], by simp [hlen], ?_⟩
     exact DecodeChain.snoc items hchain hdec
 
+/-! ## Fuel-sensitive forms (GH #11795, on top of #11711)
+
+    #11711 removed the fuel obstruction: `DecodeChainFrom` states a link at ONE
+    budget rather than at every budget, so a nested list — whose `decodeAux` is
+    fuel-sensitive — is now expressible as a link. This section carries the
+    structural results above over to that predicate, which is the half of #11795
+    that #11711 genuinely unblocks.
+
+    ⚠️ **It is only half.** #11795 says that once `DecodeChain` stops demanding
+    `∀ m`, discharging the per-item bridge "becomes assembling the existing pieces".
+    That is not so, and the reason is worth stating precisely because the issue
+    sequences work on it:
+
+    `rlpItemDecode`'s two LIST disjuncts (`WalkNext.lean:3649`, the `0xc0`–`0xf7`
+    and `≥ 0xf8` arms) require only header canonicality plus a **span fit** —
+    `¬ ult (endPtr - cursor) span`. They say nothing about the payload. `decodeAux`
+    (`Decode.lean:63`) additionally runs `decodeItems nDepth payload` and returns
+    `none` unless it consumes the payload exactly. So a list item whose span fits
+    but whose **interior is malformed** satisfies `rlpItemDecode` and is rejected by
+    `decodeAux`, at every budget.
+
+    ⇒ `RlpItemDecodeBridges`/`RlpItemDecodeBridgesFrom` remain unsatisfiable on the
+    unrestricted domain for a reason INDEPENDENT of fuel. Fuel was one of two
+    obstructions; #11711 closed that one. The residual is a genuine
+    strength mismatch between the machine relation and the model, and it is named
+    below as `RlpListInteriorsDecode` rather than left in prose — same discipline as
+    `RlpItemDecodeBridgesBytes`'s visible `hbytes` guard. -/
+
+/-- Per-item obligation in **fuel-sensitive** form: the model decode is exhibited at
+    a single budget `floor` instead of at every budget.
+
+    This is `RlpItemDecodeBridges` with #11711's fix applied. The `∀ m` in the
+    original is what a nested list cannot satisfy; this form can express one. -/
+def RlpItemDecodeBridgesFrom (bytes : List (BitVec 8)) (base endPtr : Word)
+    (floor : Nat) : Prop :=
+  ∀ (off : Nat) (next len : Word),
+    rlpItemDecode bytes off (base + BitVec.ofNat 64 off) endPtr next len →
+    ∃ item : RLPItem,
+      decodeAux floor (bytes.drop off) = some (item, bytes.drop (next - base).toNat)
+
+/-- The fuel-insensitive obligation implies the fuel-sensitive one at any positive
+    budget — instantiate `∀ m` at `m := floor - 1`. Faithfulness: the new predicate
+    asks for no more than the old one did. -/
+theorem rlpItemDecodeBridgesFrom_of_bridges {bytes : List (BitVec 8)}
+    {base endPtr : Word} {floor : Nat} (hfloor : 0 < floor)
+    (hb : RlpItemDecodeBridges bytes base endPtr) :
+    RlpItemDecodeBridgesFrom bytes base endPtr floor := by
+  intro off next len hitem
+  obtain ⟨item, hdec⟩ := hb off next len hitem
+  refine ⟨item, ?_⟩
+  obtain ⟨f, rfl⟩ : ∃ f, floor = f + 1 := ⟨floor - 1, by omega⟩
+  exact hdec f
+
+/-- `DecodeChainFrom`'s snoc lemma — the analogue of `DecodeChain.snoc`, needed for
+    the same reason: `DecodeChainFrom` recurses on the item list from the FRONT
+    while `StrictPrefix.succ` extends at the BACK. -/
+theorem DecodeChainFrom.snoc {bytes : List Byte} {item : RLPItem} {floor : Nat}
+    {off offMid offEnd : Nat} :
+    ∀ items : List RLPItem,
+      DecodeChainFrom bytes floor off items offMid →
+      decodeAux floor (bytes.drop offMid) = some (item, bytes.drop offEnd) →
+      DecodeChainFrom bytes floor off (items ++ [item]) offEnd := by
+  intro items
+  induction items generalizing off with
+  | nil =>
+    intro hchain hd
+    have hoff : off = offMid := hchain
+    subst hoff
+    exact ⟨offEnd, hd, rfl⟩
+  | cons i rest ih =>
+    intro hchain hd
+    obtain ⟨off1, hhead, htail⟩ := hchain
+    exact ⟨off1, hhead, ih htail hd⟩
+
+/-- ⭐ **The structural bridge, fuel-sensitive.** A machine-side `StrictPrefix` of
+    length `count` yields a `DecodeChainFrom` over some list of exactly `count`
+    items ending at the same offset.
+
+    Same proof shape as `StrictPrefix.decodeChain_of_itemBridge`; the point is that
+    its per-item hypothesis is now the satisfiable-in-principle
+    `RlpItemDecodeBridgesFrom` rather than a predicate that is false on the live
+    domain for fuel reasons. Composing this with `decodeItems_of_chainFrom` is what
+    a `.bridged` regrade would consume. -/
+theorem StrictPrefix.decodeChainFrom_of_itemBridge
+    {bytes : List (BitVec 8)} {base endPtr : Word} {startOff count off floor : Nat}
+    (hb : RlpItemDecodeBridgesFrom bytes base endPtr floor)
+    (h : StrictPrefix bytes base endPtr startOff count off) :
+    ∃ items : List RLPItem,
+      items.length = count ∧ DecodeChainFrom bytes floor startOff items off := by
+  induction h with
+  | zero => exact ⟨[], rfl, rfl⟩
+  | succ count off next len hprefix hitem ih =>
+    obtain ⟨items, hlen, hchain⟩ := ih
+    obtain ⟨item, hdec⟩ := hb off next len hitem
+    refine ⟨items ++ [item], by simp [hlen], ?_⟩
+    exact DecodeChainFrom.snoc items hchain hdec
+
+/-- ⛔ **The residual obstruction, named.** `rlpItemDecode`'s list disjuncts check a
+    span fit; `decodeAux` decodes the payload. This is the side condition that
+    closes the difference: whenever the machine relation accepts a LIST item, the
+    model actually decodes it at budget `floor`.
+
+    Stated as its own predicate, with the list restriction visible, so that:
+
+    * no caller can mistake `StrictPrefix.decodeChainFrom_of_itemBridge` for a
+      complete bridge, and
+    * the remaining work is one named obligation instead of prose in a docstring.
+
+    ⚠️ This is NOT dischargeable from `rlpItemDecode` alone — it is strictly more
+    information. Discharging it needs one of: a caller-side well-formedness fact
+    (on the `mpt_node_kind` path the witness has already been validated, so the
+    interiors *are* canonical — that is a precondition to import, not a theorem
+    about this relation), or strengthening `rlpItemDecode`'s list arms to record
+    what `rlp_walk_next_core` actually verifies after #11776. Choosing between those
+    is a spec-shape decision for #11795, not something to settle silently here. -/
+def RlpListInteriorsDecode (bytes : List (BitVec 8)) (base endPtr : Word)
+    (floor : Nat) : Prop :=
+  ∀ (off : Nat) (next len : Word) (b : BitVec 8),
+    bytes[off]? = some b →
+    ¬ BitVec.ult (b.zeroExtend 64) (0xc0 : Word) = true →
+    rlpItemDecode bytes off (base + BitVec.ofNat 64 off) endPtr next len →
+    ∃ inner : List RLPItem,
+      decodeAux floor (bytes.drop off)
+        = some (.list inner, bytes.drop (next - base).toNat)
+
+/-- **The two halves compose.** Byte-string items (`p < 0xc0`) plus list items
+    (`p ≥ 0xc0`) exhaust the prefix space, so the byte-string bridge and the list
+    side condition together give the full per-item obligation.
+
+    This is the honest shape of what #11795 asks for: the fuel obstruction is gone
+    (#11711), the byte-string half is proven, and exactly one named hypothesis
+    remains. It also shows the residual is not hiding additional fuel trouble —
+    given `RlpListInteriorsDecode`, nothing further is needed. -/
+theorem rlpItemDecodeBridgesFrom_of_parts {bytes : List (BitVec 8)}
+    {base endPtr : Word} {floor : Nat}
+    (hbytes : ∀ (off : Nat) (next len : Word) (b : BitVec 8),
+      bytes[off]? = some b →
+      BitVec.ult (b.zeroExtend 64) (0xc0 : Word) = true →
+      rlpItemDecode bytes off (base + BitVec.ofNat 64 off) endPtr next len →
+      ∃ item : RLPItem,
+        decodeAux floor (bytes.drop off) = some (item, bytes.drop (next - base).toNat))
+    (hlists : RlpListInteriorsDecode bytes base endPtr floor) :
+    RlpItemDecodeBridgesFrom bytes base endPtr floor := by
+  intro off next len hitem
+  -- `rlpItemDecode` exposes the prefix byte, which is what splits the two cases.
+  -- Destructure a COPY: both branches still need `hitem` itself.
+  have hcopy := hitem
+  obtain ⟨b, hget, _⟩ := hcopy
+  by_cases hlt : BitVec.ult (b.zeroExtend 64) (0xc0 : Word) = true
+  · exact hbytes off next len b hget hlt hitem
+  · obtain ⟨inner, hdec⟩ := hlists off next len b hget hlt hitem
+    exact ⟨.list inner, hdec⟩
+
 end EvmAsm.Codegen.RlpListCountItemsBridge


### PR DESCRIPTION
Addresses #11795. **Stacked on #11894** (`work/11711-decodeaux-fuel-mono`) — based against that branch, so review #11894 first; I'll retarget to `main` once it lands.

## #11795's sequencing claim is wrong, and this PR shows why

The issue says that once #11711 removes `DecodeChain`'s `∀ m` requirement, discharging the per-item bridge *"becomes assembling the existing pieces — not new mathematics"*. Fuel was **one of two** independent obstructions. #11711 closed that one. The second is a strength mismatch no amount of fuel work touches:

> `rlpItemDecode`'s two **list** disjuncts (`WalkNext.lean:3649`, the `0xc0`–`0xf7` and `≥ 0xf8` arms) require header canonicality plus a **span fit** — `¬ ult (endPtr - cursor) span` — and say nothing about the payload. `decodeAux` (`Decode.lean:63`) additionally runs `decodeItems nDepth payload` and returns `none` unless the payload is consumed exactly.

So a list item whose span fits but whose **interior is malformed** satisfies the machine relation and is rejected by the model — *at every budget*. `RlpItemDecodeBridges` therefore stays unsatisfiable on the unrestricted domain for a reason independent of fuel.

Worth noting the file's own comment at `:183-196` attributed the unsatisfiability solely to fuel; that was incomplete, and #11795 inherited the gap.

## What this delivers — the half #11711 genuinely unblocks

| Declaration | What it does |
|---|---|
| `RlpItemDecodeBridgesFrom` | per-item obligation in fuel-sensitive form: model decode exhibited at one budget `floor`, not at every budget. A nested list is expressible here; under `∀ m` it is not. |
| `rlpItemDecodeBridgesFrom_of_bridges` | the old obligation implies the new one at any positive budget — **faithfulness**: the new form asks for no more than the original |
| `DecodeChainFrom.snoc` | the `DecodeChain.snoc` analogue, for the same snoc-vs-cons reversal (`StrictPrefix.succ` extends at the back, the chain recurses from the front) |
| `StrictPrefix.decodeChainFrom_of_itemBridge` | the structural bridge over the fuel-sensitive predicate — same shape as the existing one, but its per-item hypothesis is now satisfiable-in-principle rather than false on the live domain |

## What remains — named, not described

- **`RlpListInteriorsDecode`** — the residual obligation, with the list restriction (`¬ ult b 0xc0`) **visible in the predicate**, following the discipline `RlpItemDecodeBridgesBytes` already set with its `hbytes` guard. No caller can mistake the structural bridge for a complete one.
- **`rlpItemDecodeBridgesFrom_of_parts`** — byte-string items and list items exhaust the prefix space, so the byte-string half plus `RlpListInteriorsDecode` yields the full obligation. This is the load-bearing honesty check: it proves the residual is the **only** thing left, and in particular that it hides no further fuel trouble.

**Discharging `RlpListInteriorsDecode` is a spec-shape decision that belongs to you, not to me quietly.** Two routes, and they differ in what they claim:

1. **Import a caller-side well-formedness fact.** On the `mpt_node_kind` path the witness has already been validated, so the interiors *are* canonical. That is a precondition to carry, not a theorem about `rlpItemDecode`.
2. **Strengthen `rlpItemDecode`'s list arms** to record what `rlp_walk_next_core` actually verifies after #11776 (which made the wrapper require exact cursor-to-end exhaustion, status 7 on nested-malformed).

Route 2 looks more honest to me — #11776 means the routine really does more than the relation currently admits, so the relation is understating the guest — but it changes a relation other proofs consume, so I did not do it unilaterally.

## No regrade

`rlp_list_count_items` stays `.machineOnly`. `.bridged` would claim a bridge that still rests on an undischarged hypothesis, which is exactly what the correspondence registry exists to prevent. So this **addresses** #11795 without closing it.

No `sorry` anywhere — the unproven part is a hypothesis, matching the file's existing convention that nothing claims more than it has.

## Gates

`lake build` (4727 jobs, green, **0 warnings**) + check-no-warnings, check-progress, check-drift, check-forbidden-tactics, check-unimported, check-file-size, check-layering, check-heartbeats-approved, check-statement-tamper, check-routine-liveness — **all pass**. No `native_decide`/`bv_decide`, no `maxHeartbeats`.

`check-axioms.sh` cannot run in this checkout (`worktree-build-lock.sh` needs `flock`, absent on macOS, plus GNU `sha256sum`) — CI is the authority.

No guest bytes; `.text` unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
