### PR TITLE
docs(spec): state the 200M resource envelope

### DIFF
--- a/EvmAsm/Codegen/Programs/BlockVerdictParams.lean
+++ b/EvmAsm/Codegen/Programs/BlockVerdictParams.lean
@@ -10,6 +10,7 @@
 import EvmAsm.Codegen.Programs.EvmAccessGas
 import EvmAsm.Codegen.Programs.EvmStorageAccessGas
 import EvmAsm.Codegen.RegionMapLinkPins
+import EvmAsm.Stateless.Constants
 import EvmAsm.Stateless.MemoryLayout
 
 namespace EvmAsm.Codegen
@@ -277,7 +278,8 @@ def bvReceiptRecordBytes : Nat := 64
 def bvReceiptRecordsBytes : Nat := bvReceiptRecordCapacity * bvReceiptRecordBytes
 
 /-- Current EEST resource target for Amsterdam/Prague/Osaka stateless blocks. -/
-def bvResourceBlockGasLimit : Nat := 200000000
+def bvResourceBlockGasLimit : Nat :=
+  EvmAsm.Stateless.Constants.resourceBlockGasLimit
 
 /-- EVM LOG base gas. A zero-topic, zero-data LOG0 is the cheapest way to
     increase the number of execution-derived receipt log descriptors. -/

--- a/EvmAsm/Stateless/Constants.lean
+++ b/EvmAsm/Stateless/Constants.lean
@@ -30,6 +30,18 @@
 
 namespace EvmAsm.Stateless.Constants
 
