### PR TITLE
fix(progress): register four account accessors found by proof-frontier as .proven

### DIFF
--- a/EvmAsm/Progress/AxiomWitnesses.lean
+++ b/EvmAsm/Progress/AxiomWitnesses.lean
@@ -38,6 +38,8 @@ import EvmAsm.Progress.Correspondence
 
 #print axioms EvmAsm.Codegen.AccountDecodeSpec.account_decode_spec_within
 
+#print axioms EvmAsm.Codegen.AccountIsEip161EmptySpec.account_is_eip161_empty_spec_within
+
 #print axioms EvmAsm.Codegen.AccountIsEip161EmptySpec.leniency_agrees
 
 #print axioms EvmAsm.Codegen.BgvU32leSpec.bgvU32leFlat_spec
@@ -78,6 +80,8 @@ import EvmAsm.Progress.Correspondence
 
 #print axioms EvmAsm.Codegen.HeaderValidateExtraDataLengthSpec.header_validate_extra_data_length_spec_within
 
+#print axioms EvmAsm.Codegen.ReceiptExtractLogsBloomSpec.receiptExtractLogsBloom_spec_within
+
 #print axioms EvmAsm.Codegen.RlpBytesEncodedSizeSAsm.rlpBytesEncodedSize_encode_spec
 
 #print axioms EvmAsm.Codegen.RlpBytesEncodedSizeSAsm.rlpBytesEncodedSize_spec
@@ -109,6 +113,8 @@ import EvmAsm.Progress.Correspondence
 #print axioms EvmAsm.Codegen.RlpSpliceHelperSpec.rlp_item_size_spec_within
 
 #print axioms EvmAsm.Codegen.WithdrawalDecodeSpec.withdrawal_decode_spec_within
+
+#print axioms EvmAsm.Codegen.account_extract_balance_spec_within
 
 #print axioms EvmAsm.Codegen.blsgLtP_spec_specref
 

--- a/EvmAsm/Progress/Routines.lean
+++ b/EvmAsm/Progress/Routines.lean
@@ -71,6 +71,9 @@ import EvmAsm.Codegen.Programs.AccountDecodeCompose
 -- #11516: AccountDecodeCompose imports AccountDecodeBridge, not Close6, so the
 -- whole-routine triple's module has to be imported explicitly for its witness.
 import EvmAsm.Codegen.Programs.AccountDecodeClose6
+import EvmAsm.Codegen.Programs.AccountAccessorTopSpec
+import EvmAsm.Codegen.Programs.AccountIsEip161EmptyClose6
+import EvmAsm.Codegen.Programs.ReceiptExtractLogsBloomSpec
 import EvmAsm.Codegen.Programs.AccountEip161LeniencyBridge
 import EvmAsm.Codegen.Programs.RlpFieldToU256BeWholeSAsm
 import EvmAsm.Codegen.Programs.RlpFieldToU64WholeSAsm
@@ -352,6 +355,42 @@ def routineRegistry : List RoutineEntry := [
         ++ "factor (#11461). No `Correspondence` row yet, same missing `_of_decode` "
         ++ "bridge"),
 
