### PR TITLE
proof(stateless): prove undoJournal snoc — the obstruction I recorded was in core

### DIFF
--- a/EvmAsm/Stateless/State/UndoJournalAssertions.lean
+++ b/EvmAsm/Stateless/State/UndoJournalAssertions.lean
@@ -290,23 +290,70 @@ theorem accountUndoFrom_cons (stride : Nat) (base : Word) (e : AccountUndoEntry)
       = (accountUndoEntryIs base e
           ** accountUndoFrom stride (base + BitVec.ofNat 64 stride) es) := rfl
 
-/-! ⚠️ **`snoc` is deliberately NOT proved here**, and the reason is worth recording so
-    the next attempt does not rediscover it.
+/-! ## `snoc` — the push-site direction
 
-    The natural statement indexes the appended entry at
-    `base + BitVec.ofNat 64 (stride * es.length)`, so the induction step needs
+    A push extends the journal at the BACK while the run recurses from the FRONT, so
+    `snoc` is not definitional (same shape as `DecodeChain.snoc`).
+
+    ⭐ **The arithmetic obstruction recorded here earlier is solvable, and the key is
+    `BitVec.ofNat_add_ofNat`.** The step needs
 
         (base + ofNat stride) + ofNat (stride * n) = base + ofNat (stride * (n + 1))
 
-    over `BitVec 64` with a **variable** `stride`. That is `ofNat`-of-a-product
-    arithmetic, which `bv_omega` does not see through (multiplication by a variable),
-    so it wants either a dedicated `ofNat` distribution lemma or a reformulation that
-    threads the advanced base instead of computing it.
+    over `BitVec 64` with a **variable** stride. `bv_omega` cannot see through
+    `ofNat`-of-a-product, which is what made this look blocked — but no bitvector
+    reasoning is needed at all: push the two `ofNat`s together with `ofNat_add_ofNat`,
+    then discharge `stride + stride * n = stride * (n + 1)` in `Nat` with `ring`. My
+    earlier note said this wanted "a dedicated `ofNat` distribution lemma"; that lemma is
+    in core, and looking for it beat working around it. -/
 
-    Not done because nothing consumes it yet: `snoc` is what a **push-site** triple
-    needs, and push/replay walker triples are explicitly outside #11572's scope. Doing
-    it now would be arithmetic scaffolding for an absent caller. The two `cons` lemmas
-    above are what the vocabulary itself requires. -/
+/-- The `ofNat`/stride step, isolated: advancing one stride then `n` strides equals
+    advancing `n + 1` strides. Separated because both `snoc` proofs need it and it is the
+    only arithmetic in either. -/
+theorem base_add_stride_succ (base : Word) (stride n : Nat) :
+    (base + BitVec.ofNat 64 stride) + BitVec.ofNat 64 (stride * n)
+      = base + BitVec.ofNat 64 (stride * (n + 1)) := by
+  rw [BitVec.add_assoc, BitVec.ofNat_add_ofNat]
+  congr 1
+  -- `stride + stride * n = stride * (n + 1)`. Deliberately NOT `ring`: this file does
+  -- not import `Mathlib.Tactic.Ring`, and `omega` cannot multiply two variables either.
+  rw [Nat.mul_succ, Nat.add_comm]
+
+/-- Appending one storage undo entry at the run's tail. -/
+theorem storageUndoFrom_snoc (stride : Nat) (e : StorageUndoEntry) :
+    ∀ (es : List StorageUndoEntry) (base : Word),
+      storageUndoFrom stride base (es ++ [e])
+        = (storageUndoFrom stride base es
+            ** storageUndoEntryIs (base + BitVec.ofNat 64 (stride * es.length)) e) := by
+  intro es
+  induction es with
+  | nil =>
+    intro base
+    simp only [List.nil_append, List.length_nil, Nat.mul_zero]
+    rw [storageUndoFrom_cons]
+    simp [storageUndoFrom, sepConj_emp_left', sepConj_emp_right']
+  | cons a as ih =>
+    intro base
+    rw [List.cons_append, storageUndoFrom_cons, storageUndoFrom_cons, ih,
+      ← sepConj_assoc', List.length_cons, ← base_add_stride_succ]
+
+/-- Appending one account undo entry at the run's tail. -/
+theorem accountUndoFrom_snoc (stride : Nat) (e : AccountUndoEntry) :
+    ∀ (es : List AccountUndoEntry) (base : Word),
+      accountUndoFrom stride base (es ++ [e])
+        = (accountUndoFrom stride base es
+            ** accountUndoEntryIs (base + BitVec.ofNat 64 (stride * es.length)) e) := by
+  intro es
+  induction es with
+  | nil =>
+    intro base
+    simp only [List.nil_append, List.length_nil, Nat.mul_zero]
+    rw [accountUndoFrom_cons]
+    simp [accountUndoFrom, sepConj_emp_left', sepConj_emp_right']
+  | cons a as ih =>
+    intro base
+    rw [List.cons_append, accountUndoFrom_cons, accountUndoFrom_cons, ih,
+      ← sepConj_assoc', List.length_cons, ← base_add_stride_succ]
 
 /-! ## The replay theorem, stated
 


### PR DESCRIPTION
Follows #11908 (#11572), where I left `snoc` unproved and documented the obstruction. Assigned on #11572.

## The obstruction was a lemma I didn't find

I wrote that the step needs

```
(base + ofNat stride) + ofNat (stride * n) = base + ofNat (stride * (n + 1))
```

over `BitVec 64` with a **variable** stride, that `bv_omega` cannot see through `ofNat`-of-a-product, and that it "wants either a dedicated `ofNat` distribution lemma or a reformulation" — then deferred it as scaffolding for an absent caller.

⭐ **That lemma is `BitVec.ofNat_add_ofNat`, already in Lean core.** No bitvector reasoning at all: push the two `ofNat`s together, then discharge `stride + stride * n = stride * (n + 1)` in `Nat`.

Searching for it beat working around it — which is precisely the *"search by statement, not by name"* failure I've been flagging in other people's issues all session, committed in my own file. It's recorded in the module rather than quietly fixed, since the misleading note is the part that would have cost the next person time.

## Proven

- **`base_add_stride_succ`** — the arithmetic step, isolated because both `snoc` proofs need it and it's the only arithmetic in either.
- **`storageUndoFrom_snoc`**, **`accountUndoFrom_snoc`** — appending one entry at the run's tail, the direction a **push** site needs (the run recurses from the front, a push extends at the back; same shape as `DecodeChain.snoc`).

⚠️ `ring` is deliberately avoided: this file doesn't import `Mathlib.Tactic.Ring`, and `omega` can't multiply two variables either. `Nat.mul_succ` + `Nat.add_comm` does it.

This is vocabulary the push/replay walker triples will consume. Those triples stay out of scope (#11572's non-goals) — but the arithmetic is no longer in the way, and the "deliberately NOT proved" note that would have deterred the next attempt is gone.

## Gates

`lake build` (4733 jobs, green, **0 warnings**), check-no-warnings, **`check-axioms` — OK, 157 witnesses, classical axioms only**, check-progress, check-drift, check-forbidden-tactics, check-unimported, check-file-size, check-layering, check-heartbeats-approved, check-statement-tamper, check-obligation-blockers — **all pass**. No `sorry`, no `native_decide`/`bv_decide`, no `maxHeartbeats`.

No guest bytes; `.text` unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
