### PR TITLE
codegen: derive connected RLP step bounds from input bytes

### DIFF
--- a/EvmAsm/Codegen/Programs/ChainValidateBlobGasMultipleLoop.lean
+++ b/EvmAsm/Codegen/Programs/ChainValidateBlobGasMultipleLoop.lean
@@ -208,9 +208,9 @@ theorem lengths_getElem_bang {lengths : List Nat} {i : Nat} (hi : i < lengths.le
 
 /-- K34's whole-routine step count for field index 17 (matching the flat
     spec's `((7 + 4 + callSteps) + ((1 + tailSteps) + 5))` with `index = 17`). -/
-abbrev nCall : Nat :=
+def nCall (bytesLen : Nat) : Nat :=
   (7 + 4 + (1 + ((12 + ((85 + 93 * (17 + 2)) + 6)) + 9)))
-    + ((1 + ((7 + (1 + (7 * (2 ^ 64 - 1) + 11))) + 5)) + 5)
+    + ((1 + ((7 + (1 + (7 * bytesLen + 11))) + 5)) + 5)
 
 set_option maxRecDepth 8000 in
 theorem cvbgmCall (hbi lenBase spC iW : Word) (Li : Nat)
@@ -221,7 +221,7 @@ theorem cvbgmCall (hbi lenBase spC iW : Word) (Li : Nat)
     (hover : hbi.toNat + bytes.length < 2 ^ 64)
     (hvalid : ∀ k, k < bytes.length →
       isValidByteAccess (hbi + BitVec.ofNat 64 k) = true) :
-    cpsTripleWithin (13 + 1 + nCall) (D + 72) (D + 128) fullCode
+    cpsTripleWithin (13 + 1 + nCall bytes.length) (D + 72) (D + 128) fullCode
       ((.x2 ↦ᵣ spC) ** (.x9 ↦ᵣ lenBase) ** (.x18 ↦ᵣ hbi) ** (.x21 ↦ᵣ iW) **
         (.x5 ↦ᵣ old5) ** (.x10 ↦ᵣ o10) ** (.x11 ↦ᵣ o11) ** (.x12 ↦ᵣ o12) **
         (.x13 ↦ᵣ o13) ** (.x28 ↦ᵣ o28) **
@@ -297,7 +297,7 @@ theorem cvbgmCall (hbi lenBase spC iW : Word) (Li : Nat)
     hsalign hslack hover hvalid (by show LinkRA &&& ~~~(1 : Word) = LinkRA; decide)
   have hcalleeC := cpsTripleWithin_extend_code k34_mono hcallee0
   -- Present K34's entry footprint as explicit atoms, with `x5`/`x28` shown owned.
-  have hcallee : cpsTripleWithin nCall EvmAsm.Codegen.RlpFieldToU64SAsm.B LinkRA fullCode
+  have hcallee : cpsTripleWithin (nCall bytes.length) EvmAsm.Codegen.RlpFieldToU64SAsm.B LinkRA fullCode
       (regOwn .x5 ** regOwn .x28 **
         ((.x1 ↦ᵣ LinkRA) ** (.x2 ↦ᵣ spC) ** (.x8 ↦ᵣ nN) ** (.x9 ↦ᵣ lenBase) **
           (.x18 ↦ᵣ hbi) ** (.x19 ↦ᵣ s3) ** (.x20 ↦ᵣ s4) ** (.x21 ↦ᵣ iW) **
@@ -353,7 +353,7 @@ theorem cvbgmCallOwned (hbi lenBase spC iW : Word) (Li : Nat)
     (hover : hbi.toNat + bytes.length < 2 ^ 64)
     (hvalid : ∀ k, k < bytes.length →
       isValidByteAccess (hbi + BitVec.ofNat 64 k) = true) :
-    cpsTripleWithin (13 + 1 + nCall) (D + 72) (D + 128) fullCode
+    cpsTripleWithin (13 + 1 + nCall bytes.length) (D + 72) (D + 128) fullCode
       ((((.x2 ↦ᵣ spC) ** (.x9 ↦ᵣ lenBase) ** (.x18 ↦ᵣ hbi) ** (.x21 ↦ᵣ iW) **
           memOwn IterPtr ** memOwn IterI **
           ((lenBase + (iW <<< 3)) ↦ₘ BitVec.ofNat 64 Li) **
@@ -375,7 +375,7 @@ theorem cvbgmCallOwned (hbi lenBase spC iW : Word) (Li : Nat)
         ((lenBase + (iW <<< 3)) ↦ₘ BitVec.ofNat 64 Li) ** savedFrame spC csaved) := by
   refine cpsTripleWithin_of_forall_regIs_to_regOwn (fun v1 => ?_)
   refine cpsTripleWithin_weaken (fun _ h => by xperm_hyp h) (fun _ h => h)
-    (show cpsTripleWithin (13 + 1 + nCall) (D + 72) (D + 128) fullCode
+    (show cpsTripleWithin (13 + 1 + nCall bytes.length) (D + 72) (D + 128) fullCode
       ((((.x2 ↦ᵣ spC) ** (.x9 ↦ᵣ lenBase) ** (.x18 ↦ᵣ hbi) ** (.x21 ↦ᵣ iW) **
           memOwn IterPtr ** memOwn IterI **
           ((lenBase + (iW <<< 3)) ↦ₘ BitVec.ofNat 64 Li) **
@@ -420,7 +420,7 @@ theorem cvbgmIterEntry (spC hdrBase lenBase validPtr firstBadPtr : Word)
       (bigBytes.drop (hdrOff lengths i)).length < 2 ^ 64)
     (hvalid : ∀ k, k < (bigBytes.drop (hdrOff lengths i)).length →
       isValidByteAccess (hdrBaseAt hdrBase lengths i + BitVec.ofNat 64 k) = true) :
-    cpsTripleWithin (1 + (13 + 1 + nCall)) (D + 68) (D + 128) fullCode
+    cpsTripleWithin (1 + (13 + 1 + nCall (bigBytes.drop (hdrOff lengths i)).length)) (D + 68) (D + 128) fullCode
       ((.x2 ↦ᵣ spC) ** (.x8 ↦ᵣ BitVec.ofNat 64 lengths.length) ** (.x9 ↦ᵣ lenBase) **
         (.x18 ↦ᵣ hdrBaseAt hdrBase lengths i) ** (.x19 ↦ᵣ validPtr) **
         (.x20 ↦ᵣ firstBadPtr) ** (.x21 ↦ᵣ BitVec.ofNat 64 i) ** savedFrame spC csaved **
@@ -1180,7 +1180,7 @@ theorem cvbgmIter (sp0 spC hdrBase lenBase validPtr firstBadPtr raIn : Word)
           firstBadPtr csaved bigBytes lengths (i + 1))
         (cvbgmPost sp0 spC (spC + signExtend12 (-32 : BitVec 12)) hdrBase lenBase validPtr
           firstBadPtr csaved bigBytes lengths)) :
-    cpsTripleWithin ((1 + (13 + 1 + nCall)) + (27 + nTail)) (D + 68) raIn fullCode
+    cpsTripleWithin ((1 + (13 + 1 + nCall (bigBytes.drop (hdrOff lengths i)).length)) + (27 + nTail)) (D + 68) raIn fullCode
       (LoopInv sp0 spC (spC + signExtend12 (-32 : BitVec 12)) hdrBase lenBase validPtr
         firstBadPtr csaved bigBytes lengths i)
       (cvbgmPost sp0 spC (spC + signExtend12 (-32 : BitVec 12)) hdrBase lenBase validPtr
@@ -1208,19 +1208,19 @@ theorem cvbgmIter (sp0 spC hdrBase lenBase validPtr firstBadPtr raIn : Word)
       EvmAsm.Evm64.bytesRegion_split hdrBase bigBytes (hdrOff lengths i) halign hlen,
       ← hHB, ← hLi] at hp
     rw [hEBody]; xperm_hyp hp) (fun _ hq => hq)
-    (show cpsTripleWithin ((1 + (13 + 1 + nCall)) + (27 + nTail)) (D + 68) raIn fullCode
+    (show cpsTripleWithin ((1 + (13 + 1 + nCall (bigBytes.drop (hdrOff lengths i)).length)) + (27 + nTail)) (D + 68) raIn fullCode
       (((EBody ** memOwn Field) ** memOwn RfuOff) ** memOwn RfuLen)
       (cvbgmPost sp0 spC (spC + signExtend12 (-32 : BitVec 12)) hdrBase lenBase validPtr
         firstBadPtr csaved bigBytes lengths) from ?_)
   refine cpsTripleWithin_of_forall_memIs_to_memOwn (fun oldLen => ?_)
   refine cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp) (fun _ hq => hq)
-    (show cpsTripleWithin ((1 + (13 + 1 + nCall)) + (27 + nTail)) (D + 68) raIn fullCode
+    (show cpsTripleWithin ((1 + (13 + 1 + nCall (bigBytes.drop (hdrOff lengths i)).length)) + (27 + nTail)) (D + 68) raIn fullCode
       (((EBody ** (RfuLen ↦ₘ oldLen)) ** memOwn Field) ** memOwn RfuOff)
       (cvbgmPost sp0 spC (spC + signExtend12 (-32 : BitVec 12)) hdrBase lenBase validPtr
         firstBadPtr csaved bigBytes lengths) from ?_)
   refine cpsTripleWithin_of_forall_memIs_to_memOwn (fun oldOff => ?_)
   refine cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp) (fun _ hq => hq)
-    (show cpsTripleWithin ((1 + (13 + 1 + nCall)) + (27 + nTail)) (D + 68) raIn fullCode
+    (show cpsTripleWithin ((1 + (13 + 1 + nCall (bigBytes.drop (hdrOff lengths i)).length)) + (27 + nTail)) (D + 68) raIn fullCode
       (((EBody ** (RfuLen ↦ₘ oldLen)) ** (RfuOff ↦ₘ oldOff)) ** memOwn Field)
       (cvbgmPost sp0 spC (spC + signExtend12 (-32 : BitVec 12)) hdrBase lenBase validPtr
         firstBadPtr csaved bigBytes lengths) from ?_)

--- a/EvmAsm/Codegen/Programs/ChainValidateBlobGasMultipleLoopClose.lean
+++ b/EvmAsm/Codegen/Programs/ChainValidateBlobGasMultipleLoopClose.lean
@@ -34,12 +34,13 @@ local macro "pcfx" : tactic =>
 /-- Step budget for the loop with `r = N − i` iterations remaining: each full
     iteration is `cvbgmIter`'s cost, the exhausted guard + all-valid exit is
     `11`. -/
-def cvbgmLoopSteps : Nat → Nat
+def cvbgmLoopSteps (bytesLen : Nat) : Nat → Nat
   | 0 => 11
-  | r + 1 => (1 + (13 + 1 + nCall)) + (27 + cvbgmLoopSteps r)
+  | r + 1 => (1 + (13 + 1 + nCall bytesLen)) + (27 + cvbgmLoopSteps bytesLen r)
 
-theorem cvbgmLoopSteps_succ (r : Nat) :
-    cvbgmLoopSteps (r + 1) = (1 + (13 + 1 + nCall)) + (27 + cvbgmLoopSteps r) := rfl
+theorem cvbgmLoopSteps_succ (bytesLen r : Nat) :
+    cvbgmLoopSteps bytesLen (r + 1) =
+      (1 + (13 + 1 + nCall bytesLen)) + (27 + cvbgmLoopSteps bytesLen r) := rfl
 
 set_option maxRecDepth 8000 in
 /-- The guard/loop from `D+68` entering iteration `i` (`i ≤ N`), with all
@@ -63,7 +64,7 @@ theorem cvbgmLoop (sp0 spC hdrBase lenBase validPtr firstBadPtr raIn : Word)
       isValidByteAccess (hdrBaseAt hdrBase lengths i + BitVec.ofNat 64 k) = true) :
     ∀ (f i : Nat), lengths.length - i ≤ f → i ≤ lengths.length →
       (∀ j, j < i → hdrMultiple hdrBase bigBytes lengths j) →
-      cpsTripleWithin (cvbgmLoopSteps (lengths.length - i)) (D + 68) raIn fullCode
+      cpsTripleWithin (cvbgmLoopSteps bigBytes.length (lengths.length - i)) (D + 68) raIn fullCode
         (LoopInv sp0 spC (spC + signExtend12 (-32 : BitVec 12)) hdrBase lenBase validPtr
           firstBadPtr csaved bigBytes lengths i)
         (cvbgmPost sp0 spC (spC + signExtend12 (-32 : BitVec 12)) hdrBase lenBase validPtr
@@ -75,7 +76,7 @@ theorem cvbgmLoop (sp0 spC hdrBase lenBase validPtr firstBadPtr raIn : Word)
     unfold savedFrame; rw [hraSaved]
   -- All-valid exit reached at the guard when `i = N`.
   have base : (∀ j, j < lengths.length → hdrMultiple hdrBase bigBytes lengths j) →
-      cpsTripleWithin (cvbgmLoopSteps 0) (D + 68) raIn fullCode
+      cpsTripleWithin (cvbgmLoopSteps bigBytes.length 0) (D + 68) raIn fullCode
         (LoopInv sp0 spC (spC + signExtend12 (-32 : BitVec 12)) hdrBase lenBase validPtr
           firstBadPtr csaved bigBytes lengths lengths.length)
         (cvbgmPost sp0 spC (spC + signExtend12 (-32 : BitVec 12)) hdrBase lenBase validPtr
@@ -83,7 +84,7 @@ theorem cvbgmLoop (sp0 spC hdrBase lenBase validPtr firstBadPtr raIn : Word)
     intro hpre
     refine cpsTripleWithin_weaken (fun h hp => by unfold LoopInv scratchRegs at hp; xperm_hyp hp)
       (fun _ hq => hq)
-      (show cpsTripleWithin (cvbgmLoopSteps 0) (D + 68) raIn fullCode
+      (show cpsTripleWithin (cvbgmLoopSteps bigBytes.length 0) (D + 68) raIn fullCode
         ((((.x2 ↦ᵣ spC) ** (.x8 ↦ᵣ BitVec.ofNat 64 lengths.length) ** (.x9 ↦ᵣ lenBase) **
             (.x18 ↦ᵣ hdrBaseAt hdrBase lengths lengths.length) ** (.x19 ↦ᵣ validPtr) **
             (.x20 ↦ᵣ firstBadPtr) ** (.x21 ↦ᵣ BitVec.ofNat 64 lengths.length) **
@@ -99,7 +100,7 @@ theorem cvbgmLoop (sp0 spC hdrBase lenBase validPtr firstBadPtr raIn : Word)
           firstBadPtr csaved bigBytes lengths) from ?_)
     refine cpsTripleWithin_of_forall_regIs_to_regOwn (fun o10 => ?_)
     refine cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp) (fun _ hq => hq)
-      (show cpsTripleWithin (cvbgmLoopSteps 0) (D + 68) raIn fullCode
+      (show cpsTripleWithin (cvbgmLoopSteps bigBytes.length 0) (D + 68) raIn fullCode
         (((.x2 ↦ᵣ spC) ** (.x8 ↦ᵣ BitVec.ofNat 64 lengths.length) ** (.x9 ↦ᵣ lenBase) **
             (.x18 ↦ᵣ hdrBaseAt hdrBase lengths lengths.length) ** (.x19 ↦ᵣ validPtr) **
             (.x20 ↦ᵣ firstBadPtr) ** (.x21 ↦ᵣ BitVec.ofNat 64 lengths.length) **
@@ -172,11 +173,15 @@ theorem cvbgmLoop (sp0 spC hdrBase lenBase validPtr firstBadPtr raIn : Word)
     · subst hi; rw [Nat.sub_self]; exact base hpre
     · rw [show lengths.length - i = (lengths.length - (i + 1)) + 1 from by omega,
         cvbgmLoopSteps_succ]
-      exact cvbgmIter sp0 spC hdrBase lenBase validPtr firstBadPtr raIn csaved bigBytes lengths i
-        (cvbgmLoopSteps (lengths.length - (i + 1))) hi hN hspC hraSaved hret
+      have hiter := cvbgmIter sp0 spC hdrBase lenBase validPtr firstBadPtr raIn csaved bigBytes lengths i
+        (cvbgmLoopSteps bigBytes.length (lengths.length - (i + 1))) hi hN hspC hraSaved hret
         (hAllAlign i hi) (hAllLen i hi) (hAllSalign i hi) (hAllSlack i hi) (hAllOver i hi)
         (hAllValid i hi) hpre
         (fun hpre' => ih (i + 1) (by omega) (by omega) hpre')
+      have hdrop : (bigBytes.drop (hdrOff lengths i)).length ≤ bigBytes.length := by
+        rw [List.length_drop]
+        omega
+      refine cpsTripleWithin_mono_nSteps (by unfold nCall; omega) hiter
 
 
 set_option maxRecDepth 8000 in
@@ -207,7 +212,7 @@ theorem chain_validate_blob_gas_used_multiple_spec_within
       (hdrBaseAt hdrBase lengths i).toNat + (bigBytes.drop (hdrOff lengths i)).length < 2 ^ 64)
     (hAllValid : ∀ i, i < lengths.length → ∀ k, k < (bigBytes.drop (hdrOff lengths i)).length →
       isValidByteAccess (hdrBaseAt hdrBase lengths i + BitVec.ofNat 64 k) = true) :
-    cpsTripleWithin (17 + cvbgmLoopSteps lengths.length) D raIn fullCode
+    cpsTripleWithin (17 + cvbgmLoopSteps bigBytes.length lengths.length) D raIn fullCode
       (((.x2 ↦ᵣ sp0) ** (.x1 ↦ᵣ raIn) ** (.x8 ↦ᵣ cs0) ** (.x9 ↦ᵣ cs1) **
           (.x18 ↦ᵣ cs2) ** (.x19 ↦ᵣ cs3) ** (.x20 ↦ᵣ cs4) ** (.x21 ↦ᵣ cs5) **
           (.x10 ↦ᵣ nWord) ** (.x11 ↦ᵣ lenBase) ** (.x12 ↦ᵣ hdrBase) **

--- a/EvmAsm/Codegen/Programs/ChainValidateBlobGasUnderMaxLoop.lean
+++ b/EvmAsm/Codegen/Programs/ChainValidateBlobGasUnderMaxLoop.lean
@@ -184,9 +184,9 @@ theorem lengths_getElem_bang {lengths : List Nat} {i : Nat} (hi : i < lengths.le
 
 /-- K34's whole-routine step count for field index 17 (matching the flat
     spec's `((7 + 4 + callSteps) + ((1 + tailSteps) + 5))` with `index = 17`). -/
-abbrev nCall : Nat :=
+def nCall (bytesLen : Nat) : Nat :=
   (7 + 4 + (1 + ((12 + ((85 + 93 * (17 + 2)) + 6)) + 9)))
-    + ((1 + ((7 + (1 + (7 * (2 ^ 64 - 1) + 11))) + 5)) + 5)
+    + ((1 + ((7 + (1 + (7 * bytesLen + 11))) + 5)) + 5)
 
 set_option maxRecDepth 8000 in
 theorem cvbgumCall (hbi lenBase spC iW : Word) (Li : Nat)
@@ -197,7 +197,7 @@ theorem cvbgumCall (hbi lenBase spC iW : Word) (Li : Nat)
     (hover : hbi.toNat + bytes.length < 2 ^ 64)
     (hvalid : ∀ k, k < bytes.length →
       isValidByteAccess (hbi + BitVec.ofNat 64 k) = true) :
-    cpsTripleWithin (13 + 1 + nCall) (D + 72) (D + 128) fullCode
+    cpsTripleWithin (13 + 1 + nCall bytes.length) (D + 72) (D + 128) fullCode
       ((.x2 ↦ᵣ spC) ** (.x9 ↦ᵣ lenBase) ** (.x18 ↦ᵣ hbi) ** (.x21 ↦ᵣ iW) **
         (.x5 ↦ᵣ old5) ** (.x10 ↦ᵣ o10) ** (.x11 ↦ᵣ o11) ** (.x12 ↦ᵣ o12) **
         (.x13 ↦ᵣ o13) ** (.x28 ↦ᵣ o28) **
@@ -273,7 +273,7 @@ theorem cvbgumCall (hbi lenBase spC iW : Word) (Li : Nat)
     hsalign hslack hover hvalid (by show LinkRA &&& ~~~(1 : Word) = LinkRA; decide)
   have hcalleeC := cpsTripleWithin_extend_code k34_mono hcallee0
   -- Present K34's entry footprint as explicit atoms, with `x5`/`x28` shown owned.
-  have hcallee : cpsTripleWithin nCall EvmAsm.Codegen.RlpFieldToU64SAsm.B LinkRA fullCode
+  have hcallee : cpsTripleWithin (nCall bytes.length) EvmAsm.Codegen.RlpFieldToU64SAsm.B LinkRA fullCode
       (regOwn .x5 ** regOwn .x28 **
         ((.x1 ↦ᵣ LinkRA) ** (.x2 ↦ᵣ spC) ** (.x8 ↦ᵣ nN) ** (.x9 ↦ᵣ lenBase) **
           (.x18 ↦ᵣ hbi) ** (.x19 ↦ᵣ s3) ** (.x20 ↦ᵣ s4) ** (.x21 ↦ᵣ iW) **
@@ -329,7 +329,7 @@ theorem cvbgumCallOwned (hbi lenBase spC iW : Word) (Li : Nat)
     (hover : hbi.toNat + bytes.length < 2 ^ 64)
     (hvalid : ∀ k, k < bytes.length →
       isValidByteAccess (hbi + BitVec.ofNat 64 k) = true) :
-    cpsTripleWithin (13 + 1 + nCall) (D + 72) (D + 128) fullCode
+    cpsTripleWithin (13 + 1 + nCall bytes.length) (D + 72) (D + 128) fullCode
       ((((.x2 ↦ᵣ spC) ** (.x9 ↦ᵣ lenBase) ** (.x18 ↦ᵣ hbi) ** (.x21 ↦ᵣ iW) **
           memOwn IterPtr ** memOwn IterI **
           ((lenBase + (iW <<< 3)) ↦ₘ BitVec.ofNat 64 Li) **
@@ -351,7 +351,7 @@ theorem cvbgumCallOwned (hbi lenBase spC iW : Word) (Li : Nat)
         ((lenBase + (iW <<< 3)) ↦ₘ BitVec.ofNat 64 Li) ** savedFrame spC csaved) := by
   refine cpsTripleWithin_of_forall_regIs_to_regOwn (fun v1 => ?_)
   refine cpsTripleWithin_weaken (fun _ h => by xperm_hyp h) (fun _ h => h)
-    (show cpsTripleWithin (13 + 1 + nCall) (D + 72) (D + 128) fullCode
+    (show cpsTripleWithin (13 + 1 + nCall bytes.length) (D + 72) (D + 128) fullCode
       ((((.x2 ↦ᵣ spC) ** (.x9 ↦ᵣ lenBase) ** (.x18 ↦ᵣ hbi) ** (.x21 ↦ᵣ iW) **
           memOwn IterPtr ** memOwn IterI **
           ((lenBase + (iW <<< 3)) ↦ₘ BitVec.ofNat 64 Li) **
@@ -396,7 +396,7 @@ theorem cvbgumIterEntry (spC hdrBase lenBase validPtr firstBadPtr : Word)
       (bigBytes.drop (hdrOff lengths i)).length < 2 ^ 64)
     (hvalid : ∀ k, k < (bigBytes.drop (hdrOff lengths i)).length →
       isValidByteAccess (hdrBaseAt hdrBase lengths i + BitVec.ofNat 64 k) = true) :
-    cpsTripleWithin (1 + (13 + 1 + nCall)) (D + 68) (D + 128) fullCode
+    cpsTripleWithin (1 + (13 + 1 + nCall (bigBytes.drop (hdrOff lengths i)).length)) (D + 68) (D + 128) fullCode
       ((.x2 ↦ᵣ spC) ** (.x8 ↦ᵣ BitVec.ofNat 64 lengths.length) ** (.x9 ↦ᵣ lenBase) **
         (.x18 ↦ᵣ hdrBaseAt hdrBase lengths i) ** (.x19 ↦ᵣ validPtr) **
         (.x20 ↦ᵣ firstBadPtr) ** (.x21 ↦ᵣ BitVec.ofNat 64 i) ** savedFrame spC csaved **
@@ -1152,7 +1152,7 @@ theorem cvbgumIter (sp0 spC hdrBase lenBase validPtr firstBadPtr raIn : Word)
           firstBadPtr csaved bigBytes lengths (i + 1))
         (cvbgumPost sp0 spC (spC + signExtend12 (-32 : BitVec 12)) hdrBase lenBase validPtr
           firstBadPtr csaved bigBytes lengths)) :
-    cpsTripleWithin ((1 + (13 + 1 + nCall)) + (25 + nTail)) (D + 68) raIn fullCode
+    cpsTripleWithin ((1 + (13 + 1 + nCall (bigBytes.drop (hdrOff lengths i)).length)) + (25 + nTail)) (D + 68) raIn fullCode
       (LoopInv sp0 spC (spC + signExtend12 (-32 : BitVec 12)) hdrBase lenBase validPtr
         firstBadPtr csaved bigBytes lengths i)
       (cvbgumPost sp0 spC (spC + signExtend12 (-32 : BitVec 12)) hdrBase lenBase validPtr
@@ -1180,19 +1180,19 @@ theorem cvbgumIter (sp0 spC hdrBase lenBase validPtr firstBadPtr raIn : Word)
       EvmAsm.Evm64.bytesRegion_split hdrBase bigBytes (hdrOff lengths i) halign hlen,
       ← hHB, ← hLi] at hp
     rw [hEBody]; xperm_hyp hp) (fun _ hq => hq)
-    (show cpsTripleWithin ((1 + (13 + 1 + nCall)) + (25 + nTail)) (D + 68) raIn fullCode
+    (show cpsTripleWithin ((1 + (13 + 1 + nCall (bigBytes.drop (hdrOff lengths i)).length)) + (25 + nTail)) (D + 68) raIn fullCode
       (((EBody ** memOwn Field) ** memOwn RfuOff) ** memOwn RfuLen)
       (cvbgumPost sp0 spC (spC + signExtend12 (-32 : BitVec 12)) hdrBase lenBase validPtr
         firstBadPtr csaved bigBytes lengths) from ?_)
   refine cpsTripleWithin_of_forall_memIs_to_memOwn (fun oldLen => ?_)
   refine cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp) (fun _ hq => hq)
-    (show cpsTripleWithin ((1 + (13 + 1 + nCall)) + (25 + nTail)) (D + 68) raIn fullCode
+    (show cpsTripleWithin ((1 + (13 + 1 + nCall (bigBytes.drop (hdrOff lengths i)).length)) + (25 + nTail)) (D + 68) raIn fullCode
       (((EBody ** (RfuLen ↦ₘ oldLen)) ** memOwn Field) ** memOwn RfuOff)
       (cvbgumPost sp0 spC (spC + signExtend12 (-32 : BitVec 12)) hdrBase lenBase validPtr
         firstBadPtr csaved bigBytes lengths) from ?_)
   refine cpsTripleWithin_of_forall_memIs_to_memOwn (fun oldOff => ?_)
   refine cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp) (fun _ hq => hq)
-    (show cpsTripleWithin ((1 + (13 + 1 + nCall)) + (25 + nTail)) (D + 68) raIn fullCode
+    (show cpsTripleWithin ((1 + (13 + 1 + nCall (bigBytes.drop (hdrOff lengths i)).length)) + (25 + nTail)) (D + 68) raIn fullCode
       (((EBody ** (RfuLen ↦ₘ oldLen)) ** (RfuOff ↦ₘ oldOff)) ** memOwn Field)
       (cvbgumPost sp0 spC (spC + signExtend12 (-32 : BitVec 12)) hdrBase lenBase validPtr
         firstBadPtr csaved bigBytes lengths) from ?_)

--- a/EvmAsm/Codegen/Programs/ChainValidateBlobGasUnderMaxLoopClose.lean
+++ b/EvmAsm/Codegen/Programs/ChainValidateBlobGasUnderMaxLoopClose.lean
@@ -34,12 +34,13 @@ local macro "pcfx" : tactic =>
 /-- Step budget for the loop with `r = N − i` iterations remaining: each full
     iteration is `cvbgumIter`'s cost, the exhausted guard + all-valid exit is
     `11`. -/
-def cvbgumLoopSteps : Nat → Nat
+def cvbgumLoopSteps (bytesLen : Nat) : Nat → Nat
   | 0 => 11
-  | r + 1 => (1 + (13 + 1 + nCall)) + (25 + cvbgumLoopSteps r)
+  | r + 1 => (1 + (13 + 1 + nCall bytesLen)) + (25 + cvbgumLoopSteps bytesLen r)
 
-theorem cvbgumLoopSteps_succ (r : Nat) :
-    cvbgumLoopSteps (r + 1) = (1 + (13 + 1 + nCall)) + (25 + cvbgumLoopSteps r) := rfl
+theorem cvbgumLoopSteps_succ (bytesLen r : Nat) :
+    cvbgumLoopSteps bytesLen (r + 1) =
+      (1 + (13 + 1 + nCall bytesLen)) + (25 + cvbgumLoopSteps bytesLen r) := rfl
 
 set_option maxRecDepth 8000 in
 /-- The guard/loop from `D+68` entering iteration `i` (`i ≤ N`), with all
@@ -63,7 +64,7 @@ theorem cvbgumLoop (sp0 spC hdrBase lenBase validPtr firstBadPtr raIn : Word)
       isValidByteAccess (hdrBaseAt hdrBase lengths i + BitVec.ofNat 64 k) = true) :
     ∀ (f i : Nat), lengths.length - i ≤ f → i ≤ lengths.length →
       (∀ j, j < i → hdrUnderMax hdrBase bigBytes lengths j) →
-      cpsTripleWithin (cvbgumLoopSteps (lengths.length - i)) (D + 68) raIn fullCode
+      cpsTripleWithin (cvbgumLoopSteps bigBytes.length (lengths.length - i)) (D + 68) raIn fullCode
         (LoopInv sp0 spC (spC + signExtend12 (-32 : BitVec 12)) hdrBase lenBase validPtr
           firstBadPtr csaved bigBytes lengths i)
         (cvbgumPost sp0 spC (spC + signExtend12 (-32 : BitVec 12)) hdrBase lenBase validPtr
@@ -75,7 +76,7 @@ theorem cvbgumLoop (sp0 spC hdrBase lenBase validPtr firstBadPtr raIn : Word)
     unfold savedFrame; rw [hraSaved]
   -- All-valid exit reached at the guard when `i = N`.
   have base : (∀ j, j < lengths.length → hdrUnderMax hdrBase bigBytes lengths j) →
-      cpsTripleWithin (cvbgumLoopSteps 0) (D + 68) raIn fullCode
+      cpsTripleWithin (cvbgumLoopSteps bigBytes.length 0) (D + 68) raIn fullCode
         (LoopInv sp0 spC (spC + signExtend12 (-32 : BitVec 12)) hdrBase lenBase validPtr
           firstBadPtr csaved bigBytes lengths lengths.length)
         (cvbgumPost sp0 spC (spC + signExtend12 (-32 : BitVec 12)) hdrBase lenBase validPtr
@@ -83,7 +84,7 @@ theorem cvbgumLoop (sp0 spC hdrBase lenBase validPtr firstBadPtr raIn : Word)
     intro hpre
     refine cpsTripleWithin_weaken (fun h hp => by unfold LoopInv scratchRegs at hp; xperm_hyp hp)
       (fun _ hq => hq)
-      (show cpsTripleWithin (cvbgumLoopSteps 0) (D + 68) raIn fullCode
+      (show cpsTripleWithin (cvbgumLoopSteps bigBytes.length 0) (D + 68) raIn fullCode
         ((((.x2 ↦ᵣ spC) ** (.x8 ↦ᵣ BitVec.ofNat 64 lengths.length) ** (.x9 ↦ᵣ lenBase) **
             (.x18 ↦ᵣ hdrBaseAt hdrBase lengths lengths.length) ** (.x19 ↦ᵣ validPtr) **
             (.x20 ↦ᵣ firstBadPtr) ** (.x21 ↦ᵣ BitVec.ofNat 64 lengths.length) **
@@ -99,7 +100,7 @@ theorem cvbgumLoop (sp0 spC hdrBase lenBase validPtr firstBadPtr raIn : Word)
           firstBadPtr csaved bigBytes lengths) from ?_)
     refine cpsTripleWithin_of_forall_regIs_to_regOwn (fun o10 => ?_)
     refine cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp) (fun _ hq => hq)
-      (show cpsTripleWithin (cvbgumLoopSteps 0) (D + 68) raIn fullCode
+      (show cpsTripleWithin (cvbgumLoopSteps bigBytes.length 0) (D + 68) raIn fullCode
         (((.x2 ↦ᵣ spC) ** (.x8 ↦ᵣ BitVec.ofNat 64 lengths.length) ** (.x9 ↦ᵣ lenBase) **
             (.x18 ↦ᵣ hdrBaseAt hdrBase lengths lengths.length) ** (.x19 ↦ᵣ validPtr) **
             (.x20 ↦ᵣ firstBadPtr) ** (.x21 ↦ᵣ BitVec.ofNat 64 lengths.length) **
@@ -172,11 +173,15 @@ theorem cvbgumLoop (sp0 spC hdrBase lenBase validPtr firstBadPtr raIn : Word)
     · subst hi; rw [Nat.sub_self]; exact base hpre
     · rw [show lengths.length - i = (lengths.length - (i + 1)) + 1 from by omega,
         cvbgumLoopSteps_succ]
-      exact cvbgumIter sp0 spC hdrBase lenBase validPtr firstBadPtr raIn csaved bigBytes lengths i
-        (cvbgumLoopSteps (lengths.length - (i + 1))) hi hN hspC hraSaved hret
+      have hiter := cvbgumIter sp0 spC hdrBase lenBase validPtr firstBadPtr raIn csaved bigBytes lengths i
+        (cvbgumLoopSteps bigBytes.length (lengths.length - (i + 1))) hi hN hspC hraSaved hret
         (hAllAlign i hi) (hAllLen i hi) (hAllSalign i hi) (hAllSlack i hi) (hAllOver i hi)
         (hAllValid i hi) hpre
         (fun hpre' => ih (i + 1) (by omega) (by omega) hpre')
+      have hdrop : (bigBytes.drop (hdrOff lengths i)).length ≤ bigBytes.length := by
+        rw [List.length_drop]
+        omega
+      refine cpsTripleWithin_mono_nSteps (by unfold nCall; omega) hiter
 
 
 set_option maxRecDepth 8000 in
@@ -205,7 +210,7 @@ theorem chain_validate_blob_gas_used_under_max_spec_within
       (hdrBaseAt hdrBase lengths i).toNat + (bigBytes.drop (hdrOff lengths i)).length < 2 ^ 64)
     (hAllValid : ∀ i, i < lengths.length → ∀ k, k < (bigBytes.drop (hdrOff lengths i)).length →
       isValidByteAccess (hdrBaseAt hdrBase lengths i + BitVec.ofNat 64 k) = true) :
-    cpsTripleWithin (17 + cvbgumLoopSteps lengths.length) D raIn fullCode
+    cpsTripleWithin (17 + cvbgumLoopSteps bigBytes.length lengths.length) D raIn fullCode
       (((.x2 ↦ᵣ sp0) ** (.x1 ↦ᵣ raIn) ** (.x8 ↦ᵣ cs0) ** (.x9 ↦ᵣ cs1) **
           (.x18 ↦ᵣ cs2) ** (.x19 ↦ᵣ cs3) ** (.x20 ↦ᵣ cs4) ** (.x21 ↦ᵣ cs5) **
           (.x10 ↦ᵣ nWord) ** (.x11 ↦ᵣ lenBase) ** (.x12 ↦ᵣ hdrBase) **

--- a/EvmAsm/Codegen/Programs/ChainValidateConsecutiveNumbersLoop.lean
+++ b/EvmAsm/Codegen/Programs/ChainValidateConsecutiveNumbersLoop.lean
@@ -310,9 +310,9 @@ theorem cvcnSetup (hbi lenBase iW prevVal : Word) (Li : Nat)
 
 
 /-! ## K34's whole-routine step count for field index 11. -/
-abbrev nCall : Nat :=
+def nCall (bytesLen : Nat) : Nat :=
   (7 + 4 + (1 + ((12 + ((85 + 93 * (8 + 2)) + 6)) + 9)))
-    + ((1 + ((7 + (1 + (7 * (2 ^ 64 - 1) + 11))) + 5)) + 5)
+    + ((1 + ((7 + (1 + (7 * bytesLen + 11))) + 5)) + 5)
 
 /-! ## Call block (instructions 32--48 + K34): setup ;; jal ;; rlp_field_to_u64
 
@@ -330,7 +330,7 @@ theorem cvcnCall (spC hdrBase lenBase hbi iW validPtr firstBadPtr prevVal : Word
     (hover : hbi.toNat + bytes.length < 2 ^ 64)
     (hvalid : ∀ k, k < bytes.length →
       isValidByteAccess (hbi + BitVec.ofNat 64 k) = true) :
-    cpsTripleWithin (16 + 1 + nCall) (D + 128) (D + 196) fullCode
+    cpsTripleWithin (16 + 1 + nCall bytes.length) (D + 128) (D + 196) fullCode
       ((.x2 ↦ᵣ spC) ** (.x8 ↦ᵣ nN) ** (.x9 ↦ᵣ lenBase) ** (.x6 ↦ᵣ hbi) ** (.x7 ↦ᵣ iW) **
         (.x18 ↦ᵣ hdrBase) ** (.x19 ↦ᵣ validPtr) ** (.x20 ↦ᵣ firstBadPtr) ** (.x21 ↦ᵣ prevVal) **
         (.x5 ↦ᵣ old5) ** (.x10 ↦ᵣ o10) ** (.x11 ↦ᵣ o11) ** (.x12 ↦ᵣ o12) ** (.x13 ↦ᵣ o13) **
@@ -400,7 +400,7 @@ theorem cvcnCall (spC hdrBase lenBase hbi iW validPtr firstBadPtr prevVal : Word
     hsalign hslack hover hvalid (by show LinkRA &&& ~~~(1 : Word) = LinkRA; decide)
   have hcalleeC := cpsTripleWithin_extend_code k34_mono hcallee0
   -- Present K34's entry footprint as explicit atoms, with x5/x6/x7/x28 shown owned.
-  have hcallee : cpsTripleWithin nCall EvmAsm.Codegen.RlpFieldToU64SAsm.B LinkRA fullCode
+  have hcallee : cpsTripleWithin (nCall bytes.length) EvmAsm.Codegen.RlpFieldToU64SAsm.B LinkRA fullCode
       (regOwn .x5 ** regOwn .x6 ** regOwn .x7 ** regOwn .x28 **
         ((.x1 ↦ᵣ LinkRA) ** (.x2 ↦ᵣ spC) ** (.x8 ↦ᵣ nN) ** (.x9 ↦ᵣ lenBase) **
           (.x18 ↦ᵣ hdrBase) ** (.x19 ↦ᵣ validPtr) ** (.x20 ↦ᵣ firstBadPtr) ** (.x21 ↦ᵣ prevVal) **
@@ -459,7 +459,7 @@ theorem cvcnCallOwned (spC hdrBase lenBase hbi iW validPtr firstBadPtr prevVal :
     (hover : hbi.toNat + bytes.length < 2 ^ 64)
     (hvalid : ∀ k, k < bytes.length →
       isValidByteAccess (hbi + BitVec.ofNat 64 k) = true) :
-    cpsTripleWithin (16 + 1 + nCall) (D + 128) (D + 196) fullCode
+    cpsTripleWithin (16 + 1 + nCall bytes.length) (D + 128) (D + 196) fullCode
       ((((.x2 ↦ᵣ spC) ** (.x8 ↦ᵣ nN) ** (.x9 ↦ᵣ lenBase) ** (.x6 ↦ᵣ hbi) ** (.x7 ↦ᵣ iW) **
           (.x18 ↦ᵣ hdrBase) ** (.x19 ↦ᵣ validPtr) ** (.x20 ↦ᵣ firstBadPtr) **
           (.x21 ↦ᵣ prevVal) ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
@@ -481,7 +481,7 @@ theorem cvcnCallOwned (spC hdrBase lenBase hbi iW validPtr firstBadPtr prevVal :
         ((lenBase + (iW <<< 3)) ↦ₘ BitVec.ofNat 64 Li) ** savedFrame spC csaved) := by
   refine cpsTripleWithin_of_forall_regIs_to_regOwn (fun v1 => ?_)
   refine cpsTripleWithin_weaken (fun _ h => by xperm_hyp h) (fun _ h => h)
-    (show cpsTripleWithin (16 + 1 + nCall) (D + 128) (D + 196) fullCode
+    (show cpsTripleWithin (16 + 1 + nCall bytes.length) (D + 128) (D + 196) fullCode
       ((((.x2 ↦ᵣ spC) ** (.x8 ↦ᵣ nN) ** (.x9 ↦ᵣ lenBase) ** (.x6 ↦ᵣ hbi) ** (.x7 ↦ᵣ iW) **
           (.x18 ↦ᵣ hdrBase) ** (.x19 ↦ᵣ validPtr) ** (.x20 ↦ᵣ firstBadPtr) **
           (.x21 ↦ᵣ prevVal) ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
@@ -621,7 +621,7 @@ theorem cvcnIterEntry (spC hdrBase lenBase validPtr firstBadPtr prevVal : Word)
       (bigBytes.drop (hdrOff lengths i)).length < 2 ^ 64)
     (hvalid : ∀ k, k < (bigBytes.drop (hdrOff lengths i)).length →
       isValidByteAccess (hdrBaseAt hdrBase lengths i + BitVec.ofNat 64 k) = true) :
-    cpsTripleWithin (1 + (16 + 1 + nCall)) (D + 124) (D + 196) fullCode
+    cpsTripleWithin (1 + (16 + 1 + nCall (bigBytes.drop (hdrOff lengths i)).length)) (D + 124) (D + 196) fullCode
       ((.x2 ↦ᵣ spC) ** (.x8 ↦ᵣ BitVec.ofNat 64 lengths.length) ** (.x9 ↦ᵣ lenBase) **
         (.x6 ↦ᵣ hdrBaseAt hdrBase lengths i) ** (.x18 ↦ᵣ hdrBase) ** (.x19 ↦ᵣ validPtr) **
         (.x20 ↦ᵣ firstBadPtr) ** (.x7 ↦ᵣ BitVec.ofNat 64 i) ** (.x21 ↦ᵣ prevVal) **
@@ -1336,7 +1336,7 @@ theorem cvcnIter (sp0 spC hdrBase lenBase validPtr firstBadPtr raIn : Word)
           firstBadPtr csaved bigBytes lengths (i + 1))
         (cvcnPost sp0 spC (spC + signExtend12 (-32 : BitVec 12)) hdrBase lenBase validPtr
           firstBadPtr csaved bigBytes lengths)) :
-    cpsTripleWithin ((1 + (16 + 1 + nCall)) + (25 + nTail)) (D + 124) raIn fullCode
+    cpsTripleWithin ((1 + (16 + 1 + nCall (bigBytes.drop (hdrOff lengths i)).length)) + (25 + nTail)) (D + 124) raIn fullCode
       (LoopInv sp0 spC (spC + signExtend12 (-32 : BitVec 12)) hdrBase lenBase validPtr
         firstBadPtr csaved bigBytes lengths i)
       (cvcnPost sp0 spC (spC + signExtend12 (-32 : BitVec 12)) hdrBase lenBase validPtr
@@ -1369,19 +1369,19 @@ theorem cvcnIter (sp0 spC hdrBase lenBase validPtr firstBadPtr raIn : Word)
       EvmAsm.Evm64.bytesRegion_split hdrBase bigBytes (hdrOff lengths i) halign hlen,
       ← hHB, ← hLi] at hp
     rw [hEBody]; xperm_hyp hp) (fun _ hq => hq)
-    (show cpsTripleWithin ((1 + (16 + 1 + nCall)) + (25 + nTail)) (D + 124) raIn fullCode
+    (show cpsTripleWithin ((1 + (16 + 1 + nCall (bigBytes.drop (hdrOff lengths i)).length)) + (25 + nTail)) (D + 124) raIn fullCode
       (((EBody ** memOwn Num) ** memOwn RfuOff) ** memOwn RfuLen)
       (cvcnPost sp0 spC (spC + signExtend12 (-32 : BitVec 12)) hdrBase lenBase validPtr
         firstBadPtr csaved bigBytes lengths) from ?_)
   refine cpsTripleWithin_of_forall_memIs_to_memOwn (fun oldLen => ?_)
   refine cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp) (fun _ hq => hq)
-    (show cpsTripleWithin ((1 + (16 + 1 + nCall)) + (25 + nTail)) (D + 124) raIn fullCode
+    (show cpsTripleWithin ((1 + (16 + 1 + nCall (bigBytes.drop (hdrOff lengths i)).length)) + (25 + nTail)) (D + 124) raIn fullCode
       (((EBody ** (RfuLen ↦ₘ oldLen)) ** memOwn Num) ** memOwn RfuOff)
       (cvcnPost sp0 spC (spC + signExtend12 (-32 : BitVec 12)) hdrBase lenBase validPtr
         firstBadPtr csaved bigBytes lengths) from ?_)
   refine cpsTripleWithin_of_forall_memIs_to_memOwn (fun oldOff => ?_)
   refine cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp) (fun _ hq => hq)
-    (show cpsTripleWithin ((1 + (16 + 1 + nCall)) + (25 + nTail)) (D + 124) raIn fullCode
+    (show cpsTripleWithin ((1 + (16 + 1 + nCall (bigBytes.drop (hdrOff lengths i)).length)) + (25 + nTail)) (D + 124) raIn fullCode
       (((EBody ** (RfuLen ↦ₘ oldLen)) ** (RfuOff ↦ₘ oldOff)) ** memOwn Num)
       (cvcnPost sp0 spC (spC + signExtend12 (-32 : BitVec 12)) hdrBase lenBase validPtr
         firstBadPtr csaved bigBytes lengths) from ?_)

--- a/EvmAsm/Codegen/Programs/ChainValidateConsecutiveNumbersLoopClose.lean
+++ b/EvmAsm/Codegen/Programs/ChainValidateConsecutiveNumbersLoopClose.lean
@@ -47,7 +47,7 @@ theorem cvcnHdr0Call (spC hdrBase lenBase validPtr firstBadPtr x21val : Word) (L
     (hover : hdrBase.toNat + bytes.length < 2 ^ 64)
     (hvalid : ∀ k, k < bytes.length →
       isValidByteAccess (hdrBase + BitVec.ofNat 64 k) = true) :
-    cpsTripleWithin (5 + 1 + nCall) (D + 72) (D + 96) fullCode
+    cpsTripleWithin (5 + 1 + nCall bytes.length) (D + 72) (D + 96) fullCode
       ((.x2 ↦ᵣ spC) ** (.x8 ↦ᵣ nN) ** (.x9 ↦ᵣ lenBase) ** (.x18 ↦ᵣ hdrBase) **
         (.x19 ↦ᵣ validPtr) ** (.x20 ↦ᵣ firstBadPtr) ** (.x21 ↦ᵣ x21val) **
         (.x5 ↦ᵣ old5) ** (.x10 ↦ᵣ o10) ** (.x11 ↦ᵣ o11) ** (.x12 ↦ᵣ o12) ** (.x13 ↦ᵣ o13) **
@@ -109,7 +109,7 @@ theorem cvcnHdr0Call (spC hdrBase lenBase validPtr firstBadPtr x21val : Word) (L
     hcalleeNewSp rfl (by decide) (by decide)
     hsalign hslack hover hvalid (by show LinkRA0 &&& ~~~(1 : Word) = LinkRA0; decide)
   have hcalleeC := cpsTripleWithin_extend_code k34_mono hcallee0
-  have hcallee : cpsTripleWithin nCall EvmAsm.Codegen.RlpFieldToU64SAsm.B LinkRA0 fullCode
+  have hcallee : cpsTripleWithin (nCall bytes.length) EvmAsm.Codegen.RlpFieldToU64SAsm.B LinkRA0 fullCode
       (regOwn .x5 **
         ((.x1 ↦ᵣ LinkRA0) ** (.x2 ↦ᵣ spC) ** (.x8 ↦ᵣ nN) ** (.x9 ↦ᵣ lenBase) **
           (.x18 ↦ᵣ hdrBase) ** (.x19 ↦ᵣ validPtr) ** (.x20 ↦ᵣ firstBadPtr) ** (.x21 ↦ᵣ x21val) **
@@ -201,12 +201,13 @@ theorem cvcnHdr0Finish (hdrBase lenBase ts0 : Word) (L0 : Nat) (old5 o6 o7 o21 :
 /-- Step budget for the loop with `r = N − i` iterations remaining: each full
     iteration is `cvcnIter`'s cost, the exhausted guard + all-valid exit is
     `11` (guard `1` + `retAllValid` `10`). -/
-def cvcnLoopSteps : Nat → Nat
+def cvcnLoopSteps (bytesLen : Nat) : Nat → Nat
   | 0 => 11
-  | r + 1 => (1 + (16 + 1 + nCall)) + (25 + cvcnLoopSteps r)
+  | r + 1 => (1 + (16 + 1 + nCall bytesLen)) + (25 + cvcnLoopSteps bytesLen r)
 
-theorem cvcnLoopSteps_succ (r : Nat) :
-    cvcnLoopSteps (r + 1) = (1 + (16 + 1 + nCall)) + (25 + cvcnLoopSteps r) := rfl
+theorem cvcnLoopSteps_succ (bytesLen r : Nat) :
+    cvcnLoopSteps bytesLen (r + 1) =
+      (1 + (16 + 1 + nCall bytesLen)) + (25 + cvcnLoopSteps bytesLen r) := rfl
 
 set_option maxRecDepth 8000 in
 theorem cvcnLoop (sp0 spC hdrBase lenBase validPtr firstBadPtr raIn : Word)
@@ -225,7 +226,7 @@ theorem cvcnLoop (sp0 spC hdrBase lenBase validPtr firstBadPtr raIn : Word)
     (hAllValid : ∀ i, i < lengths.length → ∀ k, k < (bigBytes.drop (hdrOff lengths i)).length →
       isValidByteAccess (hdrBaseAt hdrBase lengths i + BitVec.ofNat 64 k) = true) :
     ∀ (f i : Nat), lengths.length - i ≤ f → 1 ≤ i → i ≤ lengths.length →
-      cpsTripleWithin (cvcnLoopSteps (lengths.length - i)) (D + 124) raIn fullCode
+      cpsTripleWithin (cvcnLoopSteps bigBytes.length (lengths.length - i)) (D + 124) raIn fullCode
         (LoopInv sp0 spC (spC + signExtend12 (-32 : BitVec 12)) hdrBase lenBase validPtr
           firstBadPtr csaved bigBytes lengths i)
         (cvcnPost sp0 spC (spC + signExtend12 (-32 : BitVec 12)) hdrBase lenBase validPtr
@@ -237,7 +238,7 @@ theorem cvcnLoop (sp0 spC hdrBase lenBase validPtr firstBadPtr raIn : Word)
     unfold savedFrame; rw [hraSaved]
   -- All-valid exit reached at the guard when `i = N`.
   have base :
-      cpsTripleWithin (cvcnLoopSteps 0) (D + 124) raIn fullCode
+      cpsTripleWithin (cvcnLoopSteps bigBytes.length 0) (D + 124) raIn fullCode
         (LoopInv sp0 spC (spC + signExtend12 (-32 : BitVec 12)) hdrBase lenBase validPtr
           firstBadPtr csaved bigBytes lengths lengths.length)
         (cvcnPost sp0 spC (spC + signExtend12 (-32 : BitVec 12)) hdrBase lenBase validPtr
@@ -249,7 +250,7 @@ theorem cvcnLoop (sp0 spC hdrBase lenBase validPtr firstBadPtr raIn : Word)
     -- Expose x1 / x10 (overwritten by the exit block) as concrete regs.
     refine cpsTripleWithin_weaken (fun h hp => by unfold payload scratchRegs at hp; xperm_hyp hp)
       (fun _ hq => hq)
-      (show cpsTripleWithin (cvcnLoopSteps 0) (D + 124) raIn fullCode
+      (show cpsTripleWithin (cvcnLoopSteps bigBytes.length 0) (D + 124) raIn fullCode
         ((((.x2 ↦ᵣ spC) ** (.x8 ↦ᵣ BitVec.ofNat 64 lengths.length) ** (.x9 ↦ᵣ lenBase) **
             (.x6 ↦ᵣ hdrBaseAt hdrBase lengths lengths.length) ** (.x18 ↦ᵣ hdrBase) **
             (.x19 ↦ᵣ validPtr) ** (.x20 ↦ᵣ firstBadPtr) **
@@ -266,7 +267,7 @@ theorem cvcnLoop (sp0 spC hdrBase lenBase validPtr firstBadPtr raIn : Word)
           firstBadPtr csaved bigBytes lengths) from ?_)
     refine cpsTripleWithin_of_forall_regIs_to_regOwn (fun o10 => ?_)
     refine cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp) (fun _ hq => hq)
-      (show cpsTripleWithin (cvcnLoopSteps 0) (D + 124) raIn fullCode
+      (show cpsTripleWithin (cvcnLoopSteps bigBytes.length 0) (D + 124) raIn fullCode
         (((.x2 ↦ᵣ spC) ** (.x8 ↦ᵣ BitVec.ofNat 64 lengths.length) ** (.x9 ↦ᵣ lenBase) **
             (.x6 ↦ᵣ hdrBaseAt hdrBase lengths lengths.length) ** (.x18 ↦ᵣ hdrBase) **
             (.x19 ↦ᵣ validPtr) ** (.x20 ↦ᵣ firstBadPtr) **
@@ -361,11 +362,15 @@ theorem cvcnLoop (sp0 spC hdrBase lenBase validPtr firstBadPtr raIn : Word)
     · subst hi; rw [Nat.sub_self]; exact base
     · rw [show lengths.length - i = (lengths.length - (i + 1)) + 1 from by omega,
         cvcnLoopSteps_succ]
-      exact cvcnIter sp0 spC hdrBase lenBase validPtr firstBadPtr raIn csaved bigBytes lengths i
-        (cvcnLoopSteps (lengths.length - (i + 1))) hi1 hi hN hspC hraSaved hret
+      have hiter := cvcnIter sp0 spC hdrBase lenBase validPtr firstBadPtr raIn csaved bigBytes lengths i
+        (cvcnLoopSteps bigBytes.length (lengths.length - (i + 1))) hi1 hi hN hspC hraSaved hret
         (hAllAlign i hi) (hAllLen i hi) (hAllSalign i hi) (hAllSlack i hi) (hAllOver i hi)
         (hAllValid i hi)
         (fun _ => ih (i + 1) (by omega) (by omega) (by omega))
+      have hdrop : (bigBytes.drop (hdrOff lengths i)).length ≤ bigBytes.length := by
+        rw [List.length_drop]
+        omega
+      refine cpsTripleWithin_mono_nSteps (by unfold nCall; omega) hiter
 
 
 /-! ## Header-0 flatPost normalization (K34 saved-ra = `LinkRA0`)
@@ -827,7 +832,7 @@ theorem cvcnHdr0Block
           firstBadPtr csaved bigBytes lengths 1)
         (cvcnPost sp0 spC (spC + signExtend12 (-32 : BitVec 12)) hdrBase lenBase validPtr
           firstBadPtr csaved bigBytes lengths)) :
-    cpsTripleWithin ((5 + 1 + nCall) + (22 + nTail)) (D + 72) raIn fullCode
+    cpsTripleWithin ((5 + 1 + nCall bigBytes.length) + (22 + nTail)) (D + 72) raIn fullCode
       ((.x2 ↦ᵣ spC) ** (.x8 ↦ᵣ BitVec.ofNat 64 lengths.length) ** (.x9 ↦ᵣ lenBase) **
         (.x18 ↦ᵣ hdrBase) ** (.x19 ↦ᵣ validPtr) ** (.x20 ↦ᵣ firstBadPtr) ** (.x21 ↦ᵣ x21val) **
         (.x5 ↦ᵣ old5) ** (.x10 ↦ᵣ o10) ** (.x11 ↦ᵣ o11) ** (.x12 ↦ᵣ o12) ** (.x13 ↦ᵣ o13) **
@@ -891,7 +896,7 @@ theorem chain_validate_consecutive_numbers_spec_within
     (hAllValid : ∀ i, i < lengths.length → ∀ k, k < (bigBytes.drop (hdrOff lengths i)).length →
       isValidByteAccess (hdrBaseAt hdrBase lengths i + BitVec.ofNat 64 k) = true) :
     cpsTripleWithin
-      (17 + (1 + ((5 + 1 + nCall) + (22 + cvcnLoopSteps (lengths.length - 1)))))
+      (17 + (1 + ((5 + 1 + nCall bigBytes.length) + (22 + cvcnLoopSteps bigBytes.length (lengths.length - 1)))))
       D raIn fullCode
       (((.x2 ↦ᵣ sp0) ** (.x1 ↦ᵣ raIn) ** (.x8 ↦ᵣ cs0) ** (.x9 ↦ᵣ cs1) **
           (.x18 ↦ᵣ cs2) ** (.x19 ↦ᵣ cs3) ** (.x20 ↦ᵣ cs4) ** (.x21 ↦ᵣ cs5) **
@@ -932,7 +937,7 @@ theorem chain_validate_consecutive_numbers_spec_within
       stackFree (spC + signExtend12 (-32 : BitVec 12)) 8) (by pcfx) hpro
   -- Tail from the loop-comparand load (`D+68`): BLTU then header-0 or the N<2 exit.
   have htail :
-      cpsTripleWithin (1 + ((5 + 1 + nCall) + (22 + cvcnLoopSteps (lengths.length - 1))))
+      cpsTripleWithin (1 + ((5 + 1 + nCall bigBytes.length) + (22 + cvcnLoopSteps bigBytes.length (lengths.length - 1))))
         (D + 68) raIn fullCode
         (((.x2 ↦ᵣ spC) ** (.x1 ↦ᵣ raIn) ** (.x8 ↦ᵣ BitVec.ofNat 64 lengths.length) **
             (.x9 ↦ᵣ lenBase) ** (.x18 ↦ᵣ hdrBase) ** (.x19 ↦ᵣ validPtr) **
@@ -993,7 +998,7 @@ theorem chain_validate_consecutive_numbers_spec_within
           hdrBase validPtr firstBadPtr cs5 hspC rfl hret)
       refine cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp) (fun h hq => ?_)
         (cpsTripleWithin_mono_nSteps
-          (show 1 + 10 ≤ 1 + ((5 + 1 + nCall) + (22 + cvcnLoopSteps (lengths.length - 1))) by
+          (show 1 + 10 ≤ 1 + ((5 + 1 + nCall bigBytes.length) + (22 + cvcnLoopSteps bigBytes.length (lengths.length - 1))) by
             unfold nCall; omega)
           (cpsTripleWithin_seq_perm_same_cr (fun h hp => by xperm_hyp hp)
             htakenF hallv))
@@ -1056,21 +1061,21 @@ theorem chain_validate_consecutive_numbers_spec_within
           memOwn IterChild ** memOwn IterPrev) with hBASE
       -- Peel the three K34 scratch cells (owned) into concrete inputs; run the block+loop.
       have hcont :
-          cpsTripleWithin ((5 + 1 + nCall) + (22 + cvcnLoopSteps (lengths.length - 1)))
+          cpsTripleWithin ((5 + 1 + nCall bigBytes.length) + (22 + cvcnLoopSteps bigBytes.length (lengths.length - 1)))
             (D + 72) raIn fullCode
             (((BASE ** memOwn Num) ** memOwn RfuOff) ** memOwn RfuLen)
             (cvcnPost sp0 spC (spC + signExtend12 (-32 : BitVec 12)) hdrBase lenBase validPtr
               firstBadPtr ⟨raIn, cs0, cs1, cs2, cs3, cs4, cs5⟩ bigBytes lengths) := by
         refine cpsTripleWithin_of_forall_memIs_to_memOwn (fun oldLen => ?_)
         refine cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp) (fun _ hq => hq)
-          (show cpsTripleWithin ((5 + 1 + nCall) + (22 + cvcnLoopSteps (lengths.length - 1)))
+          (show cpsTripleWithin ((5 + 1 + nCall bigBytes.length) + (22 + cvcnLoopSteps bigBytes.length (lengths.length - 1)))
             (D + 72) raIn fullCode
             (((BASE ** (RfuLen ↦ₘ oldLen)) ** memOwn Num) ** memOwn RfuOff)
             (cvcnPost sp0 spC (spC + signExtend12 (-32 : BitVec 12)) hdrBase lenBase validPtr
               firstBadPtr ⟨raIn, cs0, cs1, cs2, cs3, cs4, cs5⟩ bigBytes lengths) from ?_)
         refine cpsTripleWithin_of_forall_memIs_to_memOwn (fun oldOff => ?_)
         refine cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp) (fun _ hq => hq)
-          (show cpsTripleWithin ((5 + 1 + nCall) + (22 + cvcnLoopSteps (lengths.length - 1)))
+          (show cpsTripleWithin ((5 + 1 + nCall bigBytes.length) + (22 + cvcnLoopSteps bigBytes.length (lengths.length - 1)))
             (D + 72) raIn fullCode
             (((BASE ** (RfuLen ↦ₘ oldLen)) ** (RfuOff ↦ₘ oldOff)) ** memOwn Num)
             (cvcnPost sp0 spC (spC + signExtend12 (-32 : BitVec 12)) hdrBase lenBase validPtr
@@ -1079,7 +1084,8 @@ theorem chain_validate_consecutive_numbers_spec_within
         have hblock := cvcnHdr0Block sp0 spC hdrBase lenBase validPtr firstBadPtr raIn cs5
           lengths[0]! oldOut oldOff oldLen firstBadPtr raIn (2 : Word)
           (BitVec.ofNat 64 lengths.length) lenBase hdrBase validPtr
-          ⟨raIn, cs0, cs1, cs2, cs3, cs4, cs5⟩ bigBytes lengths (cvcnLoopSteps (lengths.length - 1))
+          ⟨raIn, cs0, cs1, cs2, cs3, cs4, cs5⟩ bigBytes lengths
+          (cvcnLoopSteps bigBytes.length (lengths.length - 1))
           hge rfl hspC rfl hret
           (by have := hAllSalign 0 (by omega); rwa [hHB0] at this)
           (by have := hAllSlack 0 (by omega); rwa [hdrop0] at this)

--- a/EvmAsm/Codegen/Programs/ChainValidateGasUsedUnderLimitLoop.lean
+++ b/EvmAsm/Codegen/Programs/ChainValidateGasUsedUnderLimitLoop.lean
@@ -25,9 +25,9 @@ open EvmAsm.Codegen.ChainValidateExtraDataLengthSpec
 
 /-- K34's whole-routine step count for field index `index` (matching the flat
     spec's `((7 + 4 + callSteps) + ((1 + tailSteps) + 5))`). -/
-abbrev nCall (index : Nat) : Nat :=
+def nCall (index bytesLen : Nat) : Nat :=
   (7 + 4 + (1 + ((12 + ((85 + 93 * (index + 2)) + 6)) + 9)))
-    + ((1 + ((7 + (1 + (7 * (2 ^ 64 - 1) + 11))) + 5)) + 5)
+    + ((1 + ((7 + (1 + (7 * bytesLen + 11))) + 5)) + 5)
 
 theorem lengths_getElem_bang {lengths : List Nat} {i : Nat} (hi : i < lengths.length) :
     lengths[i]! = lengths[i] := getElem!_pos lengths i hi
@@ -255,7 +255,7 @@ theorem cvgulCall1 (hbi lenBase spC iW : Word) (Li : Nat)
     (hover : hbi.toNat + bytes.length < 2 ^ 64)
     (hvalid : ∀ k, k < bytes.length →
       isValidByteAccess (hbi + BitVec.ofNat 64 k) = true) :
-    cpsTripleWithin (13 + 1 + nCall 10) (D + 72) (D + 128) fullCode
+    cpsTripleWithin (13 + 1 + nCall 10 bytes.length) (D + 72) (D + 128) fullCode
       ((.x2 ↦ᵣ spC) ** (.x9 ↦ᵣ lenBase) ** (.x18 ↦ᵣ hbi) ** (.x21 ↦ᵣ iW) **
         (.x5 ↦ᵣ old5) ** (.x10 ↦ᵣ o10) ** (.x11 ↦ᵣ o11) ** (.x12 ↦ᵣ o12) **
         (.x13 ↦ᵣ o13) ** (.x28 ↦ᵣ o28) **
@@ -327,7 +327,7 @@ theorem cvgulCall1 (hbi lenBase spC iW : Word) (Li : Nat)
     hcalleeNewSp rfl (by decide) (by decide)
     hsalign hslack hover hvalid (by show LinkRA1 &&& ~~~(1 : Word) = LinkRA1; decide)
   have hcalleeC := cpsTripleWithin_extend_code k34_mono hcallee0
-  have hcallee : cpsTripleWithin (nCall 10) EvmAsm.Codegen.RlpFieldToU64SAsm.B LinkRA1 fullCode
+  have hcallee : cpsTripleWithin (nCall 10 bytes.length) EvmAsm.Codegen.RlpFieldToU64SAsm.B LinkRA1 fullCode
       (regOwn .x5 ** regOwn .x28 **
         ((.x1 ↦ᵣ LinkRA1) ** (.x2 ↦ᵣ spC) ** (.x8 ↦ᵣ nN) ** (.x9 ↦ᵣ lenBase) **
           (.x18 ↦ᵣ hbi) ** (.x19 ↦ᵣ s3) ** (.x20 ↦ᵣ s4) ** (.x21 ↦ᵣ iW) **
@@ -379,7 +379,7 @@ theorem cvgulCall1Owned (hbi lenBase spC iW : Word) (Li : Nat)
     (hover : hbi.toNat + bytes.length < 2 ^ 64)
     (hvalid : ∀ k, k < bytes.length →
       isValidByteAccess (hbi + BitVec.ofNat 64 k) = true) :
-    cpsTripleWithin (13 + 1 + nCall 10) (D + 72) (D + 128) fullCode
+    cpsTripleWithin (13 + 1 + nCall 10 bytes.length) (D + 72) (D + 128) fullCode
       ((((.x2 ↦ᵣ spC) ** (.x9 ↦ᵣ lenBase) ** (.x18 ↦ᵣ hbi) ** (.x21 ↦ᵣ iW) **
           memOwn IterPtr ** memOwn IterI **
           ((lenBase + (iW <<< 3)) ↦ₘ BitVec.ofNat 64 Li) **
@@ -401,7 +401,7 @@ theorem cvgulCall1Owned (hbi lenBase spC iW : Word) (Li : Nat)
         ((lenBase + (iW <<< 3)) ↦ₘ BitVec.ofNat 64 Li) ** savedFrame spC csaved) := by
   refine cpsTripleWithin_of_forall_regIs_to_regOwn (fun v1 => ?_)
   refine cpsTripleWithin_weaken (fun _ h => by xperm_hyp h) (fun _ h => h)
-    (show cpsTripleWithin (13 + 1 + nCall 10) (D + 72) (D + 128) fullCode
+    (show cpsTripleWithin (13 + 1 + nCall 10 bytes.length) (D + 72) (D + 128) fullCode
       ((((.x2 ↦ᵣ spC) ** (.x9 ↦ᵣ lenBase) ** (.x18 ↦ᵣ hbi) ** (.x21 ↦ᵣ iW) **
           memOwn IterPtr ** memOwn IterI **
           ((lenBase + (iW <<< 3)) ↦ₘ BitVec.ofNat 64 Li) **
@@ -445,7 +445,7 @@ theorem cvgulCall2 (hbi lenBase spC iW : Word) (Li : Nat)
     (hover : hbi.toNat + bytes.length < 2 ^ 64)
     (hvalid : ∀ k, k < bytes.length →
       isValidByteAccess (hbi + BitVec.ofNat 64 k) = true) :
-    cpsTripleWithin (13 + 1 + nCall 9) (D + 132) (D + 188) fullCode
+    cpsTripleWithin (13 + 1 + nCall 9 bytes.length) (D + 132) (D + 188) fullCode
       ((.x2 ↦ᵣ spC) ** (.x9 ↦ᵣ lenBase) ** (.x18 ↦ᵣ o18) ** (.x21 ↦ᵣ o21) **
         (.x5 ↦ᵣ old5) ** (.x10 ↦ᵣ o10) ** (.x11 ↦ᵣ o11) ** (.x12 ↦ᵣ o12) **
         (.x13 ↦ᵣ o13) ** (.x28 ↦ᵣ o28) **
@@ -517,7 +517,7 @@ theorem cvgulCall2 (hbi lenBase spC iW : Word) (Li : Nat)
     hcalleeNewSp rfl (by decide) (by decide)
     hsalign hslack hover hvalid (by show LinkRA2 &&& ~~~(1 : Word) = LinkRA2; decide)
   have hcalleeC := cpsTripleWithin_extend_code k34_mono hcallee0
-  have hcallee : cpsTripleWithin (nCall 9) EvmAsm.Codegen.RlpFieldToU64SAsm.B LinkRA2 fullCode
+  have hcallee : cpsTripleWithin (nCall 9 bytes.length) EvmAsm.Codegen.RlpFieldToU64SAsm.B LinkRA2 fullCode
       (regOwn .x5 ** regOwn .x28 **
         ((.x1 ↦ᵣ LinkRA2) ** (.x2 ↦ᵣ spC) ** (.x8 ↦ᵣ nN) ** (.x9 ↦ᵣ lenBase) **
           (.x18 ↦ᵣ hbi) ** (.x19 ↦ᵣ s3) ** (.x20 ↦ᵣ s4) ** (.x21 ↦ᵣ iW) **
@@ -678,7 +678,7 @@ theorem cvgulIterEntry (spC hdrBase lenBase validPtr firstBadPtr : Word)
       (bigBytes.drop (hdrOff lengths i)).length < 2 ^ 64)
     (hvalid : ∀ k, k < (bigBytes.drop (hdrOff lengths i)).length →
       isValidByteAccess (hdrBaseAt hdrBase lengths i + BitVec.ofNat 64 k) = true) :
-    cpsTripleWithin (1 + (13 + 1 + nCall 10)) (D + 68) (D + 128) fullCode
+    cpsTripleWithin (1 + (13 + 1 + nCall 10 (bigBytes.drop (hdrOff lengths i)).length)) (D + 68) (D + 128) fullCode
       ((.x2 ↦ᵣ spC) ** (.x8 ↦ᵣ BitVec.ofNat 64 lengths.length) ** (.x9 ↦ᵣ lenBase) **
         (.x18 ↦ᵣ hdrBaseAt hdrBase lengths i) ** (.x19 ↦ᵣ validPtr) **
         (.x20 ↦ᵣ firstBadPtr) ** (.x21 ↦ᵣ BitVec.ofNat 64 i) ** savedFrame spC csaved **

--- a/EvmAsm/Codegen/Programs/ChainValidateGasUsedUnderLimitLoopClose.lean
+++ b/EvmAsm/Codegen/Programs/ChainValidateGasUsedUnderLimitLoopClose.lean
@@ -23,6 +23,27 @@ open EvmAsm.Codegen.ChainValidateExtraDataLengthSpec
    wordArrayFrom_append shiftLeft3_ofNat hdrOff hdrBaseAt hdrOff_succ hdrBaseAt_succ
    ofNat_ne_of_lt ofNat_succ_tie)
 
+@[irreducible] def nCall9 (bytesLen : Nat) : Nat := nCall 9 bytesLen
+@[irreducible] def nCall10 (bytesLen : Nat) : Nat := nCall 10 bytesLen
+
+theorem nCall9_eq (bytesLen : Nat) : nCall9 bytesLen = nCall 9 bytesLen := by
+  unfold nCall9
+  rfl
+
+theorem nCall10_eq (bytesLen : Nat) : nCall10 bytesLen = nCall 10 bytesLen := by
+  unfold nCall10
+  rfl
+
+theorem nCall9_mono {a b : Nat} (h : a ≤ b) : nCall9 a ≤ nCall9 b := by
+  rw [nCall9_eq, nCall9_eq]
+  unfold nCall
+  omega
+
+theorem nCall10_mono {a b : Nat} (h : a ≤ b) : nCall10 a ≤ nCall10 b := by
+  rw [nCall10_eq, nCall10_eq]
+  unfold nCall
+  omega
+
 local macro "pcfx" : tactic =>
   `(tactic| repeat' first
       | apply pcFree_sepConj | exact pcFree_regIs | exact pcFree_regOwn
@@ -598,7 +619,7 @@ theorem cvgulCall2Owned (hbi lenBase spC iW : Word) (Li : Nat)
     (hover : hbi.toNat + bytes.length < 2 ^ 64)
     (hvalid : ∀ k, k < bytes.length →
       isValidByteAccess (hbi + BitVec.ofNat 64 k) = true) :
-    cpsTripleWithin (13 + 1 + nCall 9) (D + 132) (D + 188) fullCode
+    cpsTripleWithin (13 + 1 + nCall9 bytes.length) (D + 132) (D + 188) fullCode
       ((((((.x2 ↦ᵣ spC) ** (.x9 ↦ᵣ lenBase) **
             (IterPtr ↦ₘ hbi) ** (IterI ↦ₘ iW) **
             ((lenBase + (iW <<< 3)) ↦ₘ BitVec.ofNat 64 Li) **
@@ -620,7 +641,7 @@ theorem cvgulCall2Owned (hbi lenBase spC iW : Word) (Li : Nat)
         ((lenBase + (iW <<< 3)) ↦ₘ BitVec.ofNat 64 Li) ** savedFrame spC csaved) := by
   refine cpsTripleWithin_of_forall_regIs_to_regOwn (fun v21 => ?_)
   refine cpsTripleWithin_weaken (fun _ h => by xperm_hyp h) (fun _ h => h)
-    (show cpsTripleWithin (13 + 1 + nCall 9) (D + 132) (D + 188) fullCode
+    (show cpsTripleWithin (13 + 1 + nCall9 bytes.length) (D + 132) (D + 188) fullCode
       ((((((.x2 ↦ᵣ spC) ** (.x9 ↦ᵣ lenBase) **
             (IterPtr ↦ₘ hbi) ** (IterI ↦ₘ iW) **
             ((lenBase + (iW <<< 3)) ↦ₘ BitVec.ofNat 64 Li) **
@@ -642,7 +663,7 @@ theorem cvgulCall2Owned (hbi lenBase spC iW : Word) (Li : Nat)
         ((lenBase + (iW <<< 3)) ↦ₘ BitVec.ofNat 64 Li) ** savedFrame spC csaved) from ?_)
   refine cpsTripleWithin_of_forall_regIs_to_regOwn (fun v18 => ?_)
   refine cpsTripleWithin_weaken (fun _ h => by xperm_hyp h) (fun _ h => h)
-    (show cpsTripleWithin (13 + 1 + nCall 9) (D + 132) (D + 188) fullCode
+    (show cpsTripleWithin (13 + 1 + nCall9 bytes.length) (D + 132) (D + 188) fullCode
       (((((.x2 ↦ᵣ spC) ** (.x9 ↦ᵣ lenBase) **
             (IterPtr ↦ₘ hbi) ** (IterI ↦ₘ iW) **
             ((lenBase + (iW <<< 3)) ↦ₘ BitVec.ofNat 64 Li) **
@@ -664,7 +685,7 @@ theorem cvgulCall2Owned (hbi lenBase spC iW : Word) (Li : Nat)
         ((lenBase + (iW <<< 3)) ↦ₘ BitVec.ofNat 64 Li) ** savedFrame spC csaved) from ?_)
   refine cpsTripleWithin_of_forall_regIs_to_regOwn (fun v1 => ?_)
   refine cpsTripleWithin_weaken (fun _ h => by xperm_hyp h) (fun _ h => h)
-    (show cpsTripleWithin (13 + 1 + nCall 9) (D + 132) (D + 188) fullCode
+    (show cpsTripleWithin (13 + 1 + nCall9 bytes.length) (D + 132) (D + 188) fullCode
       (((.x2 ↦ᵣ spC) ** (.x9 ↦ᵣ lenBase) **
           (IterPtr ↦ₘ hbi) ** (IterI ↦ₘ iW) **
           ((lenBase + (iW <<< 3)) ↦ₘ BitVec.ofNat 64 Li) **
@@ -687,9 +708,10 @@ theorem cvgulCall2Owned (hbi lenBase spC iW : Word) (Li : Nat)
         ((lenBase + (iW <<< 3)) ↦ₘ BitVec.ofNat 64 Li) ** savedFrame spC csaved) from ?_)
   refine EvmAsm.Codegen.RlpListNthItemSAsm.cpsTripleWithin_of_forall_regIs_to_regOwn7
     (fun v5 v10 v11 v12 v13 v14 v28 => ?_)
-  exact cpsTripleWithin_weaken (fun _ h => by xperm_hyp h) (fun _ h => by xperm_hyp h)
-    (cvgulCall2 hbi lenBase spC iW Li nN s3 s4 oldOut oldOff oldLen v14 v1 v5 v10 v11 v12 v13
-      v18 v21 v28 bytes csaved hsalign hslack hover hvalid)
+  have hcall := cvgulCall2 hbi lenBase spC iW Li nN s3 s4 oldOut oldOff oldLen v14 v1 v5 v10 v11 v12 v13
+    v18 v21 v28 bytes csaved hsalign hslack hover hvalid
+  rw [← nCall9_eq bytes.length] at hcall
+  exact cpsTripleWithin_weaken (fun _ h => by xperm_hyp h) (fun _ h => by xperm_hyp h) hcall
 
 
 /-! ## Dispatch from the first call (`D+128` onward): gas-used status + call 2
@@ -723,7 +745,7 @@ theorem cvgulDispatch1
           firstBadPtr csaved bigBytes lengths (i + 1))
         (cvgulPost sp0 spC (spC + signExtend12 (-32 : BitVec 12)) hdrBase lenBase validPtr
           firstBadPtr csaved bigBytes lengths)) :
-    cpsTripleWithin (1 + ((13 + 1 + nCall 9) + (27 + nTail))) (D + 128) raIn fullCode
+    cpsTripleWithin (1 + ((13 + 1 + nCall9 bigBytes.length) + (27 + nTail))) (D + 128) raIn fullCode
       ((.x1 ↦ᵣ LinkRA1) **
         EvmAsm.Codegen.RlpFieldToU64SAsm.flatPost spC (spC + signExtend12 (-32 : BitVec 12))
           (hdrBaseAt hdrBase lengths i) oldOff oldLen
@@ -751,7 +773,7 @@ theorem cvgulDispatch1
   refine cpsTripleWithin_weaken (fun h hp => ?hstrip) (fun _ hq => hq)
     (EvmAsm.Codegen.RlpListNthItemSAsm.cpsTripleWithin_exists_assertion (fun status =>
       EvmAsm.Codegen.RlpListNthItemSAsm.cpsTripleWithin_exists_assertion (fun value =>
-        (show cpsTripleWithin (1 + ((13 + 1 + nCall 9) + (27 + nTail))) (D + 128) raIn fullCode
+        (show cpsTripleWithin (1 + ((13 + 1 + nCall9 bigBytes.length) + (27 + nTail))) (D + 128) raIn fullCode
           ((.x1 ↦ᵣ LinkRA1) **
             (dispNorm spC (spC + signExtend12 (-32 : BitVec 12)) (hdrBaseAt hdrBase lengths i)
                 validPtr firstBadPtr (BitVec.ofNat 64 lengths.length) lenBase (BitVec.ofNat 64 i)
@@ -833,7 +855,7 @@ theorem cvgulDispatch1
           obtain ⟨_, _, _, _, _, hrest⟩ := hq
           exact absurd rfl ((sepConj_pure_right _).1 hrest).2)
         rw [show (D + 128 + 4 : Word) = D + 132 from by bv_omega] at hntaken
-        have hcont : cpsTripleWithin ((13 + 1 + nCall 9) + (27 + nTail)) (D + 132) raIn fullCode
+        have hcont : cpsTripleWithin ((13 + 1 + nCall9 bigBytes.length) + (27 + nTail)) (D + 132) raIn fullCode
             (((.x10 ↦ᵣ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word))) ** RframeOk1)
             (cvgulPost sp0 spC (spC + signExtend12 (-32 : BitVec 12)) hdrBase lenBase
               validPtr firstBadPtr csaved bigBytes lengths) := by
@@ -857,13 +879,13 @@ theorem cvgulDispatch1
               savedFrame spC csaved) with hBODY
           refine cpsTripleWithin_weaken (fun h hp => by
             rw [hRframeOk1] at hp; rw [hBODY]; xperm_hyp hp) (fun _ hq => hq)
-            (show cpsTripleWithin ((13 + 1 + nCall 9) + (27 + nTail)) (D + 132) raIn fullCode
+            (show cpsTripleWithin ((13 + 1 + nCall9 bigBytes.length) + (27 + nTail)) (D + 132) raIn fullCode
               ((BODY ** memOwn RfuOff) ** memOwn RfuLen)
               (cvgulPost sp0 spC (spC + signExtend12 (-32 : BitVec 12)) hdrBase lenBase
                 validPtr firstBadPtr csaved bigBytes lengths) from ?_)
           refine cpsTripleWithin_of_forall_memIs_to_memOwn (fun oldLen2 => ?_)
           refine cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp) (fun _ hq => hq)
-            (show cpsTripleWithin ((13 + 1 + nCall 9) + (27 + nTail)) (D + 132) raIn fullCode
+            (show cpsTripleWithin ((13 + 1 + nCall9 bigBytes.length) + (27 + nTail)) (D + 132) raIn fullCode
               ((BODY ** (RfuLen ↦ₘ oldLen2)) ** memOwn RfuOff)
               (cvgulPost sp0 spC (spC + signExtend12 (-32 : BitVec 12)) hdrBase lenBase
                 validPtr firstBadPtr csaved bigBytes lengths) from ?_)
@@ -880,6 +902,14 @@ theorem cvgulDispatch1
               bytesRegion hdrBase (bigBytes.take (hdrOff lengths i)) **
               (validPtr ↦ₘ (1 : Word)) ** (firstBadPtr ↦ₘ (0 : Word)))
             (by pcfx) hc2
+          have hdropLen : (bigBytes.drop (hdrOff lengths i)).length ≤ bigBytes.length := by
+            rw [List.length_drop]
+            omega
+          have hbound : 13 + 1 + nCall9 (bigBytes.drop (hdrOff lengths i)).length ≤
+              13 + 1 + nCall9 bigBytes.length := by
+            have hmono := nCall9_mono hdropLen
+            omega
+          have hc2F' := cpsTripleWithin_mono_nSteps hbound hc2F
           have hd2 := cvgulDispatch2 sp0 spC hdrBase lenBase validPtr firstBadPtr raIn csaved
             bigBytes lengths i oldOff2 oldLen2 value nTail hi hspC hraSaved hret halign hlen
             hResult hprefix htail
@@ -911,7 +941,7 @@ theorem cvgulDispatch1
               (sepConj_mono (regIs_implies_regOwn .x21)
               (sepConj_mono (k34SavedFrame_implies_frameSlotsOwn _ _) (fun _ x => x))))) h hp1
             xperm_hyp hp2) (fun _ hq => hq)
-            (cpsTripleWithin_seq_perm_same_cr (fun h hq => by xperm_hyp hq) hc2F hd2)
+            (cpsTripleWithin_seq_perm_same_cr (fun h hq => by xperm_hyp hq) hc2F' hd2)
         have hntakenF := cpsTripleWithin_frameR RframeOk1 (by rw [hRframeOk1]; pcfx) hntaken
         refine cpsTripleWithin_weaken (fun h hp => by rw [hRframeOk1]; xperm_hyp hp)
           (fun _ hq => hq)
@@ -993,7 +1023,7 @@ theorem cvgulDispatch1
           xperm_hyp hp2) htakenF hpfC
         refine cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp) (fun h hq => ?_)
           (cpsTripleWithin_mono_nSteps
-            (show 1 + 11 ≤ 1 + ((13 + 1 + nCall 9) + (27 + nTail)) by omega) hcompose)
+            (show 1 + 11 ≤ 1 + ((13 + 1 + nCall9 bigBytes.length) + (27 + nTail)) by omega) hcompose)
         refine Or.inr (Or.inr ⟨i, status, ?_⟩)
         refine (sepConj_pure_left h).mpr
           ⟨⟨hi, hprefix, Or.inl ⟨value, hResult, hstatus⟩⟩, ?_⟩
@@ -1057,8 +1087,8 @@ theorem cvgulIter (sp0 spC hdrBase lenBase validPtr firstBadPtr raIn : Word)
           firstBadPtr csaved bigBytes lengths (i + 1))
         (cvgulPost sp0 spC (spC + signExtend12 (-32 : BitVec 12)) hdrBase lenBase validPtr
           firstBadPtr csaved bigBytes lengths)) :
-    cpsTripleWithin ((1 + (13 + 1 + nCall 10)) +
-        (1 + ((13 + 1 + nCall 9) + (27 + nTail)))) (D + 68) raIn fullCode
+    cpsTripleWithin ((1 + (13 + 1 + nCall10 bigBytes.length)) +
+        (1 + ((13 + 1 + nCall9 bigBytes.length) + (27 + nTail)))) (D + 68) raIn fullCode
       (LoopInv sp0 spC (spC + signExtend12 (-32 : BitVec 12)) hdrBase lenBase validPtr
         firstBadPtr csaved bigBytes lengths i)
       (cvgulPost sp0 spC (spC + signExtend12 (-32 : BitVec 12)) hdrBase lenBase validPtr
@@ -1085,55 +1115,66 @@ theorem cvgulIter (sp0 spC hdrBase lenBase validPtr firstBadPtr raIn : Word)
       EvmAsm.Evm64.bytesRegion_split hdrBase bigBytes (hdrOff lengths i) halign hlen,
       ← hHB, ← hLi] at hp
     rw [hEBody]; xperm_hyp hp) (fun _ hq => hq)
-    (show cpsTripleWithin ((1 + (13 + 1 + nCall 10)) +
-        (1 + ((13 + 1 + nCall 9) + (27 + nTail)))) (D + 68) raIn fullCode
+    (show cpsTripleWithin ((1 + (13 + 1 + nCall10 bigBytes.length)) +
+        (1 + ((13 + 1 + nCall9 bigBytes.length) + (27 + nTail)))) (D + 68) raIn fullCode
       ((((EBody ** memOwn GasUsed) ** memOwn GasLimit) ** memOwn RfuOff) ** memOwn RfuLen)
       (cvgulPost sp0 spC (spC + signExtend12 (-32 : BitVec 12)) hdrBase lenBase validPtr
         firstBadPtr csaved bigBytes lengths) from ?_)
   refine cpsTripleWithin_of_forall_memIs_to_memOwn (fun oldLen => ?_)
   refine cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp) (fun _ hq => hq)
-    (show cpsTripleWithin ((1 + (13 + 1 + nCall 10)) +
-        (1 + ((13 + 1 + nCall 9) + (27 + nTail)))) (D + 68) raIn fullCode
+    (show cpsTripleWithin ((1 + (13 + 1 + nCall10 bigBytes.length)) +
+        (1 + ((13 + 1 + nCall9 bigBytes.length) + (27 + nTail)))) (D + 68) raIn fullCode
       ((((EBody ** (RfuLen ↦ₘ oldLen)) ** memOwn GasUsed) ** memOwn GasLimit) ** memOwn RfuOff)
       (cvgulPost sp0 spC (spC + signExtend12 (-32 : BitVec 12)) hdrBase lenBase validPtr
         firstBadPtr csaved bigBytes lengths) from ?_)
   refine cpsTripleWithin_of_forall_memIs_to_memOwn (fun oldOff => ?_)
   refine cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp) (fun _ hq => hq)
-    (show cpsTripleWithin ((1 + (13 + 1 + nCall 10)) +
-        (1 + ((13 + 1 + nCall 9) + (27 + nTail)))) (D + 68) raIn fullCode
+    (show cpsTripleWithin ((1 + (13 + 1 + nCall10 bigBytes.length)) +
+        (1 + ((13 + 1 + nCall9 bigBytes.length) + (27 + nTail)))) (D + 68) raIn fullCode
       ((((EBody ** (RfuLen ↦ₘ oldLen)) ** (RfuOff ↦ₘ oldOff)) ** memOwn GasUsed) **
         memOwn GasLimit)
       (cvgulPost sp0 spC (spC + signExtend12 (-32 : BitVec 12)) hdrBase lenBase validPtr
         firstBadPtr csaved bigBytes lengths) from ?_)
   refine cpsTripleWithin_of_forall_memIs_to_memOwn (fun oldLimit => ?_)
   refine cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp) (fun _ hq => hq)
-    (show cpsTripleWithin ((1 + (13 + 1 + nCall 10)) +
-        (1 + ((13 + 1 + nCall 9) + (27 + nTail)))) (D + 68) raIn fullCode
+    (show cpsTripleWithin ((1 + (13 + 1 + nCall10 bigBytes.length)) +
+        (1 + ((13 + 1 + nCall9 bigBytes.length) + (27 + nTail)))) (D + 68) raIn fullCode
       ((((EBody ** (RfuLen ↦ₘ oldLen)) ** (RfuOff ↦ₘ oldOff)) ** (GasLimit ↦ₘ oldLimit)) **
         memOwn GasUsed)
       (cvgulPost sp0 spC (spC + signExtend12 (-32 : BitVec 12)) hdrBase lenBase validPtr
         firstBadPtr csaved bigBytes lengths) from ?_)
   refine cpsTripleWithin_of_forall_memIs_to_memOwn (fun oldOut => ?_)
-  refine cpsTripleWithin_weaken (fun h hp => by rw [hEBody] at hp; xperm_hyp hp)
-    (fun _ hq => hq)
-    (cpsTripleWithin_seq_same_cr
-      (cvgulIterEntry spC hdrBase lenBase validPtr firstBadPtr csaved bigBytes lengths i
-        oldOut oldLimit oldOff oldLen hi hN hsalign hslack hover hvalid)
-      (cvgulDispatch1 sp0 spC hdrBase lenBase validPtr firstBadPtr raIn csaved bigBytes lengths i
-        oldOff oldLen oldLimit nTail hi hspC hraSaved hret halign hlen hsalign hslack hover
-        hvalid hprefix htail))
+  have hentry := cvgulIterEntry spC hdrBase lenBase validPtr firstBadPtr csaved bigBytes lengths i
+    oldOut oldLimit oldOff oldLen hi hN hsalign hslack hover hvalid
+  rw [← nCall10_eq (bigBytes.drop (hdrOff lengths i)).length] at hentry
+  have hdropLen : (bigBytes.drop (hdrOff lengths i)).length ≤ bigBytes.length := by
+    rw [List.length_drop]
+    omega
+  have hbound : 1 + (13 + 1 + nCall10 (bigBytes.drop (hdrOff lengths i)).length) ≤
+      1 + (13 + 1 + nCall10 bigBytes.length) := by
+    have hmono := nCall10_mono hdropLen
+    omega
+  have hentry' := cpsTripleWithin_mono_nSteps hbound hentry
+  have hdispatch := cvgulDispatch1 sp0 spC hdrBase lenBase validPtr firstBadPtr raIn csaved
+    bigBytes lengths i oldOff oldLen oldLimit nTail hi hspC hraSaved hret halign hlen hsalign hslack
+    hover hvalid hprefix htail
+  have hseq := cpsTripleWithin_seq_same_cr hentry' hdispatch
+  exact cpsTripleWithin_weaken (fun h hp => by rw [hEBody] at hp; xperm_hyp hp)
+    (fun _ hq => hq) hseq
 
 
 /-- Step budget for the loop with `r = N − i` iterations remaining: each full
     iteration is `cvgulIter`'s cost (two K34 calls); the exhausted guard +
     all-valid exit is `11`. -/
-def cvgulLoopSteps : Nat → Nat
+def cvgulLoopSteps (bytesLen : Nat) : Nat → Nat
   | 0 => 11
-  | r + 1 => (1 + (13 + 1 + nCall 10)) + (1 + ((13 + 1 + nCall 9) + (27 + cvgulLoopSteps r)))
+  | r + 1 => (1 + (13 + 1 + nCall10 bytesLen)) +
+      (1 + ((13 + 1 + nCall9 bytesLen) + (27 + cvgulLoopSteps bytesLen r)))
 
-theorem cvgulLoopSteps_succ (r : Nat) :
-    cvgulLoopSteps (r + 1) =
-      (1 + (13 + 1 + nCall 10)) + (1 + ((13 + 1 + nCall 9) + (27 + cvgulLoopSteps r))) := rfl
+theorem cvgulLoopSteps_succ (bytesLen r : Nat) :
+    cvgulLoopSteps bytesLen (r + 1) =
+      (1 + (13 + 1 + nCall10 bytesLen)) +
+        (1 + ((13 + 1 + nCall9 bytesLen) + (27 + cvgulLoopSteps bytesLen r))) := rfl
 
 set_option maxRecDepth 8000 in
 /-- The guard/loop from `D+68` entering iteration `i` (`i ≤ N`), with all earlier
@@ -1157,7 +1198,7 @@ theorem cvgulLoop (sp0 spC hdrBase lenBase validPtr firstBadPtr raIn : Word)
       isValidByteAccess (hdrBaseAt hdrBase lengths i + BitVec.ofNat 64 k) = true) :
     ∀ (f i : Nat), lengths.length - i ≤ f → i ≤ lengths.length →
       (∀ j, j < i → hdrGasOk hdrBase bigBytes lengths j) →
-      cpsTripleWithin (cvgulLoopSteps (lengths.length - i)) (D + 68) raIn fullCode
+      cpsTripleWithin (cvgulLoopSteps bigBytes.length (lengths.length - i)) (D + 68) raIn fullCode
         (LoopInv sp0 spC (spC + signExtend12 (-32 : BitVec 12)) hdrBase lenBase validPtr
           firstBadPtr csaved bigBytes lengths i)
         (cvgulPost sp0 spC (spC + signExtend12 (-32 : BitVec 12)) hdrBase lenBase validPtr
@@ -1168,7 +1209,7 @@ theorem cvgulLoop (sp0 spC hdrBase lenBase validPtr firstBadPtr raIn : Word)
         ((spC + 40) ↦ₘ csaved.s4) ** ((spC + 48) ↦ₘ csaved.s5)) := by
     unfold savedFrame; rw [hraSaved]
   have base : (∀ j, j < lengths.length → hdrGasOk hdrBase bigBytes lengths j) →
-      cpsTripleWithin (cvgulLoopSteps 0) (D + 68) raIn fullCode
+      cpsTripleWithin (cvgulLoopSteps bigBytes.length 0) (D + 68) raIn fullCode
         (LoopInv sp0 spC (spC + signExtend12 (-32 : BitVec 12)) hdrBase lenBase validPtr
           firstBadPtr csaved bigBytes lengths lengths.length)
         (cvgulPost sp0 spC (spC + signExtend12 (-32 : BitVec 12)) hdrBase lenBase validPtr
@@ -1176,7 +1217,7 @@ theorem cvgulLoop (sp0 spC hdrBase lenBase validPtr firstBadPtr raIn : Word)
     intro hpre
     refine cpsTripleWithin_weaken (fun h hp => by unfold LoopInv scratchRegs at hp; xperm_hyp hp)
       (fun _ hq => hq)
-      (show cpsTripleWithin (cvgulLoopSteps 0) (D + 68) raIn fullCode
+      (show cpsTripleWithin (cvgulLoopSteps bigBytes.length 0) (D + 68) raIn fullCode
         ((((.x2 ↦ᵣ spC) ** (.x8 ↦ᵣ BitVec.ofNat 64 lengths.length) ** (.x9 ↦ᵣ lenBase) **
             (.x18 ↦ᵣ hdrBaseAt hdrBase lengths lengths.length) ** (.x19 ↦ᵣ validPtr) **
             (.x20 ↦ᵣ firstBadPtr) ** (.x21 ↦ᵣ BitVec.ofNat 64 lengths.length) **
@@ -1192,7 +1233,7 @@ theorem cvgulLoop (sp0 spC hdrBase lenBase validPtr firstBadPtr raIn : Word)
           firstBadPtr csaved bigBytes lengths) from ?_)
     refine cpsTripleWithin_of_forall_regIs_to_regOwn (fun o10 => ?_)
     refine cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp) (fun _ hq => hq)
-      (show cpsTripleWithin (cvgulLoopSteps 0) (D + 68) raIn fullCode
+      (show cpsTripleWithin (cvgulLoopSteps bigBytes.length 0) (D + 68) raIn fullCode
         (((.x2 ↦ᵣ spC) ** (.x8 ↦ᵣ BitVec.ofNat 64 lengths.length) ** (.x9 ↦ᵣ lenBase) **
             (.x18 ↦ᵣ hdrBaseAt hdrBase lengths lengths.length) ** (.x19 ↦ᵣ validPtr) **
             (.x20 ↦ᵣ firstBadPtr) ** (.x21 ↦ᵣ BitVec.ofNat 64 lengths.length) **
@@ -1263,11 +1304,15 @@ theorem cvgulLoop (sp0 spC hdrBase lenBase validPtr firstBadPtr raIn : Word)
     · subst hi; rw [Nat.sub_self]; exact base hpre
     · rw [show lengths.length - i = (lengths.length - (i + 1)) + 1 from by omega,
         cvgulLoopSteps_succ]
-      exact cvgulIter sp0 spC hdrBase lenBase validPtr firstBadPtr raIn csaved bigBytes lengths i
-        (cvgulLoopSteps (lengths.length - (i + 1))) hi hN hspC hraSaved hret
+      have hiter := cvgulIter sp0 spC hdrBase lenBase validPtr firstBadPtr raIn csaved bigBytes lengths i
+        (cvgulLoopSteps bigBytes.length (lengths.length - (i + 1))) hi hN hspC hraSaved hret
         (hAllAlign i hi) (hAllLen i hi) (hAllSalign i hi) (hAllSlack i hi) (hAllOver i hi)
         (hAllValid i hi) hpre
         (fun hpre' => ih (i + 1) (by omega) (by omega) hpre')
+      have hdrop : (bigBytes.drop (hdrOff lengths i)).length ≤ bigBytes.length := by
+        rw [List.length_drop]
+        omega
+      refine cpsTripleWithin_mono_nSteps (by unfold nCall9 nCall10 nCall; omega) hiter
 
 
 set_option maxRecDepth 8000 in
@@ -1296,7 +1341,7 @@ theorem chain_validate_gas_used_under_limit_spec_within
       (hdrBaseAt hdrBase lengths i).toNat + (bigBytes.drop (hdrOff lengths i)).length < 2 ^ 64)
     (hAllValid : ∀ i, i < lengths.length → ∀ k, k < (bigBytes.drop (hdrOff lengths i)).length →
       isValidByteAccess (hdrBaseAt hdrBase lengths i + BitVec.ofNat 64 k) = true) :
-    cpsTripleWithin (17 + cvgulLoopSteps lengths.length) D raIn fullCode
+    cpsTripleWithin (17 + cvgulLoopSteps bigBytes.length lengths.length) D raIn fullCode
       (((.x2 ↦ᵣ sp0) ** (.x1 ↦ᵣ raIn) ** (.x8 ↦ᵣ cs0) ** (.x9 ↦ᵣ cs1) **
           (.x18 ↦ᵣ cs2) ** (.x19 ↦ᵣ cs3) ** (.x20 ↦ᵣ cs4) ** (.x21 ↦ᵣ cs5) **
           (.x10 ↦ᵣ nWord) ** (.x11 ↦ᵣ lenBase) ** (.x12 ↦ᵣ hdrBase) **

--- a/EvmAsm/Codegen/Programs/ChainValidateIncreasingTimestampsLoop.lean
+++ b/EvmAsm/Codegen/Programs/ChainValidateIncreasingTimestampsLoop.lean
@@ -303,9 +303,9 @@ theorem cvitSetup (hbi lenBase iW prevVal : Word) (Li : Nat)
 
 
 /-! ## K34's whole-routine step count for field index 11. -/
-abbrev nCall : Nat :=
+def nCall (bytesLen : Nat) : Nat :=
   (7 + 4 + (1 + ((12 + ((85 + 93 * (11 + 2)) + 6)) + 9)))
-    + ((1 + ((7 + (1 + (7 * (2 ^ 64 - 1) + 11))) + 5)) + 5)
+    + ((1 + ((7 + (1 + (7 * bytesLen + 11))) + 5)) + 5)
 
 /-! ## Call block (instructions 32--48 + K34): setup ;; jal ;; rlp_field_to_u64
 
@@ -323,7 +323,7 @@ theorem cvitCall (spC hdrBase lenBase hbi iW validPtr firstBadPtr prevVal : Word
     (hover : hbi.toNat + bytes.length < 2 ^ 64)
     (hvalid : ∀ k, k < bytes.length →
       isValidByteAccess (hbi + BitVec.ofNat 64 k) = true) :
-    cpsTripleWithin (16 + 1 + nCall) (D + 128) (D + 196) fullCode
+    cpsTripleWithin (16 + 1 + nCall bytes.length) (D + 128) (D + 196) fullCode
       ((.x2 ↦ᵣ spC) ** (.x8 ↦ᵣ nN) ** (.x9 ↦ᵣ lenBase) ** (.x6 ↦ᵣ hbi) ** (.x7 ↦ᵣ iW) **
         (.x18 ↦ᵣ hdrBase) ** (.x19 ↦ᵣ validPtr) ** (.x20 ↦ᵣ firstBadPtr) ** (.x21 ↦ᵣ prevVal) **
         (.x5 ↦ᵣ old5) ** (.x10 ↦ᵣ o10) ** (.x11 ↦ᵣ o11) ** (.x12 ↦ᵣ o12) ** (.x13 ↦ᵣ o13) **
@@ -393,7 +393,7 @@ theorem cvitCall (spC hdrBase lenBase hbi iW validPtr firstBadPtr prevVal : Word
     hsalign hslack hover hvalid (by show LinkRA &&& ~~~(1 : Word) = LinkRA; decide)
   have hcalleeC := cpsTripleWithin_extend_code k34_mono hcallee0
   -- Present K34's entry footprint as explicit atoms, with x5/x6/x7/x28 shown owned.
-  have hcallee : cpsTripleWithin nCall EvmAsm.Codegen.RlpFieldToU64SAsm.B LinkRA fullCode
+  have hcallee : cpsTripleWithin (nCall bytes.length) EvmAsm.Codegen.RlpFieldToU64SAsm.B LinkRA fullCode
       (regOwn .x5 ** regOwn .x6 ** regOwn .x7 ** regOwn .x28 **
         ((.x1 ↦ᵣ LinkRA) ** (.x2 ↦ᵣ spC) ** (.x8 ↦ᵣ nN) ** (.x9 ↦ᵣ lenBase) **
           (.x18 ↦ᵣ hdrBase) ** (.x19 ↦ᵣ validPtr) ** (.x20 ↦ᵣ firstBadPtr) ** (.x21 ↦ᵣ prevVal) **
@@ -452,7 +452,7 @@ theorem cvitCallOwned (spC hdrBase lenBase hbi iW validPtr firstBadPtr prevVal :
     (hover : hbi.toNat + bytes.length < 2 ^ 64)
     (hvalid : ∀ k, k < bytes.length →
       isValidByteAccess (hbi + BitVec.ofNat 64 k) = true) :
-    cpsTripleWithin (16 + 1 + nCall) (D + 128) (D + 196) fullCode
+    cpsTripleWithin (16 + 1 + nCall bytes.length) (D + 128) (D + 196) fullCode
       ((((.x2 ↦ᵣ spC) ** (.x8 ↦ᵣ nN) ** (.x9 ↦ᵣ lenBase) ** (.x6 ↦ᵣ hbi) ** (.x7 ↦ᵣ iW) **
           (.x18 ↦ᵣ hdrBase) ** (.x19 ↦ᵣ validPtr) ** (.x20 ↦ᵣ firstBadPtr) **
           (.x21 ↦ᵣ prevVal) ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
@@ -474,7 +474,7 @@ theorem cvitCallOwned (spC hdrBase lenBase hbi iW validPtr firstBadPtr prevVal :
         ((lenBase + (iW <<< 3)) ↦ₘ BitVec.ofNat 64 Li) ** savedFrame spC csaved) := by
   refine cpsTripleWithin_of_forall_regIs_to_regOwn (fun v1 => ?_)
   refine cpsTripleWithin_weaken (fun _ h => by xperm_hyp h) (fun _ h => h)
-    (show cpsTripleWithin (16 + 1 + nCall) (D + 128) (D + 196) fullCode
+    (show cpsTripleWithin (16 + 1 + nCall bytes.length) (D + 128) (D + 196) fullCode
       ((((.x2 ↦ᵣ spC) ** (.x8 ↦ᵣ nN) ** (.x9 ↦ᵣ lenBase) ** (.x6 ↦ᵣ hbi) ** (.x7 ↦ᵣ iW) **
           (.x18 ↦ᵣ hdrBase) ** (.x19 ↦ᵣ validPtr) ** (.x20 ↦ᵣ firstBadPtr) **
           (.x21 ↦ᵣ prevVal) ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
@@ -614,7 +614,7 @@ theorem cvitIterEntry (spC hdrBase lenBase validPtr firstBadPtr prevVal : Word)
       (bigBytes.drop (hdrOff lengths i)).length < 2 ^ 64)
     (hvalid : ∀ k, k < (bigBytes.drop (hdrOff lengths i)).length →
       isValidByteAccess (hdrBaseAt hdrBase lengths i + BitVec.ofNat 64 k) = true) :
-    cpsTripleWithin (1 + (16 + 1 + nCall)) (D + 124) (D + 196) fullCode
+    cpsTripleWithin (1 + (16 + 1 + nCall (bigBytes.drop (hdrOff lengths i)).length)) (D + 124) (D + 196) fullCode
       ((.x2 ↦ᵣ spC) ** (.x8 ↦ᵣ BitVec.ofNat 64 lengths.length) ** (.x9 ↦ᵣ lenBase) **
         (.x6 ↦ᵣ hdrBaseAt hdrBase lengths i) ** (.x18 ↦ᵣ hdrBase) ** (.x19 ↦ᵣ validPtr) **
         (.x20 ↦ᵣ firstBadPtr) ** (.x7 ↦ᵣ BitVec.ofNat 64 i) ** (.x21 ↦ᵣ prevVal) **
@@ -1323,7 +1323,7 @@ theorem cvitIter (sp0 spC hdrBase lenBase validPtr firstBadPtr raIn : Word)
           firstBadPtr csaved bigBytes lengths (i + 1))
         (cvitPost sp0 spC (spC + signExtend12 (-32 : BitVec 12)) hdrBase lenBase validPtr
           firstBadPtr csaved bigBytes lengths)) :
-    cpsTripleWithin ((1 + (16 + 1 + nCall)) + (24 + nTail)) (D + 124) raIn fullCode
+    cpsTripleWithin ((1 + (16 + 1 + nCall (bigBytes.drop (hdrOff lengths i)).length)) + (24 + nTail)) (D + 124) raIn fullCode
       (LoopInv sp0 spC (spC + signExtend12 (-32 : BitVec 12)) hdrBase lenBase validPtr
         firstBadPtr csaved bigBytes lengths i)
       (cvitPost sp0 spC (spC + signExtend12 (-32 : BitVec 12)) hdrBase lenBase validPtr
@@ -1356,19 +1356,19 @@ theorem cvitIter (sp0 spC hdrBase lenBase validPtr firstBadPtr raIn : Word)
       EvmAsm.Evm64.bytesRegion_split hdrBase bigBytes (hdrOff lengths i) halign hlen,
       ← hHB, ← hLi] at hp
     rw [hEBody]; xperm_hyp hp) (fun _ hq => hq)
-    (show cpsTripleWithin ((1 + (16 + 1 + nCall)) + (24 + nTail)) (D + 124) raIn fullCode
+    (show cpsTripleWithin ((1 + (16 + 1 + nCall (bigBytes.drop (hdrOff lengths i)).length)) + (24 + nTail)) (D + 124) raIn fullCode
       (((EBody ** memOwn Ts) ** memOwn RfuOff) ** memOwn RfuLen)
       (cvitPost sp0 spC (spC + signExtend12 (-32 : BitVec 12)) hdrBase lenBase validPtr
         firstBadPtr csaved bigBytes lengths) from ?_)
   refine cpsTripleWithin_of_forall_memIs_to_memOwn (fun oldLen => ?_)
   refine cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp) (fun _ hq => hq)
-    (show cpsTripleWithin ((1 + (16 + 1 + nCall)) + (24 + nTail)) (D + 124) raIn fullCode
+    (show cpsTripleWithin ((1 + (16 + 1 + nCall (bigBytes.drop (hdrOff lengths i)).length)) + (24 + nTail)) (D + 124) raIn fullCode
       (((EBody ** (RfuLen ↦ₘ oldLen)) ** memOwn Ts) ** memOwn RfuOff)
       (cvitPost sp0 spC (spC + signExtend12 (-32 : BitVec 12)) hdrBase lenBase validPtr
         firstBadPtr csaved bigBytes lengths) from ?_)
   refine cpsTripleWithin_of_forall_memIs_to_memOwn (fun oldOff => ?_)
   refine cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp) (fun _ hq => hq)
-    (show cpsTripleWithin ((1 + (16 + 1 + nCall)) + (24 + nTail)) (D + 124) raIn fullCode
+    (show cpsTripleWithin ((1 + (16 + 1 + nCall (bigBytes.drop (hdrOff lengths i)).length)) + (24 + nTail)) (D + 124) raIn fullCode
       (((EBody ** (RfuLen ↦ₘ oldLen)) ** (RfuOff ↦ₘ oldOff)) ** memOwn Ts)
       (cvitPost sp0 spC (spC + signExtend12 (-32 : BitVec 12)) hdrBase lenBase validPtr
         firstBadPtr csaved bigBytes lengths) from ?_)

--- a/EvmAsm/Codegen/Programs/ChainValidateIncreasingTimestampsLoopClose.lean
+++ b/EvmAsm/Codegen/Programs/ChainValidateIncreasingTimestampsLoopClose.lean
@@ -47,7 +47,7 @@ theorem cvitHdr0Call (spC hdrBase lenBase validPtr firstBadPtr x21val : Word) (L
     (hover : hdrBase.toNat + bytes.length < 2 ^ 64)
     (hvalid : ∀ k, k < bytes.length →
       isValidByteAccess (hdrBase + BitVec.ofNat 64 k) = true) :
-    cpsTripleWithin (5 + 1 + nCall) (D + 72) (D + 96) fullCode
+    cpsTripleWithin (5 + 1 + nCall bytes.length) (D + 72) (D + 96) fullCode
       ((.x2 ↦ᵣ spC) ** (.x8 ↦ᵣ nN) ** (.x9 ↦ᵣ lenBase) ** (.x18 ↦ᵣ hdrBase) **
         (.x19 ↦ᵣ validPtr) ** (.x20 ↦ᵣ firstBadPtr) ** (.x21 ↦ᵣ x21val) **
         (.x5 ↦ᵣ old5) ** (.x10 ↦ᵣ o10) ** (.x11 ↦ᵣ o11) ** (.x12 ↦ᵣ o12) ** (.x13 ↦ᵣ o13) **
@@ -109,7 +109,7 @@ theorem cvitHdr0Call (spC hdrBase lenBase validPtr firstBadPtr x21val : Word) (L
     hcalleeNewSp rfl (by decide) (by decide)
     hsalign hslack hover hvalid (by show LinkRA0 &&& ~~~(1 : Word) = LinkRA0; decide)
   have hcalleeC := cpsTripleWithin_extend_code k34_mono hcallee0
-  have hcallee : cpsTripleWithin nCall EvmAsm.Codegen.RlpFieldToU64SAsm.B LinkRA0 fullCode
+  have hcallee : cpsTripleWithin (nCall bytes.length) EvmAsm.Codegen.RlpFieldToU64SAsm.B LinkRA0 fullCode
       (regOwn .x5 **
         ((.x1 ↦ᵣ LinkRA0) ** (.x2 ↦ᵣ spC) ** (.x8 ↦ᵣ nN) ** (.x9 ↦ᵣ lenBase) **
           (.x18 ↦ᵣ hdrBase) ** (.x19 ↦ᵣ validPtr) ** (.x20 ↦ᵣ firstBadPtr) ** (.x21 ↦ᵣ x21val) **
@@ -201,12 +201,13 @@ theorem cvitHdr0Finish (hdrBase lenBase ts0 : Word) (L0 : Nat) (old5 o6 o7 o21 :
 /-- Step budget for the loop with `r = N − i` iterations remaining: each full
     iteration is `cvitIter`'s cost, the exhausted guard + all-valid exit is
     `11` (guard `1` + `retAllValid` `10`). -/
-def cvitLoopSteps : Nat → Nat
+def cvitLoopSteps (bytesLen : Nat) : Nat → Nat
   | 0 => 11
-  | r + 1 => (1 + (16 + 1 + nCall)) + (24 + cvitLoopSteps r)
+  | r + 1 => (1 + (16 + 1 + nCall bytesLen)) + (24 + cvitLoopSteps bytesLen r)
 
-theorem cvitLoopSteps_succ (r : Nat) :
-    cvitLoopSteps (r + 1) = (1 + (16 + 1 + nCall)) + (24 + cvitLoopSteps r) := rfl
+theorem cvitLoopSteps_succ (bytesLen r : Nat) :
+    cvitLoopSteps bytesLen (r + 1) =
+      (1 + (16 + 1 + nCall bytesLen)) + (24 + cvitLoopSteps bytesLen r) := rfl
 
 set_option maxRecDepth 8000 in
 theorem cvitLoop (sp0 spC hdrBase lenBase validPtr firstBadPtr raIn : Word)
@@ -225,7 +226,7 @@ theorem cvitLoop (sp0 spC hdrBase lenBase validPtr firstBadPtr raIn : Word)
     (hAllValid : ∀ i, i < lengths.length → ∀ k, k < (bigBytes.drop (hdrOff lengths i)).length →
       isValidByteAccess (hdrBaseAt hdrBase lengths i + BitVec.ofNat 64 k) = true) :
     ∀ (f i : Nat), lengths.length - i ≤ f → 1 ≤ i → i ≤ lengths.length →
-      cpsTripleWithin (cvitLoopSteps (lengths.length - i)) (D + 124) raIn fullCode
+      cpsTripleWithin (cvitLoopSteps bigBytes.length (lengths.length - i)) (D + 124) raIn fullCode
         (LoopInv sp0 spC (spC + signExtend12 (-32 : BitVec 12)) hdrBase lenBase validPtr
           firstBadPtr csaved bigBytes lengths i)
         (cvitPost sp0 spC (spC + signExtend12 (-32 : BitVec 12)) hdrBase lenBase validPtr
@@ -237,7 +238,7 @@ theorem cvitLoop (sp0 spC hdrBase lenBase validPtr firstBadPtr raIn : Word)
     unfold savedFrame; rw [hraSaved]
   -- All-valid exit reached at the guard when `i = N`.
   have base :
-      cpsTripleWithin (cvitLoopSteps 0) (D + 124) raIn fullCode
+      cpsTripleWithin (cvitLoopSteps bigBytes.length 0) (D + 124) raIn fullCode
         (LoopInv sp0 spC (spC + signExtend12 (-32 : BitVec 12)) hdrBase lenBase validPtr
           firstBadPtr csaved bigBytes lengths lengths.length)
         (cvitPost sp0 spC (spC + signExtend12 (-32 : BitVec 12)) hdrBase lenBase validPtr
@@ -249,7 +250,7 @@ theorem cvitLoop (sp0 spC hdrBase lenBase validPtr firstBadPtr raIn : Word)
     -- Expose x1 / x10 (overwritten by the exit block) as concrete regs.
     refine cpsTripleWithin_weaken (fun h hp => by unfold payload scratchRegs at hp; xperm_hyp hp)
       (fun _ hq => hq)
-      (show cpsTripleWithin (cvitLoopSteps 0) (D + 124) raIn fullCode
+      (show cpsTripleWithin (cvitLoopSteps bigBytes.length 0) (D + 124) raIn fullCode
         ((((.x2 ↦ᵣ spC) ** (.x8 ↦ᵣ BitVec.ofNat 64 lengths.length) ** (.x9 ↦ᵣ lenBase) **
             (.x6 ↦ᵣ hdrBaseAt hdrBase lengths lengths.length) ** (.x18 ↦ᵣ hdrBase) **
             (.x19 ↦ᵣ validPtr) ** (.x20 ↦ᵣ firstBadPtr) **
@@ -266,7 +267,7 @@ theorem cvitLoop (sp0 spC hdrBase lenBase validPtr firstBadPtr raIn : Word)
           firstBadPtr csaved bigBytes lengths) from ?_)
     refine cpsTripleWithin_of_forall_regIs_to_regOwn (fun o10 => ?_)
     refine cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp) (fun _ hq => hq)
-      (show cpsTripleWithin (cvitLoopSteps 0) (D + 124) raIn fullCode
+      (show cpsTripleWithin (cvitLoopSteps bigBytes.length 0) (D + 124) raIn fullCode
         (((.x2 ↦ᵣ spC) ** (.x8 ↦ᵣ BitVec.ofNat 64 lengths.length) ** (.x9 ↦ᵣ lenBase) **
             (.x6 ↦ᵣ hdrBaseAt hdrBase lengths lengths.length) ** (.x18 ↦ᵣ hdrBase) **
             (.x19 ↦ᵣ validPtr) ** (.x20 ↦ᵣ firstBadPtr) **
@@ -361,11 +362,15 @@ theorem cvitLoop (sp0 spC hdrBase lenBase validPtr firstBadPtr raIn : Word)
     · subst hi; rw [Nat.sub_self]; exact base
     · rw [show lengths.length - i = (lengths.length - (i + 1)) + 1 from by omega,
         cvitLoopSteps_succ]
-      exact cvitIter sp0 spC hdrBase lenBase validPtr firstBadPtr raIn csaved bigBytes lengths i
-        (cvitLoopSteps (lengths.length - (i + 1))) hi1 hi hN hspC hraSaved hret
+      have hiter := cvitIter sp0 spC hdrBase lenBase validPtr firstBadPtr raIn csaved bigBytes lengths i
+        (cvitLoopSteps bigBytes.length (lengths.length - (i + 1))) hi1 hi hN hspC hraSaved hret
         (hAllAlign i hi) (hAllLen i hi) (hAllSalign i hi) (hAllSlack i hi) (hAllOver i hi)
         (hAllValid i hi)
         (fun _ => ih (i + 1) (by omega) (by omega) (by omega))
+      have hdrop : (bigBytes.drop (hdrOff lengths i)).length ≤ bigBytes.length := by
+        rw [List.length_drop]
+        omega
+      refine cpsTripleWithin_mono_nSteps (by unfold nCall; omega) hiter
 
 
 /-! ## Header-0 flatPost normalization (K34 saved-ra = `LinkRA0`)
@@ -827,7 +832,7 @@ theorem cvitHdr0Block
           firstBadPtr csaved bigBytes lengths 1)
         (cvitPost sp0 spC (spC + signExtend12 (-32 : BitVec 12)) hdrBase lenBase validPtr
           firstBadPtr csaved bigBytes lengths)) :
-    cpsTripleWithin ((5 + 1 + nCall) + (22 + nTail)) (D + 72) raIn fullCode
+    cpsTripleWithin ((5 + 1 + nCall bigBytes.length) + (22 + nTail)) (D + 72) raIn fullCode
       ((.x2 ↦ᵣ spC) ** (.x8 ↦ᵣ BitVec.ofNat 64 lengths.length) ** (.x9 ↦ᵣ lenBase) **
         (.x18 ↦ᵣ hdrBase) ** (.x19 ↦ᵣ validPtr) ** (.x20 ↦ᵣ firstBadPtr) ** (.x21 ↦ᵣ x21val) **
         (.x5 ↦ᵣ old5) ** (.x10 ↦ᵣ o10) ** (.x11 ↦ᵣ o11) ** (.x12 ↦ᵣ o12) ** (.x13 ↦ᵣ o13) **
@@ -887,7 +892,7 @@ theorem chain_validate_increasing_timestamps_spec_within
     (hAllValid : ∀ i, i < lengths.length → ∀ k, k < (bigBytes.drop (hdrOff lengths i)).length →
       isValidByteAccess (hdrBaseAt hdrBase lengths i + BitVec.ofNat 64 k) = true) :
     cpsTripleWithin
-      (17 + (1 + ((5 + 1 + nCall) + (22 + cvitLoopSteps (lengths.length - 1)))))
+      (17 + (1 + ((5 + 1 + nCall bigBytes.length) + (22 + cvitLoopSteps bigBytes.length (lengths.length - 1)))))
       D raIn fullCode
       (((.x2 ↦ᵣ sp0) ** (.x1 ↦ᵣ raIn) ** (.x8 ↦ᵣ cs0) ** (.x9 ↦ᵣ cs1) **
           (.x18 ↦ᵣ cs2) ** (.x19 ↦ᵣ cs3) ** (.x20 ↦ᵣ cs4) ** (.x21 ↦ᵣ cs5) **
@@ -928,7 +933,7 @@ theorem chain_validate_increasing_timestamps_spec_within
       stackFree (spC + signExtend12 (-32 : BitVec 12)) 8) (by pcfx) hpro
   -- Tail from the loop-comparand load (`D+68`): BLTU then header-0 or the N<2 exit.
   have htail :
-      cpsTripleWithin (1 + ((5 + 1 + nCall) + (22 + cvitLoopSteps (lengths.length - 1))))
+      cpsTripleWithin (1 + ((5 + 1 + nCall bigBytes.length) + (22 + cvitLoopSteps bigBytes.length (lengths.length - 1))))
         (D + 68) raIn fullCode
         (((.x2 ↦ᵣ spC) ** (.x1 ↦ᵣ raIn) ** (.x8 ↦ᵣ BitVec.ofNat 64 lengths.length) **
             (.x9 ↦ᵣ lenBase) ** (.x18 ↦ᵣ hdrBase) ** (.x19 ↦ᵣ validPtr) **
@@ -989,7 +994,7 @@ theorem chain_validate_increasing_timestamps_spec_within
           hdrBase validPtr firstBadPtr cs5 hspC rfl hret)
       refine cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp) (fun h hq => ?_)
         (cpsTripleWithin_mono_nSteps
-          (show 1 + 10 ≤ 1 + ((5 + 1 + nCall) + (22 + cvitLoopSteps (lengths.length - 1))) by
+          (show 1 + 10 ≤ 1 + ((5 + 1 + nCall bigBytes.length) + (22 + cvitLoopSteps bigBytes.length (lengths.length - 1))) by
             unfold nCall; omega)
           (cpsTripleWithin_seq_perm_same_cr (fun h hp => by xperm_hyp hp)
             htakenF hallv))
@@ -1052,21 +1057,21 @@ theorem chain_validate_increasing_timestamps_spec_within
           memOwn IterChild ** memOwn IterPrev) with hBASE
       -- Peel the three K34 scratch cells (owned) into concrete inputs; run the block+loop.
       have hcont :
-          cpsTripleWithin ((5 + 1 + nCall) + (22 + cvitLoopSteps (lengths.length - 1)))
+          cpsTripleWithin ((5 + 1 + nCall bigBytes.length) + (22 + cvitLoopSteps bigBytes.length (lengths.length - 1)))
             (D + 72) raIn fullCode
             (((BASE ** memOwn Ts) ** memOwn RfuOff) ** memOwn RfuLen)
             (cvitPost sp0 spC (spC + signExtend12 (-32 : BitVec 12)) hdrBase lenBase validPtr
               firstBadPtr ⟨raIn, cs0, cs1, cs2, cs3, cs4, cs5⟩ bigBytes lengths) := by
         refine cpsTripleWithin_of_forall_memIs_to_memOwn (fun oldLen => ?_)
         refine cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp) (fun _ hq => hq)
-          (show cpsTripleWithin ((5 + 1 + nCall) + (22 + cvitLoopSteps (lengths.length - 1)))
+          (show cpsTripleWithin ((5 + 1 + nCall bigBytes.length) + (22 + cvitLoopSteps bigBytes.length (lengths.length - 1)))
             (D + 72) raIn fullCode
             (((BASE ** (RfuLen ↦ₘ oldLen)) ** memOwn Ts) ** memOwn RfuOff)
             (cvitPost sp0 spC (spC + signExtend12 (-32 : BitVec 12)) hdrBase lenBase validPtr
               firstBadPtr ⟨raIn, cs0, cs1, cs2, cs3, cs4, cs5⟩ bigBytes lengths) from ?_)
         refine cpsTripleWithin_of_forall_memIs_to_memOwn (fun oldOff => ?_)
         refine cpsTripleWithin_weaken (fun h hp => by xperm_hyp hp) (fun _ hq => hq)
-          (show cpsTripleWithin ((5 + 1 + nCall) + (22 + cvitLoopSteps (lengths.length - 1)))
+          (show cpsTripleWithin ((5 + 1 + nCall bigBytes.length) + (22 + cvitLoopSteps bigBytes.length (lengths.length - 1)))
             (D + 72) raIn fullCode
             (((BASE ** (RfuLen ↦ₘ oldLen)) ** (RfuOff ↦ₘ oldOff)) ** memOwn Ts)
             (cvitPost sp0 spC (spC + signExtend12 (-32 : BitVec 12)) hdrBase lenBase validPtr
@@ -1075,7 +1080,8 @@ theorem chain_validate_increasing_timestamps_spec_within
         have hblock := cvitHdr0Block sp0 spC hdrBase lenBase validPtr firstBadPtr raIn cs5
           lengths[0]! oldOut oldOff oldLen firstBadPtr raIn (2 : Word)
           (BitVec.ofNat 64 lengths.length) lenBase hdrBase validPtr
-          ⟨raIn, cs0, cs1, cs2, cs3, cs4, cs5⟩ bigBytes lengths (cvitLoopSteps (lengths.length - 1))
+          ⟨raIn, cs0, cs1, cs2, cs3, cs4, cs5⟩ bigBytes lengths
+          (cvitLoopSteps bigBytes.length (lengths.length - 1))
           hge rfl hspC rfl hret
           (by have := hAllSalign 0 (by omega); rwa [hHB0] at this)
           (by have := hAllSlack 0 (by omega); rwa [hdrop0] at this)

--- a/EvmAsm/Codegen/Programs/HeaderExtractNumberSpec.lean
+++ b/EvmAsm/Codegen/Programs/HeaderExtractNumberSpec.lean
@@ -389,15 +389,9 @@ theorem header_extract_number_spec_within
       { ra := B + 48, s0 := listBase, s1 := outputPtr, s2 := s2, s3 := s3,
         s4 := s4, s5 := s5 }
     let callSteps := 1 + ((12 + ((85 + 93 * (8 + 2)) + 6)) + 9)
-    -- ⚠️ The `7 * (2 ^ 64 - 1)` factor is INHERITED verbatim from the callee, not
-    -- chosen here, and it is loose: it comes from the range of a 64-bit counter
-    -- rather than from the data, so this triple does NOT establish that the tail
-    -- loop is bounded by its input. Origin `Field0ToU64Top.lean:215` (the
-    -- `rlp_content_to_u64` scalar loop), via `RlpFieldToU64FinishSAsm.lean:843,965`
-    -- and `RlpFieldToU64FlatSAsm.lean:74-75`. No wrapper can tighten it; tracked
-    -- at the origin as issue #11461. Anyone composing against this theorem
-    -- inherits the looseness.
-    let tailSteps := (7 + (1 + (7 * (2 ^ 64 - 1) + 11))) + 5
+    -- The tail bound follows the caller-owned input byte region, as in the
+    -- callee's data-derived `rlpFieldToU64_flat_spec_within` bound.
+    let tailSteps := (7 + (1 + (7 * bytes.length + 11))) + 5
     let n34 := (7 + 4 + callSteps) + ((1 + tailSteps) + 5)
     cpsTripleWithin (4 + (1 + n34) + 3) H raIn fullCode
       (hdrPre sp0 raIn oldRaSlot spH newSp listBase listLenW outputPtr old13

--- a/EvmAsm/Codegen/Programs/RlpFieldToU64FinishSAsm.lean
+++ b/EvmAsm/Codegen/Programs/RlpFieldToU64FinishSAsm.lean
@@ -706,7 +706,7 @@ theorem callContentWithOutput
     (hover : listBase.toNat + bytes.length < 2 ^ 64)
     (hvalid : ∀ k, k < bytes.length →
       isValidByteAccess (listBase + BitVec.ofNat 64 k) = true) :
-    cpsTripleWithin (1 + (7 * (2 ^ 64 - 1) + 11))
+    cpsTripleWithin (1 + (7 * bytes.length + 11))
       (B + 80) (B + 84) code
       (((.x1 ↦ᵣ vOld) ** contentReady sp0 listBase saved bytes listLen index) **
        (saved.s1 ↦ₘ (0 : Word)))
@@ -730,7 +730,7 @@ theorem selectedToJoin
     (hvalid : ∀ k, k < bytes.length →
       isValidByteAccess (listBase + BitVec.ofNat 64 k) = true) :
     cpsTripleWithin
-      ((7 + (1 + (7 * (2 ^ 64 - 1) + 11))) + 5)
+      ((7 + (1 + (7 * bytes.length + 11))) + 5)
       (B + 52) (B + 128) code
       (((.x1 ↦ᵣ (B + 48)) **
         listSelected sp0 listBase offsetCell lengthCell saved bytes listLen index) **
@@ -780,7 +780,7 @@ theorem selectedToAllJoin
     (hvalid : ∀ k, k < bytes.length →
       isValidByteAccess (listBase + BitVec.ofNat 64 k) = true) :
     cpsTripleWithin
-      ((7 + (1 + (7 * (2 ^ 64 - 1) + 11))) + 5)
+      ((7 + (1 + (7 * bytes.length + 11))) + 5)
       (B + 52) (B + 128) code
       (((.x1 ↦ᵣ (B + 48)) **
         listSelected sp0 listBase offsetCell lengthCell saved bytes listLen index) **
@@ -828,7 +828,7 @@ theorem listDispatchToJoin
     (hover : listBase.toNat + bytes.length < 2 ^ 64)
     (hvalid : ∀ k, k < bytes.length →
       isValidByteAccess (listBase + BitVec.ofNat 64 k) = true) :
-    let tailSteps := (7 + (1 + (7 * (2 ^ 64 - 1) + 11))) + 5
+    let tailSteps := (7 + (1 + (7 * bytes.length + 11))) + 5
     cpsTripleWithin (1 + tailSteps) (B + 48) (B + 128) code
       (((.x1 ↦ᵣ (B + 48)) **
         listCallResult sp0 listBase offsetCell lengthCell oldOffset oldLen saved
@@ -842,7 +842,7 @@ theorem listDispatchToJoin
   have hs0' := selectedToAllJoin sp0 listBase oldOffset oldLen saved bytes
     listLen index hs0 hsalign hslack hover hvalid
   have hs : cpsTripleWithin
-      ((7 + (1 + (7 * (2 ^ 64 - 1) + 11))) + 5)
+      ((7 + (1 + (7 * bytes.length + 11))) + 5)
       (B + 52) (B + 128) code
       (listSelected sp0 listBase offsetCell lengthCell saved bytes listLen index **
        ((.x1 ↦ᵣ (B + 48)) ** (saved.s1 ↦ₘ (0 : Word))))
@@ -853,7 +853,7 @@ theorem listDispatchToJoin
   have hf0 := failureToAllJoin sp0 listBase oldOffset oldLen saved bytes
     listLen index
   have hf : cpsTripleWithin
-      ((7 + (1 + (7 * (2 ^ 64 - 1) + 11))) + 5)
+      ((7 + (1 + (7 * bytes.length + 11))) + 5)
       (B + 116) (B + 128) code
       (listFailed sp0 listBase offsetCell lengthCell oldOffset oldLen saved bytes
         listLen index **

--- a/EvmAsm/Codegen/Programs/RlpFieldToU64FlatSAsm.lean
+++ b/EvmAsm/Codegen/Programs/RlpFieldToU64FlatSAsm.lean
@@ -72,7 +72,7 @@ theorem rlpFieldToU64_flat_spec_within
       { ra := B + 48, s0 := listBase, s1 := outputPtr, s2 := s2, s3 := s3,
         s4 := s4, s5 := s5 }
     let callSteps := 1 + ((12 + ((85 + 93 * (index + 2)) + 6)) + 9)
-    let tailSteps := (7 + (1 + (7 * (2 ^ 64 - 1) + 11))) + 5
+    let tailSteps := (7 + (1 + (7 * bytes.length + 11))) + 5
     cpsTripleWithin ((7 + 4 + callSteps) + ((1 + tailSteps) + 5)) B outer.ra code
       ((.x1 ↦ᵣ outer.ra) **
        flatPre spOuter newSp listBase listLenW indexW outputPtr oldOut oldOffset

--- a/EvmAsm/Codegen/Programs/RlpFieldToU64SAsm.lean
+++ b/EvmAsm/Codegen/Programs/RlpFieldToU64SAsm.lean
@@ -1217,12 +1217,11 @@ theorem callContentOwned
     (hover : listBase.toNat + bytes.length < 2 ^ 64)
     (hvalid : ∀ k, k < bytes.length →
       isValidByteAccess (listBase + BitVec.ofNat 64 k) = true) :
-    cpsTripleWithin (1 + (7 * (2 ^ 64 - 1) + 11))
+    cpsTripleWithin (1 + (7 * bytes.length + 11))
       (B + 80) (B + 84) code
       (contentReadyRa sp0 listBase vOld saved bytes listLen index)
       (contentDone sp0 listBase saved bytes listLen index) := by
-  -- The displayed bound is normalized per selected `len` below; monotonicity
-  -- to a caller-wide bound is supplied by the whole-routine theorem.
+  -- The selected content span is bounded by the caller-owned byte region.
   unfold contentReadyRa
   refine EvmAsm.Codegen.RlpListNthItemSAsm.cpsTripleWithin_exists_assertion
     (fun offset => ?_)
@@ -1275,7 +1274,7 @@ theorem callContentOwned
           have hc0 := callContentFramedExact sp0 listBase offset len vOld x6Old
             x7Old x28Old v12 saved bytes listLen index h_ok hsalign hslack hover
             hvalid
-          have hc : cpsTripleWithin (1 + (7 * (2 ^ 64 - 1) + 11))
+          have hc : cpsTripleWithin (1 + (7 * bytes.length + 11))
               (B + 80) (B + 84) code
               ((((.x1 ↦ᵣ vOld) **
                 ((.x10 ↦ᵣ (listBase + offset)) ** (.x11 ↦ᵣ len) **
@@ -1289,7 +1288,7 @@ theorem callContentOwned
                 contentCarry sp0 listBase offset len v12 saved) **
                ⌜EvmAsm.Codegen.RlpListNthItemSAsm.Success bytes listBase listLen
                  index offset len⌝) := cpsTripleWithin_mono_nSteps (by
-            have := len.isLt
+            have hb := success_content_bounds h_ok hslack hover
             omega) hc0
           refine cpsTripleWithin_weaken (fun h hp => by
               unfold P28 at hp
@@ -1319,7 +1318,7 @@ theorem callContent
     (hover : listBase.toNat + bytes.length < 2 ^ 64)
     (hvalid : ∀ k, k < bytes.length →
       isValidByteAccess (listBase + BitVec.ofNat 64 k) = true) :
-    cpsTripleWithin (1 + (7 * (2 ^ 64 - 1) + 11))
+    cpsTripleWithin (1 + (7 * bytes.length + 11))
       (B + 80) (B + 84) code
       ((.x1 ↦ᵣ vOld) ** contentReady sp0 listBase saved bytes listLen index)
       (contentDone sp0 listBase saved bytes listLen index) := by

--- a/EvmAsm/Codegen/Programs/RlpFieldToU64WholeSAsm.lean
+++ b/EvmAsm/Codegen/Programs/RlpFieldToU64WholeSAsm.lean
@@ -37,7 +37,7 @@ theorem dispatchAndRestore
       isValidByteAccess (listBase + BitVec.ofNat 64 k) = true)
     (hnewSp : newSp = spOuter + signExtend12 (-32 : BitVec 12))
     (hret : outer.ra &&& ~~~(1 : Word) = outer.ra) :
-    let tailSteps := (7 + (1 + (7 * (2 ^ 64 - 1) + 11))) + 5
+    let tailSteps := (7 + (1 + (7 * bytes.length + 11))) + 5
     cpsTripleWithin ((1 + tailSteps) + 5) (B + 48) outer.ra code
       ((((.x1 ↦ᵣ (B + 48)) **
         listCallResult newSp listBase offsetCell lengthCell oldOffset oldLen saved
@@ -195,7 +195,7 @@ theorem rlpFieldToU64_spec_within
       { ra := B + 48, s0 := listBase, s1 := outputPtr, s2 := s2, s3 := s3,
         s4 := s4, s5 := s5 }
     let callSteps := 1 + ((12 + ((85 + 93 * (index + 2)) + 6)) + 9)
-    let tailSteps := (7 + (1 + (7 * (2 ^ 64 - 1) + 11))) + 5
+    let tailSteps := (7 + (1 + (7 * bytes.length + 11))) + 5
     cpsTripleWithin ((7 + 4 + callSteps) + ((1 + tailSteps) + 5))
       B outer.ra code
       ((.x2 ↦ᵣ spOuter) ** regsAt frame (savedVals outer) **

--- a/EvmAsm/Codegen/Programs/WithdrawalDecodeClose2.lean
+++ b/EvmAsm/Codegen/Programs/WithdrawalDecodeClose2.lean
@@ -513,7 +513,7 @@ theorem wdField0Call
       { ra := B + 48, s0 := listBase, s1 := outBase, s2 := outBase, s3 := s3,
         s4 := s4, s5 := s5 }
     let callSteps := 1 + ((12 + ((85 + 93 * (0 + 2)) + 6)) + 9)
-    let tailSteps := (7 + (1 + (7 * (2 ^ 64 - 1) + 11))) + 5
+    let tailSteps := (7 + (1 + (7 * bytes.length + 11))) + 5
     let n34 := (7 + 4 + callSteps) + ((1 + tailSteps) + 5)
     cpsTripleWithin (4 + (1 + n34)) (WB + 32) (WB + 52) fullCode
       (((.x1 : Reg) ↦ᵣ raIn) ** (.x2 ↦ᵣ spW) ** (.x8 ↦ᵣ listBase) ** (.x9 ↦ᵣ len) **
@@ -593,7 +593,7 @@ theorem wdField1Call
       { ra := B + 48, s0 := listBase, s1 := outBase + 8, s2 := outBase, s3 := s3,
         s4 := s4, s5 := s5 }
     let callSteps := 1 + ((12 + ((85 + 93 * (1 + 2)) + 6)) + 9)
-    let tailSteps := (7 + (1 + (7 * (2 ^ 64 - 1) + 11))) + 5
+    let tailSteps := (7 + (1 + (7 * bytes.length + 11))) + 5
     let n34 := (7 + 4 + callSteps) + ((1 + tailSteps) + 5)
     cpsTripleWithin (4 + (1 + n34)) (WB + 56) (WB + 76) fullCode
       (((.x1 : Reg) ↦ᵣ raIn) ** (.x2 ↦ᵣ spW) ** (.x8 ↦ᵣ listBase) ** (.x9 ↦ᵣ len) **
@@ -670,7 +670,7 @@ theorem wdField3Call
       { ra := B + 48, s0 := listBase, s1 := outBase + 40, s2 := outBase, s3 := s3,
         s4 := s4, s5 := s5 }
     let callSteps := 1 + ((12 + ((85 + 93 * (3 + 2)) + 6)) + 9)
-    let tailSteps := (7 + (1 + (7 * (2 ^ 64 - 1) + 11))) + 5
+    let tailSteps := (7 + (1 + (7 * bytes.length + 11))) + 5
     let n34 := (7 + 4 + callSteps) + ((1 + tailSteps) + 5)
     cpsTripleWithin (4 + (1 + n34)) (WB + 180) (WB + 200) fullCode
       (((.x1 : Reg) ↦ᵣ raIn) ** (.x2 ↦ᵣ spW) ** (.x8 ↦ᵣ listBase) ** (.x9 ↦ᵣ len) **

--- a/EvmAsm/Codegen/Programs/WithdrawalDecodeClose3.lean
+++ b/EvmAsm/Codegen/Programs/WithdrawalDecodeClose3.lean
@@ -377,7 +377,7 @@ theorem wdField0Stage
       { ra := B + 48, s0 := listBase, s1 := outBase, s2 := outBase, s3 := s3,
         s4 := s4, s5 := s5 }
     let callSteps := 1 + ((12 + ((85 + 93 * (0 + 2)) + 6)) + 9)
-    let tailSteps := (7 + (1 + (7 * (2 ^ 64 - 1) + 11))) + 5
+    let tailSteps := (7 + (1 + (7 * bytes.length + 11))) + 5
     let n34 := (7 + 4 + callSteps) + ((1 + tailSteps) + 5)
     cpsBranchWithin (4 + (1 + n34) + 1) (WB + 32) fullCode
       (((.x1 : Reg) ↦ᵣ raIn) ** (.x2 ↦ᵣ spW) ** (.x8 ↦ᵣ listBase) ** (.x9 ↦ᵣ len) **
@@ -429,7 +429,7 @@ theorem wdField1Stage
       { ra := B + 48, s0 := listBase, s1 := outBase + 8, s2 := outBase, s3 := s3,
         s4 := s4, s5 := s5 }
     let callSteps := 1 + ((12 + ((85 + 93 * (1 + 2)) + 6)) + 9)
-    let tailSteps := (7 + (1 + (7 * (2 ^ 64 - 1) + 11))) + 5
+    let tailSteps := (7 + (1 + (7 * bytes.length + 11))) + 5
     let n34 := (7 + 4 + callSteps) + ((1 + tailSteps) + 5)
     cpsBranchWithin (4 + (1 + n34) + 1) (WB + 56) fullCode
       (((.x1 : Reg) ↦ᵣ raIn) ** (.x2 ↦ᵣ spW) ** (.x8 ↦ᵣ listBase) ** (.x9 ↦ᵣ len) **
@@ -481,7 +481,7 @@ theorem wdField3Stage
       { ra := B + 48, s0 := listBase, s1 := outBase + 40, s2 := outBase, s3 := s3,
         s4 := s4, s5 := s5 }
     let callSteps := 1 + ((12 + ((85 + 93 * (3 + 2)) + 6)) + 9)
-    let tailSteps := (7 + (1 + (7 * (2 ^ 64 - 1) + 11))) + 5
+    let tailSteps := (7 + (1 + (7 * bytes.length + 11))) + 5
     let n34 := (7 + 4 + callSteps) + ((1 + tailSteps) + 5)
     cpsBranchWithin (4 + (1 + n34) + 1) (WB + 180) fullCode
       (((.x1 : Reg) ↦ᵣ raIn) ** (.x2 ↦ᵣ spW) ** (.x8 ↦ᵣ listBase) ** (.x9 ↦ᵣ len) **

--- a/EvmAsm/Codegen/Programs/WithdrawalDecodeClose5.lean
+++ b/EvmAsm/Codegen/Programs/WithdrawalDecodeClose5.lean
@@ -228,7 +228,7 @@ theorem wdBBField3
     (hf2 : EvmAsm.Codegen.RlpListNthItemSAsm.Success bytes listBase listLen 2 o2 l2)
     (hl2 : l2.toNat = 20) :
     let callSteps := 1 + ((12 + ((85 + 93 * (3 + 2)) + 6)) + 9)
-    let tailSteps := (7 + (1 + (7 * (2 ^ 64 - 1) + 11))) + 5
+    let tailSteps := (7 + (1 + (7 * bytes.length + 11))) + 5
     let n34 := (7 + 4 + callSteps) + ((1 + tailSteps) + 5)
     cpsTripleWithin ((4 + (1 + n34) + 1) + 8) (WB + 180) raSaved fullCode
       ((((.x1 : Reg) ↦ᵣ raEntry) ** (.x2 ↦ᵣ spW) ** (.x8 ↦ᵣ listBase) ** (.x9 ↦ᵣ len) **
@@ -420,7 +420,7 @@ theorem wdField2ContEpi
         s5 := s5 }
     cpsTripleWithin (5 + (5 + (6 * (19 + 1)) +
         ((4 + (1 + ((7 + 4 + (1 + ((12 + ((85 + 93 * (3 + 2)) + 6)) + 9))) +
-          ((1 + ((7 + (1 + (7 * (2 ^ 64 - 1) + 11))) + 5)) + 5))) + 1) + 8)))
+          ((1 + ((7 + (1 + (7 * bytes.length + 11))) + 5)) + 5))) + 1) + 8)))
       (WB + 116) raIn fullCode
       (k20ContPost spW listBase saved2 bytes listLen **
        (wdStackK20Deep spW ** (spW ↦ₘ raIn) ** ((spW + 8) ↦ₘ s0Old) **
@@ -726,7 +726,7 @@ theorem wdBBField2
     cpsTripleWithin ((7 + (1 + ((12 + ((85 + 93 * (2 + 2)) + 6)) + 9)) + 1) +
         (5 + (5 + (6 * (19 + 1)) +
         ((4 + (1 + ((7 + 4 + (1 + ((12 + ((85 + 93 * (3 + 2)) + 6)) + 9))) +
-          ((1 + ((7 + (1 + (7 * (2 ^ 64 - 1) + 11))) + 5)) + 5))) + 1) + 8))))
+          ((1 + ((7 + (1 + (7 * bytes.length + 11))) + 5)) + 5))) + 1) + 8))))
       (WB + 80) raSaved fullCode
       ((((.x1 : Reg) ↦ᵣ raEntry) ** (.x2 ↦ᵣ spW) ** (.x8 ↦ᵣ listBase) ** (.x9 ↦ᵣ len) **
         (.x18 ↦ᵣ outBase) ** (.x19 ↦ᵣ s3) ** (.x20 ↦ᵣ s4) ** (.x21 ↦ᵣ s5) **
@@ -754,7 +754,7 @@ theorem wdBBField2
   -- fail edge → DecodeFailure.field2List via wdK20FailArm
   have h_t : cpsTripleWithin (5 + (5 + (6 * (19 + 1)) +
         ((4 + (1 + ((7 + 4 + (1 + ((12 + ((85 + 93 * (3 + 2)) + 6)) + 9))) +
-          ((1 + ((7 + (1 + (7 * (2 ^ 64 - 1) + 11))) + 5)) + 5))) + 1) + 8)))
+          ((1 + ((7 + (1 + (7 * bytes.length + 11))) + 5)) + 5))) + 1) + 8)))
       (WB + 212) raSaved fullCode
       (k20FailPost spW listBase wOldOff wOldLen
         { ra := WB + 112, s0 := listBase, s1 := len, s2 := outBase, s3 := s3, s4 := s4,
@@ -831,11 +831,11 @@ theorem wdBBField1
       isValidByteAccess ((outBase + 16) + BitVec.ofNat 64 k) = true)
     (hf0 : Result bytes listBase listLen 0 (0 : Word) v0) :
     cpsTripleWithin ((4 + (1 + ((7 + 4 + (1 + ((12 + ((85 + 93 * (1 + 2)) + 6)) + 9))) +
-        ((1 + ((7 + (1 + (7 * (2 ^ 64 - 1) + 11))) + 5)) + 5))) + 1) +
+        ((1 + ((7 + (1 + (7 * bytes.length + 11))) + 5)) + 5))) + 1) +
         ((7 + (1 + ((12 + ((85 + 93 * (2 + 2)) + 6)) + 9)) + 1) +
         (5 + (5 + (6 * (19 + 1)) +
         ((4 + (1 + ((7 + 4 + (1 + ((12 + ((85 + 93 * (3 + 2)) + 6)) + 9))) +
-          ((1 + ((7 + (1 + (7 * (2 ^ 64 - 1) + 11))) + 5)) + 5))) + 1) + 8)))))
+          ((1 + ((7 + (1 + (7 * bytes.length + 11))) + 5)) + 5))) + 1) + 8)))))
       (WB + 56) raSaved fullCode
       ((((.x1 : Reg) ↦ᵣ raEntry) ** (.x2 ↦ᵣ spW) ** (.x8 ↦ᵣ listBase) ** (.x9 ↦ᵣ len) **
         (.x18 ↦ᵣ outBase) ** (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ v11) ** (.x12 ↦ᵣ v12) **
@@ -876,13 +876,13 @@ theorem wdBBField1
     (show (7 : Nat) ≤ ((7 + (1 + ((12 + ((85 + 93 * (2 + 2)) + 6)) + 9)) + 1) +
         (5 + (5 + (6 * (19 + 1)) +
         ((4 + (1 + ((7 + 4 + (1 + ((12 + ((85 + 93 * (3 + 2)) + 6)) + 9))) +
-          ((1 + ((7 + (1 + (7 * (2 ^ 64 - 1) + 11))) + 5)) + 5))) + 1) + 8)))) from by omega)
+          ((1 + ((7 + (1 + (7 * bytes.length + 11))) + 5)) + 5))) + 1) + 8)))) from by omega)
     harm
   -- continue edge → field-1 Result pinned, K34→K20 reshape, field-2 backbone
   have h_f : cpsTripleWithin ((7 + (1 + ((12 + ((85 + 93 * (2 + 2)) + 6)) + 9)) + 1) +
       (5 + (5 + (6 * (19 + 1)) +
       ((4 + (1 + ((7 + 4 + (1 + ((12 + ((85 + 93 * (3 + 2)) + 6)) + 9))) +
-        ((1 + ((7 + (1 + (7 * (2 ^ 64 - 1) + 11))) + 5)) + 5))) + 1) + 8))))
+        ((1 + ((7 + (1 + (7 * bytes.length + 11))) + 5)) + 5))) + 1) + 8))))
       (WB + 80) raSaved fullCode
       (k34ContPost spW newSp listBase (WB + 76) { ra := WB + 76, s0 := listBase, s1 := len }
         { ra := B + 48, s0 := listBase, s1 := outBase + 8, s2 := outBase, s3 := s3, s4 := s4,
@@ -1000,13 +1000,13 @@ theorem wdBBField0
     (houtvalid : ∀ k, k < 20 →
       isValidByteAccess ((outBase + 16) + BitVec.ofNat 64 k) = true) :
     cpsTripleWithin ((4 + (1 + ((7 + 4 + (1 + ((12 + ((85 + 93 * (0 + 2)) + 6)) + 9))) +
-        ((1 + ((7 + (1 + (7 * (2 ^ 64 - 1) + 11))) + 5)) + 5))) + 1) +
+        ((1 + ((7 + (1 + (7 * bytes.length + 11))) + 5)) + 5))) + 1) +
         ((4 + (1 + ((7 + 4 + (1 + ((12 + ((85 + 93 * (1 + 2)) + 6)) + 9))) +
-        ((1 + ((7 + (1 + (7 * (2 ^ 64 - 1) + 11))) + 5)) + 5))) + 1) +
+        ((1 + ((7 + (1 + (7 * bytes.length + 11))) + 5)) + 5))) + 1) +
         ((7 + (1 + ((12 + ((85 + 93 * (2 + 2)) + 6)) + 9)) + 1) +
         (5 + (5 + (6 * (19 + 1)) +
         ((4 + (1 + ((7 + 4 + (1 + ((12 + ((85 + 93 * (3 + 2)) + 6)) + 9))) +
-          ((1 + ((7 + (1 + (7 * (2 ^ 64 - 1) + 11))) + 5)) + 5))) + 1) + 8))))))
+          ((1 + ((7 + (1 + (7 * bytes.length + 11))) + 5)) + 5))) + 1) + 8))))))
       (WB + 32) raSaved fullCode
       ((((.x1 : Reg) ↦ᵣ raEntry) ** (.x2 ↦ᵣ spW) ** (.x8 ↦ᵣ listBase) ** (.x9 ↦ᵣ len) **
         (.x18 ↦ᵣ outBase) ** (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ v11) ** (.x12 ↦ᵣ v12) **
@@ -1045,19 +1045,19 @@ theorem wdBBField0
       xperm_hyp hp)
   have h_t := cpsTripleWithin_mono_nSteps
     (show (7 : Nat) ≤ ((4 + (1 + ((7 + 4 + (1 + ((12 + ((85 + 93 * (1 + 2)) + 6)) + 9))) +
-        ((1 + ((7 + (1 + (7 * (2 ^ 64 - 1) + 11))) + 5)) + 5))) + 1) +
+        ((1 + ((7 + (1 + (7 * bytes.length + 11))) + 5)) + 5))) + 1) +
         ((7 + (1 + ((12 + ((85 + 93 * (2 + 2)) + 6)) + 9)) + 1) +
         (5 + (5 + (6 * (19 + 1)) +
         ((4 + (1 + ((7 + 4 + (1 + ((12 + ((85 + 93 * (3 + 2)) + 6)) + 9))) +
-          ((1 + ((7 + (1 + (7 * (2 ^ 64 - 1) + 11))) + 5)) + 5))) + 1) + 8))))) from by omega)
+          ((1 + ((7 + (1 + (7 * bytes.length + 11))) + 5)) + 5))) + 1) + 8))))) from by omega)
     harm
   -- continue edge → field-0 Result pinned, K34→K34 passthrough, field-1 backbone
   have h_f : cpsTripleWithin ((4 + (1 + ((7 + 4 + (1 + ((12 + ((85 + 93 * (1 + 2)) + 6)) + 9))) +
-      ((1 + ((7 + (1 + (7 * (2 ^ 64 - 1) + 11))) + 5)) + 5))) + 1) +
+      ((1 + ((7 + (1 + (7 * bytes.length + 11))) + 5)) + 5))) + 1) +
       ((7 + (1 + ((12 + ((85 + 93 * (2 + 2)) + 6)) + 9)) + 1) +
       (5 + (5 + (6 * (19 + 1)) +
       ((4 + (1 + ((7 + 4 + (1 + ((12 + ((85 + 93 * (3 + 2)) + 6)) + 9))) +
-        ((1 + ((7 + (1 + (7 * (2 ^ 64 - 1) + 11))) + 5)) + 5))) + 1) + 8)))))
+          ((1 + ((7 + (1 + (7 * bytes.length + 11))) + 5)) + 5))) + 1) + 8)))))
       (WB + 56) raSaved fullCode
       (k34ContPost spW newSp listBase (WB + 52) { ra := WB + 52, s0 := listBase, s1 := len }
         { ra := B + 48, s0 := listBase, s1 := outBase, s2 := outBase, s3 := s3, s4 := s4,
@@ -1174,13 +1174,13 @@ theorem withdrawal_decode_spec_within
       isValidByteAccess ((outBase + 16) + BitVec.ofNat 64 k) = true) :
     cpsTripleWithin (8 +
         ((4 + (1 + ((7 + 4 + (1 + ((12 + ((85 + 93 * (0 + 2)) + 6)) + 9))) +
-        ((1 + ((7 + (1 + (7 * (2 ^ 64 - 1) + 11))) + 5)) + 5))) + 1) +
+        ((1 + ((7 + (1 + (7 * bytes.length + 11))) + 5)) + 5))) + 1) +
         ((4 + (1 + ((7 + 4 + (1 + ((12 + ((85 + 93 * (1 + 2)) + 6)) + 9))) +
-        ((1 + ((7 + (1 + (7 * (2 ^ 64 - 1) + 11))) + 5)) + 5))) + 1) +
+        ((1 + ((7 + (1 + (7 * bytes.length + 11))) + 5)) + 5))) + 1) +
         ((7 + (1 + ((12 + ((85 + 93 * (2 + 2)) + 6)) + 9)) + 1) +
         (5 + (5 + (6 * (19 + 1)) +
         ((4 + (1 + ((7 + 4 + (1 + ((12 + ((85 + 93 * (3 + 2)) + 6)) + 9))) +
-          ((1 + ((7 + (1 + (7 * (2 ^ 64 - 1) + 11))) + 5)) + 5))) + 1) + 8)))))))
+          ((1 + ((7 + (1 + (7 * bytes.length + 11))) + 5)) + 5))) + 1) + 8)))))))
       WB raSaved fullCode
       (stackFree spW 12 ** (.x2 ↦ᵣ sp0) ** (.x1 ↦ᵣ raSaved) ** (.x8 ↦ᵣ s0Old) **
        (.x9 ↦ᵣ s1Old) ** (.x18 ↦ᵣ s2Old) ** (.x10 ↦ᵣ listBase) ** (.x11 ↦ᵣ len) **


### PR DESCRIPTION
## Summary\n\nIssue 11461 replaces the loose 7 * (2^64 - 1) RLP tail bounds with bounds derived from the caller-owned input byte region.\n\nThe change is one connected proof component. Tightening the RlpFieldToU64SAsm callee changes the step-bound types of its consumers, so the component is carried through the full dependency chain:\n\n- RlpFieldToU64SAsm -> Finish -> Whole -> Flat\n- Flat consumers: HeaderExtractNumberSpec, WithdrawalDecodeClose2, and the five ChainValidate loop bodies\n- the five ChainValidate LoopClose consumers and WithdrawalDecodeClose3\n- WithdrawalDecodeClose5\n\nScope accounting: the original census found 59 literal sites in 14 files. The PR changes 18 files because the five LoopClose files contain no old literal but consume parent loop-bound types that changed. Field0ToU64Top was one of the original 14 files and remains intentionally untouched, so the net expansion beyond the original file population is four files. The five no-literal consumers are ChainValidateBlobGasMultipleLoopClose, ChainValidateBlobGasUnderMaxLoopClose, ChainValidateConsecutiveNumbersLoopClose, ChainValidateGasUsedUnderLimitLoopClose, and ChainValidateIncreasingTimestampsLoopClose.\n\nThe 18 changed files use bytes.length for local calls and bigBytes.length for caller-wide loop budgets, with explicit monotonicity bridges for dropped per-header slices. No new input-domain premise was introduced: the three-way classification remains 19 leaf, 40 blocked-on-callee, and 0 record-only; all new obligations use existing static byte-length, validity, and slice-length facts.\n\nGasUsedUnderLimitLoopClose is the non-mechanical case. Expanding the data-derived arithmetic directly inside its large separation-logic assertions hit the default heartbeat budget during whnf/xperm. It therefore uses irreducible nCall9/nCall10 aliases, explicit equality lemmas back to the parent nCall definition, and named monotonicity bridges from dropped-slice length to whole-input length. This keeps the proof opaque at the expensive composition points without raising maxHeartbeats.\n\nField0ToU64Top remains intentionally out of scope: its 16 loose sites are an independent leaf and do not unblock this dependency chain.\n\nNo emitted guest code changes.\n\n## Verification\n\n- LAKE_ARTIFACT_CACHE=false lake build — 4750/4750 jobs\n- bash scripts/check-forbidden-tactics.sh\n- bash scripts/check-file-size.sh\n- git diff --check\n\nThis supersedes PRs #11973, #11974, and #11975. They were isolated tranches, but the bound tightening is non-additive: each tightened callee changes the types expected by unconverted consumers, so the component must merge as one PR.