### PR TITLE
codegen: derive whole-step bounds from input bytes

### DIFF
--- a/EvmAsm/Codegen/Programs/RlpFieldToU64WholeSAsm.lean
+++ b/EvmAsm/Codegen/Programs/RlpFieldToU64WholeSAsm.lean
@@ -37,7 +37,7 @@ theorem dispatchAndRestore
       isValidByteAccess (listBase + BitVec.ofNat 64 k) = true)
     (hnewSp : newSp = spOuter + signExtend12 (-32 : BitVec 12))
     (hret : outer.ra &&& ~~~(1 : Word) = outer.ra) :
-    let tailSteps := (7 + (1 + (7 * (2 ^ 64 - 1) + 11))) + 5
+    let tailSteps := (7 + (1 + (7 * bytes.length + 11))) + 5
     cpsTripleWithin ((1 + tailSteps) + 5) (B + 48) outer.ra code
       ((((.x1 ↦ᵣ (B + 48)) **
         listCallResult newSp listBase offsetCell lengthCell oldOffset oldLen saved
@@ -195,7 +195,7 @@ theorem rlpFieldToU64_spec_within
       { ra := B + 48, s0 := listBase, s1 := outputPtr, s2 := s2, s3 := s3,
         s4 := s4, s5 := s5 }
     let callSteps := 1 + ((12 + ((85 + 93 * (index + 2)) + 6)) + 9)
-    let tailSteps := (7 + (1 + (7 * (2 ^ 64 - 1) + 11))) + 5
+    let tailSteps := (7 + (1 + (7 * bytes.length + 11))) + 5
     cpsTripleWithin ((7 + 4 + callSteps) + ((1 + tailSteps) + 5))
       B outer.ra code
       ((.x2 ↦ᵣ spOuter) ** regsAt frame (savedVals outer) **


### PR DESCRIPTION
## Summary

- Replace the two remaining loose bounds in `RlpFieldToU64WholeSAsm` with the caller-owned `bytes.length` bound.
- The converted Finish tranche carries the data-derived bound through both whole-program compositions; no new input hypothesis was added.
- Proof-only change: no emitted guest change.

This is step 3 of the callee-first migration for issue 11461. It converts 2 of 59 sites and unblocks `RlpFieldToU64FlatSAsm`; after Flat, `HeaderExtractNumberSpec`, `WithdrawalDecodeClose2`, and all five `ChainValidate` loops become available. The independent `Field0ToU64Top` leaf still holds 16 sites but unblocks nothing.

This is a stacked PR targeting `codex2/11461-finish`; it must merge after #11974, which itself follows #11973.

This is critical-path work for the gas-derived fuel bound in issue 10552 and umbrella 11802: counter-range bounds cannot compose into the top-level fuel constant, while these data-derived bounds can.

Current classification: 19 leaf candidates, 40 blocked-on-callee, 0 record-only; the split may change as deeper sites are attempted.