+  -- #11925 continuation: the first registrations out of scripts/proof-frontier.py's
+  -- present-but-unrowed bucket (the #11637 row-existence debt). All four are direct
+  -- whole-routine `cpsTripleWithin` triples found live by the frontier census; the
+  -- `hbound`-style hypotheses each carries are STATIC input well-formedness / slack
+  -- facts tied to the decode predicates, not runtime-outcome gates — the posts stay
+  -- total disjunctions that still state the failure branches. Graded `.proven`.
+  routine "account_decode" .proven (some "account_decode_spec_within")
+      (notes := "whole-routine triple at `GuestAddrs.account_decode`: decodes the "
+        ++ "RLP account record (balance/root/codeHash) to `a0 = 0` with a total "
+        ++ "whole-routine post `adWholePost`. Every hypothesis is ABI/resource "
+        ++ "(`hspW` frame base, `hret` ret alignment, `hlenW` definitional, and "
+        ++ "align/slack/over/valid for the input region plus the three output cells). "
+        ++ "No input-domain gate"),
+  routine "account_extract_balance" .proven (some "account_extract_balance_spec_within")
+      (notes := "whole-routine triple at `GuestAddrs.account_extract_balance`: writes "
+        ++ "`word256Bytes32 a.balance` and returns `a0 = 0`. Its callee "
+        ++ "`rlp_content_to_u256_be` is itself `.proven` (Routines.lean:207), and its "
+        ++ "only value-shaped hypothesis is `hnonce : a.nonce < 2 ^ 256` — the "
+        ++ "NATURAL `Word256` bound, not a restriction (identical to the u256 callee's "
+        ++ "own hypothesis). All other hyps are ABI/resource. No input-domain gate"),
+  routine "account_is_eip161_empty" .proven (some "account_is_eip161_empty_spec_within")
+      (notes := "whole-routine triple at `GuestAddrs.account_is_eip161_empty`: the post "
+        ++ "`aieOutcome` is a TOTAL 4-way disjunction on `(a0, outVal)` — "
+        ++ "`accountEip161Empty` verdict, non-empty verdict, and two error statuses. "
+        ++ "EIP-161 empty-ness is the OUTPUT the routine verifies, not a precondition. "
+        ++ "Hyps are ABI/resource plus a static slack hypothesis over the RLP decode "
+        ++ "predicate. No input-domain gate; axiom-clean confirmed via lean_verify"),
+  routine "receipt_extract_logs_bloom" .proven (some "receiptExtractLogsBloom_spec_within")
+      (notes := "whole-routine triple at `GuestAddrs.receipt_extract_logs_bloom`: the "
+        ++ "post `relbRetPost` is a TOTAL 3-way disjunction — success with the 256-byte "
+        ++ "bloom copied, success with a short/long payload left intact, and the RLP "
+        ++ "decode-failure arm. `hbound` is a static slack fact keyed on the input's "
+        ++ "`Success` decode predicate (so the COPY target is in range), not a runtime "
+        ++ "outcome gate — the failure branch is still stated. ABI/resource hyps only; "
+        ++ "calls RlpFieldToU64SAsm.code"),
+
   routine "rlp_list_encoded_size" .proven (some "rlpListEncodedSize_spec")
       (notes := "total: the result covers BOTH the `ult v 56` short branch and "
         ++ "the long branch, so it is not form-gated — the only hyp is `halignRet`"),
@@ -458,9 +497,9 @@ def routineCount : Nat := routineRegistry.length
 def routineCountTier (t : ProofTier) : Nat :=
   (routineRegistry.filter (fun e => e.tier == t)).length
 
-theorem routineCount_eq : routineCount = 39 := by decide
+theorem routineCount_eq : routineCount = 43 := by decide
 
-theorem routineProvenCount_eq      : routineCountTier .proven      = 30 := by decide
+theorem routineProvenCount_eq      : routineCountTier .proven      = 34 := by decide
 theorem routineConditionalCount_eq : routineCountTier .conditional = 9 := by decide
 theorem routinePartlyCount_eq      : routineCountTier .partly      = 0 := by decide
 
@@ -475,7 +514,7 @@ theorem routineRegistry_all_witnessed :
 def routineSymbols : List String :=
   routineRegistry.map (·.symbol) |>.eraseDups
 
-theorem routineSymbols_eq : routineSymbols.length = 29 := by decide
+theorem routineSymbols_eq : routineSymbols.length = 33 := by decide
 
 /-! ## Cross-registry consistency (#11294)
 
@@ -596,6 +635,19 @@ private noncomputable abbrev _chain_validate_blob_gas_used_under_max_routine_wit
   @EvmAsm.Codegen.ChainValidateBlobGasUnderMaxSpec.chain_validate_blob_gas_used_under_max_spec_within
 private noncomputable abbrev _chain_validate_extra_data_length_routine_witness :=
   @EvmAsm.Codegen.ChainValidateExtraDataLengthSpec.chain_validate_extra_data_length_spec_within
+-- #11925 continuation: whole-routine triples surfaced by scripts/proof-frontier.py.
+-- Namespace/molecule note (mirrors the twins): account_extract_balance_spec_within
+-- lives in the bare `EvmAsm.Codegen` NAMESPACE inside AccountAccessorTopSpec.lean;
+-- account_decode_spec_within is in `EvmAsm.Codegen.AccountDecodeSpec` inside
+-- AccountDecodeClose6.lean; the other two follow the `…Spec` namespace convention.
+private noncomputable abbrev _account_decode_routine_witness :=
+  @EvmAsm.Codegen.AccountDecodeSpec.account_decode_spec_within
+private noncomputable abbrev _account_extract_balance_routine_witness :=
+  @EvmAsm.Codegen.account_extract_balance_spec_within
+private noncomputable abbrev _account_is_eip161_empty_routine_witness :=
+  @EvmAsm.Codegen.AccountIsEip161EmptySpec.account_is_eip161_empty_spec_within
+private noncomputable abbrev _receipt_extract_logs_bloom_routine_witness :=
+  @EvmAsm.Codegen.ReceiptExtractLogsBloomSpec.receiptExtractLogsBloom_spec_within
 -- Correspondence row #11351 names this; it is Codegen-side, and Correspondence
 -- deliberately does not import Codegen, so the witness abbrev lives here.
 private noncomputable abbrev _header_number_of_decode_witness :=

--- a/scripts/registry-coverage-allow.txt
+++ b/scripts/registry-coverage-allow.txt
@@ -26,10 +26,8 @@
 #   structured-only spec as a flat triple is exactly the invisible overclaim this
 #   gate exists to prevent — it would turn a visible backlog into a false census.
 
-# --- TIER A: flat triple at the guest address; registrable now (19) ---
-account_extract_balance	tier A — flat triple `account_extract_balance_spec_within` at GuestAddrs.account_extract_balance (EvmAsm/Codegen/Programs/AccountAccessorTopSpec.lean); registrable as .proven, not yet rowed (#11637)
+# --- TIER A: flat triple at the guest address; registrable now (14) ---
 account_extract_nonce	tier A — flat triple `account_extract_nonce_spec_within` at GuestAddrs.account_extract_nonce (EvmAsm/Codegen/Programs/AccountAccessorNonceSpec.lean); registrable as .proven, not yet rowed (#11637)
-account_is_eip161_empty	tier A — flat triple `account_is_eip161_empty_spec_within` at GuestAddrs.account_is_eip161_empty (EvmAsm/Codegen/Programs/AccountIsEip161EmptyClose6.lean); registrable as .proven, not yet rowed (#11637)
 blq_zero	tier A — flat triple `blqZeroFlat_spec` at GuestAddrs.blq_zero (EvmAsm/Codegen/Programs/Bls12Fq12SetOneSAsm.lean); registrable as .proven, not yet rowed (#11637)
 blsg_le_to_be	tier A — flat triple `blsgLeToBeFn_spec` at GuestAddrs.blsg_le_to_be (EvmAsm/Codegen/Programs/Bls12G1LeToBeSAsm.lean); registrable as .proven, not yet rowed (#11637)
 bnf_be_to_le	tier A — flat triple `bnfBeToLeFlat_spec` at GuestAddrs.bnf_be_to_le (EvmAsm/Codegen/Programs/Bn254FieldAddModPSAsmStage.lean); registrable as .proven, not yet rowed (#11637)
@@ -37,7 +35,6 @@ bnf_le_to_be	tier A — flat triple `bnfLeToBeFlat_spec` at GuestAddrs.bnf_le_to
 bnq_zero	tier A — flat triple `bnqZeroFlat_spec` at GuestAddrs.bnq_zero (EvmAsm/Codegen/Programs/Bn254Fq12SetOneSAsm.lean); registrable as .proven, not yet rowed (#11637)
 eip8037_tx_state_gas	tier A — flat triple `eip8037TxStateGas_spec_within` at GuestAddrs.eip8037_tx_state_gas (EvmAsm/Codegen/Programs/Eip8037TxStateGasSpec.lean); registrable as .proven, not yet rowed (#11637)
 mset_memcpy	tier A — flat triple `mset_memcpy_spec_within` at GuestAddrs.mset_memcpy (EvmAsm/Codegen/Programs/AccountBalanceHelperSpec.lean); registrable as .proven, not yet rowed (#11637)
-receipt_extract_logs_bloom	tier A — flat triple `receiptExtractLogsBloom_spec_within` at GuestAddrs.receipt_extract_logs_bloom (EvmAsm/Codegen/Programs/ReceiptExtractLogsBloomSpec.lean); registrable as .proven, not yet rowed (#11637)
 secf_be_to_le	tier A — flat triple `secfBeToLeFn_spec` at GuestAddrs.secf_be_to_le (EvmAsm/Codegen/Programs/Secp256k1FieldConvSAsm.lean); registrable as .proven, not yet rowed (#11637)
 secf_is_zero32	tier A — flat triple `secfIsZero32Fn_spec` at GuestAddrs.secf_is_zero32 (EvmAsm/Codegen/Programs/Secp256k1FieldIsZeroSAsm.lean); registrable as .proven, not yet rowed (#11637)
 secf_le_to_be	tier A — flat triple `secfLeToBeFn_spec` at GuestAddrs.secf_le_to_be (EvmAsm/Codegen/Programs/Secp256k1FieldLeToBeSAsm.lean); registrable as .proven, not yet rowed (#11637)
@@ -45,7 +42,7 @@ secf_zero32	tier A — flat triple `secfZero32Fn_spec` at GuestAddrs.secf_zero32
 tx_type_dispatch	tier A — flat triple `txTypeDispatch_spec_within` at GuestAddrs.tx_type_dispatch (EvmAsm/Codegen/Programs/TxTypeDispatchTop.lean); registrable as .proven, not yet rowed (#11637)
 u256_sub_be	tier A — flat triple `u256SubBeFlat_spec` at GuestAddrs.u256_sub_be (EvmAsm/Codegen/Programs/Secp256k1FieldReduceOnceSAsmSupport.lean); registrable as .proven, not yet rowed (#11637)
 
-# --- TIER B: structured SAsm spec only; needs Fn.retSpecFlat first (83) ---
+# --- TIER B: structured SAsm spec only; needs Fn.retSpecFlat first (75) ---
 bah_u32le	tier B — structured SAsm spec `bahU32leFn_spec` (EvmAsm/Codegen/Programs/BlockAccessListHashSAsm.lean); needs Fn.retSpecFlat before a .proven row is honest (#11637)
 bgv_u64le	tier B — structured SAsm spec `bgvU64leFn_spec` (EvmAsm/Codegen/Programs/BalGasValidU64SAsm.lean); needs Fn.retSpecFlat before a .proven row is honest (#11637)
 bhr_rev_le_be	tier B — structured SAsm spec `bhrRevLeBeFn_spec` (EvmAsm/Codegen/Programs/BhrRevLeBeSAsm.lean); needs Fn.retSpecFlat before a .proven row is honest (#11637)


### PR DESCRIPTION
# Register four account accessors as `.proven`

First registrations out of scripts/proof-frontier.py (#11925): four whole-routine
triples from the census's present-but-unrowed bucket (the #11637 row-existence
debt my earlier transcript calls "the actionable class"). Rows, witness abbrevs,
AxiomWitnesses re-generation and allowlist drain, all in this PR.

## The four rows

| routine | theorem | location |
|---|---|---|
| `account_decode` | `account_decode_spec_within` | AccountDecodeClose6.lean:1360 (ns `EvmAsm.Codegen.AccountDecodeSpec`) |
| `account_extract_balance` | `account_extract_balance_spec_within` | AccountAccessorTopSpec.lean:737 (bare `EvmAsm.Codegen` ns) |
| `account_is_eip161_empty` | `account_is_eip161_empty_spec_within` | AccountIsEip161EmptyClose6.lean:950 (ns `...AccountIsEip161EmptySpec`) |
| `receipt_extract_logs_bloom` | `receiptExtractLogsBloom_spec_within` | ReceiptExtractLogsBloomSpec.lean:1290 (ns `...ReceiptExtractLogsBloomSpec`) |

## Why `.proven` and not `.conditional`

Same discipline as the chain_validate family (#11928/#11931): graded from the
actual theorem statement, not the name. Every hypothesis is resource/ABI:

- `account_decode`: `hspW` frame, `hret` alignment, `hlenW` definitional, and
  align/slack/over/valid for input + three output cells. Post `adWholePost`
  total.
- `account_extract_balance`: only value-shaped hyp is `hnonce : a.nonce < 2^256`,
  the NATURAL `Word256` bound — identical to the hypothesis of its `.proven`
  callee `rlp_content_to_u256_be` (Routines.lean:207).
- `account_is_eip161_empty`: EIP-161 empty-ness is the OUTPUT — the `aieOutcome`
  post is a total 4-way disjunction (empty / non-empty / two error statuses).
  The `hbound` hyps are static slack facts over the RLP decode predicate.
- `receipt_extract_logs_bloom`: `relbRetPost` is a total 3-way disjunction
  incl. the decode-failure arm; `hbound` is static slack keyed on the input's
  `Success` decode predicate, not a runtime outcome gate.

## Verification honesty

- `check-axioms.sh` **cannot run in this checkout**: artifact-cache mode leaves
  `lake env lean` unable to resolve cache-satisfied modules (issue #10537).
  Substituted `lean_verify` on each of the four triples — `propext /
  Classical.choice / Quot.sound` only, zero sorries, zero warnings. CI (non-cache
  runner) is the authority and runs `check-axioms.sh` as a blocking gate.
- `lake build EvmAsm.Progress.Routines` clean (2478 jobs).
- `check-registry-coverage.py` OK — three stale tier-A allowlist entries for the
  now-registered symbols drained (plus header counts 19/83 corrected to actual
  14/75, verified by the script's own tier counts).
- `check-progress.sh` and `check-drift.sh` exit 0.

## Count bumps (for the reviewer / gates)

- `routineCount` 39 -> **43**
- `.proven` rows 30 -> **34** (`.conditional` unchanged at 9)
- `routineSymbols` 29 -> **33**

## Out of scope

`account_extract_nonce` (`.conditional`, inherits its callee's caliber —
separate PR) and `tx_type_dispatch` (held: PR #11929, which modifies that
routine, must land first). Documented on the issue.