### PR TITLE
feat(proofs): add concrete Keccak accelerator seam

### DIFF
--- a/EvmAsm.lean
+++ b/EvmAsm.lean
@@ -25,6 +25,7 @@ import EvmAsm.Codegen.Proofs.DoWhileDemo
 import EvmAsm.Codegen.Proofs.GuardedHandlerSpecs
 import EvmAsm.Codegen.Proofs.GuestImage
 import EvmAsm.Codegen.Proofs.GuestImageEntries
+import EvmAsm.Codegen.Proofs.HashBridgeKeccakSpec
 import EvmAsm.Codegen.Proofs.HandleFocusReal
 import EvmAsm.Codegen.Proofs.HandlerHandles
 import EvmAsm.Codegen.Proofs.HandlerHandlesBinary

--- a/EvmAsm/Codegen/Proofs/HashBridgeKeccakSpec.lean
+++ b/EvmAsm/Codegen/Proofs/HashBridgeKeccakSpec.lean
@@ -1,0 +1,72 @@
+/-
+  EvmAsm.Codegen.Proofs.HashBridgeKeccakSpec
+
+  Proof-only correspondence facts for the inline Keccak bridge.  The emitted
+  `zkvmKeccak256_prog` remains the flat 69-instruction Program in
+  `HashBridgeProg`; this module supplies the concrete CSRS seam and the pure
+  padding/absorption facts needed to structure its proof.
+
+  The eventual wrapper theorem quantifies over the ABI envelope documented at
+  `docs/4ch8f-top-spec.md:55` and §2a (`MAX_INPUT_BYTES = 0x37FFFFF8`).  That
+  envelope is a resource fact, not a smaller proof convenience cap; the fuel
+  bound is derived from the input length.
+-/
+
+import EvmAsm.Codegen.Programs.HashBridge
+import EvmAsm.Rv64.SAsm.KeccakStep
+import EvmAsm.Stateless.SpecRef.Crypto
+
+namespace EvmAsm.Codegen.Proofs
+
+open EvmAsm.Rv64
+open EvmAsm.Rv64.SAsm
+open EvmAsm.Stateless.SpecRef
+
+/-- The padding suffix for a message whose length is a multiple of the rate.
+    This is the branch that is easy to lose when modelling the emitted
+    residual loop: a zero remainder still gets a complete pad-only block. -/
+theorem keccakPad_zero_remainder (msg : Bytes)
+    (hrem : msg.length % keccakRateBytes = 0) :
+    (keccakPad msg).drop msg.length =
+      (0x01 : Byte) :: List.replicate 134 (0 : Byte) ++ [(0x80 : Byte)] := by
+  have hrem' : msg.length % 136 = 0 := by
+    simpa [keccakRateBytes] using hrem
+  simp [keccakPad, keccakRateBytes, hrem']
+
+/-- Two consecutive inline accelerator calls cover the two adjacent
+    permutation points used by a full block followed by a pad-only block.
+    This is proof-only structure: the emitted bridge remains the flat
+    69-instruction program, and this theorem deliberately keeps the concrete
+    `Accel.keccakF` image at each seam. -/
+theorem keccak_two_csrs_spec_within
+    (entry : Word) (rs1 : Reg) (hrs1 : Reg.isExposed rs1 = true)
+    (B : Word) (len : Nat) (ws : List (BitVec 8)) (rf : RegFile)
+    (hwslen : ws.length = len)
+    (hb8 : B.toNat % 8 = 0)
+    (hvalid : ∀ j, j < len → isValidMemAddr (B + BitVec.ofNat 64 j) = true)
+    (pOff : Nat) (hp : rf.get rs1 = B + BitVec.ofNat 64 pOff)
+    (h8p : 8 ∣ pOff) (hpfit : pOff + 200 ≤ len) :
+    cpsTripleWithin 2 entry (entry + BitVec.ofNat 64 8)
+      (CodeReq.ofProg entry [.CSRS 0x800 rs1, .CSRS 0x800 rs1])
+      ((regFileIs rf) ** bytesRegion B ws)
+      ((regFileIs rf) ** bytesRegion B
+        (setBytes (setBytes ws pOff (keccakBytes ws pOff)) pOff
+          (keccakBytes (setBytes ws pOff (keccakBytes ws pOff)) pOff))) := by
+  have hws1len : (setBytes ws pOff (keccakBytes ws pOff)).length = len := by
+    rw [length_setBytes]
+    exact hwslen
+  have h1 := csrs_keccak_spec_within entry rs1 hrs1 B len ws rf hwslen
+    hb8 hvalid pOff hp h8p hpfit
+  have h2 := csrs_keccak_spec_within (entry + 4) rs1 hrs1 B len
+    (setBytes ws pOff (keccakBytes ws pOff)) rf hws1len hb8 hvalid pOff hp
+    h8p hpfit
+  have hd : (CodeReq.singleton entry (.CSRS 0x800 rs1)).Disjoint
+      (CodeReq.singleton (entry + 4) (.CSRS 0x800 rs1)) :=
+    CodeReq.Disjoint.singleton (by bv_omega)
+  have hseq := cpsTripleWithin_seq hd h1 h2
+  rw [← CodeReq.ofProg_pair] at hseq
+  have hExit : entry + 4 + 4 = entry + BitVec.ofNat 64 8 := by bv_omega
+  rw [hExit] at hseq
+  exact hseq
+
+end EvmAsm.Codegen.Proofs

--- a/EvmAsm/Rv64/SAsm.lean
+++ b/EvmAsm/Rv64/SAsm.lean
@@ -46,6 +46,7 @@ import EvmAsm.Rv64.SAsm.LoopFuel
 import EvmAsm.Rv64.SAsm.LoopFuelDemo
 import EvmAsm.Rv64.SAsm.InterpLoopDemo
 import EvmAsm.Rv64.SAsm.AccelStep
+import EvmAsm.Rv64.SAsm.KeccakStep
 import EvmAsm.Rv64.SAsm.PowLadderDemo
 import EvmAsm.Rv64.SAsm.MultiRw
 import EvmAsm.Rv64.SAsm.MultiRead

--- a/EvmAsm/Rv64/SAsm/KeccakStep.lean
+++ b/EvmAsm/Rv64/SAsm/KeccakStep.lean
@@ -1,0 +1,166 @@
+/-
+  EvmAsm.Rv64.SAsm.KeccakStep
+
+  The machine-level seam for the concrete ZisK Keccak-f accelerator.  This
+  deliberately proves only the inline `CSRS 0x800` instruction and its
+  two-instruction return wrapper; the hash bridge's flat 69-instruction
+  program remains emitted exactly as-is.
+-/
+
+import EvmAsm.Rv64.SAsm.AccelStep
+
+namespace EvmAsm.Rv64
+namespace SAsm
+
+/-- The 25 little-endian dwords read by `csrs 0x800` from a state window. -/
+def keccakDwords (ws : List (BitVec 8)) (k : Nat) : List Word :=
+  (List.range 25).map fun i => wsDword ws (k + 8 * i)
+
+/-- The byte image written back by the concrete Keccak-f accelerator. -/
+def keccakBytes (ws : List (BitVec 8)) (k : Nat) : List (BitVec 8) :=
+  (Accel.keccakF (keccakDwords ws k)).flatMap dwordBytes
+
+@[simp] theorem length_keccakDwords (ws : List (BitVec 8)) (k : Nat) :
+    (keccakDwords ws k).length = 25 := by
+  simp [keccakDwords]
+
+@[simp] theorem length_keccakBytes (ws : List (BitVec 8)) (k : Nat) :
+  (keccakBytes ws k).length = 200 := by
+  rw [keccakBytes, length_flatMap_dwordBytes, Accel.keccakF_length]
+
+private theorem csrsValid_keccak (s : MachineState) (rs1 : Reg) :
+    s.csrsValid 0x800 rs1 = MachineState.validDwordRange (s.getReg rs1) 25 := rfl
+
+private theorem csrsWrite_keccak (s : MachineState) (rs1 : Reg) :
+    s.csrsWrite 0x800 rs1 =
+      (s.getReg rs1, Accel.keccakF (s.readWords (s.getReg rs1) 25)) := rfl
+
+/-- One inline `csrs 0x800, rs1` step, with the state window decoded from the
+    entry bytes and the post written back as concrete `Accel.keccakF` bytes.
+    The only preconditions are the fixed 200-byte aligned scratch resource
+    and the exposed register containing its offset. -/
+theorem csrs_keccak_spec_within
+    (base : Word) (rs1 : Reg) (hrs1 : Reg.isExposed rs1 = true)
+    (B : Word) (len : Nat) (ws : List (BitVec 8)) (rf : RegFile)
+    (hwslen : ws.length = len)
+    (hb8 : B.toNat % 8 = 0)
+    (hvalid : ∀ j, j < len → isValidMemAddr (B + BitVec.ofNat 64 j) = true)
+    (pOff : Nat) (hp : rf.get rs1 = B + BitVec.ofNat 64 pOff)
+    (h8p : 8 ∣ pOff) (hpfit : pOff + 200 ≤ len) :
+    cpsTripleWithin 1 base (base + 4)
+      (CodeReq.singleton base (.CSRS 0x800 rs1))
+      ((regFileIs rf) ** bytesRegion B ws)
+      ((regFileIs rf) ** bytesRegion B
+        (setBytes ws pOff (keccakBytes ws pOff))) := by
+  apply csrs_step_spec_within 0x800 rs1 base B ws rf pOff
+    (Accel.keccakF (keccakDwords ws pOff)) h8p
+  · rw [Accel.keccakF_length]
+    rw [hwslen]
+    exact hpfit
+  · intro R s hPR
+    rw [sepConj_assoc'] at hPR
+    have hregs : s.getReg rs1 = rf.get rs1 :=
+      holdsFor_regFileIs_getReg hPR hrs1
+    have hMem := hPR
+    rw [sepConj_left_comm] at hMem
+    have hsrs1 : s.getReg rs1 = B + BitVec.ofNat 64 pOff := by
+      rw [hregs, hp]
+    have hvrange :
+        MachineState.validDwordRange (B + BitVec.ofNat 64 pOff) 25 = true :=
+      validDwordRange_of_window hb8 hvalid h8p (by omega)
+    have hread : s.readWords (B + BitVec.ofNat 64 pOff) 25 =
+        keccakDwords ws pOff := by
+      rw [holdsFor_bytesRegion_readWords hMem 25 pOff h8p (by omega)]
+      rfl
+    constructor
+    · rw [csrsValid_keccak, hsrs1]
+      exact hvrange
+    · rw [csrsWrite_keccak, hsrs1, hread]
+/-- The inline Keccak step followed by the ordinary return epilogue. -/
+theorem csrs_keccak_ret_spec
+    (entry : Word) (rs1 : Reg) (hrs1 : Reg.isExposed rs1 = true)
+    (B : Word) (len : Nat) (ws : List (BitVec 8)) (rf : RegFile)
+    (hwslen : ws.length = len)
+    (hb8 : B.toNat % 8 = 0)
+    (hvalid : ∀ j, j < len → isValidMemAddr (B + BitVec.ofNat 64 j) = true)
+    (pOff : Nat) (hp : rf.get rs1 = B + BitVec.ofNat 64 pOff)
+    (h8p : 8 ∣ pOff) (hpfit : pOff + 200 ≤ len)
+    (A : Assertion) (hA : A.pcFree)
+    (ret : Word) (halign : (ret &&& ~~~(1 : Word)) = ret) :
+    cpsTripleWithin 2 entry ret
+      (CodeReq.ofProg entry (csrsRetProgram 0x800 rs1))
+      ((.x1 ↦ᵣ ret) ** (((regFileIs rf) ** bytesRegion B ws) ** A))
+      ((.x1 ↦ᵣ ret) ** (((regFileIs rf) ** bytesRegion B
+        (setBytes ws pOff (keccakBytes ws pOff))) ** A)) :=
+  csrs_ret_spec_of_step
+    (csrs_keccak_spec_within entry rs1 hrs1 B len ws rf hwslen hb8 hvalid
+      pOff hp h8p hpfit)
+    A hA ret halign
+
+/-- The proof-only snapshot handle for a concrete Keccak-f step.  It is useful
+    to structured proofs of the bridge, but does not replace the inline CSRS
+    in `HashBridgeProg`. -/
+def keccakPre (B : Word) (rs1 : Reg) (pOff : Nat) : Reach :=
+  fun rf _ _ => rf.get rs1 = B + BitVec.ofNat 64 pOff
+
+def keccakPost (pOff : Nat) :
+    RegFile → List (BitVec 8) → Assertion → Reach :=
+  fun rf₀ ws₀ A₀ rf ws A =>
+    rf = rf₀ ∧ A = A₀ ∧ ws = setBytes ws₀ pOff (keccakBytes ws₀ pOff)
+
+theorem keccakHandle_sound (entry : Word) (rs1 : Reg)
+    (hrs1 : Reg.isExposed rs1 = true)
+    (ro : Region) (B : Word) (len : Nat)
+    (hrw : (RwRegion.mk B len).wf)
+    (pOff : Nat) (h8p : 8 ∣ pOff) (hpfit : pOff + 200 ≤ len) :
+    ∀ (rf₀ : RegFile) (ws₀ : List (BitVec 8)) (A₀ : Assertion),
+      ws₀.length = len → A₀.pcFree →
+      keccakPre B rs1 pOff rf₀ ws₀ A₀ →
+      ∀ ret : Word, (ret &&& ~~~(1 : Word)) = ret →
+      cpsTripleWithin 2 entry ret
+        (CodeReq.ofProg entry (csrsRetProgram 0x800 rs1))
+        ((.x1 ↦ᵣ ret) ** asrtM ro ⟨B, len⟩
+          (Reach.exact rf₀ ws₀ A₀))
+        ((.x1 ↦ᵣ ret) ** asrtM ro ⟨B, len⟩
+          (keccakPost pOff rf₀ ws₀ A₀)) := by
+  intro rf₀ ws₀ A₀ hlen hApc hpre ret halign
+  have hcore := csrs_keccak_ret_spec entry rs1 hrs1 B len ws₀ rf₀ hlen
+    hrw.1 hrw.2.2 pOff hpre h8p hpfit
+    (A₀ ** bytesRegion ro.base ro.bytes)
+    (pcFree_sepConj hApc (bytesRegion_pcFree _ _)) ret halign
+  refine cpsTripleWithin_weaken (fun hq hh => ?_) (fun hq hh => ?_) hcore
+  · rw [show asrtM ro ⟨B, len⟩ (Reach.exact rf₀ ws₀ A₀)
+        = (asrtOf ⟨B, len⟩ (Reach.exact rf₀ ws₀ A₀)
+          ** bytesRegion ro.base ro.bytes) from rfl, sepConj_comm'] at hh
+    rw [sepConj_comm']
+    refine sepConj_mono_left (fun hq' hh' => ?_) hq hh
+    rw [← sepConj_assoc']
+    refine sepConj_mono_left (fun hq'' hh'' => ?_) hq' hh'
+    obtain ⟨rf, ws', A, -, -, ⟨rfl, rfl, rfl⟩, hsts⟩ := hh''
+    exact hsts
+  · rw [show asrtM ro ⟨B, len⟩ (keccakPost pOff rf₀ ws₀ A₀)
+        = (asrtOf ⟨B, len⟩ (keccakPost pOff rf₀ ws₀ A₀)
+          ** bytesRegion ro.base ro.bytes) from rfl, sepConj_comm']
+    rw [sepConj_comm'] at hh
+    refine sepConj_mono_left (fun hq' hh' => ?_) hq hh
+    rw [← sepConj_assoc'] at hh'
+    refine sepConj_mono_left (fun hq'' hh'' => ?_) hq' hh'
+    exact ⟨rf₀, _, A₀, by rw [length_setBytes]; exact hlen,
+      hApc, ⟨rfl, rfl, rfl⟩, hh''⟩
+
+def keccakHandle (entry : Word) (rs1 : Reg)
+    (hrs1 : Reg.isExposed rs1 = true)
+    (ro : Region) (B : Word) (len : Nat)
+    (hrw : (RwRegion.mk B len).wf)
+    (pOff : Nat) (h8p : 8 ∣ pOff) (hpfit : pOff + 200 ≤ len) : FnHandleS where
+  entry := entry
+  code := CodeReq.ofProg entry (csrsRetProgram 0x800 rs1)
+  nSteps := 2
+  region := ro
+  rw := ⟨B, len⟩
+  pre := keccakPre B rs1 pOff
+  post := keccakPost pOff
+  sound := keccakHandle_sound entry rs1 hrs1 ro B len hrw pOff h8p hpfit
+
+end SAsm
+end EvmAsm.Rv64


### PR DESCRIPTION
## Summary

This lands the proof-only Keccak accelerator seam for issue 11924.

- HashBridgeProg emits CSRS 0x800 (2048), not ECALL; the flat 69-instruction wrapper uses two inline CSRS sites.
- The machine-level seam goes through concrete Accel.keccakF. Execution.step dispatches valid CSRS to execInstrBr, step_csrs proves the one-step transition, and csrs_step_spec_within frames the concrete writeWords payload. No axiom or new cps vocabulary is needed.
- SpecRef.Crypto.keccak256 is built from the same concrete Accel.keccakF.
- The zero-remainder padding fact and a two-adjacent-CSRS composition theorem are included.
- No emitted program was changed.

## Hypothesis classification

Scratch validity and alignment, output validity, input-output disjointness, input pointer alignment, and MAX_INPUT_BYTES = 0x37FFFFF8 are ABI or resource facts. MAX_INPUT_BYTES is an ABI envelope, not a proof artefact or proof-convenience cap. The nSteps bound is a function of input length. There is no smaller ad hoc domain restriction; the target classification is proven.

## Explicit remaining scope

The wrapper loop framing is intentionally not complete. The flat 69-instruction Program has inline CSRS, while Stmt.callRegS emits a JALR to a separate handle, so the callRegS shape cannot flatten byte-identically. The remaining route is a proof-only structured decomposition; this PR does not restructure emitted code.

The literal ECALL route remains blocked on concrete ECALL state-transition semantics: Execution.step treats a non-special ECALL as PC+4, while executeKeccakEcall is parameterized by an arbitrary accelerator function and is not tied to Accel.keccakF. Instantiating it for Keccak would be an axiom-shaped gap.

No registry row is added for the unfinished wrapper.

## Byte-neutrality evidence

Clean isolated worktrees were built with lake exe codegen --program stateless_guest --halt linux93, using base commit 6dbfd3d24 and candidate commit 15fe4aa43.

- Production .text: 340820 bytes; base SHA256 65983da27d1b5132ec202cd425564aa21d185a7e689889ac9a4f7b2996c5e60d; candidate SHA256 65983da27d1b5132ec202cd425564aa21d185a7e689889ac9a4f7b2996c5e60d.
- Production .data: 21264 bytes; base SHA256 4305fdaf302a5e4a3769d9f76dc38f47221e8372247b224ec76d889efaac92f5; candidate SHA256 4305fdaf302a5e4a3769d9f76dc38f47221e8372247b224ec76d889efaac92f5.
- cmp passed for both sections.

## Verification

- lake build
- check-file-size.sh
- check-unimported.sh
- check-layering.sh
- check-forbidden-tactics.sh
- git diff --check