### PR TITLE
feat(proofs): frame inline Keccak wrapper loops

### DIFF
--- a/EvmAsm/Codegen/Proofs/HashBridgeKeccakSpec.lean
+++ b/EvmAsm/Codegen/Proofs/HashBridgeKeccakSpec.lean
@@ -4,7 +4,10 @@
   Proof-only correspondence facts for the inline Keccak bridge.  The emitted
   `zkvmKeccak256_prog` remains the flat 69-instruction Program in
   `HashBridgeProg`; this module supplies the concrete CSRS seam and the pure
-  padding/absorption facts needed to structure its proof.
+  padding/absorption facts needed to structure its proof.  The loop-framing
+  toolkit now has the three relevant shapes: `countdownLoop_spec`, the
+  count-up sibling `upLoop_spec`, and this signed `BLT` companion
+  `signedCountdownLoop_spec`.
 
   The eventual wrapper theorem quantifies over the ABI envelope documented at
   `docs/4ch8f-top-spec.md:55` and §2a (`MAX_INPUT_BYTES = 0x37FFFFF8`).  That
@@ -14,6 +17,9 @@
 
 import EvmAsm.Codegen.Programs.HashBridge
 import EvmAsm.Rv64.SAsm.KeccakStep
+import EvmAsm.Rv64.SAsm.AbiFrameLoop
+import EvmAsm.Rv64.SAsm.AbiFrameLoopBottom
+import EvmAsm.Rv64.SAsm.Flatten
 import EvmAsm.Stateless.SpecRef.Crypto
 
 namespace EvmAsm.Codegen.Proofs
@@ -21,6 +27,352 @@ namespace EvmAsm.Codegen.Proofs
 open EvmAsm.Rv64
 open EvmAsm.Rv64.SAsm
 open EvmAsm.Stateless.SpecRef
