### PR TITLE
feat(stateless): Assertion vocabulary for the spec-shaped write maps

### DIFF
--- a/EvmAsm/Stateless.lean
+++ b/EvmAsm/Stateless.lean
@@ -67,6 +67,7 @@ import EvmAsm.Stateless.Headers.Spec
 import EvmAsm.Stateless.Headers.Validate
 import EvmAsm.Stateless.State.Account
 import EvmAsm.Stateless.State.AccountAssertions
+import EvmAsm.Stateless.State.WriteMapAssertions
 import EvmAsm.Stateless.State.BlockState
 import EvmAsm.Stateless.State.Diff
 import EvmAsm.Stateless.State.PreState

--- a/EvmAsm/Stateless/State/WriteMapAssertions.lean
+++ b/EvmAsm/Stateless/State/WriteMapAssertions.lean
@@ -1,0 +1,490 @@
+/-
+  EvmAsm.Stateless.State.WriteMapAssertions
+
+  Separation-logic assertions for the guest's **spec-shaped write maps** (GH #11571).
+
+  The guest has converged on `state_tracker.py`'s two-container model (#11326 item 3,
+  #11329): a block-level map and a per-transaction map for account writes, and the
+  same pair for storage writes. Those arenas had **no `Assertion` vocabulary** — the
+  predicate inventory covered the *legacy* append-only logs (`storageLogIs`,
+  `Evm64/StorageAssertions.lean`) and the byte-level regions, so the containers the
+  whole convergence is moving *toward* were describable only as raw bytes.
+
+  Defining them now is a sequencing decision, per #11655: the attribution cluster
+  (#11648–#11653) has closed, so the shapes are final, and a stated predicate is what
+  freezes a shape and converts later drift into a build failure. #11654 is the
+  cautionary case — SLOAD's 45-theorem spec was deleted the day its container retired,
+  because the spec was written against the container rather than against a predicate.
+
+  ## Why this is core and not beside the maps
+
+  The maps themselves live in `Codegen/Programs/AccountWriteMap.lean` and
+  `StorageWriteMap.lean`, and `Codegen/RegionPredicates.lean` has the run-predicate
+  pattern (`teerEntriesFrom`) that #11571 asks these to follow. **None of that can be
+  imported here.** `check-layering` L1 makes `EvmAsm/Codegen` a pure sink: the point
+  of these predicates is to be consumed by *core-side* bridges against
+  `SpecRef/StateTracker.lean`, so they must live in core, which may not import
+  Codegen. `Stateless/Crypto/FieldAssertions.lean` records the identical decision for
+  the crypto field predicates and is the precedent followed here.
+
+  Consequence: `teerEntriesFrom`'s shape is **mirrored, not reused**, and the row
+  layouts below are *restated* from the emitted maps rather than shared with them.
+  That restatement is the thing a later routine triple pins; until such a triple
+  exists, a layout drift in `Codegen` would not be caught here. Stated plainly
+  because it is the one weakness of a core-side predicate over an emitted structure.
+
+  ## Layout provenance (read from the emitted maps, 2026-08-10)
+
+  **Account rows** — `AccountWriteMap.lean:207`, stride **128**:
+
+      { addr_BE20@0, padding@20..31, balance@32, nonce@64, optionalState@72,
+        codePtr@80, codeLen@88, execFlags@96, reserved@104, validMask@112,
+        reserved@120 }
+
+  Bases: `ACCOUNT_WRITES_AREA` (block) and `TX_ACCOUNT_WRITES_AREA` (tx),
+  `Stateless/MemoryLayout.lean`. `execFlags@96` value **2 = live**; zero means
+  present-dead or deleted (`AccountWriteMap.lean:177`). ⚠️ That flag is why a row
+  list is not by itself a map: see `AccountWriteRow.live` and the note on
+  `accountWriteRowsFrom`.
+
+  **Storage rows** — `StorageWriteMap.lean:357`, stride **128**:
+  `(rowAddress@0 : 32 B, slotKey@32 : 32 B, value@64 : 32 B, baseline@96 : 32 B)`,
+  where `baseline` is the slot's value at the start of the transaction, captured on
+  append so `block_access_lists.py`'s net-zero-write exclusion can be computed.
+
+  All multi-byte scalar fields are accessed by the guest with `sd`/`ld`, so they are
+  modelled with `↦ₘ` (little-endian, 8-byte aligned) rather than by byte-splatting.
+  Every offset used here is a multiple of 8, and both bases are 8-aligned, so the
+  alignment requirement of `memIs` is met by construction.
+
+  ## ⚠️ A shape divergence the abstraction has to cross
+
+  `SpecRef`'s storage side is **nested** — `BlockState.storageWrites :
+  List (Address × List (Bytes32 × U256))`, mirroring Python's
+  `Dict[Address, Dict[Bytes32, U256]]` — while the guest's rows are **flat**, one row
+  per `(address, slot)` pair. #11571's proposed signature is the flat one, which is
+  right for the guest, so the correspondence needs a **group-by**, not a rename.
+  `groupByAddress` below is that function and `storageRowsAbstract` is the hook a
+  `StateTracker` correspondence proof hangs from.
+
+  ## Scope
+
+  Vocabulary only, per #11571's non-goals: no routine triples (`account_writes_upsert`
+  / `_lookup`, commit/reset walkers are follow-ons), and the **undo journals** are
+  deliberately excluded — their counterpart is `restore_tx_state`'s dict-copy
+  semantics and the theorem shape differs (#11572).
+-/
+
+import EvmAsm.Rv64.MemRegion
+import EvmAsm.Stateless.MemoryLayout
+import EvmAsm.Stateless.SpecRef.StateTracker
+
+namespace EvmAsm.Stateless
+
+open EvmAsm.Rv64
+
+/-! ## Row strides and field offsets
+
+    Named rather than inlined so a caller cites a symbol and a later drift is a
+    one-line change, per the #11571 discipline of parameterising the stride instead
+    of hardcoding it at every use. -/
+
+/-- Bytes per `account_writes` / `tx_account_writes` row (`AccountWriteMap.lean:172`). -/
+def accountWriteRowBytes : Nat := 128
+
+/-- Bytes per `storage_writes` row (`StorageWriteMap.lean`, the `* 128` capacity
+    guards). -/
+def storageWriteRowBytes : Nat := 128
+
+/-- `execFlags@96` value marking a row **live**; zero means present-dead or deleted
+    (`AccountWriteMap.lean:177`). A value, not a bit index — it is the emitted `andi`
+    immediate. -/
+def accountWriteLiveFlag : Nat := 2
+
+/-! ## Account write rows -/
+
+/-- One `account_writes` row, as the guest lays it out.
+
+    The 20-byte address key and the 32-byte big-endian balance are byte strings; the
+    remaining fields are `sd`/`ld` words. `padding@20..31` and the two reserved words
+    are deliberately absent: a row predicate should not claim what the writers do not
+    establish, and both `.Lawr_store` and `.Lawb_store` leave them unconstrained. -/
+structure AccountWriteRow where
+  /-- 20-byte big-endian address key at `+0`, identical to the builder's address
+      segment (`AccountWriteMap.lean:208`). -/
+  address : List (BitVec 8)
+  /-- 32-byte big-endian balance at `+32`. -/
+  balance : List (BitVec 8)
+  /-- u64 nonce at `+64`. -/
+  nonce : Word
+  /-- `optionalState` word at `+72` — the `Optional[Account]` discriminant, which is
+      what makes a deleted account representable at all. -/
+  optionalState : Word
+  /-- code pointer at `+80`. -/
+  codePtr : Word
+  /-- code length at `+88`. -/
+  codeLen : Word
+  /-- `execFlags` at `+96`; `accountWriteLiveFlag` is the live bit. -/
+  execFlags : Word
+  /-- components mask at `+112`, gating whether `execFlags` is stored or copied. -/
+  validMask : Word
+
+namespace AccountWriteRow
+
+/-- Well-formedness: the key is 20 bytes and the balance 32, exactly as the writers
+    store them. Mirrors `TeerEntry.wf`'s role — a length side condition the render
+    lemma needs, kept out of the predicate so it can be assumed once per caller. -/
+def wf (r : AccountWriteRow) : Prop :=
+  r.address.length = 20 ∧ r.balance.length = 32
+
+/-- Is this row live? Zero `execFlags & 2` means present-dead or deleted, so a row
+    being *present* is not the same as its address being *in* the map. -/
+def live (r : AccountWriteRow) : Prop :=
+  r.execFlags &&& BitVec.ofNat 64 accountWriteLiveFlag ≠ 0
+
+end AccountWriteRow
+
+/-- One account row at `base`, field by field.
+
+    Offsets are the emitted ones; every scalar is a `↦ₘ` word because the guest reads
+    and writes them with `ld`/`sd`. Unmodelled bytes (`+20..31`, `+104`, `+120`) are
+    simply not mentioned, so this composes with whatever a caller holds for them. -/
+def accountWriteRowIs (base : Word) (r : AccountWriteRow) : Assertion :=
+  bytesRegion base r.address
+    ** bytesRegion (base + 32) r.balance
+    ** ((base + 64) ↦ₘ r.nonce)
+    ** ((base + 72) ↦ₘ r.optionalState)
+    ** ((base + 80) ↦ₘ r.codePtr)
+    ** ((base + 88) ↦ₘ r.codeLen)
+    ** ((base + 96) ↦ₘ r.execFlags)
+    ** ((base + 112) ↦ₘ r.validMask)
+
+/-- **The partial run** — `rs` in consecutive rows from `base`, saying nothing about
+    what follows. The composable form, and the one a routine touching a single row
+    should be handed.
+
+    Structure mirrors `Codegen/RegionPredicates.lean`'s `teerEntriesFrom` (itself
+    copied from `evmStackIs`): base as a parameter, contents as a `List`, recursion
+    with `**` and a stride step, `empAssertion` at nil.
+
+    ⚠️ **This is a row list, not a map.** Rows carry a live flag and the arena is
+    append-with-scan, so two rows may share an address (the later one winning) and a
+    row may be dead. `AccountWriteRowsMap` below is the well-formedness that makes the
+    list denote a finite map; keeping them separate is deliberate, because a routine
+    mid-upsert holds the run *without* the map property. -/
+def accountWriteRowsFrom (base : Word) : List AccountWriteRow → Assertion
+  | [] => empAssertion
+  | r :: rs =>
+      accountWriteRowIs base r
+        ** accountWriteRowsFrom (base + BitVec.ofNat 64 accountWriteRowBytes) rs
+
+/-- Block-level `account_writes`, at `ACCOUNT_WRITES_AREA`. Filled only by
+    `account_writes_incorporate_tx`, mirroring `BlockState.accountWrites`. -/
+def accountWritesMapIs (rs : List AccountWriteRow) : Assertion :=
+  accountWriteRowsFrom ACCOUNT_WRITES_AREA rs
+
+/-- Per-transaction `account_writes`, at `TX_ACCOUNT_WRITES_AREA`. The target of
+    `account_write_record`, mirroring `TransactionState.accountWrites`. -/
+def txAccountWritesMapIs (rs : List AccountWriteRow) : Assertion :=
+  accountWriteRowsFrom TX_ACCOUNT_WRITES_AREA rs
+
+/-! ## Storage write rows -/
+
+/-- One `storage_writes` row: the outer address key, the inner slot key, the value,
+    and the pre-transaction baseline captured on append. All four are 32-byte
+    big-endian buffers. -/
+structure StorageWriteRow where
+  /-- 32-byte outer `Address` key at `+0`, keyed exactly as `storage_read_record`
+      keys its reads — so the same slot in two contracts is two rows. -/
+  rowAddress : List (BitVec 8)
+  /-- 32-byte inner `Bytes32` slot key at `+32`. -/
+  slotKey : List (BitVec 8)
+  /-- 32-byte `U256` value at `+64`. -/
+  value : List (BitVec 8)
+  /-- 32-byte pre-transaction baseline at `+96`. Zero *is* the spec's answer for a
+      slot with no prior value (`_get_pre_tx_storage` "Returns 0 if not set"), so a
+      zero baseline is not a sentinel. -/
+  baseline : List (BitVec 8)
+
+namespace StorageWriteRow
+
+/-- All four fields are exactly 32 bytes. -/
+def wf (r : StorageWriteRow) : Prop :=
+  r.rowAddress.length = 32 ∧ r.slotKey.length = 32
+    ∧ r.value.length = 32 ∧ r.baseline.length = 32
+
+/-- The `(address, slot)` pair this row keys on. Flat, matching the guest. -/
+def key (r : StorageWriteRow) : List (BitVec 8) × List (BitVec 8) :=
+  (r.rowAddress, r.slotKey)
+
+end StorageWriteRow
+
+/-- One storage row at `base`, field by field. -/
+def storageWriteRowIs (base : Word) (r : StorageWriteRow) : Assertion :=
+  bytesRegion base r.rowAddress
+    ** bytesRegion (base + 32) r.slotKey
+    ** bytesRegion (base + 64) r.value
+    ** bytesRegion (base + 96) r.baseline
+
+/-- **The partial run** for storage rows, same shape as `accountWriteRowsFrom`. -/
+def storageWriteRowsFrom (base : Word) : List StorageWriteRow → Assertion
+  | [] => empAssertion
+  | r :: rs =>
+      storageWriteRowIs base r
+        ** storageWriteRowsFrom (base + BitVec.ofNat 64 storageWriteRowBytes) rs
+
+/-- `storage_writes` at a caller-supplied base.
+
+    Unlike the account maps this takes the base as a parameter rather than pinning
+    `MemoryLayout` constants: the storage arenas' bases are computed in
+    `Codegen/Programs/StorageWriteMap.lean` (`storageWritesBlockBase` /
+    `storageWritesTxBase`) and are **not** exported as `Stateless/MemoryLayout`
+    definitions the way the account areas are, so pinning them here would duplicate a
+    literal that core cannot see. A caller supplies the base it owns. -/
+def storageWritesMapIs (base : Word) (rs : List StorageWriteRow) : Assertion :=
+  storageWriteRowsFrom base rs
+
+/-! ## `pcFree`
+
+    Every predicate here is program-counter-free, which is what lets it be framed
+    across a call. Same obligation `pcFree_teerEntriesFrom` discharges for the
+    Codegen-side run. -/
+
+theorem pcFree_accountWriteRowIs (base : Word) (r : AccountWriteRow) :
+    (accountWriteRowIs base r).pcFree := by
+  unfold accountWriteRowIs
+  repeat' first
+    | apply pcFree_sepConj
+    | exact bytesRegion_pcFree _ _
+    | exact pcFree_memIs
+
+theorem pcFree_accountWriteRowsFrom (base : Word) (rs : List AccountWriteRow) :
+    (accountWriteRowsFrom base rs).pcFree := by
+  induction rs generalizing base with
+  | nil => exact pcFree_emp
+  | cons r rs ih => exact pcFree_sepConj (pcFree_accountWriteRowIs _ _) (ih _)
+
+theorem pcFree_storageWriteRowIs (base : Word) (r : StorageWriteRow) :
+    (storageWriteRowIs base r).pcFree := by
+  unfold storageWriteRowIs
+  repeat' first
+    | apply pcFree_sepConj
+    | exact bytesRegion_pcFree _ _
+
+theorem pcFree_storageWriteRowsFrom (base : Word) (rs : List StorageWriteRow) :
+    (storageWriteRowsFrom base rs).pcFree := by
+  induction rs generalizing base with
+  | nil => exact pcFree_emp
+  | cons r rs ih => exact pcFree_sepConj (pcFree_storageWriteRowIs _ _) (ih _)
+
+/-! ## Structural lemmas
+
+    `cons` and `snoc`. The `snoc` direction is the one an append-at-the-tail upsert
+    needs and is not definitional, exactly as `DecodeChain.snoc` was not — the
+    recursion is from the front while the writer extends at the back. -/
+
+theorem accountWriteRowsFrom_cons (base : Word) (r : AccountWriteRow)
+    (rs : List AccountWriteRow) :
+    accountWriteRowsFrom base (r :: rs)
+      = (accountWriteRowIs base r
+          ** accountWriteRowsFrom (base + BitVec.ofNat 64 accountWriteRowBytes) rs) :=
+  rfl
+
+theorem storageWriteRowsFrom_cons (base : Word) (r : StorageWriteRow)
+    (rs : List StorageWriteRow) :
+    storageWriteRowsFrom base (r :: rs)
+      = (storageWriteRowIs base r
+          ** storageWriteRowsFrom (base + BitVec.ofNat 64 storageWriteRowBytes) rs) :=
+  rfl
+
+/-! ## The map abstraction
+
+    #11571 item 2: state, per predicate, that the entry list viewed as a finite map is
+    well-formed — no duplicate keys under the container's insert discipline. This is
+    the hook a `SpecRef/StateTracker` correspondence proof hangs from.
+
+    ⚠️ Stated as a **precondition-shaped predicate over the list**, not proved. The
+    guest's arena is append-with-scan (`.Lawr_scan`), so uniqueness is a property of
+    the *writer*, and proving it belongs to the upsert routine's triple — which does
+    not exist yet (#11571's non-goals). Asserting it here without that triple would be
+    an unearned claim; naming it makes the obligation citable and keeps the shape
+    frozen. Same discipline as [[write-predicates-to-survive-movement]]: uniqueness is
+    a PRECONDITION, not a step. -/
+
+/-- The live rows of an account run, in order. Dead rows are present in memory and
+    absent from the map. -/
+def liveAccountRows (rs : List AccountWriteRow) : List AccountWriteRow :=
+  rs.filter (fun r => decide (r.execFlags &&& BitVec.ofNat 64 accountWriteLiveFlag ≠ 0))
+
+/-- **The map property for account rows**: every row is well-formed, and no two live
+    rows share an address key. Under it, `liveAccountRows` denotes a finite
+    `Address ⇀ Optional[Account]` — the shape of `BlockState.accountWrites` and
+    `TransactionState.accountWrites` (`SpecRef/StateTracker.lean:90,110`). -/
+def AccountWriteRowsMap (rs : List AccountWriteRow) : Prop :=
+  (∀ r ∈ rs, r.wf)
+    ∧ ((liveAccountRows rs).map AccountWriteRow.address).Nodup
+
+/-- **The map property for storage rows**: every row is well-formed and no two rows
+    share an `(address, slot)` pair. -/
+def StorageWriteRowsMap (rs : List StorageWriteRow) : Prop :=
+  (∀ r ∈ rs, r.wf) ∧ (rs.map StorageWriteRow.key).Nodup
+
+/-! ### Crossing the flat/nested divergence
+
+    `SpecRef` stores storage writes nested by address; the guest stores flat rows.
+    Neither is wrong — they are different encodings of the same dictionary — so the
+    abstraction is a group-by rather than a coercion. -/
+
+/-- Group flat rows by their outer address, preserving first-appearance order of
+    addresses and, within an address, row order. The shape of
+    `List (Address × List (Bytes32 × U256))` that `SpecRef` uses. -/
+def groupByAddress (rs : List StorageWriteRow) :
+    List (List (BitVec 8) × List (List (BitVec 8) × List (BitVec 8))) :=
+  rs.foldl
+    (fun acc r =>
+      if acc.any (fun p => p.1 = r.rowAddress) then
+        acc.map (fun p =>
+          if p.1 = r.rowAddress then (p.1, p.2 ++ [(r.slotKey, r.value)]) else p)
+      else acc ++ [(r.rowAddress, [(r.slotKey, r.value)])])
+    []
+
+/-- ⭐ **The abstraction hook.** Under the map property, the flat guest rows and the
+    nested `SpecRef` shape agree: grouping the rows by address yields one group per
+    distinct address, and every `(slot, value)` pair of the flat list appears in
+    exactly one group.
+
+    Stated, not proved — the statement is the deliverable #11571 asks for ("state the
+    intended abstraction lemma per predicate"), and discharging it wants the upsert
+    routine's uniqueness fact, which is a follow-on. Naming it here means the
+    `StateTracker` correspondence proof has a single named obligation to consume
+    rather than re-deriving the grouping inline. -/
+def storageRowsAbstract (rs : List StorageWriteRow) : Prop :=
+  StorageWriteRowsMap rs →
+    (((groupByAddress rs).map Prod.fst).Nodup
+      ∧ (groupByAddress rs).foldl (fun n p => n + p.2.length) 0 = rs.length)
+
+/-! ## Non-vacuity, kernel-checked
+
+    A predicate nobody has instantiated is indistinguishable from one that cannot be.
+    These are concrete witnesses plus the matching negative controls, in the style of
+    `Progress/Routines.lean`'s `crossVerdictOk` control: the point is not that the
+    definitions elaborate, but that they *separate* the cases they claim to. -/
+
+section NonVacuity
+
+/-- A live, well-formed account row. -/
+private def sampleRowA : AccountWriteRow :=
+  { address := List.replicate 19 0 ++ [1]
+    balance := List.replicate 32 0
+    nonce := 7
+    optionalState := 1
+    codePtr := 0
+    codeLen := 0
+    execFlags := BitVec.ofNat 64 accountWriteLiveFlag
+    validMask := 0 }
+
+/-- A second live row at a **different** address. -/
+private def sampleRowB : AccountWriteRow :=
+  { sampleRowA with address := List.replicate 19 0 ++ [2] }
+
+/-- A **dead** row (zero `execFlags`) sharing `sampleRowA`'s address. -/
+private def sampleRowDead : AccountWriteRow :=
+  { sampleRowA with execFlags := 0 }
+
+/-- `wf` is satisfiable: the sample row has a 20-byte key and a 32-byte balance. -/
+example : sampleRowA.wf := by
+  unfold AccountWriteRow.wf sampleRowA; simp
+
+/-- `live` separates the two: the flagged row is live, the zero-flag row is not. So
+    `execFlags` is load-bearing rather than decorative. -/
+example : sampleRowA.live ∧ ¬ sampleRowDead.live := by
+  unfold AccountWriteRow.live sampleRowA sampleRowDead accountWriteLiveFlag
+  refine ⟨?_, ?_⟩ <;> decide
+
+/-- ⭐ The map property holds on two live rows with distinct addresses. -/
+example : AccountWriteRowsMap [sampleRowA, sampleRowB] := by
+  refine ⟨?_, ?_⟩
+  · intro r hr
+    simp only [List.mem_cons, List.not_mem_nil, or_false] at hr
+    rcases hr with rfl | rfl
+    · unfold AccountWriteRow.wf sampleRowA; simp
+    · unfold AccountWriteRow.wf sampleRowB sampleRowA; simp
+  · unfold liveAccountRows sampleRowA sampleRowB accountWriteLiveFlag
+    decide
+
+/-- ⭐ **Negative control.** The map property FAILS on two live rows sharing an
+    address — so `Nodup` is doing real work and the predicate is not trivially true.
+    This is the check that distinguishes a map from a row list. -/
+example : ¬ AccountWriteRowsMap [sampleRowA, sampleRowA] := by
+  intro h
+  have := h.2
+  unfold liveAccountRows sampleRowA accountWriteLiveFlag at this
+  revert this
+  decide
+
+/-- ⭐ **The dead-row case, which is the reason `liveAccountRows` exists.** Two rows
+    sharing an address are fine when one is dead — the map is over *live* rows, and an
+    append-with-scan arena legitimately retains superseded rows. A predicate that
+    demanded `Nodup` over all rows would reject reachable states. -/
+example : AccountWriteRowsMap [sampleRowDead, sampleRowA] := by
+  refine ⟨?_, ?_⟩
+  · intro r hr
+    simp only [List.mem_cons, List.not_mem_nil, or_false] at hr
+    rcases hr with rfl | rfl
+    · unfold AccountWriteRow.wf sampleRowDead sampleRowA; simp
+    · unfold AccountWriteRow.wf sampleRowA; simp
+  · unfold liveAccountRows sampleRowDead sampleRowA accountWriteLiveFlag
+    decide
+
+/-- Two storage rows: same contract, two different slots. -/
+private def sampleStoreA : StorageWriteRow :=
+  { rowAddress := List.replicate 32 1
+    slotKey := List.replicate 31 0 ++ [1]
+    value := List.replicate 31 0 ++ [9]
+    baseline := List.replicate 32 0 }
+
+private def sampleStoreB : StorageWriteRow :=
+  { sampleStoreA with slotKey := List.replicate 31 0 ++ [2] }
+
+/-- A row in a **different** contract at the same slot as `sampleStoreA` — the case
+    the docstring calls out as two entries, not one. -/
+private def sampleStoreC : StorageWriteRow :=
+  { sampleStoreA with rowAddress := List.replicate 32 2 }
+
+/-- The storage map property holds across distinct `(address, slot)` pairs, including
+    the same slot in two contracts. -/
+example : StorageWriteRowsMap [sampleStoreA, sampleStoreB, sampleStoreC] := by
+  refine ⟨?_, ?_⟩
+  · intro r hr
+    simp only [List.mem_cons, List.not_mem_nil, or_false] at hr
+    rcases hr with rfl | rfl | rfl <;>
+      simp [StorageWriteRow.wf, sampleStoreA, sampleStoreB, sampleStoreC]
+  · unfold StorageWriteRow.key sampleStoreA sampleStoreB sampleStoreC
+    decide
+
+/-- **Negative control** for the storage map property: the identical `(address, slot)`
+    twice is rejected. -/
+example : ¬ StorageWriteRowsMap [sampleStoreA, sampleStoreA] := by
+  intro h
+  have := h.2
+  unfold StorageWriteRow.key sampleStoreA at this
+  revert this
+  decide
+
+/-- ⭐ **The flat/nested divergence, concretely.** Three flat rows over two contracts
+    group into exactly two address buckets — 2, not 3 — which is the whole content of
+    the group-by and the reason a rename would have been wrong. -/
+example : (groupByAddress [sampleStoreA, sampleStoreB, sampleStoreC]).length = 2 := by
+  unfold groupByAddress sampleStoreA sampleStoreB sampleStoreC
+  decide
+
+/-- And no bucket is lost or duplicated: the flattened count returns the row count. -/
+example :
+    (groupByAddress [sampleStoreA, sampleStoreB, sampleStoreC]).foldl
+      (fun n p => n + p.2.length) 0 = 3 := by
+  unfold groupByAddress sampleStoreA sampleStoreB sampleStoreC
+  decide
+
+end NonVacuity
+
+end EvmAsm.Stateless

--- a/PLAN.md
+++ b/PLAN.md
@@ -435,7 +435,39 @@ All deleted spec files have been recreated. See **Pending: Recreate Deleted Spec
   recipe"); `mptNodeIs`/`nodeDbIs` with the
   `build_node_db` lookup tie (`Evm64/MptAssertions.lean`);
   `witnessSectionIs`/`witnessIndexIs`/`codeDbIs` with the `build_code_db`
-  tie (`Evm64/WitnessAssertions.lean`). The concrete↔abstract refinement
+  tie (`Evm64/WitnessAssertions.lean`).
+  - **Spec-shaped write maps** (2026-08-10, #11571):
+    `accountWritesMapIs` / `txAccountWritesMapIs` / `storageWritesMapIs` in
+    `Stateless/State/WriteMapAssertions.lean`, over `AccountWriteRow` (stride
+    **128**, `addr_BE20@0 balance@32 nonce@64 optionalState@72 codePtr@80
+    codeLen@88 execFlags@96 validMask@112`) and `StorageWriteRow` (stride 128,
+    `rowAddress@0 slotKey@32 value@64 baseline@96`). Scalars use `↦ₘ` because the
+    guest reads them with `ld`/`sd`; every offset is 8-aligned so `memIs`'s
+    alignment holds by construction. Unlocked by #11655's Lane-1 close: the
+    attribution cluster is shape-final, and #11654 (SLOAD's spec deleted the day
+    its container retired) is why a predicate goes in *before* the triples.
+    ⚠️ **Three design facts worth not re-deriving:**
+    (i) these must be **core-side**, so `Codegen/RegionPredicates.lean`'s
+    `teerEntriesFrom` is *mirrored, not imported* — `check-layering` L1 makes
+    Codegen a pure sink and the consumers are core bridges against
+    `SpecRef/StateTracker`; `Stateless/Crypto/FieldAssertions.lean` is the
+    precedent for the same call;
+    (ii) **a row list is not a map** — `execFlags@96` value 2 is a *live* flag and
+    the arena is append-with-scan, so duplicate addresses across a dead/live pair
+    are reachable. Hence `liveAccountRows` + `AccountWriteRowsMap`, with `Nodup`
+    over *live* rows only; a predicate demanding `Nodup` over all rows would
+    reject real states (kernel-checked both ways in the file's non-vacuity
+    section, including that negative control);
+    (iii) ⭐ **SpecRef's storage side is NESTED** (`List (Address × List (Bytes32 ×
+    U256))`, mirroring `Dict[Address, Dict[...]]`) while the guest's rows are
+    **flat** per `(address, slot)`. #11571's proposed signature is the flat one,
+    which is right — so the correspondence is a **group-by**, not a rename.
+    `groupByAddress` + `storageRowsAbstract` are that hook (3 flat rows over 2
+    contracts → 2 buckets, `decide`-checked).
+    Uniqueness is stated as a PRECONDITION, not proved: it is a property of the
+    upsert *writer*, whose triple does not exist yet (#11571 non-goals). Undo
+    journals excluded — #11572.
+    The concrete↔abstract refinement
   map (abstraction functions, divergences, `guestStateCorresponds`
   north-star) is `docs/4ch8f-slstate-specref-correspondence.md`; remaining
   work is decomposed as beads `evm-asm-4ch8f.75.*` (MSTORE


### PR DESCRIPTION
Addresses #11571. I'm assigned on it.

The `account_writes` / `tx_account_writes` / `storage_writes` arenas had **no `Assertion`** — the containers the whole convergence moves *toward* were describable only as raw bytes, while the predicate inventory covered the legacy append-only logs.

**Timing is #11655's ruling.** Its Lane-1 attribution cluster (#11648–#11653, #11581) has now fully closed, and that issue says the vocabulary work should start at exactly that moment: *"that is the moment a stated predicate freezes the shape and converts future drift into build failures."* #11654 is the cautionary case — SLOAD's 45-theorem spec was deleted the day its container retired, because it was written against the container rather than a predicate.

## What's in it

New `EvmAsm/Stateless/State/WriteMapAssertions.lean`:

- `AccountWriteRow` → `accountWriteRowIs` → `accountWriteRowsFrom`, then `accountWritesMapIs` / `txAccountWritesMapIs` at `ACCOUNT_WRITES_AREA` / `TX_ACCOUNT_WRITES_AREA`. Stride **128**, layout read from `AccountWriteMap.lean:207`.
- `StorageWriteRow` → `storageWriteRowIs` → `storageWriteRowsFrom` → `storageWritesMapIs`.
- `pcFree_*` for all four, `_cons` structural lemmas.
- `AccountWriteRowsMap` / `StorageWriteRowsMap` (item 2), plus `groupByAddress` / `storageRowsAbstract`.

Scalars use `↦ₘ` rather than byte-splatting, because the guest reads them with `ld`/`sd`. Every offset is a multiple of 8 and both bases are 8-aligned, so `memIs`'s alignment holds by construction.

## Three design facts I'd rather record than have re-derived

**1. These must be core-side, so `teerEntriesFrom` is mirrored, not imported.** The issue asks to follow that pattern, but it lives in `Codegen/RegionPredicates.lean` and `check-layering` L1 makes Codegen a pure sink — while the consumers are core bridges against `SpecRef/StateTracker`. `Stateless/Crypto/FieldAssertions.lean:20-25` records the identical decision and is the precedent I followed. **Cost, stated plainly:** the row layouts are *restated* from the emitted maps, so a Codegen-side drift isn't caught until a routine triple pins it.

**2. A row list is not a map.** `execFlags@96` value 2 is a *live* flag and the arena is append-with-scan, so a dead row and a live row sharing an address is a **reachable** state. Hence `liveAccountRows` and `Nodup` over **live** rows only — a predicate demanding `Nodup` over all rows would reject real states. Proved both directions below.

**3. ⭐ SpecRef's storage side is NESTED; the guest's is FLAT.** `BlockState.storageWrites : List (Address × List (Bytes32 × U256))` mirrors `Dict[Address, Dict[Bytes32, U256]]`, while guest rows are one per `(address, slot)`. The issue's proposed flat signature is right for the guest — so the correspondence is a **group-by, not a rename**. `groupByAddress` is that function; `storageRowsAbstract` is the hook a `StateTracker` proof consumes. I don't think this was noticed when the issue was written.

## Non-vacuity, kernel-checked — with negative controls

A predicate nobody has instantiated is indistinguishable from one that cannot be:

| check | result |
|---|---|
| `wf` satisfiable | ✅ |
| `live` separates flagged from zero-flag row | ✅ (so `execFlags` is load-bearing) |
| map property on 2 live rows, distinct addresses | ✅ |
| **map property FAILS on 2 live rows sharing an address** | ✅ negative control |
| **dead + live duplicate accepted** | ✅ — fact 2; a stricter predicate would reject reachable states |
| storage map: same slot in 2 contracts | ✅ (2 rows, not 1) |
| **storage map FAILS on exact duplicate** | ✅ negative control |
| group-by: 3 flat rows / 2 contracts → **2** buckets, no row lost | ✅ `decide` |

## Scope, honestly

Vocabulary only, per the issue's non-goals — no routine triples (`account_writes_upsert`/`_lookup`, commit/reset walkers), undo journals excluded (#11572).

**Uniqueness is a precondition, not a theorem.** It's a property of the upsert *writer*, whose triple doesn't exist yet. Asserting it without that would be unearned; naming it makes the obligation citable and freezes the shape. Same discipline as the BAL-sort ruling that uniqueness is a precondition rather than a step.

**Item 3 (#11517 registration) left open** — per your correction there, the unit is a registry row with verdict + basis, which wants `storageRowsAbstract` discharged first.

**No axiom witness added, flagged as a judgment call:** the substantive content is definitions plus non-vacuity `example`s, and the only theorems are `pcFree`/`cons` framing plumbing. When `storageRowsAbstract` is *proved*, that's the thing to witness. Say the word if you'd rather have the `pcFree` lemmas in the gate now.

## Gates

`lake build` (4728 jobs, green, **0 warnings**) + check-no-warnings, **check-layering** (run explicitly — this PR's main risk, and it passes), check-unimported (new file wired into `EvmAsm/Stateless.lean`), check-progress, check-drift, check-forbidden-tactics, check-file-size, check-heartbeats-approved, check-statement-tamper, check-obligation-blockers — **all pass**. No `sorry`/`admit`, no `native_decide`/`bv_decide`, no `maxHeartbeats`.

`check-axioms.sh` cannot run in this checkout (#11897); CI is the authority.

No guest bytes; `.text` unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
