### PR TITLE
codegen: derive finish-step bounds from input bytes

### DIFF
--- a/EvmAsm/Codegen/Programs/RlpFieldToU64FinishSAsm.lean
+++ b/EvmAsm/Codegen/Programs/RlpFieldToU64FinishSAsm.lean
@@ -706,7 +706,7 @@ theorem callContentWithOutput
     (hover : listBase.toNat + bytes.length < 2 ^ 64)
     (hvalid : ∀ k, k < bytes.length →
       isValidByteAccess (listBase + BitVec.ofNat 64 k) = true) :
-    cpsTripleWithin (1 + (7 * (2 ^ 64 - 1) + 11))
+    cpsTripleWithin (1 + (7 * bytes.length + 11))
       (B + 80) (B + 84) code
       (((.x1 ↦ᵣ vOld) ** contentReady sp0 listBase saved bytes listLen index) **
        (saved.s1 ↦ₘ (0 : Word)))
@@ -730,7 +730,7 @@ theorem selectedToJoin
     (hvalid : ∀ k, k < bytes.length →
       isValidByteAccess (listBase + BitVec.ofNat 64 k) = true) :
     cpsTripleWithin
-      ((7 + (1 + (7 * (2 ^ 64 - 1) + 11))) + 5)
+      ((7 + (1 + (7 * bytes.length + 11))) + 5)
       (B + 52) (B + 128) code
       (((.x1 ↦ᵣ (B + 48)) **
         listSelected sp0 listBase offsetCell lengthCell saved bytes listLen index) **
@@ -780,7 +780,7 @@ theorem selectedToAllJoin
     (hvalid : ∀ k, k < bytes.length →
       isValidByteAccess (listBase + BitVec.ofNat 64 k) = true) :
     cpsTripleWithin
-      ((7 + (1 + (7 * (2 ^ 64 - 1) + 11))) + 5)
+      ((7 + (1 + (7 * bytes.length + 11))) + 5)
       (B + 52) (B + 128) code
       (((.x1 ↦ᵣ (B + 48)) **
         listSelected sp0 listBase offsetCell lengthCell saved bytes listLen index) **
@@ -828,7 +828,7 @@ theorem listDispatchToJoin
     (hover : listBase.toNat + bytes.length < 2 ^ 64)
     (hvalid : ∀ k, k < bytes.length →
       isValidByteAccess (listBase + BitVec.ofNat 64 k) = true) :
-    let tailSteps := (7 + (1 + (7 * (2 ^ 64 - 1) + 11))) + 5
+    let tailSteps := (7 + (1 + (7 * bytes.length + 11))) + 5
     cpsTripleWithin (1 + tailSteps) (B + 48) (B + 128) code
       (((.x1 ↦ᵣ (B + 48)) **
         listCallResult sp0 listBase offsetCell lengthCell oldOffset oldLen saved
@@ -842,7 +842,7 @@ theorem listDispatchToJoin
   have hs0' := selectedToAllJoin sp0 listBase oldOffset oldLen saved bytes
     listLen index hs0 hsalign hslack hover hvalid
   have hs : cpsTripleWithin
-      ((7 + (1 + (7 * (2 ^ 64 - 1) + 11))) + 5)
+      ((7 + (1 + (7 * bytes.length + 11))) + 5)
       (B + 52) (B + 128) code
       (listSelected sp0 listBase offsetCell lengthCell saved bytes listLen index **
        ((.x1 ↦ᵣ (B + 48)) ** (saved.s1 ↦ₘ (0 : Word))))
@@ -853,7 +853,7 @@ theorem listDispatchToJoin
   have hf0 := failureToAllJoin sp0 listBase oldOffset oldLen saved bytes
     listLen index
   have hf : cpsTripleWithin
-      ((7 + (1 + (7 * (2 ^ 64 - 1) + 11))) + 5)
+      ((7 + (1 + (7 * bytes.length + 11))) + 5)
       (B + 116) (B + 128) code
       (listFailed sp0 listBase offsetCell lengthCell oldOffset oldLen saved bytes
         listLen index **


### PR DESCRIPTION
## Summary

- Replace the six remaining loose scalar-call bounds in `RlpFieldToU64FinishSAsm` with `bytes.length`-derived bounds.
- The existing byte/slack/overflow facts and the already-converted `RlpFieldToU64SAsm` callee carry the proof; no new input hypothesis was added.
- Proof-only change: no emitted guest change.

This is step 2 of the callee-first migration for issue 11461. It converts 6 of 59 sites and unblocks `RlpFieldToU64WholeSAsm`, then `RlpFieldToU64FlatSAsm`; after Flat, `HeaderExtractNumberSpec`, `WithdrawalDecodeClose2`, and all five `ChainValidate` loops become available. The independent `Field0ToU64Top` leaf still holds 16 sites but unblocks nothing.

This is a stacked PR targeting `codex2/11461-rlp-leaf`; it must merge after #11973.

This is critical-path work for the gas-derived fuel bound in issue 10552 and umbrella 11802: counter-range bounds cannot compose into the top-level fuel constant, while these data-derived bounds can.

Current classification: 19 leaf candidates, 40 blocked-on-callee, 0 record-only; the split may change as deeper sites are attempted.