+open Stmt
+
+abbrev KeccakLoopInv :=
+  Nat → RegFile → List (BitVec 8) → Assertion → Prop
+
+/-! ## Proof-only wrapper shape
+
+The flat wrapper cannot be expressed with `Stmt.callRegS`: that node emits a
+`JALR`, while the guest has the two Keccak `CSRS 0x800` instructions inline.
+The decomposition below therefore keeps every emitted instruction in the same
+raw block, but gives the three runtime loops structured boundaries and leaves
+their invariants as explicit arguments.  In particular, the block-loop
+invariant below names the sponge state after `k` full input blocks; it is the
+fact that the eventual VC proof must preserve, not a proof-convenience size
+cap.
+-/
+
+def keccakAbsorbBlocks (input : Bytes) (k : Nat) : List Bytes :=
+  chunkBytes keccakRateBytes (input.take (keccakRateBytes * k))
+
+def keccakStateBytes (st : List (BitVec 64)) : List (BitVec 8) :=
+  st.flatMap dwordBytes
+
+def keccakAbsorbedState (input : Bytes) (k : Nat) : List (BitVec 8) :=
+  keccakStateBytes
+    (keccakAbsorb (List.replicate 25 (0 : BitVec 64))
+      (keccakAbsorbBlocks input k))
+
+/-- Runtime fuel derived from the input length: one slot beyond the maximum
+    number of complete rate blocks, so the final failing header check is
+    representable.  This is not a proof-convenience input cap. -/
+def keccakAbsorbFuel (len : Nat) : Nat := len / keccakRateBytes + 1
+
+/-- The remainder loop's fuel is exactly the input remainder after complete
+    rate blocks; the enclosing `when` makes the zero case unreachable. -/
+def keccakRemainderFuel (len : Nat) : Nat := len % keccakRateBytes
+
+private theorem word_ofNat_slt_iff {i j : Nat} (hi : i < 2 ^ 63) (hj : j < 2 ^ 63) :
+    BitVec.slt (BitVec.ofNat 64 i) (BitVec.ofNat 64 j) ↔ i < j := by
+  have hiNat : (BitVec.ofNat 64 i).toNat = i := by
+    rw [BitVec.toNat_ofNat, Nat.mod_eq_of_lt (by omega)]
+  have hjNat : (BitVec.ofNat 64 j).toNat = j := by
+    rw [BitVec.toNat_ofNat, Nat.mod_eq_of_lt (by omega)]
+  have hi' : (BitVec.ofNat 64 i).toInt = i := by
+    rw [BitVec.toInt_eq_toNat_of_lt (by rw [hiNat]; omega), hiNat]
+  have hj' : (BitVec.ofNat 64 j).toInt = j := by
+    rw [BitVec.toInt_eq_toNat_of_lt (by rw [hjNat]; omega), hjNat]
+  simp only [BitVec.slt, hi', hj', decide_eq_true_eq]
+  omega
+
+/-! ### The outer loop's direct CPS shape
+
+`countdownLoop_spec` is the reusable BEQ-counter form used by the inline
+bottom-test loops below.  The outer loop is the one deliberate variation in
+the emitted wrapper: it is a signed `BLT remaining, rate, exit`, followed by a
+136-byte decrement and a `JAL` back-edge.  This companion keeps that variation
+at the same register-agnostic `cpsTripleWithin` level.  Its only arithmetic
+side condition is the signed-comparison envelope needed to justify the RV64
+`BLT`; it is not an additional input-size cap.  At the wrapper call site,
+`remaining` is derived from the ABI resource envelope
+`MAX_INPUT_BYTES = 0x37FFFFF8`, so `step * N + rem` is at most that bound and
+therefore lies inside the signed range; the envelope is a resource fact, not
+a smaller proof-domain assumption.  The caller supplies that ABI envelope,
+and the fuel is still derived from `len`.
+-/
+
+theorem signedCountdownLoop_spec
+    (cr : CodeReq) (hdr exitAddr : Word) (ctr lim : Reg) (exitOff : BitVec 13)
+    (bodyStep step N rem : Nat) (inv : Nat → Assertion)
+    (_hctr_ne : ctr ≠ .x0) (_hctr_lim_ne : ctr ≠ lim)
+    (hrem : rem < step) (hstepBound : step < 2 ^ 63)
+    (hNbound : step * N + rem < 2 ^ 63)
+    (hexit : hdr + signExtend13 exitOff = exitAddr)
+    (hpcFree : ∀ n, (inv n).pcFree)
+    (hguardMem : ∀ a i,
+      CodeReq.singleton hdr (.BLT ctr lim exitOff) a = some i → cr a = some i)
+    (hbody : ∀ n, n < N →
+      cpsTripleWithin bodyStep (hdr + 4) hdr cr
+        ((ctr ↦ᵣ BitVec.ofNat 64 (step * (n + 1) + rem))
+          ** (lim ↦ᵣ BitVec.ofNat 64 step) ** inv (n + 1))
+        ((ctr ↦ᵣ BitVec.ofNat 64 (step * n + rem))
+          ** (lim ↦ᵣ BitVec.ofNat 64 step) ** inv n)) :
+    cpsTripleWithin (N * (bodyStep + 1) + 1) hdr exitAddr cr
+      ((ctr ↦ᵣ BitVec.ofNat 64 (step * N + rem))
+        ** (lim ↦ᵣ BitVec.ofNat 64 step) ** inv N)
+      ((ctr ↦ᵣ BitVec.ofNat 64 rem)
+        ** (lim ↦ᵣ BitVec.ofNat 64 step) ** inv 0) := by
+  suffices h : ∀ n, n ≤ N →
+      cpsTripleWithin (n * (bodyStep + 1) + 1) hdr exitAddr cr
+        ((ctr ↦ᵣ BitVec.ofNat 64 (step * n + rem))
+          ** (lim ↦ᵣ BitVec.ofNat 64 step) ** inv n)
+        ((ctr ↦ᵣ BitVec.ofNat 64 rem)
+          ** (lim ↦ᵣ BitVec.ofNat 64 step) ** inv 0) from
+    h N (Nat.le_refl N)
+  intro n
+  induction n with
+  | zero =>
+    intro _
+    have hblt := blt_spec_gen_within ctr lim exitOff
+      (BitVec.ofNat 64 rem) (BitVec.ofNat 64 step) hdr
+    rw [hexit] at hblt
+    have hbr := cpsBranchWithin_extend_code hguardMem
+      (cpsBranchWithin_frameR (inv 0) (hpcFree 0) hblt)
+    have hlt := (word_ofNat_slt_iff (by omega) hstepBound).2 hrem
+    have htaken := cpsBranchWithin_takenPath hbr
+      (fun hp hQf => by
+        obtain ⟨_, _, _, _, ⟨_, _, _, _, _, h_pure⟩, _⟩ := hQf
+        exact ((sepConj_pure_right _).1 h_pure).2 hlt)
+    simp only [Nat.zero_mul, Nat.mul_zero, Nat.zero_add]
+    exact cpsTripleWithin_weaken
+      (fun h hp => by xperm_hyp hp)
+      (fun h hq => by
+        have hq1 := sepConj_mono_left
+          (sepConj_mono_right (fun h' hp' => ((sepConj_pure_right h').1 hp').1)) h hq
+        xperm_hyp hq1) htaken
+  | succ k ih =>
+    intro hk
+    have hkN : k < N := Nat.lt_of_succ_le hk
+    have hkn_le : k + 1 ≤ N := Nat.succ_le_iff.mp hk
+    have hcurr : step * (k + 1) + rem < 2 ^ 63 := by
+      have hmono : step * (k + 1) ≤ step * N :=
+        Nat.mul_le_mul_left step hkn_le
+      omega
+    have hge : step ≤ step * (k + 1) + rem := by
+      have hstep_pos : 0 < step := by omega
+      have hmul : step ≤ step * (k + 1) := by
+        rw [Nat.mul_succ]
+        omega
+      omega
+    have hblt := blt_spec_gen_within ctr lim exitOff
+      (BitVec.ofNat 64 (step * (k + 1) + rem))
+      (BitVec.ofNat 64 step) hdr
+    rw [hexit] at hblt
+    have hbr := cpsBranchWithin_extend_code hguardMem
+      (cpsBranchWithin_frameR (inv (k + 1)) (hpcFree (k + 1)) hblt)
+    have hnlt : ¬BitVec.slt
+        (BitVec.ofNat 64 (step * (k + 1) + rem))
+        (BitVec.ofNat 64 step) := by
+      intro hlt'
+      exact (Nat.not_lt_of_ge hge)
+        ((word_ofNat_slt_iff hcurr hstepBound).1 hlt')
+    have hguard := cpsBranchWithin_ntakenPath hbr
+      (fun hp hQt => by
+        obtain ⟨_, _, _, _, ⟨_, _, _, _, _, h_pure⟩, _⟩ := hQt
+        exact hnlt ((sepConj_pure_right _).1 h_pure).2)
+    have hbodyk := hbody k hkN
+    have ihk := ih (Nat.le_of_lt hkN)
+    have s1 := cpsTripleWithin_seq_perm_same_cr
+      (fun h hp => by
+        have hp2 := sepConj_mono_left
+          (sepConj_mono_right (fun h' hp' => ((sepConj_pure_right h').1 hp').1)) h hp
+        xperm_hyp hp2) hguard hbodyk
+    have s2 := cpsTripleWithin_seq_perm_same_cr
+      (fun h hp => by xperm_hyp hp) s1 ihk
+    have hstep' : (k + 1) * (bodyStep + 1) + 1
+        = 1 + bodyStep + (k * (bodyStep + 1) + 1) := by
+      rw [Nat.add_mul, Nat.one_mul]
+      omega
+    rw [hstep']
+    exact cpsTripleWithin_weaken
+      (fun h hp => by xperm_hyp hp) (fun h hp => by xperm_hyp hp) s2
+
+/- The two inner loops use the existing register-agnostic countdown abstraction;
+   these wrappers make their fixed emitted counts explicit without changing the
+   flat program.  The caller supplies the per-iteration body triple and the
+   enclosing `CodeReq` membership, so the loop proof remains proof-only. -/
+
+theorem keccakDwordLoop_spec
+    (cr : CodeReq) (hdr : Word) (inv : Nat → Assertion)
+    (hpcFree : ∀ n, (inv n).pcFree)
+    (hguardMem : ∀ a i,
+      CodeReq.singleton (hdr + BitVec.ofNat 64 28)
+        (.BNE .x31 .x0 (-28 : BitVec 13)) a = some i → cr a = some i)
+    (hbody : ∀ n, n < 17 →
+      cpsTripleWithin 7 hdr (hdr + BitVec.ofNat 64 28) cr
+        ((.x31 ↦ᵣ BitVec.ofNat 64 (n + 1)) ** (.x0 ↦ᵣ (0 : Word)) ** inv (n + 1))
+        ((.x31 ↦ᵣ BitVec.ofNat 64 n) ** (.x0 ↦ᵣ (0 : Word)) ** inv n)) :
+    cpsTripleWithin (17 * 8) hdr (hdr + BitVec.ofNat 64 32) cr
+      ((.x31 ↦ᵣ BitVec.ofNat 64 17) ** (.x0 ↦ᵣ (0 : Word)) ** inv 17)
+      ((.x31 ↦ᵣ BitVec.ofNat 64 0) ** (.x0 ↦ᵣ (0 : Word)) ** inv 0) := by
+  have hloop := countdownLoopBottom_spec cr hdr (hdr + BitVec.ofNat 64 28) .x31
+    (-28 : BitVec 13) 7 17 inv (by decide) (by decide) (by decide)
+    (by
+      rw [show signExtend13 (-28 : BitVec 13) = (-28 : Word) by decide]
+      bv_omega) hpcFree (by simpa using hguardMem) hbody
+  rw [show 17 * (7 + 1) = 17 * 8 by decide,
+    show hdr + BitVec.ofNat 64 28 + 4 = hdr + BitVec.ofNat 64 32 by bv_omega] at hloop
+  exact hloop
+
+theorem keccakRemainderLoop_spec
+    (cr : CodeReq) (hdr : Word) (rem : Nat) (inv : Nat → Assertion)
+    (hrem_pos : 1 ≤ rem) (hrem_bound : rem < 2 ^ 64)
+    (hpcFree : ∀ n, (inv n).pcFree)
+    (hguardMem : ∀ a i,
+      CodeReq.singleton (hdr + BitVec.ofNat 64 28)
+        (.BNE .x9 .x0 (-28 : BitVec 13)) a = some i → cr a = some i)
+    (hbody : ∀ n, n < rem →
+      cpsTripleWithin 7 hdr (hdr + BitVec.ofNat 64 28) cr
+        ((.x9 ↦ᵣ BitVec.ofNat 64 (n + 1)) ** (.x0 ↦ᵣ (0 : Word)) ** inv (n + 1))
+        ((.x9 ↦ᵣ BitVec.ofNat 64 n) ** (.x0 ↦ᵣ (0 : Word)) ** inv n)) :
+    cpsTripleWithin (rem * 8) hdr (hdr + BitVec.ofNat 64 32) cr
+      ((.x9 ↦ᵣ BitVec.ofNat 64 rem) ** (.x0 ↦ᵣ (0 : Word)) ** inv rem)
+      ((.x9 ↦ᵣ BitVec.ofNat 64 0) ** (.x0 ↦ᵣ (0 : Word)) ** inv 0) := by
+  have hloop := countdownLoopBottom_spec cr hdr (hdr + BitVec.ofNat 64 28) .x9
+    (-28 : BitVec 13) 7 rem inv (by decide) hrem_pos hrem_bound
+    (by
+      rw [show signExtend13 (-28 : BitVec 13) = (-28 : Word) by decide]
+      bv_omega) hpcFree (by simpa using hguardMem) hbody
+  rw [show rem * (7 + 1) = rem * 8 by omega,
+    show hdr + BitVec.ofNat 64 28 + 4 = hdr + BitVec.ofNat 64 32 by bv_omega] at hloop
+  exact hloop
+
+/-- The outer-loop relation after `k` complete 136-byte blocks.  The scratch
+    bytes are the concrete 25-lane sponge state, while `x20`/`x9` identify the
+    unconsumed input suffix.  The output atom is carried in the ambient
+    assertion and is untouched until the final `blockAt` copy. -/
+def keccakAbsorbInv (inputBase scratchBase outputBase : Word)
+    (input output : Bytes) (len : Nat) : KeccakLoopInv :=
+  fun k rf ws A =>
+    k ≤ len / keccakRateBytes ∧
+    input.length = len ∧
+    rf.get .x8 = scratchBase ∧
+    rf.get .x9 = BitVec.ofNat 64 (len - keccakRateBytes * k) ∧
+    rf.get .x20 = inputBase + BitVec.ofNat 64 (keccakRateBytes * k) ∧
+    rf.get .x29 = BitVec.ofNat 64 keccakRateBytes ∧
+    ws = keccakAbsorbedState input k ∧
+    ws.length = 200 ∧
+    A = bytesRegion outputBase output
+
+def keccakZeroStateBody : Stmt :=
+  .block "zero_state.body"
+    [.SD .x28 .x0 (0 : BitVec 12),
+     .ADDI .x28 .x28 (8 : BitVec 12),
+     .ADDI .x29 .x29 (-1 : BitVec 12)]
+
+def keccakDwordAbsorbBody : Stmt :=
+  .block "absorb_dword.body"
+    [.LD .x5 .x30 (0 : BitVec 12),
+     .LD .x6 .x28 (0 : BitVec 12),
+     .XOR .x6 .x6 .x5,
+     .SD .x28 .x6 (0 : BitVec 12),
+     .ADDI .x28 .x28 (8 : BitVec 12),
+     .ADDI .x30 .x30 (8 : BitVec 12),
+     .ADDI .x31 .x31 (-1 : BitVec 12)]
+
+def keccakRemainderBody : Stmt :=
+  .block "remainder.body"
+    [.LBU .x5 .x30 (0 : BitVec 12),
+     .LBU .x6 .x28 (0 : BitVec 12),
+     .XOR .x5 .x5 .x6,
+     .SB .x28 .x5 (0 : BitVec 12),
+     .ADDI .x28 .x28 (1 : BitVec 12),
+     .ADDI .x30 .x30 (1 : BitVec 12),
+     .ADDI .x9 .x9 (-1 : BitVec 12)]
+
+def keccakOutputWinR (outputBase : Word) (output : Bytes) :
+    RegFile → List (BitVec 8) → Assertion →
+      List (BitVec 8) → Assertion → Prop :=
+  fun rf _ _ win rest =>
+    rf.get .x18 = outputBase ∧ win = output ∧ rest.pcFree
+
+def keccakWrapperStmt (L : GuestLayout) (len : Nat)
+    (outputBase : Word) (output : Bytes)
+    (zeroInv dwordInv absorbInv remainderInv : KeccakLoopInv) : Stmt :=
+  .block "prologue"
+    [.ADDI .x2 .x2 (-32 : BitVec 12),
+     .SD .x2 .x8 (0 : BitVec 12),
+     .SD .x2 .x9 (8 : BitVec 12),
+     .SD .x2 .x18 (16 : BitVec 12),
+     .SD .x2 .x20 (24 : BitVec 12),
+     .MV .x20 .x10,
+     .MV .x9 .x11,
+     .MV .x18 .x12,
+     .AUIPC .x8 (laHi L.zk3_state (L.zkvm_keccak256 + 32)),
+     .ADDI .x8 .x8 (laLo L.zk3_state (L.zkvm_keccak256 + 32)),
+     .MV .x28 .x8,
+     .LI .x29 (25 : Word)]
+  ;;; .doWhile "zero_state" (.bne .x29 .x0) 25 zeroInv
+        keccakZeroStateBody
+  ;;; .whileHeader "absorb_blocks" (.block "absorb_blocks.header"
+          [.LI .x29 (136 : Word)]) (.bge .x9 .x29)
+        (keccakAbsorbFuel len) absorbInv
+        (.block "absorb_blocks.setup"
+          [.MV .x28 .x8, .MV .x30 .x20, .LI .x31 (17 : Word)]
+         ;;; .doWhile "absorb_dword" (.bne .x31 .x0) 17 dwordInv
+               keccakDwordAbsorbBody
+         ;;; .block "absorb_blocks.permute"
+          [.MV .x10 .x8,
+           .CSRS (2048 : BitVec 12) .x10,
+           .ADDI .x20 .x20 (136 : BitVec 12),
+           .ADDI .x9 .x9 (-136 : BitVec 12)])
+  ;;; .block "remainder.setup" [.MV .x28 .x8, .MV .x30 .x20]
+  ;;; .when "remainder" (.bne .x9 .x0)
+        (.doWhile "remainder_bytes" (.bne .x9 .x0) (keccakRemainderFuel len)
+          remainderInv keccakRemainderBody)
+  ;;; .block "pad"
+    [.LBU .x5 .x28 (0 : BitVec 12),
+     .XORI .x5 .x5 (1 : BitVec 12),
+     .SB .x28 .x5 (0 : BitVec 12),
+     .ADDI .x28 .x8 (135 : BitVec 12),
+     .LBU .x5 .x28 (0 : BitVec 12),
+     .XORI .x5 .x5 (128 : BitVec 12),
+     .SB .x28 .x5 (0 : BitVec 12)]
+  ;;; .block "final_permute"
+    [.MV .x10 .x8, .CSRS (2048 : BitVec 12) .x10]
+  ;;; .blockAt "digest_out" .x18 (keccakOutputWinR outputBase output)
+    [.LD .x5 .x8 (0 : BitVec 12),
+     .SD .x18 .x5 (0 : BitVec 12),
+     .LD .x5 .x8 (8 : BitVec 12),
+     .SD .x18 .x5 (8 : BitVec 12),
+     .LD .x5 .x8 (16 : BitVec 12),
+     .SD .x18 .x5 (16 : BitVec 12),
+     .LD .x5 .x8 (24 : BitVec 12),
+     .SD .x18 .x5 (24 : BitVec 12)]
+  ;;; .block "return"
+    [.LI .x10 (0 : Word),
+     .LD .x8 .x2 (0 : BitVec 12),
+     .LD .x9 .x2 (8 : BitVec 12),
+     .LD .x18 .x2 (16 : BitVec 12),
+     .LD .x20 .x2 (24 : BitVec 12),
+     .ADDI .x2 .x2 (32 : BitVec 12),
+     .JALR .x0 .x1 (0 : BitVec 12)]
+
+/- The list shape is a proof-only view: the emitted program remains the
+   generated flat `zkvmKeccak256_prog_of`; no emitter or byte changes flow from
+   this statement.  Keeping the guard here makes that promise kernel-checked. -/
+theorem keccakWrapperStmt_flatten (L : GuestLayout) (len : Nat)
+    (outputBase : Word) (output : Bytes)
+    (zeroInv dwordInv absorbInv remainderInv : KeccakLoopInv) :
+    (keccakWrapperStmt L len outputBase output zeroInv dwordInv absorbInv remainderInv).flatten 0 =
+      zkvmKeccak256_prog_of L := by
+  rfl
+
+#guard (keccakWrapperStmt .zero 0 0 []
+    (fun _ _ _ _ => True) (fun _ _ _ _ => True)
+    (fun _ _ _ _ => True) (fun _ _ _ _ => True)).flatten 0 =
+  zkvmKeccak256_prog_of .zero
+#guard (keccakWrapperStmt .zero 0 0 []
+    (fun _ _ _ _ => True) (fun _ _ _ _ => True)
+    (fun _ _ _ _ => True) (fun _ _ _ _ => True)).size = 69
+
+/- `offsetsOk` is intentionally not asserted here: the flat wrapper's `BLT`
+   and `BNE` guards read `x9`, a callee-saved register that the caller-only
+   SAsm AST excludes from `Reg.isExposed`.  The flatten tie is therefore a
+   structural map for the direct `cpsTripleWithin`/ABI-frame proof route, not
+   a claim that `Stmt.sound` can consume this shape. -/
 
 /-- The padding suffix for a message whose length is a multiple of the rate.
     This is the branch that is easy to lose when modelling the emitted


### PR DESCRIPTION
## Summary

- Add a direct `cpsTripleWithin` signed-countdown companion for the outer `BLT remaining, rate` loop, with the 136-byte stride and exact emitted control-flow shape.
- Compose the two inner bottom-tested `BNE` loops through `countdownLoopBottom_spec`, exposing the fixed 17-dword and input-remainder loop bounds.
- Retain the byte-exact 69-instruction flatten tie, `keccakAbsorbInv`, derived fuel, and pure padding/absorption facts.

This is proof-only: no emitted Program, guest image, or `Progress.lean` change.

The signed comparison envelope is an ABI/resource fact, not a smaller proof-domain cap: at the wrapper call site `remaining` is derived from `MAX_INPUT_BYTES = 0x37FFFFF8`, so `step * N + rem` is at most that bound and remains inside the signed RV64 range. Fuel remains derived from the input length.

## Checks

- `env LAKE_ARTIFACT_CACHE=false lake build EvmAsm.Codegen.Proofs.HashBridgeKeccakSpec` (912/912)
- `env LAKE_ARTIFACT_CACHE=false lake build` (4740/4740)
- `scripts/check-forbidden-tactics.sh`
- `scripts/check-file-size.sh`
- `scripts/check-unimported.sh` (2770/2770 reachable)
- `scripts/check-layering.sh`
- `git diff --check`