+/-! ## Resource-envelope constants
+
+    The stateless guest's finite arenas are derived for this declared
+    block-gas envelope.  It is a precondition of the top-level soundness
+    statement, not a consensus rule and not a runtime rejection gate. -/
+
+/-- The declared block-gas limit covered by the finite-resource theorem.
+    Inputs declaring a larger limit remain outside that theorem's promise. -/
+def resourceBlockGasLimit : Nat := 200000000
+
+#guard resourceBlockGasLimit = 200000000
+
 /-- Hex string of `keccak256(b"")`. Same value also doubles as
     `EMPTY_CODE_HASH` (accounts without contract code reference
     this hash; per EIP-161 these accounts get deleted from the

--- a/EvmAsm/Stateless/EntrySpec.lean
+++ b/EvmAsm/Stateless/EntrySpec.lean
@@ -6,8 +6,10 @@
 
   The headline Prop is `runStatelessGuestSound cr fuel fr execute`:
 
-    for every host-supplied input (≤ `MAX_INPUT_BYTES`), starting at the
-    guest ELF entry with the input framed at `INPUT_ADDR` and owning the
+    for every host-supplied input (≤ `MAX_INPUT_BYTES`) except one that
+    successfully decodes to an execution payload declaring a gas limit above
+    `Constants.resourceBlockGasLimit`,
+    starting at the guest ELF entry with the input framed at `INPUT_ADDR` and owning the
     work regions, the guest HALTS within `fuel` steps, and whatever the
     verifier then reads at `OUTPUT_ADDR` is a SOUND claim: if the
     `successful_validation` byte (OUTPUT[32]) is 1, then the input
@@ -44,6 +46,7 @@
 -/
 
 import EvmAsm.Stateless.Entry
+import EvmAsm.Stateless.Constants
 import EvmAsm.Stateless.SpecRef.Guest
 import EvmAsm.Rv64.CPSSpec
 import EvmAsm.Rv64.MemRegion
@@ -120,6 +123,30 @@ def guestInputAssertion (input : Bytes) : Assertion :=
   bytesRegion (INPUT_ADDR + INPUT_LEN_OFFSET) (u64LEBytes input.length) **
   bytesRegion (INPUT_ADDR + INPUT_BODY_OFFSET) input
 
+/-! ## Resource-envelope precondition
+
+    The finite arenas used by the emitted guest are derived for the named
+    `resourceBlockGasLimit` envelope.  This is deliberately a statement
+    precondition rather than a guest rejection: inputs outside the envelope
+    may still be accepted by the implementation, but this theorem makes no
+    claim about them. -/
+
+/-- A decoded stateless input lies within the finite-resource theorem's
+    declared block-gas envelope.  The field is the execution payload's
+    declared `header.gas_limit`; it is not the gas actually consumed. -/
+def statelessInputWithinResourceEnvelope (si : StatelessInput) : Prop :=
+  si.newPayloadRequest.executionPayload.gasLimit ≤
+    Constants.resourceBlockGasLimit
+
+/-- The serialized-input form of the resource-envelope precondition.  The
+    universal implication is vacuously true for inputs that do not deserialize,
+    while excluding exactly successfully decoded inputs whose declared gas
+    limit exceeds the resource bound.  Thus soundness still constrains any
+    acceptance of malformed input. -/
+def inputWithinResourceEnvelope (input : Bytes) : Prop :=
+  ∀ si, deserialize_stateless_input input = .ok si →
+    statelessInputWithinResourceEnvelope si
+
 /-! ## Postcondition: the verifier-facing claim -/
 
 /-- The spec-side acceptance condition the guest's `valid = 1` claim must
@@ -176,10 +203,12 @@ structure GuestFraming where
 /-! ## The top-level Props -/
 
 /-- **The headline statement shape** (soundness + termination): for every
-    host input within the size bound, the guest — running from the ELF
-    entry with the input framed and `fr.scratch` owned — halts within
-    `fuel` steps in a state that splits into the sound 40-byte
-    observation window and `fr.residue`.
+    host input within the size bound **and** `inputWithinResourceEnvelope`,
+    the guest — running from the ELF entry with the input framed and
+    `fr.scratch` owned — halts within `fuel` steps in a state that splits into
+    the sound 40-byte observation window and `fr.residue`.  The resource
+    predicate is a promise boundary, not a runtime gate: above the named
+    200M envelope the guest may still accept, but this theorem says nothing.
 
     Bead `.64` proves this for the concrete `(cr, fuel, fr, execute)`
     quadruple: the guest-image `CodeReq` (bead .63), the gas-derived step
@@ -188,6 +217,7 @@ structure GuestFraming where
 def runStatelessGuestSound (cr : CodeReq) (fuel : Nat) (fr : GuestFraming)
     (execute : ExecutionSeam) : Prop :=
   ∀ input : Bytes, input.length ≤ MAX_INPUT_BYTES →
+    inputWithinResourceEnvelope input →
     cpsHaltTripleWithin fuel GUEST_ENTRY cr
       (guestInputAssertion input ** fr.scratch)
       (guestOutputSound execute input ** fr.residue)


### PR DESCRIPTION
## Summary

Make the 200M block-gas resource envelope explicit in the top-level
`runStatelessGuestSound` statement.  This is a theorem precondition, not a
runtime rejection: above the envelope the guest may still accept, but this
finite-resource theorem makes no claim.

## Change

- Add the shared core constant `EvmAsm.Stateless.Constants.resourceBlockGasLimit`
  (`200,000,000`) and make the Codegen-side
  `EvmAsm.Codegen.bvResourceBlockGasLimit` definition use it.
- Add `statelessInputWithinResourceEnvelope`, which checks the decoded
  execution-payload `gasLimit` (the declared block `gas_limit`, not gas
  consumed).
- Add the serialized-input predicate `inputWithinResourceEnvelope`, which
  excludes exactly successfully decoded inputs whose declared limit exceeds
  the named bound.
- Require that predicate in `runStatelessGuestSound` alongside the existing
  input-size bound.

The literal predicates are:

```lean
def statelessInputWithinResourceEnvelope (si : StatelessInput) : Prop :=
  si.newPayloadRequest.executionPayload.gasLimit ≤
    Constants.resourceBlockGasLimit

def inputWithinResourceEnvelope (input : Bytes) : Prop :=
  ∀ si, deserialize_stateless_input input = .ok si →
    statelessInputWithinResourceEnvelope si
```

Thus malformed or undecodable inputs are **inside** the theorem domain; the
only excluded class is an input that successfully decodes to a block declaring
`gas_limit > 200,000,000`.  No guest gate or rejection path was added.  The
corpus measurement reported on issue #11957 remains relevant: 1,177 currently
passing valid rows declare above 200M (only 10 consume above it), so this
precondition must not be read as a claim that the implementation rejects or
excludes those rows.

## Scope check

`runStatelessGuestSound` has no downstream theorem applications in the tree, so
the new premise does not propagate through an intermediate theorem chain.  The
core remains Codegen-free; Codegen aliases the shared core constant rather than
creating a second 200M source of truth.

## Verification

- `lake build EvmAsm` — 4,741 jobs, successful.
- `scripts/check-unimported.sh` — 2,771 reachable, 0 orphans.
- `scripts/check-file-size.sh` — clean.
- `scripts/check-layering.sh` — clean (existing advisory RV64→Evm64 notices only).
