### PR TITLE
perf(codegen): move witness-index arenas to BSS

### DIFF
--- a/EvmAsm/Codegen/Programs/MptWitnessIndex.lean
+++ b/EvmAsm/Codegen/Programs/MptWitnessIndex.lean
@@ -268,8 +268,13 @@ def witnessIndexFunctions : String :=
   "wlh_linear_iterations:\n  .zero 8\n" ++
   "wlh_linear_last_section_len:\n  .zero 8\n" ++
   "wlh_linear_max_section_len:\n  .zero 8\n" ++
+  ".popsection\n" ++
+  -- The index arena is runtime-built scratch, not initialized data.  Keep the
+  -- metadata above in `.data`, but place the six-MiB record arena in NOBITS so
+  -- it does not occupy the linked image's PROGBITS payload.
+  ".section .bss, \"aw\", @nobits\n" ++
   ".balign 8\n" ++
   "widx_records:\n  .zero " ++ toString mptWitnessIndexArenaBytes ++ "\n" ++
-  ".popsection"
+  ".section .text"
 
 end EvmAsm.Codegen


### PR DESCRIPTION
## Summary

Move only the two runtime-built witness-index record arenas, `widx_records` and
`wcidx_records`, from `.data` to `.bss`.  Each arena is 6,291,456 bytes (48-byte
records × 131,072 capacity), for 12,582,912 bytes total.  The metadata cells,
modexp scratch, and all initialized data remain in `.data`.

The emitted source enters `.bss` with `.section .bss, "aw", @nobits` and then
returns explicitly to `.text`; `.popsection` would be incorrect here because
the BSS section was opened with `.section`, not `.pushsection`.

## Base and scope

This branch is based on current `origin/main`
`eab6fcc278947de8c06521a8d97d26fe97f0a7bb` (post-11963); the change commit is
`0b723d1ff`.  Only `widx_records` and `wcidx_records` move.  No metadata,
modexp scratch, or other initialized data is moved.

The production `stateless_guest` image at the base already canonicalizes these
zero-only arenas into BSS: at `eab6fcc27` with tracked-tree dirty flag zero its
`.data` is 21,264 bytes (`0x5310`) and `.bss` is `0x1b38cda0` (ELF SHA256
`653d3731c56b41d6f03889feb3a989fde58bdf9cb87b78d0243734e6ae321aa2`).  The
12,617,296-byte figure in the issue belongs to the debug/probe image, not
production; this change therefore recovers no production bytes.  Its real
justification is making the source declaration truthful instead of depending
on the linker to canonicalize zero-only `.data`, while also fixing the
debug/probe image that reviewers inspect.

## Debug/probe layout evidence

The paired debug/probe artifacts were built from the same post-11963 base,
with only this source change differing:

| section | baseline (`447d1f973ed65a68ad169c40be78731c1e4e062c8cac8a248059af56dca55169`) | candidate (`c569381fcf33a6d909a09b2aa8a4f8cbd3e38991426b1e3385617efc7765cd0f`) | delta |
|---|---:|---:|---:|
| `.text` | `0x50a04` | `0x50a04` | `0` |
| `.data` | `0xc085f0` | `0x85f0` | `-0xc00000` |
| `.bss` | `0x19289940` | `0x19e89940` | `+0xc00000` |

Both `.data` images contain 11,996 nonzero bytes in the same 920 runs and 11
clusters; after removing the 12 MiB arena prefix, the candidate has identical
bytes and relative spacing.  The base already includes 11963's independent
`0x1500` BSS increase, so the isolated 10881 delta is exactly `0xc00000`.

## Pin and build checks

After the final rebase, all four generated artifacts were regenerated:
`symbol-addresses.tsv`, `GuestAddrs.lean`, `GuestImageEntries.lean`, and
`RegionMapLinkPins.lean`.  A complete third regeneration was a no-op.  The
post-rebase checks passed:

- `lake build` (4,741 jobs).
- `scripts/check-region-map.sh`.
- `scripts/check-asm-to-program.sh` (371 converted definitions).
- `scripts/check-unimported.sh` (2,771 reachable modules, 0 orphans).
- `scripts/check-file-size.sh`.
- `scripts/check-no-hardcoded-guest-pc.sh`.
- `scripts/check-guestaddrs-starts.sh` (330/330 linked entries).

## Paired EEST evidence

The post-rebase production paired random-200 used the same seed (`10881`),
fixture tag `tests-zkevm@v0.6.2`, Spike backend, and 30 jobs.  The baseline
ELF was `653d3731c56b41d6f03889feb3a989fde58bdf9cb87b78d0243734e6ae321aa2`;
the candidate ELF was
`64e2e299b35d4a077a13522921c83620955d813b2427725caeb2434936869a9a`.

Both legs ran 200/200 with 0 errors, FA=0, FR=0, budget=0, and 200/200 full,
root, success, and tail matches.  `eest-ab-compare.py` joined 195 rows (four
shared-input groups cover nine rows each), with no unmatched inputs, no status
differences, and no output-byte differences.  The flip sets are explicitly:

- base-PASS → candidate-FR: `∅`
- candidate-PASS → base-FR: `∅`

The candidate outputs are byte-identical to the baseline on all 195 joined
rows.

An earlier paired run on pre-11963 `76889ef97` is not used as landing evidence;
the numbers above are the matched post-11963 run.
