### PR TITLE
feat(progress): register tx_type_dispatch as .proven

### DIFF
--- a/EvmAsm/Progress/AxiomWitnesses.lean
+++ b/EvmAsm/Progress/AxiomWitnesses.lean
@@ -114,6 +114,8 @@ import EvmAsm.Progress.Correspondence
 
 #print axioms EvmAsm.Codegen.RlpSpliceHelperSpec.rlp_item_size_spec_within
 
+#print axioms EvmAsm.Codegen.TxTypeDispatchSpec.txTypeDispatch_spec_within
+
 #print axioms EvmAsm.Codegen.WithdrawalDecodeSpec.withdrawal_decode_spec_within
 
 #print axioms EvmAsm.Codegen.account_extract_balance_spec_within

--- a/EvmAsm/Progress/Routines.lean
+++ b/EvmAsm/Progress/Routines.lean
@@ -96,6 +96,7 @@ import EvmAsm.Codegen.Programs.ChainValidateGasUsedUnderLimitLoopClose
 import EvmAsm.Codegen.Programs.ChainValidateBlobGasMultipleLoopClose
 import EvmAsm.Codegen.Programs.ChainValidateBlobGasUnderMaxLoopClose
 import EvmAsm.Codegen.Programs.ChainValidateExtraDataLengthLoopClose
+import EvmAsm.Codegen.Programs.TxTypeDispatchTop
 
 namespace EvmAsm.Progress
 
@@ -497,7 +498,27 @@ def routineRegistry : List RoutineEntry := [
         ++ "reference read the same 32 bytes and the restatement is total. ⚠️ It is "
         ++ "the `x`-BOUND CLAUSE of `bytes_to_g1`, not its verdict: that function "
         ++ "also bounds `y` and tests the curve equation, neither of which this "
-        ++ "routine looks at")
+        ++ "routine looks at"),
+
+  -- #11925 last-of-six: `tx_type_dispatch` re-derived as `.proven` FROM THE
+  -- MERGED text of #11929 (not the pre-merge read). #11929 appended the
+  -- legacy upper-bound guard (0xff guard; routine 45 -> 48 instructions):
+  -- `0xff` moved OUT of the legacy arm into its own FAILURE disjunct. The
+  -- post remains TOTAL over the byte: empty, byte at or above 0xc0 and not
+  -- 0xff -> legacy; byte equals 0xff -> ff-fail; byte under 0xc0 in 1..4 ->
+  -- typed; otherwise -> unknown-fail. A failure disjunct inside a total post
+  -- is still a total post. No input-domain precondition on `txBytes` (only
+  -- ABI: ra-alignment, 8-aligned base, size bound, byte-access validity).
+  routine "tx_type_dispatch" .proven (some "txTypeDispatch_spec_within")
+      (notes := "whole-routine triple at `GuestAddrs.tx_type_dispatch` over "
+        ++ "the emitted `txTypeDispatch_prog` (48 instrs after #11929's appended "
+        ++ "0xff guard). Classifies via `teerTxTypeDispatch`: empty -> fail "
+        ++ "(1,0,0); 0xc0..0xfe -> legacy (0,0,0); 0xff -> fail (1,0,0); 1..4 -> "
+        ++ "typed (0,N,1); otherwise -> fail (1,0,0). Step budget "
+        ++ "`nTxTypeDispatchSteps` = 256; five BGEU witnesses (shared, four "
+        ++ "non-taken Typed, unknown) all carry immediate 168 = "
+        ++ "`brOff (GuestAddrs.tx_type_dispatch+180) (GuestAddrs.tx_type_dispatch+12)`, "
+        ++ "matching the emitted guard target at D+180")
 ]
 
 /-! ## Counts (kernel-checked) -/
@@ -509,9 +530,9 @@ def routineCount : Nat := routineRegistry.length
 def routineCountTier (t : ProofTier) : Nat :=
   (routineRegistry.filter (fun e => e.tier == t)).length
 
-theorem routineCount_eq : routineCount = 44 := by decide
+theorem routineCount_eq : routineCount = 45 := by decide
 
-theorem routineProvenCount_eq      : routineCountTier .proven      = 34 := by decide
+theorem routineProvenCount_eq      : routineCountTier .proven      = 35 := by decide
 theorem routineConditionalCount_eq : routineCountTier .conditional = 10 := by decide
 theorem routinePartlyCount_eq      : routineCountTier .partly      = 0 := by decide
 
