### PR TITLE
docs(codegen): past-tense M25 ABI-removal tombstone (#11556)

### DIFF
--- a/CODEGEN.md
+++ b/CODEGEN.md
@@ -2117,11 +2117,12 @@ with M25; neither artifact exists now.
    is not in the tree; the four M25 cases could not fail for
    a wrong slot list — cannot-fail-for-the-right-reason.
 
-ABI removal (#11556): drop `OpcodeTestCase.expectedPostStorage`,
-the TSV column, the four M25-only cases, and this historical
-"DONE" claim. **No guest-image / four-artefact regen** — the
-serializer was already gone from the linked image; only the
-test-tooling declaration remained.
+ABI removal (#11556): dropped `OpcodeTestCase.expectedPostStorage`,
+the TSV column, the four M25-only cases, and the historical
+"DONE" claim (landed in `036336d7c` / PR #11758). **No
+guest-image / four-artefact regen** — the serializer was already
+gone from the linked image; only the test-tooling declaration
+remained, and that is gone too.
 
 ### M27 — Real EXP (0x0a): graduate from no-op to verified body — **DONE (2026-06-02)**
 


### PR DESCRIPTION
## Summary
One-line docs polish on the M25 tombstone in `CODEGEN.md`.

After #11758 / `036336d7c` the `expectedPostStorage` ABI is already gone from Cases/Cli emission. The residual imperative “ABI removal: drop …” still read as an unfinished TODO. Past tense only.

## Scope held
- **Only** `CODEGEN.md` ~L2120 tense
- Do **not** touch `Cli.lean:145` (accurate retirement comment)
- Do **not** touch the L2099 tombstone body
- No code deletion (nothing left to delete)
- No guest image / four-artefact / r200 (docs-only; production never carried the ABI)

## Context
Issue #11556 closed on evidence that the declared+emitted complaint was already fixed by #11758; this PR only clears the half-present tombstone wording.