### PR TITLE
fix(scripts): portable worktree-build-lock without dropping exclusion (#11897)

### DIFF
--- a/scripts/lib/worktree-build-lock.sh
+++ b/scripts/lib/worktree-build-lock.sh
@@ -3,8 +3,18 @@
 #
 # The lock lives outside the worktree: artifact-cache materialisation can make
 # .lake/build read-only, and a lock file there would turn that environmental
-# condition into a second failure mode. flock releases it automatically when
-# the driver exits, including on a crash.
+# condition into a second failure mode.
+#
+# Acquisition (never runs unlocked):
+#   1. flock when available (Linux/GNU) — fd held until this process exits,
+#      including on crash. Behaviour identical to the historical helper.
+#   2. Else atomic mkdir (portable; macOS has no flock). Released via EXIT
+#      trap; stale dir from a dead pid is reclaimed once. If acquisition
+#      fails, exit 75 — same as the flock busy path.
+#
+# Lock key: sha256 of the absolute worktree path, first 16 hex chars. Prefer
+# sha256sum (GNU); else shasum -a 256. Both emit the same hex digest for the
+# same bytes, so an existing lock file remains recognised across tools.
 set -euo pipefail
 
 if [[ $# -eq 0 ]]; then
@@ -12,25 +22,75 @@ if [[ $# -eq 0 ]]; then
   exit 2
 fi
 
-command -v flock >/dev/null 2>&1 || {
-  echo "worktree-build-lock: required command 'flock' is missing" >&2
-  exit 2
-}
-
 repo_root="$(cd "$(dirname "$0")/../.." && pwd -P)"
 lock_dir="${EVMASM_BUILD_LOCK_DIR:-${TMPDIR:-/tmp}}"
-lock_key="$(printf '%s' "$repo_root" | sha256sum | cut -c1-16)"
+
+if command -v sha256sum >/dev/null 2>&1; then
+  lock_key="$(printf '%s' "$repo_root" | sha256sum | cut -c1-16)"
+elif command -v shasum >/dev/null 2>&1; then
+  lock_key="$(printf '%s' "$repo_root" | shasum -a 256 | cut -c1-16)"
+else
+  echo "worktree-build-lock: required command 'sha256sum' or 'shasum' is missing" >&2
+  exit 2
+fi
+
 lock_file="${EVMASM_BUILD_LOCK_FILE:-$lock_dir/evm-asm-build-$lock_key.lock}"
 mkdir -p "$(dirname "$lock_file")"
 
-exec 9>"$lock_file"
-if ! flock -n 9; then
+busy() {
   echo "worktree-build-lock: another build/regen driver is already running" >&2
   echo "  worktree: $repo_root" >&2
-  echo "  lock:     $lock_file" >&2
+  echo "  lock:     $1" >&2
   echo "  wait for it to finish before retrying" >&2
   exit 75
+}
+
+if command -v flock >/dev/null 2>&1; then
+  # --- GNU/Linux path (unchanged semantics) ---------------------------------
+  exec 9>"$lock_file"
+  if ! flock -n 9; then
+    busy "$lock_file"
+  fi
+  echo "==> acquired worktree build lock: $lock_file"
+  EVMASM_BUILD_LOCK_HELD=1 "$@"
+  exit $?
 fi
 
-echo "==> acquired worktree build lock: $lock_file"
+# --- Portable fallback: atomic mkdir (no unlocked run) ----------------------
+mkdir_lock="${lock_file}.d"
+
+acquire_mkdir_lock() {
+  if mkdir "$mkdir_lock" 2>/dev/null; then
+    printf '%s\n' "$$" >"$mkdir_lock/pid"
+    return 0
+  fi
+  # One stale reclaim if the holder pid is dead.
+  if [[ -f "$mkdir_lock/pid" ]]; then
+    local old_pid
+    old_pid="$(cat "$mkdir_lock/pid" 2>/dev/null || true)"
+    if [[ "$old_pid" =~ ^[0-9]+$ ]] && ! kill -0 "$old_pid" 2>/dev/null; then
+      rm -rf "$mkdir_lock"
+      if mkdir "$mkdir_lock" 2>/dev/null; then
+        printf '%s\n' "$$" >"$mkdir_lock/pid"
+        return 0
+      fi
+    fi
+  fi
+  return 1
+}
+
+if ! acquire_mkdir_lock; then
+  busy "$mkdir_lock"
+fi
+
+release_mkdir_lock() {
+  if [[ -d "$mkdir_lock" ]] && [[ -f "$mkdir_lock/pid" ]] \
+      && [[ "$(cat "$mkdir_lock/pid" 2>/dev/null || true)" == "$$" ]]; then
+    rm -rf "$mkdir_lock"
+  fi
+}
+trap release_mkdir_lock EXIT INT TERM
+
+echo "==> acquired worktree build lock: $mkdir_lock (mkdir fallback; flock missing)"
 EVMASM_BUILD_LOCK_HELD=1 "$@"
+exit $?


### PR DESCRIPTION
## Summary
`scripts/lib/worktree-build-lock.sh` hard-required GNU `flock` + `sha256sum`, so `check-axioms.sh` (and every other caller) dies exit 2 on macOS before the gate runs.

## Behaviour
| path | when | semantics |
|---|---|---|
| **flock** | `flock` on PATH | **Unchanged** vs main: same `lock_file`, same non-blocking `flock -n`, exit 75 busy, `EVMASM_BUILD_LOCK_HELD=1` |
| **mkdir fallback** | no `flock` | Atomic `mkdir ${lock_file}.d` + pid file; EXIT/INT/TERM trap releases; one stale reclaim if holder pid dead; busy → exit 75. **Never runs unlocked.** |
| **hash** | `sha256sum` else `shasum -a 256` | First 16 hex chars of the worktree path digest — **identical** across tools (verified) |

## What this is not
- Not a soundness hole fix — the old failure was loud exit 2, not a vacuous pass.
- Does **not** drop mutual exclusion as a “fallback”.

## Verification (Linux only — **no macOS host**)
Forced not-found branches by stripping `flock` / `sha256sum` from PATH while keeping coreutils:

- flock path: acquire OK; concurrent second → 75; lock file name `evm-asm-build-<key>.lock` unchanged
- mkdir fallback: acquire OK; concurrent → 75; released after exit; stale dead-pid reclaimed
- `sha256sum` vs `shasum -a 256` key match for same path

**macOS path exercised only by simulation on Linux.** Do not read this PR as “verified on macOS.”

## Scope
- One file: `scripts/lib/worktree-build-lock.sh`
- Hands off guest / SpecRef / other open PRs

Closes #11897