@@ -526,7 +547,7 @@ theorem routineRegistry_all_witnessed :
 def routineSymbols : List String :=
   routineRegistry.map (·.symbol) |>.eraseDups
 
-theorem routineSymbols_eq : routineSymbols.length = 34 := by decide
+theorem routineSymbols_eq : routineSymbols.length = 35 := by decide
 
 /-! ## Cross-registry consistency (#11294)
 
@@ -730,5 +751,9 @@ private noncomputable abbrev _bnf_lt_p_routine_witness :=
   @EvmAsm.Codegen.Bn254FieldLtPSAsm.bnfLtP_spec
 private noncomputable abbrev _bnf_lt_p_specref_routine_witness :=
   @EvmAsm.Codegen.bnfLtP_spec_specref
+-- #11925 last-of-six: the whole-routine triple lives in the `TxTypeDispatchTop`
+-- module, in the `…TxTypeDispatchSpec` namespace.
+private noncomputable abbrev _tx_type_dispatch_routine_witness :=
+  @EvmAsm.Codegen.TxTypeDispatchSpec.txTypeDispatch_spec_within
 
 end EvmAsm.Progress


### PR DESCRIPTION
## Summary

Register **`tx_type_dispatch`** as `.proven` in the guest-routine registry (`EvmAsm/Progress/Routines.lean`). Grade re-derived **from the merged text of #11929** (not the pre-merge read).

### Why the grade is still `.proven`

#11929 appended the legacy upper-bound **0xff guard**, taking the routine 45 → 48 instructions and moving `0xff` out of the legacy arm into its **own failure disjunct**. The merged top-level `txTypeDispatch_spec_within`:

- has **no input-domain precondition on `txBytes`** — only ABI facts (ra-alignment, 8-aligned base, size bound, byte-access validity);
- its post (`typeFlatPostOf`, via `teerTxTypeDispatch`) is **exhaustive over the byte**: empty → fail (1,0,0); 0xc0..0xfe → legacy (0,0,0); 0xff → ff-fail (1,0,0); 1..4 → typed (0,N,1); otherwise → unknown-fail (1,0,0).

A **failure disjunct inside a total post is still a total post** — the checked property is a postcondition, not an input gate.

### Witness / immediate check (the #11929 hazard)

All **five** BGEU witnesses (the shared one, the four non-taken Typed type1–4, and the unknown one in Top) carry immediate `168` = `brOff (GuestAddrs.tx_type_dispatch+180) (GuestAddrs.tx_type_dispatch+12)`, matching the emitted program instr-3 target to the appended guard at D+180. `CodeReq.ofProg_mem_at` closes **full-instruction (incl. immediate) equality by `rfl`**, so a stale immediate in any of them is a **compile-time impossibility** — confirmed by `lake build` succeeding.

### Changes

- `EvmAsm/Progress/Routines.lean`: add `routine "tx_type_dispatch" .proven (some "txTypeDispatch_spec_within")`, witness abbrev `_tx_type_dispatch_routine_witness`, and the `TxTypeDispatchTop` import.
- `EvmAsm/Progress/AxiomWitnesses.lean`: regenerated **by script** (`python3 scripts/gen-axiom-witnesses.py --write`), not by hand (170 witnesses; cross-check passes, regenerated file is byte-identical).

### Count bumps (kernel-checked)

- `routineCount` 44 → **45**
- `routineProvenCount` 34 → **35**
- `routineSymbols` 34 → **35**
- `routineConditionalCount` / `routinePartlyCount` unchanged (10 / 0)

### Axioms

`EvmAsm.Codegen.TxTypeDispatchSpec.txTypeDispatch_spec_within` (and every sub-spec) depends only on **propext / Classical.choice / Quot.sound** (classical-3) per `#print axioms` in the build log.

⚠️ `check-axioms.sh` **cannot run in this checkout** (artifact-cache mode, issue #10537) — CI is the authority for the axiom gate in this PR. I verified the footprint via `lake build` output instead. Ref built and pushed at: branch `work/11925-register-tx-type-dispatch` based on `origin/main` `c39de0460`.

This is the **last of the six census rows** (four `.proven` in #11940, `extract_nonce` `.conditional` in #11947, and this one) — the actionable subset is fully drained.
