### PR TITLE
fix: route header U64 fields through strict RLP

### DIFF
--- a/EvmAsm/Codegen/Programs/BlobGasPairAtBlockHash.lean
+++ b/EvmAsm/Codegen/Programs/BlobGasPairAtBlockHash.lean
@@ -118,7 +118,8 @@ def ziskBlobGasPairAtBlockHashPrologue : String :=
   zkvmKeccak256Function ++ "\n" ++
   witnessLookupByHashFunction ++ "\n" ++
   rlpListNthItemFunction ++ "\n" ++
-  rlpFieldToU64Function ++ "\n" ++
+  rlpContentToU64StrictFunction ++ "\n" ++
+  rlpFieldToU64StrictFunction ++ "\n" ++
   headerExtractBlobGasPairFunction ++ "\n" ++
   blobGasPairAtBlockHashFunction ++ "\n" ++
   ".Lbgpbh_pdone:"

--- a/EvmAsm/Codegen/Programs/BlobGasUsedAtBlockHash.lean
+++ b/EvmAsm/Codegen/Programs/BlobGasUsedAtBlockHash.lean
@@ -114,7 +114,8 @@ def ziskBlobGasUsedAtBlockHashPrologue : String :=
   zkvmKeccak256Function ++ "\n" ++
   witnessLookupByHashFunction ++ "\n" ++
   rlpListNthItemFunction ++ "\n" ++
-  rlpFieldToU64Function ++ "\n" ++
+  rlpContentToU64StrictFunction ++ "\n" ++
+  rlpFieldToU64StrictFunction ++ "\n" ++
   headerExtractBlobGasUsedFunction ++ "\n" ++
   blobGasUsedAtBlockHashFunction ++ "\n" ++
   ".Lbgubh_pdone:"

--- a/EvmAsm/Codegen/Programs/BlobGasUsedAtBlockNumber.lean
+++ b/EvmAsm/Codegen/Programs/BlobGasUsedAtBlockNumber.lean
@@ -152,7 +152,8 @@ def ziskBlobGasUsedAtBlockNumberPrologue : String :=
   "  sd a0, 0(t0)\n" ++
   "  j .Lbgbn_pdone\n" ++
   rlpListNthItemFunction ++ "\n" ++
-  rlpFieldToU64Function ++ "\n" ++
+  rlpContentToU64StrictFunction ++ "\n" ++
+  rlpFieldToU64StrictFunction ++ "\n" ++
   headerExtractNumberFunction ++ "\n" ++
   headerExtractBlobGasUsedFunction ++ "\n" ++
   blobGasUsedAtBlockNumberFunction ++ "\n" ++

--- a/EvmAsm/Codegen/Programs/Chain.lean
+++ b/EvmAsm/Codegen/Programs/Chain.lean
@@ -70,7 +70,7 @@ def chainComputeTotalBlobGasFunction : String :=
   "  ld a1, 0(t0)\n" ++
   "  mv a0, s2; li a2, 17\n" ++
   "  la a3, cctbg_field\n" ++
-  "  jal ra, rlp_field_to_u64\n" ++
+  "  jal ra, rlp_field_to_u64_strict\n" ++
   "  li t0, 1\n" ++
   "  beq a0, t0, .Lcctbg_parse_fail\n" ++
   "  li t0, 2\n" ++
@@ -110,7 +110,8 @@ def ziskChainComputeTotalBlobGasPrologue : String :=
   "  sd a0, 0(t0)\n" ++
   "  j .Lcctbg_pdone\n" ++
   rlpListNthItemFunction ++ "\n" ++
-  rlpFieldToU64Function ++ "\n" ++
+  rlpContentToU64StrictFunction ++ "\n" ++
+  rlpFieldToU64StrictFunction ++ "\n" ++
   chainComputeTotalBlobGasFunction ++ "\n" ++
   ".Lcctbg_pdone:"
 
@@ -168,7 +169,7 @@ def chainComputeMaxBlobGasUsedFunction : String :=
   "  ld a1, 0(t0)\n" ++
   "  mv a0, s2; li a2, 17\n" ++
   "  la a3, ccmbgu_field\n" ++
-  "  jal ra, rlp_field_to_u64\n" ++
+  "  jal ra, rlp_field_to_u64_strict\n" ++
   "  li t0, 1\n" ++
   "  beq a0, t0, .Lccmbgu_parse_fail\n" ++
   "  li t0, 2\n" ++
@@ -211,7 +212,8 @@ def ziskChainComputeMaxBlobGasUsedPrologue : String :=
   "  sd a0, 0(t0)\n" ++
   "  j .Lccmbgu_pdone\n" ++
   rlpListNthItemFunction ++ "\n" ++
-  rlpFieldToU64Function ++ "\n" ++
+  rlpContentToU64StrictFunction ++ "\n" ++
+  rlpFieldToU64StrictFunction ++ "\n" ++
   chainComputeMaxBlobGasUsedFunction ++ "\n" ++
   ".Lccmbgu_pdone:"
 
@@ -476,7 +478,7 @@ def chainComputeMinBlobGasUsedFunction : String :=
   "  ld a1, 0(t0)\n" ++
   "  mv a0, s2; li a2, 17\n" ++
   "  la a3, ccminbg_field\n" ++
-  "  jal ra, rlp_field_to_u64\n" ++
+  "  jal ra, rlp_field_to_u64_strict\n" ++
   "  li t0, 1\n" ++
   "  beq a0, t0, .Lccminbg_parse_fail\n" ++
   "  li t0, 2\n" ++
@@ -521,7 +523,8 @@ def ziskChainComputeMinBlobGasUsedPrologue : String :=
   "  sd a0, 0(t0)\n" ++
   "  j .Lccminbg_pdone\n" ++
   rlpListNthItemFunction ++ "\n" ++
-  rlpFieldToU64Function ++ "\n" ++
+  rlpContentToU64StrictFunction ++ "\n" ++
+  rlpFieldToU64StrictFunction ++ "\n" ++
   chainComputeMinBlobGasUsedFunction ++ "\n" ++
   ".Lccminbg_pdone:"
 
@@ -699,7 +702,7 @@ def chainExtractBlobGasUsedRangeFunction : String :=
   "  ld a1, 0(t0)\n" ++
   "  mv a0, s2; li a2, 17\n" ++
   "  la a3, cebgur_field\n" ++
-  "  jal ra, rlp_field_to_u64\n" ++
+  "  jal ra, rlp_field_to_u64_strict\n" ++
   "  li t0, 1\n" ++
   "  beq a0, t0, .Lcebgur_parse_fail\n" ++
   "  li t0, 2\n" ++
@@ -753,7 +756,8 @@ def ziskChainExtractBlobGasUsedRangePrologue : String :=
   "  sd a0, 0(t0)\n" ++
   "  j .Lcebgur_pdone\n" ++
   rlpListNthItemFunction ++ "\n" ++
-  rlpFieldToU64Function ++ "\n" ++
+  rlpContentToU64StrictFunction ++ "\n" ++
+  rlpFieldToU64StrictFunction ++ "\n" ++
   chainExtractBlobGasUsedRangeFunction ++ "\n" ++
   ".Lcebgur_pdone:"
 
@@ -912,7 +916,7 @@ def chainComputeTotalBlobCountFunction : String :=
   "  ld a1, 0(t0)\n" ++
   "  mv a0, s2; li a2, 17\n" ++
   "  la a3, cctbc_field\n" ++
-  "  jal ra, rlp_field_to_u64\n" ++
+  "  jal ra, rlp_field_to_u64_strict\n" ++
   "  li t0, 1\n" ++
   "  beq a0, t0, .Lcctbc_parse_fail\n" ++
   "  li t0, 2\n" ++
@@ -953,7 +957,8 @@ def ziskChainComputeTotalBlobCountPrologue : String :=
   "  sd a0, 0(t0)\n" ++
   "  j .Lcctbc_pdone\n" ++
   rlpListNthItemFunction ++ "\n" ++
-  rlpFieldToU64Function ++ "\n" ++
+  rlpContentToU64StrictFunction ++ "\n" ++
+  rlpFieldToU64StrictFunction ++ "\n" ++
   chainComputeTotalBlobCountFunction ++ "\n" ++
   ".Lcctbc_pdone:"
 

--- a/EvmAsm/Codegen/Programs/ChainBlobCount.lean
+++ b/EvmAsm/Codegen/Programs/ChainBlobCount.lean
@@ -70,7 +70,7 @@ def chainComputeMaxBlobCountFunction : String :=
   "  ld a1, 0(t0)\n" ++
   "  mv a0, s2; li a2, 17\n" ++
   "  la a3, ccmbc_field\n" ++
-  "  jal ra, rlp_field_to_u64\n" ++
+  "  jal ra, rlp_field_to_u64_strict\n" ++
   "  li t0, 1\n" ++
   "  beq a0, t0, .Lccmbc_parse_fail\n" ++
   "  li t0, 2\n" ++
@@ -114,7 +114,8 @@ def ziskChainComputeMaxBlobCountPrologue : String :=
   "  sd a0, 0(t0)\n" ++
   "  j .Lccmbc_pdone\n" ++
   rlpListNthItemFunction ++ "\n" ++
-  rlpFieldToU64Function ++ "\n" ++
+  rlpContentToU64StrictFunction ++ "\n" ++
+  rlpFieldToU64StrictFunction ++ "\n" ++
   chainComputeMaxBlobCountFunction ++ "\n" ++
   ".Lccmbc_pdone:"
 
@@ -173,7 +174,7 @@ def chainComputeMinBlobCountFunction : String :=
   "  ld a1, 0(t0)\n" ++
   "  mv a0, s2; li a2, 17\n" ++
   "  la a3, ccminbc_field\n" ++
-  "  jal ra, rlp_field_to_u64\n" ++
+  "  jal ra, rlp_field_to_u64_strict\n" ++
   "  li t0, 1\n" ++
   "  beq a0, t0, .Lccminbc_parse_fail\n" ++
   "  li t0, 2\n" ++
@@ -219,7 +220,8 @@ def ziskChainComputeMinBlobCountPrologue : String :=
   "  sd a0, 0(t0)\n" ++
   "  j .Lccminbc_pdone\n" ++
   rlpListNthItemFunction ++ "\n" ++
-  rlpFieldToU64Function ++ "\n" ++
+  rlpContentToU64StrictFunction ++ "\n" ++
+  rlpFieldToU64StrictFunction ++ "\n" ++
   chainComputeMinBlobCountFunction ++ "\n" ++
   ".Lccminbc_pdone:"
 

--- a/EvmAsm/Codegen/Programs/ChainExcessBlobGas.lean
+++ b/EvmAsm/Codegen/Programs/ChainExcessBlobGas.lean
@@ -70,7 +70,7 @@ def chainComputeMaxExcessBlobGasFunction : String :=
   "  ld a1, 0(t0)\n" ++
   "  mv a0, s2; li a2, 18\n" ++
   "  la a3, ccmebg_field\n" ++
-  "  jal ra, rlp_field_to_u64\n" ++
+  "  jal ra, rlp_field_to_u64_strict\n" ++
   "  li t0, 1\n" ++
   "  beq a0, t0, .Lccmebg_parse_fail\n" ++
   "  li t0, 2\n" ++
@@ -113,7 +113,8 @@ def ziskChainComputeMaxExcessBlobGasPrologue : String :=
   "  sd a0, 0(t0)\n" ++
   "  j .Lccmebg_pdone\n" ++
   rlpListNthItemFunction ++ "\n" ++
-  rlpFieldToU64Function ++ "\n" ++
+  rlpContentToU64StrictFunction ++ "\n" ++
+  rlpFieldToU64StrictFunction ++ "\n" ++
   chainComputeMaxExcessBlobGasFunction ++ "\n" ++
   ".Lccmebg_pdone:"
 
@@ -176,7 +177,7 @@ def chainComputeMinExcessBlobGasFunction : String :=
   "  ld a1, 0(t0)\n" ++
   "  mv a0, s2; li a2, 18\n" ++
   "  la a3, ccminebg_field\n" ++
-  "  jal ra, rlp_field_to_u64\n" ++
+  "  jal ra, rlp_field_to_u64_strict\n" ++
   "  li t0, 1\n" ++
   "  beq a0, t0, .Lccminebg_parse_fail\n" ++
   "  li t0, 2\n" ++
@@ -221,7 +222,8 @@ def ziskChainComputeMinExcessBlobGasPrologue : String :=
   "  sd a0, 0(t0)\n" ++
   "  j .Lccminebg_pdone\n" ++
   rlpListNthItemFunction ++ "\n" ++
-  rlpFieldToU64Function ++ "\n" ++
+  rlpContentToU64StrictFunction ++ "\n" ++
+  rlpFieldToU64StrictFunction ++ "\n" ++
   chainComputeMinExcessBlobGasFunction ++ "\n" ++
   ".Lccminebg_pdone:"
 
@@ -286,7 +288,7 @@ def chainComputeTotalExcessBlobGasFunction : String :=
   "  ld a1, 0(t0)\n" ++
   "  mv a0, s2; li a2, 18\n" ++
   "  la a3, cctebg_field\n" ++
-  "  jal ra, rlp_field_to_u64\n" ++
+  "  jal ra, rlp_field_to_u64_strict\n" ++
   "  li t0, 1\n" ++
   "  beq a0, t0, .Lcctebg_parse_fail\n" ++
   "  li t0, 2\n" ++
@@ -326,7 +328,8 @@ def ziskChainComputeTotalExcessBlobGasPrologue : String :=
   "  sd a0, 0(t0)\n" ++
   "  j .Lcctebg_pdone\n" ++
   rlpListNthItemFunction ++ "\n" ++
-  rlpFieldToU64Function ++ "\n" ++
+  rlpContentToU64StrictFunction ++ "\n" ++
+  rlpFieldToU64StrictFunction ++ "\n" ++
   chainComputeTotalExcessBlobGasFunction ++ "\n" ++
   ".Lcctebg_pdone:"
 

--- a/EvmAsm/Codegen/Programs/ChainValidate.lean
+++ b/EvmAsm/Codegen/Programs/ChainValidate.lean
@@ -484,7 +484,7 @@ def chainValidateNoBlobTxsFunction : String :=
   "  ld a1, 0(t3)\n" ++
   "  mv a0, s2; li a2, 17\n" ++
   "  la a3, cvnbt_field\n" ++
-  "  jal ra, rlp_field_to_u64\n" ++
+  "  jal ra, rlp_field_to_u64_strict\n" ++
   "  la t0, cvnbt_iter_ptr; ld s2, 0(t0)\n" ++
   "  la t0, cvnbt_iter_i;   ld s5, 0(t0)\n" ++
   "  li t0, 1\n" ++
@@ -532,7 +532,8 @@ def ziskChainValidateNoBlobTxsPrologue : String :=
   "  sd a0, 0(t0)\n" ++
   "  j .Lcvnbt_pdone\n" ++
   rlpListNthItemFunction ++ "\n" ++
-  rlpFieldToU64Function ++ "\n" ++
+  rlpContentToU64StrictFunction ++ "\n" ++
+  rlpFieldToU64StrictFunction ++ "\n" ++
   chainValidateNoBlobTxsFunction ++ "\n" ++
   ".Lcvnbt_pdone:"
 

--- a/EvmAsm/Codegen/Programs/ChainValidateBlob.lean
+++ b/EvmAsm/Codegen/Programs/ChainValidateBlob.lean
@@ -73,7 +73,7 @@ def chainValidateExcessBlobGasNonDecreasingFunction : String :=
   "  mv a0, s2\n" ++
   "  li a2, 18\n" ++
   "  la a3, cvebnd_field\n" ++
-  "  jal ra, rlp_field_to_u64\n" ++
+  "  jal ra, rlp_field_to_u64_strict\n" ++
   "  bnez a0, .Lcvebnd_propagate\n" ++
   "  la t0, cvebnd_field; ld s5, 0(t0)\n" ++
   "  ld t0, 0(s1)\n" ++
@@ -90,7 +90,7 @@ def chainValidateExcessBlobGasNonDecreasingFunction : String :=
   "  mv a0, t1\n" ++
   "  li a2, 18\n" ++
   "  la a3, cvebnd_field\n" ++
-  "  jal ra, rlp_field_to_u64\n" ++
+  "  jal ra, rlp_field_to_u64_strict\n" ++
   "  bnez a0, .Lcvebnd_propagate\n" ++
   "  la t0, cvebnd_field;        ld t3, 0(t0)\n" ++
   "  la t0, cvebnd_iter_prev;    ld t4, 0(t0)\n" ++
@@ -137,7 +137,8 @@ def ziskChainValidateExcessBlobGasNonDecreasingPrologue : String :=
   "  sd a0, 0(t0)\n" ++
   "  j .Lcvebnd_pdone\n" ++
   rlpListNthItemFunction ++ "\n" ++
-  rlpFieldToU64Function ++ "\n" ++
+  rlpContentToU64StrictFunction ++ "\n" ++
+  rlpFieldToU64StrictFunction ++ "\n" ++
   chainValidateExcessBlobGasNonDecreasingFunction ++ "\n" ++
   ".Lcvebnd_pdone:"
 
@@ -203,7 +204,7 @@ def chainValidateExcessBlobGasNonIncreasingFunction : String :=
   "  mv a0, s2\n" ++
   "  li a2, 18\n" ++
   "  la a3, cvebni_field\n" ++
-  "  jal ra, rlp_field_to_u64\n" ++
+  "  jal ra, rlp_field_to_u64_strict\n" ++
   "  bnez a0, .Lcvebni_propagate\n" ++
   "  la t0, cvebni_field; ld s5, 0(t0)\n" ++
   "  ld t0, 0(s1)\n" ++
@@ -220,7 +221,7 @@ def chainValidateExcessBlobGasNonIncreasingFunction : String :=
   "  mv a0, t1\n" ++
   "  li a2, 18\n" ++
   "  la a3, cvebni_field\n" ++
-  "  jal ra, rlp_field_to_u64\n" ++
+  "  jal ra, rlp_field_to_u64_strict\n" ++
   "  bnez a0, .Lcvebni_propagate\n" ++
   "  la t0, cvebni_field;        ld t3, 0(t0)\n" ++
   "  la t0, cvebni_iter_prev;    ld t4, 0(t0)\n" ++
@@ -267,7 +268,8 @@ def ziskChainValidateExcessBlobGasNonIncreasingPrologue : String :=
   "  sd a0, 0(t0)\n" ++
   "  j .Lcvebni_pdone\n" ++
   rlpListNthItemFunction ++ "\n" ++
-  rlpFieldToU64Function ++ "\n" ++
+  rlpContentToU64StrictFunction ++ "\n" ++
+  rlpFieldToU64StrictFunction ++ "\n" ++
   chainValidateExcessBlobGasNonIncreasingFunction ++ "\n" ++
   ".Lcvebni_pdone:"
 
@@ -354,7 +356,7 @@ def chainValidateBlobGasUsedUnderMax_prog : Program :=
     .LI .x12 (17 : Word),
     .AUIPC .x13 (laHi GuestAddrs.cvbgum_field (GuestAddrs.chain_validate_blob_gas_used_under_max + 116)),
     .ADDI .x13 .x13 (laLo GuestAddrs.cvbgum_field (GuestAddrs.chain_validate_blob_gas_used_under_max + 116)),
-    .JAL .x1 (jalOff GuestAddrs.rlp_field_to_u64 (GuestAddrs.chain_validate_blob_gas_used_under_max + 124)),
+    .JAL .x1 (jalOff GuestAddrs.rlp_field_to_u64_strict (GuestAddrs.chain_validate_blob_gas_used_under_max + 124)),
     .BNE .x10 .x0 (88 : BitVec 13),
     .AUIPC .x5 (laHi GuestAddrs.cvbgum_iter_ptr (GuestAddrs.chain_validate_blob_gas_used_under_max + 132)),
     .ADDI .x5 .x5 (laLo GuestAddrs.cvbgum_iter_ptr (GuestAddrs.chain_validate_blob_gas_used_under_max + 132)),
@@ -397,7 +399,7 @@ def chainValidateBlobGasUsedUnderMax_relocs : RelocTable :=
   [ (18, .la .x5 "cvbgum_iter_ptr"),
     (21, .la .x5 "cvbgum_iter_i"),
     (29, .la .x13 "cvbgum_field"),
-    (31, .jal .x1 "rlp_field_to_u64"),
+    (31, .jal .x1 "rlp_field_to_u64_strict"),
     (33, .la .x5 "cvbgum_iter_ptr"),
     (36, .la .x5 "cvbgum_iter_i"),
     (39, .la .x5 "cvbgum_field") ]
@@ -429,7 +431,8 @@ def ziskChainValidateBlobGasUsedUnderMaxPrologue : String :=
   "  sd a0, 0(t0)\n" ++
   "  j .Lcvbgum_pdone\n" ++
   rlpListNthItemFunction ++ "\n" ++
-  rlpFieldToU64Function ++ "\n" ++
+  rlpContentToU64StrictFunction ++ "\n" ++
+  rlpFieldToU64StrictFunction ++ "\n" ++
   chainValidateBlobGasUsedUnderMaxFunction ++ "\n" ++
   ".Lcvbgum_pdone:"
 
@@ -513,7 +516,7 @@ def chainValidateBlobGasUsedMultiple_prog : Program :=
     .LI .x12 (17 : Word),
     .AUIPC .x13 (laHi GuestAddrs.cvbgm_field (GuestAddrs.chain_validate_blob_gas_used_multiple + 116)),
     .ADDI .x13 .x13 (laLo GuestAddrs.cvbgm_field (GuestAddrs.chain_validate_blob_gas_used_multiple + 116)),
-    .JAL .x1 (jalOff GuestAddrs.rlp_field_to_u64 (GuestAddrs.chain_validate_blob_gas_used_multiple + 124)),
+    .JAL .x1 (jalOff GuestAddrs.rlp_field_to_u64_strict (GuestAddrs.chain_validate_blob_gas_used_multiple + 124)),
     .BNE .x10 .x0 (96 : BitVec 13),
     .AUIPC .x5 (laHi GuestAddrs.cvbgm_iter_ptr (GuestAddrs.chain_validate_blob_gas_used_multiple + 132)),
     .ADDI .x5 .x5 (laLo GuestAddrs.cvbgm_iter_ptr (GuestAddrs.chain_validate_blob_gas_used_multiple + 132)),
@@ -558,7 +561,7 @@ def chainValidateBlobGasUsedMultiple_relocs : RelocTable :=
   [ (18, .la .x5 "cvbgm_iter_ptr"),
     (21, .la .x5 "cvbgm_iter_i"),
     (29, .la .x13 "cvbgm_field"),
-    (31, .jal .x1 "rlp_field_to_u64"),
+    (31, .jal .x1 "rlp_field_to_u64_strict"),
     (33, .la .x5 "cvbgm_iter_ptr"),
     (36, .la .x5 "cvbgm_iter_i"),
     (39, .la .x5 "cvbgm_field") ]
@@ -590,7 +593,8 @@ def ziskChainValidateBlobGasUsedMultiplePrologue : String :=
   "  sd a0, 0(t0)\n" ++
   "  j .Lcvbgm_pdone\n" ++
   rlpListNthItemFunction ++ "\n" ++
-  rlpFieldToU64Function ++ "\n" ++
+  rlpContentToU64StrictFunction ++ "\n" ++
+  rlpFieldToU64StrictFunction ++ "\n" ++
   chainValidateBlobGasUsedMultipleFunction ++ "\n" ++
   ".Lcvbgm_pdone:"
 

--- a/EvmAsm/Codegen/Programs/ChainValidateBlobGasMultipleLoop.lean
+++ b/EvmAsm/Codegen/Programs/ChainValidateBlobGasMultipleLoop.lean
@@ -4,7 +4,7 @@
   Builds on `ChainValidateBlobGasMultipleSpec` (model, prologue, epilogue, exit
   blocks) and reuses the generic array pieces from
   `ChainValidateExtraDataLengthSpec`.  The per-header body decodes field 17 via
-  the strict `rlp_field_to_u64` K34 wrapper, then checks that the decoded u64 is
+  the strict `rlp_field_to_u64_strict` K34 wrapper, then checks that the decoded u64 is
   a multiple of `GAS_PER_BLOB = 2^17` with `and x30, x6, x7 ; bne x30, x0`
   (`x7 = Mask = GAS_PER_BLOB - 1 = 131071`), i.e. `(value &&& Mask) = 0`.
 -/
@@ -200,7 +200,7 @@ theorem cvbgmAdvance (hbi lenBase iW : Word) (Li : Nat) (o28 o29 : Word) :
 theorem lengths_getElem_bang {lengths : List Nat} {i : Nat} (hi : i < lengths.length) :
     lengths[i]! = lengths[i] := getElem!_pos lengths i hi
 
-/-! ## Call block (instructions 18--31 + K34): setup ;; jal ;; rlp_field_to_u64
+/-! ## Call block (instructions 18--31 + K34): setup ;; jal ;; rlp_field_to_u64_strict
 
     From the loop-guard fall-through (`D+72`) to the return site (`D+128`),
     producing K34's `flatPost` for header `hbi` (field 17), with the spill
@@ -208,9 +208,9 @@ theorem lengths_getElem_bang {lengths : List Nat} {i : Nat} (hi : i < lengths.le
 
 /-- K34's whole-routine step count for field index 17 (matching the flat
     spec's `((7 + 4 + callSteps) + ((1 + tailSteps) + 5))` with `index = 17`). -/
-def nCall (bytesLen : Nat) : Nat :=
+def nCall (_bytesLen : Nat) : Nat :=
   (7 + 4 + (1 + ((12 + ((85 + 93 * (17 + 2)) + 6)) + 9)))
-    + ((1 + ((7 + (1 + (7 * bytesLen + 11))) + 5)) + 5)
+    + ((1 + ((7 + (1 + (7 * (2 ^ 64 - 1) + 11))) + 5)) + 5)
 
 set_option maxRecDepth 8000 in
 theorem cvbgmCall (hbi lenBase spC iW : Word) (Li : Nat)
@@ -230,14 +230,14 @@ theorem cvbgmCall (hbi lenBase spC iW : Word) (Li : Nat)
         (.x1 ↦ᵣ oldX1) ** (.x8 ↦ᵣ nN) ** (.x19 ↦ᵣ s3) ** (.x20 ↦ᵣ s4) **
         (.x14 ↦ᵣ old14) ** regOwn .x6 ** regOwn .x7 ** regOwn .x29 ** regOwn .x30 **
         regOwn .x31 ** (.x0 ↦ᵣ (0 : Word)) **
-        frameSlotsOwn EvmAsm.Codegen.RlpFieldToU64SAsm.frame (spC + signExtend12 (-32 : BitVec 12)) **
+        frameSlotsOwn EvmAsm.Codegen.RlpFieldToU64StrictSAsm.frame (spC + signExtend12 (-32 : BitVec 12)) **
         stackFree (spC + signExtend12 (-32 : BitVec 12)) 8 **
         (Field ↦ₘ oldOut) ** (RfuOff ↦ₘ oldOff) ** (RfuLen ↦ₘ oldLen) **
         bytesRegion hbi bytes ** savedFrame spC csaved)
       ((.x1 ↦ᵣ LinkRA) **
-        EvmAsm.Codegen.RlpFieldToU64SAsm.flatPost spC (spC + signExtend12 (-32 : BitVec 12)) hbi
-          oldOff oldLen (⟨LinkRA, nN, lenBase⟩ : EvmAsm.Codegen.RlpFieldToU64SAsm.Saved)
-          (⟨EvmAsm.Codegen.RlpFieldToU64SAsm.B + 48, hbi, Field, hbi, s3, s4, iW⟩ : Saved)
+        EvmAsm.Codegen.RlpFieldToU64StrictSAsm.flatPost spC (spC + signExtend12 (-32 : BitVec 12)) hbi
+          oldOff oldLen (⟨LinkRA, nN, lenBase⟩ : EvmAsm.Codegen.RlpFieldToU64StrictSAsm.Saved)
+          (⟨EvmAsm.Codegen.RlpFieldToU64StrictSAsm.B + 48, hbi, Field, hbi, s3, s4, iW⟩ : Saved)
           bytes Li 17 **
         (IterPtr ↦ₘ hbi) ** (IterI ↦ₘ iW) **
         ((lenBase + (iW <<< 3)) ↦ₘ BitVec.ofNat 64 Li) ** savedFrame spC csaved) := by
@@ -249,7 +249,7 @@ theorem cvbgmCall (hbi lenBase spC iW : Word) (Li : Nat)
     ((.x1 ↦ᵣ oldX1) ** (.x8 ↦ᵣ nN) ** (.x19 ↦ᵣ s3) ** (.x20 ↦ᵣ s4) **
       (.x14 ↦ᵣ old14) ** regOwn .x6 ** regOwn .x7 ** regOwn .x29 ** regOwn .x30 **
       regOwn .x31 ** (.x0 ↦ᵣ (0 : Word)) **
-      frameSlotsOwn EvmAsm.Codegen.RlpFieldToU64SAsm.frame calleeNewSp **
+      frameSlotsOwn EvmAsm.Codegen.RlpFieldToU64StrictSAsm.frame calleeNewSp **
       stackFree calleeNewSp 8 **
       (Field ↦ₘ oldOut) ** (RfuOff ↦ₘ oldOff) ** (RfuLen ↦ₘ oldLen) **
       bytesRegion hbi bytes ** savedFrame spC csaved)
@@ -257,19 +257,19 @@ theorem cvbgmCall (hbi lenBase spC iW : Word) (Li : Nat)
                       | exact pcFree_memIs | exact pcFree_memOwn
                       | exact pcFree_frameSlotsOwn _ _ | exact pcFree_stackFree _ _
                       | exact bytesRegion_pcFree _ _) hsetup
-  -- [31] jal x1, rlp_field_to_u64
+  -- [31] jal x1, rlp_field_to_u64_strict
   have hjal := jal_link_spec_within
-    (EvmAsm.Codegen.jalOff GuestAddrs.rlp_field_to_u64
+    (EvmAsm.Codegen.jalOff GuestAddrs.rlp_field_to_u64_strict
       (GuestAddrs.chain_validate_blob_gas_used_multiple + 124)) (D + 124) oldX1
-  rw [show (D + 124) + signExtend21 (EvmAsm.Codegen.jalOff GuestAddrs.rlp_field_to_u64
+  rw [show (D + 124) + signExtend21 (EvmAsm.Codegen.jalOff GuestAddrs.rlp_field_to_u64_strict
       (GuestAddrs.chain_validate_blob_gas_used_multiple + 124))
-      = EvmAsm.Codegen.RlpFieldToU64SAsm.B from by decide,
+      = EvmAsm.Codegen.RlpFieldToU64StrictSAsm.B from by decide,
     show (D + 124 + 4 : Word) = LinkRA from by
       change (D + 124 + 4 : Word) = D + 128; bv_omega] at hjal
   have hjalC := cpsTripleWithin_extend_code cvbgm_mono
     (cpsTripleWithin_extend_code (cr' := cvbgmCode)
       (CodeReq.ofProg_mem_at D (D + 124) cvbgmProg 31
-        (.JAL .x1 (EvmAsm.Codegen.jalOff GuestAddrs.rlp_field_to_u64
+        (.JAL .x1 (EvmAsm.Codegen.jalOff GuestAddrs.rlp_field_to_u64_strict
           (GuestAddrs.chain_validate_blob_gas_used_multiple + 124))) (by bv_omega)
         (by rw [cvbgm_length]; decide) rfl (by rw [cvbgm_length]; decide)) hjal)
   have hjalF := cpsTripleWithin_frameR
@@ -281,7 +281,7 @@ theorem cvbgmCall (hbi lenBase spC iW : Word) (Li : Nat)
       (.x8 ↦ᵣ nN) ** (.x19 ↦ᵣ s3) ** (.x20 ↦ᵣ s4) ** (.x14 ↦ᵣ old14) **
       regOwn .x6 ** regOwn .x7 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
       (.x0 ↦ᵣ (0 : Word)) **
-      frameSlotsOwn EvmAsm.Codegen.RlpFieldToU64SAsm.frame calleeNewSp **
+      frameSlotsOwn EvmAsm.Codegen.RlpFieldToU64StrictSAsm.frame calleeNewSp **
       stackFree calleeNewSp 8 **
       (Field ↦ₘ oldOut) ** (RfuOff ↦ₘ oldOff) ** (RfuLen ↦ₘ oldLen) **
       bytesRegion hbi bytes ** savedFrame spC csaved)
@@ -290,30 +290,30 @@ theorem cvbgmCall (hbi lenBase spC iW : Word) (Li : Nat)
                       | exact pcFree_frameSlotsOwn _ _ | exact pcFree_stackFree _ _
                       | exact bytesRegion_pcFree _ _) hjalC
   -- K34 flat callee, lifted to fullCode, framed with the spill/array/chain payload.
-  have hcallee0 := EvmAsm.Codegen.RlpFieldToU64SAsm.rlpFieldToU64_flat_spec_within
+  have hcallee0 := EvmAsm.Codegen.RlpFieldToU64StrictSAsm.rlpFieldToU64_flat_spec_within
     spC calleeNewSp hbi (BitVec.ofNat 64 Li) (17 : Word) Field oldOut oldOff oldLen old14
-    (⟨LinkRA, nN, lenBase⟩ : EvmAsm.Codegen.RlpFieldToU64SAsm.Saved) hbi s3 s4 iW bytes Li 17
+    (⟨LinkRA, nN, lenBase⟩ : EvmAsm.Codegen.RlpFieldToU64StrictSAsm.Saved) hbi s3 s4 iW bytes Li 17
     hcalleeNewSp rfl (by decide) (by decide)
     hsalign hslack hover hvalid (by show LinkRA &&& ~~~(1 : Word) = LinkRA; decide)
   have hcalleeC := cpsTripleWithin_extend_code k34_mono hcallee0
   -- Present K34's entry footprint as explicit atoms, with `x5`/`x28` shown owned.
-  have hcallee : cpsTripleWithin (nCall bytes.length) EvmAsm.Codegen.RlpFieldToU64SAsm.B LinkRA fullCode
+  have hcallee : cpsTripleWithin (nCall bytes.length) EvmAsm.Codegen.RlpFieldToU64StrictSAsm.B LinkRA fullCode
       (regOwn .x5 ** regOwn .x28 **
         ((.x1 ↦ᵣ LinkRA) ** (.x2 ↦ᵣ spC) ** (.x8 ↦ᵣ nN) ** (.x9 ↦ᵣ lenBase) **
           (.x18 ↦ᵣ hbi) ** (.x19 ↦ᵣ s3) ** (.x20 ↦ᵣ s4) ** (.x21 ↦ᵣ iW) **
           (.x10 ↦ᵣ hbi) ** (.x11 ↦ᵣ BitVec.ofNat 64 Li) ** (.x12 ↦ᵣ (17 : Word)) **
           (.x13 ↦ᵣ Field) ** (.x14 ↦ᵣ old14) ** regOwn .x6 ** regOwn .x7 **
           regOwn .x29 ** regOwn .x30 ** regOwn .x31 ** (.x0 ↦ᵣ (0 : Word)) **
-          frameSlotsOwn EvmAsm.Codegen.RlpFieldToU64SAsm.frame calleeNewSp **
+          frameSlotsOwn EvmAsm.Codegen.RlpFieldToU64StrictSAsm.frame calleeNewSp **
           stackFree calleeNewSp 8 ** bytesRegion hbi bytes **
           (Field ↦ₘ oldOut) ** (RfuOff ↦ₘ oldOff) ** (RfuLen ↦ₘ oldLen)))
       ((.x1 ↦ᵣ LinkRA) **
-        EvmAsm.Codegen.RlpFieldToU64SAsm.flatPost spC calleeNewSp hbi oldOff oldLen
-          (⟨LinkRA, nN, lenBase⟩ : EvmAsm.Codegen.RlpFieldToU64SAsm.Saved)
-          (⟨EvmAsm.Codegen.RlpFieldToU64SAsm.B + 48, hbi, Field, hbi, s3, s4, iW⟩ : Saved)
+        EvmAsm.Codegen.RlpFieldToU64StrictSAsm.flatPost spC calleeNewSp hbi oldOff oldLen
+          (⟨LinkRA, nN, lenBase⟩ : EvmAsm.Codegen.RlpFieldToU64StrictSAsm.Saved)
+          (⟨EvmAsm.Codegen.RlpFieldToU64StrictSAsm.B + 48, hbi, Field, hbi, s3, s4, iW⟩ : Saved)
           bytes Li 17) :=
     cpsTripleWithin_weaken (fun h hp => by
-      unfold EvmAsm.Codegen.RlpFieldToU64SAsm.flatPre EvmAsm.Codegen.RlpFieldToU64SAsm.wholeRest
+      unfold EvmAsm.Codegen.RlpFieldToU64StrictSAsm.flatPre EvmAsm.Codegen.RlpFieldToU64StrictSAsm.wholeRest
       xperm_hyp hp) (fun _ hq => hq) hcalleeC
   have hcalleeF := cpsTripleWithin_frameR
     ((IterPtr ↦ₘ hbi) ** (IterI ↦ₘ iW) **
@@ -329,7 +329,7 @@ theorem cvbgmCall (hbi lenBase spC iW : Word) (Li : Nat)
         (.x10 ↦ᵣ hbi) ** (.x11 ↦ᵣ BitVec.ofNat 64 Li) ** (.x12 ↦ᵣ (17 : Word)) **
         (.x13 ↦ᵣ Field) ** (.x14 ↦ᵣ old14) ** regOwn .x6 ** regOwn .x7 **
         regOwn .x29 ** regOwn .x30 ** regOwn .x31 ** (.x0 ↦ᵣ (0 : Word)) **
-        frameSlotsOwn EvmAsm.Codegen.RlpFieldToU64SAsm.frame calleeNewSp **
+        frameSlotsOwn EvmAsm.Codegen.RlpFieldToU64StrictSAsm.frame calleeNewSp **
         stackFree calleeNewSp 8 ** bytesRegion hbi bytes **
         (Field ↦ₘ oldOut) ** (RfuOff ↦ₘ oldOff) ** (RfuLen ↦ₘ oldLen) **
         (IterPtr ↦ₘ hbi) ** (IterI ↦ₘ iW) **
@@ -360,16 +360,16 @@ theorem cvbgmCallOwned (hbi lenBase spC iW : Word) (Li : Nat)
           (.x8 ↦ᵣ nN) ** (.x19 ↦ᵣ s3) ** (.x20 ↦ᵣ s4) **
           regOwn .x6 ** regOwn .x7 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
           (.x0 ↦ᵣ (0 : Word)) **
-          frameSlotsOwn EvmAsm.Codegen.RlpFieldToU64SAsm.frame (spC + signExtend12 (-32 : BitVec 12)) **
+          frameSlotsOwn EvmAsm.Codegen.RlpFieldToU64StrictSAsm.frame (spC + signExtend12 (-32 : BitVec 12)) **
           stackFree (spC + signExtend12 (-32 : BitVec 12)) 8 **
           (Field ↦ₘ oldOut) ** (RfuOff ↦ₘ oldOff) ** (RfuLen ↦ₘ oldLen) **
           bytesRegion hbi bytes ** savedFrame spC csaved) **
         regOwn .x5 ** regOwn .x10 ** regOwn .x11 ** regOwn .x12 ** regOwn .x13 **
         regOwn .x14 ** regOwn .x28) ** regOwn .x1)
       ((.x1 ↦ᵣ LinkRA) **
-        EvmAsm.Codegen.RlpFieldToU64SAsm.flatPost spC (spC + signExtend12 (-32 : BitVec 12)) hbi
-          oldOff oldLen (⟨LinkRA, nN, lenBase⟩ : EvmAsm.Codegen.RlpFieldToU64SAsm.Saved)
-          (⟨EvmAsm.Codegen.RlpFieldToU64SAsm.B + 48, hbi, Field, hbi, s3, s4, iW⟩ : Saved)
+        EvmAsm.Codegen.RlpFieldToU64StrictSAsm.flatPost spC (spC + signExtend12 (-32 : BitVec 12)) hbi
+          oldOff oldLen (⟨LinkRA, nN, lenBase⟩ : EvmAsm.Codegen.RlpFieldToU64StrictSAsm.Saved)
+          (⟨EvmAsm.Codegen.RlpFieldToU64StrictSAsm.B + 48, hbi, Field, hbi, s3, s4, iW⟩ : Saved)
           bytes Li 17 **
         (IterPtr ↦ₘ hbi) ** (IterI ↦ₘ iW) **
         ((lenBase + (iW <<< 3)) ↦ₘ BitVec.ofNat 64 Li) ** savedFrame spC csaved) := by
@@ -382,16 +382,16 @@ theorem cvbgmCallOwned (hbi lenBase spC iW : Word) (Li : Nat)
           (.x8 ↦ᵣ nN) ** (.x19 ↦ᵣ s3) ** (.x20 ↦ᵣ s4) **
           regOwn .x6 ** regOwn .x7 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
           (.x0 ↦ᵣ (0 : Word)) **
-          frameSlotsOwn EvmAsm.Codegen.RlpFieldToU64SAsm.frame (spC + signExtend12 (-32 : BitVec 12)) **
+          frameSlotsOwn EvmAsm.Codegen.RlpFieldToU64StrictSAsm.frame (spC + signExtend12 (-32 : BitVec 12)) **
           stackFree (spC + signExtend12 (-32 : BitVec 12)) 8 **
           (Field ↦ₘ oldOut) ** (RfuOff ↦ₘ oldOff) ** (RfuLen ↦ₘ oldLen) **
           bytesRegion hbi bytes ** savedFrame spC csaved) ** (.x1 ↦ᵣ v1)) **
         regOwn .x5 ** regOwn .x10 ** regOwn .x11 ** regOwn .x12 ** regOwn .x13 **
         regOwn .x14 ** regOwn .x28)
       ((.x1 ↦ᵣ LinkRA) **
-        EvmAsm.Codegen.RlpFieldToU64SAsm.flatPost spC (spC + signExtend12 (-32 : BitVec 12)) hbi
-          oldOff oldLen (⟨LinkRA, nN, lenBase⟩ : EvmAsm.Codegen.RlpFieldToU64SAsm.Saved)
-          (⟨EvmAsm.Codegen.RlpFieldToU64SAsm.B + 48, hbi, Field, hbi, s3, s4, iW⟩ : Saved)
+        EvmAsm.Codegen.RlpFieldToU64StrictSAsm.flatPost spC (spC + signExtend12 (-32 : BitVec 12)) hbi
+          oldOff oldLen (⟨LinkRA, nN, lenBase⟩ : EvmAsm.Codegen.RlpFieldToU64StrictSAsm.Saved)
+          (⟨EvmAsm.Codegen.RlpFieldToU64StrictSAsm.B + 48, hbi, Field, hbi, s3, s4, iW⟩ : Saved)
           bytes Li 17 **
         (IterPtr ↦ₘ hbi) ** (IterI ↦ₘ iW) **
         ((lenBase + (iW <<< 3)) ↦ₘ BitVec.ofNat 64 Li) ** savedFrame spC csaved) from ?_)
@@ -435,14 +435,14 @@ theorem cvbgmIterEntry (spC hdrBase lenBase validPtr firstBadPtr : Word)
         regOwn .x1 ** regOwn .x5 ** regOwn .x6 ** regOwn .x7 ** regOwn .x10 **
         regOwn .x11 ** regOwn .x12 ** regOwn .x13 ** regOwn .x14 ** regOwn .x28 **
         regOwn .x29 ** regOwn .x30 ** regOwn .x31 ** (.x0 ↦ᵣ (0 : Word)) **
-        frameSlotsOwn EvmAsm.Codegen.RlpFieldToU64SAsm.frame (spC + signExtend12 (-32 : BitVec 12)) **
+        frameSlotsOwn EvmAsm.Codegen.RlpFieldToU64StrictSAsm.frame (spC + signExtend12 (-32 : BitVec 12)) **
         stackFree (spC + signExtend12 (-32 : BitVec 12)) 8)
       ((.x1 ↦ᵣ LinkRA) **
-        EvmAsm.Codegen.RlpFieldToU64SAsm.flatPost spC (spC + signExtend12 (-32 : BitVec 12))
+        EvmAsm.Codegen.RlpFieldToU64StrictSAsm.flatPost spC (spC + signExtend12 (-32 : BitVec 12))
           (hdrBaseAt hdrBase lengths i) oldOff oldLen
           (⟨LinkRA, BitVec.ofNat 64 lengths.length, lenBase⟩ :
-            EvmAsm.Codegen.RlpFieldToU64SAsm.Saved)
-          (⟨EvmAsm.Codegen.RlpFieldToU64SAsm.B + 48, hdrBaseAt hdrBase lengths i, Field,
+            EvmAsm.Codegen.RlpFieldToU64StrictSAsm.Saved)
+          (⟨EvmAsm.Codegen.RlpFieldToU64StrictSAsm.B + 48, hdrBaseAt hdrBase lengths i, Field,
             hdrBaseAt hdrBase lengths i, validPtr, firstBadPtr, BitVec.ofNat 64 i⟩ : Saved)
           (bigBytes.drop (hdrOff lengths i)) lengths[i]! 17 **
         (IterPtr ↦ₘ hdrBaseAt hdrBase lengths i) ** (IterI ↦ₘ BitVec.ofNat 64 i) **
@@ -478,7 +478,7 @@ theorem cvbgmIterEntry (spC hdrBase lenBase validPtr firstBadPtr : Word)
       regOwn .x1 ** regOwn .x5 ** regOwn .x6 ** regOwn .x7 ** regOwn .x10 **
       regOwn .x11 ** regOwn .x12 ** regOwn .x13 ** regOwn .x14 ** regOwn .x28 **
       regOwn .x29 ** regOwn .x30 ** regOwn .x31 ** (.x0 ↦ᵣ (0 : Word)) **
-      frameSlotsOwn EvmAsm.Codegen.RlpFieldToU64SAsm.frame (spC + signExtend12 (-32 : BitVec 12)) **
+      frameSlotsOwn EvmAsm.Codegen.RlpFieldToU64StrictSAsm.frame (spC + signExtend12 (-32 : BitVec 12)) **
       stackFree (spC + signExtend12 (-32 : BitVec 12)) 8)
     (by repeat' first | apply pcFree_sepConj | exact pcFree_regIs | exact pcFree_regOwn
                       | exact pcFree_memIs | exact pcFree_memOwn
@@ -520,26 +520,26 @@ def dispNorm (spC calleeNewSp hbi validPtr firstBadPtr nN lenBase iW value statu
   regOwn .x14 ** regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
   memOwn RfuOff ** memOwn RfuLen ** stackFree calleeNewSp 8 **
   bytesRegion hbi bytes **
-  EvmAsm.Codegen.RlpFieldToU64SAsm.savedFrame calleeNewSp ⟨LinkRA, nN, lenBase⟩
+  EvmAsm.Codegen.RlpFieldToU64StrictSAsm.savedFrame calleeNewSp ⟨LinkRA, nN, lenBase⟩
 
 set_option maxRecDepth 8000 in
 theorem flatPost_normalize (spC hbi validPtr firstBadPtr nN lenBase iW oldOff oldLen : Word)
     (bytes : List (BitVec 8)) (Li : Nat) : ∀ h,
-    (EvmAsm.Codegen.RlpFieldToU64SAsm.flatPost spC (spC + signExtend12 (-32 : BitVec 12)) hbi
-      oldOff oldLen (⟨LinkRA, nN, lenBase⟩ : EvmAsm.Codegen.RlpFieldToU64SAsm.Saved)
-      (⟨EvmAsm.Codegen.RlpFieldToU64SAsm.B + 48, hbi, Field, hbi, validPtr, firstBadPtr, iW⟩ : Saved)
+    (EvmAsm.Codegen.RlpFieldToU64StrictSAsm.flatPost spC (spC + signExtend12 (-32 : BitVec 12)) hbi
+      oldOff oldLen (⟨LinkRA, nN, lenBase⟩ : EvmAsm.Codegen.RlpFieldToU64StrictSAsm.Saved)
+      (⟨EvmAsm.Codegen.RlpFieldToU64StrictSAsm.B + 48, hbi, Field, hbi, validPtr, firstBadPtr, iW⟩ : Saved)
       bytes Li 17) h →
     (∃ status value,
       (dispNorm spC (spC + signExtend12 (-32 : BitVec 12)) hbi validPtr firstBadPtr nN lenBase iW
           value status bytes **
-        ⌜EvmAsm.Codegen.RlpFieldToU64SAsm.Result bytes hbi Li 17 status value⌝) h) := by
+        ⌜EvmAsm.Codegen.RlpFieldToU64StrictSAsm.Result bytes hbi Li 17 status value⌝) h) := by
   intro h hp
-  unfold EvmAsm.Codegen.RlpFieldToU64SAsm.flatPost at hp
+  unfold EvmAsm.Codegen.RlpFieldToU64StrictSAsm.flatPost at hp
   rcases hp with hs | hf
   · -- success arm: status = wrapperStatus, value = outputValue.
-    unfold EvmAsm.Codegen.RlpFieldToU64SAsm.flatSuccessReturned at hs
+    unfold EvmAsm.Codegen.RlpFieldToU64StrictSAsm.flatSuccessReturned at hs
     obtain ⟨offset, len, v12, x5v, scalarStatus, wrapperStatus, outputValue, hs⟩ := hs
-    unfold EvmAsm.Codegen.RlpFieldToU64SAsm.successPayload at hs
+    unfold EvmAsm.Codegen.RlpFieldToU64StrictSAsm.successPayload at hs
     refine ⟨wrapperStatus, outputValue, ?_⟩
     obtain ⟨h1, h2, hd, hu, hO, hP⟩ := hs
     obtain ⟨hBig, hRes⟩ := (sepConj_pure_right _).1 hP
@@ -554,16 +554,16 @@ theorem flatPost_normalize (spC hbi validPtr firstBadPtr nN lenBase iW oldOff ol
           regOwn .x6 ** regOwn .x7 ** regOwn .x13 ** regOwn .x14 ** regOwn .x28 **
           regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
           stackFree (spC + signExtend12 (-32 : BitVec 12)) 8 ** bytesRegion hbi bytes **
-          EvmAsm.Codegen.RlpFieldToU64SAsm.savedFrame (spC + signExtend12 (-32 : BitVec 12))
+          EvmAsm.Codegen.RlpFieldToU64StrictSAsm.savedFrame (spC + signExtend12 (-32 : BitVec 12))
             ⟨LinkRA, nN, lenBase⟩)) h := by xperm_hyp hOB
     have hp2 := sepConj_mono memIs_implies_memOwn (sepConj_mono memIs_implies_memOwn
       (sepConj_mono (regIs_implies_regOwn .x5) (sepConj_mono (regIs_implies_regOwn .x11)
         (sepConj_mono (regIs_implies_regOwn .x12) (fun _ x => x))))) h hp1
     xperm_hyp hp2
   · -- failure arm: status = 1, value = 0.
-    unfold EvmAsm.Codegen.RlpFieldToU64SAsm.flatFailureReturned at hf
+    unfold EvmAsm.Codegen.RlpFieldToU64StrictSAsm.flatFailureReturned at hf
     obtain ⟨v11, v12, hf⟩ := hf
-    unfold EvmAsm.Codegen.RlpFieldToU64SAsm.failurePayload at hf
+    unfold EvmAsm.Codegen.RlpFieldToU64StrictSAsm.failurePayload at hf
     refine ⟨(1 : Word), (0 : Word), ?_⟩
     obtain ⟨h1, h2, hd, hu, hO, hP⟩ := hf
     obtain ⟨hBig, hRes⟩ := (sepConj_pure_right _).1 hP
@@ -578,7 +578,7 @@ theorem flatPost_normalize (spC hbi validPtr firstBadPtr nN lenBase iW oldOff ol
           regOwn .x5 ** regOwn .x6 ** regOwn .x7 ** regOwn .x13 ** regOwn .x14 **
           regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
           stackFree (spC + signExtend12 (-32 : BitVec 12)) 8 ** bytesRegion hbi bytes **
-          EvmAsm.Codegen.RlpFieldToU64SAsm.savedFrame (spC + signExtend12 (-32 : BitVec 12))
+          EvmAsm.Codegen.RlpFieldToU64StrictSAsm.savedFrame (spC + signExtend12 (-32 : BitVec 12))
             ⟨LinkRA, nN, lenBase⟩)) h := by xperm_hyp hOB
     have hp2 := sepConj_mono memIs_implies_memOwn (sepConj_mono memIs_implies_memOwn
       (sepConj_mono (regIs_implies_regOwn .x11) (sepConj_mono (regIs_implies_regOwn .x12)
@@ -589,14 +589,14 @@ theorem flatPost_normalize (spC hbi validPtr firstBadPtr nN lenBase iW oldOff ol
 /-- K34's 3-slot saved frame, once restored, weakens to the merely-owned frame
     slots the loop invariant carries. -/
 theorem k34SavedFrame_implies_frameSlotsOwn (newSp : Word)
-    (saved : EvmAsm.Codegen.RlpFieldToU64SAsm.Saved) : ∀ h,
-    EvmAsm.Codegen.RlpFieldToU64SAsm.savedFrame newSp saved h →
-    frameSlotsOwn EvmAsm.Codegen.RlpFieldToU64SAsm.frame newSp h := by
+    (saved : EvmAsm.Codegen.RlpFieldToU64StrictSAsm.Saved) : ∀ h,
+    EvmAsm.Codegen.RlpFieldToU64StrictSAsm.savedFrame newSp saved h →
+    frameSlotsOwn EvmAsm.Codegen.RlpFieldToU64StrictSAsm.frame newSp h := by
   intro h hp
-  rw [← EvmAsm.Codegen.RlpFieldToU64SAsm.frameSlotsSaved_frame] at hp
+  rw [← EvmAsm.Codegen.RlpFieldToU64StrictSAsm.frameSlotsSaved_frame] at hp
   exact EvmAsm.Codegen.ChainValidateExtraDataLengthSpec.frameSlotsSaved_implies_frameSlotsOwn
-    EvmAsm.Codegen.RlpFieldToU64SAsm.frame newSp
-    (EvmAsm.Codegen.RlpFieldToU64SAsm.savedVals saved) h hp
+    EvmAsm.Codegen.RlpFieldToU64StrictSAsm.frame newSp
+    (EvmAsm.Codegen.RlpFieldToU64StrictSAsm.savedVals saved) h hp
 
 /-- pcFree discharger covering the assertion atoms used in the dispatch. -/
 local macro "pcfx" : tactic =>
@@ -606,7 +606,7 @@ local macro "pcfx" : tactic =>
       | exact bytesRegion_pcFree _ _ | exact pcFree_frameSlotsOwn _ _
       | exact pcFree_stackFree _ _
       | exact pcFree_wordArrayFrom _ _ _ | unfold savedFrame
-      | unfold EvmAsm.Codegen.RlpFieldToU64SAsm.savedFrame)
+      | unfold EvmAsm.Codegen.RlpFieldToU64StrictSAsm.savedFrame)
 
 /-! ## Status dispatch (instruction 32 onward): tie K34's `Result` to the post
 
@@ -638,11 +638,11 @@ theorem cvbgmIterDispatch
           bigBytes lengths)) :
     cpsTripleWithin (27 + nTail) (D + 128) raIn fullCode
       ((.x1 ↦ᵣ LinkRA) **
-        EvmAsm.Codegen.RlpFieldToU64SAsm.flatPost spC (spC + signExtend12 (-32 : BitVec 12))
+        EvmAsm.Codegen.RlpFieldToU64StrictSAsm.flatPost spC (spC + signExtend12 (-32 : BitVec 12))
           (hdrBaseAt hdrBase lengths i) oldOff oldLen
           (⟨LinkRA, BitVec.ofNat 64 lengths.length, lenBase⟩ :
-            EvmAsm.Codegen.RlpFieldToU64SAsm.Saved)
-          (⟨EvmAsm.Codegen.RlpFieldToU64SAsm.B + 48, hdrBaseAt hdrBase lengths i, Field,
+            EvmAsm.Codegen.RlpFieldToU64StrictSAsm.Saved)
+          (⟨EvmAsm.Codegen.RlpFieldToU64StrictSAsm.B + 48, hdrBaseAt hdrBase lengths i, Field,
             hdrBaseAt hdrBase lengths i, validPtr, firstBadPtr, BitVec.ofNat 64 i⟩ : Saved)
           (bigBytes.drop (hdrOff lengths i)) lengths[i]! 17 **
         (IterPtr ↦ₘ hdrBaseAt hdrBase lengths i) ** (IterI ↦ₘ BitVec.ofNat 64 i) **
@@ -671,7 +671,7 @@ theorem cvbgmIterDispatch
             (dispNorm spC (spC + signExtend12 (-32 : BitVec 12)) (hdrBaseAt hdrBase lengths i)
                 validPtr firstBadPtr (BitVec.ofNat 64 lengths.length) lenBase (BitVec.ofNat 64 i)
                 value status (bigBytes.drop (hdrOff lengths i)) **
-              ⌜EvmAsm.Codegen.RlpFieldToU64SAsm.Result (bigBytes.drop (hdrOff lengths i))
+              ⌜EvmAsm.Codegen.RlpFieldToU64StrictSAsm.Result (bigBytes.drop (hdrOff lengths i))
                 (hdrBaseAt hdrBase lengths i) lengths[i]! 17 status value⌝) **
             ((IterPtr ↦ₘ hdrBaseAt hdrBase lengths i) ** (IterI ↦ₘ BitVec.ofNat 64 i) **
               ((lenBase + BitVec.ofNat 64 (8 * i)) ↦ₘ BitVec.ofNat 64 lengths[i]!) **
@@ -692,7 +692,7 @@ theorem cvbgmIterDispatch
     -- Pull the semantic `Result` out of the precondition.
     refine cpsTripleWithin_weaken (fun h hp => ?hpull) (fun _ hq => hq)
       (cpsTripleWithin_pure_pre
-        (P := EvmAsm.Codegen.RlpFieldToU64SAsm.Result (bigBytes.drop (hdrOff lengths i))
+        (P := EvmAsm.Codegen.RlpFieldToU64StrictSAsm.Result (bigBytes.drop (hdrOff lengths i))
           (hdrBaseAt hdrBase lengths i) lengths[i]! 17 status value)
         (H := (.x1 ↦ᵣ LinkRA) ** (.x2 ↦ᵣ spC) ** (.x8 ↦ᵣ BitVec.ofNat 64 lengths.length) **
           (.x9 ↦ᵣ lenBase) ** (.x18 ↦ᵣ hdrBaseAt hdrBase lengths i) ** (.x19 ↦ᵣ validPtr) **
@@ -703,7 +703,7 @@ theorem cvbgmIterDispatch
           regOwn .x31 ** memOwn RfuOff ** memOwn RfuLen **
           stackFree (spC + signExtend12 (-32 : BitVec 12)) 8 **
           bytesRegion (hdrBaseAt hdrBase lengths i) (bigBytes.drop (hdrOff lengths i)) **
-          EvmAsm.Codegen.RlpFieldToU64SAsm.savedFrame (spC + signExtend12 (-32 : BitVec 12))
+          EvmAsm.Codegen.RlpFieldToU64StrictSAsm.savedFrame (spC + signExtend12 (-32 : BitVec 12))
             ⟨LinkRA, BitVec.ofNat 64 lengths.length, lenBase⟩ **
           (IterPtr ↦ₘ hdrBaseAt hdrBase lengths i) ** (IterI ↦ₘ BitVec.ofNat 64 i) **
           ((lenBase + BitVec.ofNat 64 (8 * i)) ↦ₘ BitVec.ofNat 64 lengths[i]!) **
@@ -730,7 +730,7 @@ theorem cvbgmIterDispatch
             regOwn .x31 ** memOwn RfuOff ** memOwn RfuLen **
             stackFree (spC + signExtend12 (-32 : BitVec 12)) 8 **
             bytesRegion (hdrBaseAt hdrBase lengths i) (bigBytes.drop (hdrOff lengths i)) **
-            EvmAsm.Codegen.RlpFieldToU64SAsm.savedFrame (spC + signExtend12 (-32 : BitVec 12))
+            EvmAsm.Codegen.RlpFieldToU64StrictSAsm.savedFrame (spC + signExtend12 (-32 : BitVec 12))
               ⟨LinkRA, BitVec.ofNat 64 lengths.length, lenBase⟩ **
             (IterPtr ↦ₘ hdrBaseAt hdrBase lengths i) ** (IterI ↦ₘ BitVec.ofNat 64 i) **
             ((lenBase + BitVec.ofNat 64 (8 * i)) ↦ₘ BitVec.ofNat 64 lengths[i]!) **
@@ -767,7 +767,7 @@ theorem cvbgmIterDispatch
                 memOwn RfuOff ** memOwn RfuLen **
                 stackFree (spC + signExtend12 (-32 : BitVec 12)) 8 **
                 bytesRegion (hdrBaseAt hdrBase lengths i) (bigBytes.drop (hdrOff lengths i)) **
-                EvmAsm.Codegen.RlpFieldToU64SAsm.savedFrame (spC + signExtend12 (-32 : BitVec 12))
+                EvmAsm.Codegen.RlpFieldToU64StrictSAsm.savedFrame (spC + signExtend12 (-32 : BitVec 12))
                   ⟨LinkRA, BitVec.ofNat 64 lengths.length, lenBase⟩ **
                 (IterPtr ↦ₘ hdrBaseAt hdrBase lengths i) ** (IterI ↦ₘ BitVec.ofNat 64 i) **
                 ((lenBase + BitVec.ofNat 64 (8 * i)) ↦ₘ BitVec.ofNat 64 lengths[i]!) **
@@ -791,7 +791,7 @@ theorem cvbgmIterDispatch
               regOwn .x14 ** memOwn RfuOff ** memOwn RfuLen **
               stackFree (spC + signExtend12 (-32 : BitVec 12)) 8 **
               bytesRegion (hdrBaseAt hdrBase lengths i) (bigBytes.drop (hdrOff lengths i)) **
-              EvmAsm.Codegen.RlpFieldToU64SAsm.savedFrame (spC + signExtend12 (-32 : BitVec 12))
+              EvmAsm.Codegen.RlpFieldToU64StrictSAsm.savedFrame (spC + signExtend12 (-32 : BitVec 12))
                 ⟨LinkRA, BitVec.ofNat 64 lengths.length, lenBase⟩ **
               ((lenBase + BitVec.ofNat 64 (8 * i)) ↦ₘ BitVec.ofNat 64 lengths[i]!) **
               wordArrayFrom lenBase 0 (lengths.take i) **
@@ -841,7 +841,7 @@ theorem cvbgmIterDispatch
                   memOwn RfuOff ** memOwn RfuLen **
                   stackFree (spC + signExtend12 (-32 : BitVec 12)) 8 **
                   bytesRegion (hdrBaseAt hdrBase lengths i) (bigBytes.drop (hdrOff lengths i)) **
-                  EvmAsm.Codegen.RlpFieldToU64SAsm.savedFrame (spC + signExtend12 (-32 : BitVec 12))
+                  EvmAsm.Codegen.RlpFieldToU64StrictSAsm.savedFrame (spC + signExtend12 (-32 : BitVec 12))
                     ⟨LinkRA, BitVec.ofNat 64 lengths.length, lenBase⟩ **
                   ((lenBase + BitVec.ofNat 64 (8 * i)) ↦ₘ BitVec.ofNat 64 lengths[i]!) **
                   wordArrayFrom lenBase 0 (lengths.take i) **
@@ -861,7 +861,7 @@ theorem cvbgmIterDispatch
                   memOwn RfuOff ** memOwn RfuLen **
                   stackFree (spC + signExtend12 (-32 : BitVec 12)) 8 **
                   bytesRegion (hdrBaseAt hdrBase lengths i) (bigBytes.drop (hdrOff lengths i)) **
-                  EvmAsm.Codegen.RlpFieldToU64SAsm.savedFrame (spC + signExtend12 (-32 : BitVec 12))
+                  EvmAsm.Codegen.RlpFieldToU64StrictSAsm.savedFrame (spC + signExtend12 (-32 : BitVec 12))
                     ⟨LinkRA, BitVec.ofNat 64 lengths.length, lenBase⟩ **
                   ((lenBase + BitVec.ofNat 64 (8 * i)) ↦ₘ BitVec.ofNat 64 lengths[i]!) **
                   wordArrayFrom lenBase 0 (lengths.take i) **
@@ -885,7 +885,7 @@ theorem cvbgmIterDispatch
                       regOwn .x14 ** memOwn RfuOff ** memOwn RfuLen **
                       stackFree (spC + signExtend12 (-32 : BitVec 12)) 8 **
                       bytesRegion (hdrBaseAt hdrBase lengths i) (bigBytes.drop (hdrOff lengths i)) **
-                      EvmAsm.Codegen.RlpFieldToU64SAsm.savedFrame
+                      EvmAsm.Codegen.RlpFieldToU64StrictSAsm.savedFrame
                         (spC + signExtend12 (-32 : BitVec 12))
                         ⟨LinkRA, BitVec.ofNat 64 lengths.length, lenBase⟩ **
                       ((lenBase + BitVec.ofNat 64 (8 * i)) ↦ₘ BitVec.ofNat 64 lengths[i]!) **
@@ -907,7 +907,7 @@ theorem cvbgmIterDispatch
                 (.x28 ↦ᵣ v28) ** (.x29 ↦ᵣ v29) ** (.x30 ↦ᵣ (value &&& Mask)) ** (.x31 ↦ᵣ v31) **
                 (Field ↦ₘ value) ** (IterPtr ↦ₘ hdrBaseAt hdrBase lengths i) **
                 (IterI ↦ₘ BitVec.ofNat 64 i) **
-                EvmAsm.Codegen.RlpFieldToU64SAsm.savedFrame (spC + signExtend12 (-32 : BitVec 12))
+                EvmAsm.Codegen.RlpFieldToU64StrictSAsm.savedFrame (spC + signExtend12 (-32 : BitVec 12))
                   ⟨LinkRA, BitVec.ofNat 64 lengths.length, lenBase⟩ **
                 ((.x10 ↦ᵣ (0 : Word)) ** (validPtr ↦ₘ (0 : Word)) **
                   (firstBadPtr ↦ₘ BitVec.ofNat 64 i) ** (.x1 ↦ᵣ raIn) ** (.x2 ↦ᵣ sp0) **
@@ -952,7 +952,7 @@ theorem cvbgmIterDispatch
                   memOwn RfuOff ** memOwn RfuLen **
                   stackFree (spC + signExtend12 (-32 : BitVec 12)) 8 **
                   bytesRegion (hdrBaseAt hdrBase lengths i) (bigBytes.drop (hdrOff lengths i)) **
-                  EvmAsm.Codegen.RlpFieldToU64SAsm.savedFrame (spC + signExtend12 (-32 : BitVec 12))
+                  EvmAsm.Codegen.RlpFieldToU64StrictSAsm.savedFrame (spC + signExtend12 (-32 : BitVec 12))
                     ⟨LinkRA, BitVec.ofNat 64 lengths.length, lenBase⟩ **
                   ((lenBase + BitVec.ofNat 64 (8 * i)) ↦ₘ BitVec.ofNat 64 lengths[i]!) **
                   wordArrayFrom lenBase 0 (lengths.take i) **
@@ -982,7 +982,7 @@ theorem cvbgmIterDispatch
                 regOwn .x13 ** regOwn .x14 ** memOwn RfuOff ** memOwn RfuLen **
                 stackFree (spC + signExtend12 (-32 : BitVec 12)) 8 **
                 bytesRegion (hdrBaseAt hdrBase lengths i) (bigBytes.drop (hdrOff lengths i)) **
-                EvmAsm.Codegen.RlpFieldToU64SAsm.savedFrame (spC + signExtend12 (-32 : BitVec 12))
+                EvmAsm.Codegen.RlpFieldToU64StrictSAsm.savedFrame (spC + signExtend12 (-32 : BitVec 12))
                   ⟨LinkRA, BitVec.ofNat 64 lengths.length, lenBase⟩ **
                 wordArrayFrom lenBase 0 (lengths.take i) **
                 wordArrayFrom lenBase (i + 1) (lengths.drop (i + 1)) **
@@ -1005,7 +1005,7 @@ theorem cvbgmIterDispatch
                       (.x29 ↦ᵣ BitVec.ofNat 64 lengths[i]!) ** (.x30 ↦ᵣ (value &&& Mask)) ** (.x31 ↦ᵣ v31) **
                       (Field ↦ₘ value) ** (IterPtr ↦ₘ hdrBaseAt hdrBase lengths i) **
                       (IterI ↦ₘ BitVec.ofNat 64 i) **
-                      EvmAsm.Codegen.RlpFieldToU64SAsm.savedFrame
+                      EvmAsm.Codegen.RlpFieldToU64StrictSAsm.savedFrame
                         (spC + signExtend12 (-32 : BitVec 12))
                         ⟨LinkRA, BitVec.ofNat 64 lengths.length, lenBase⟩ **
                       ((.x2 ↦ᵣ spC) ** (.x8 ↦ᵣ BitVec.ofNat 64 lengths.length) **
@@ -1067,7 +1067,7 @@ theorem cvbgmIterDispatch
             regOwn .x31 ** memOwn RfuOff ** memOwn RfuLen **
             stackFree (spC + signExtend12 (-32 : BitVec 12)) 8 **
             bytesRegion (hdrBaseAt hdrBase lengths i) (bigBytes.drop (hdrOff lengths i)) **
-            EvmAsm.Codegen.RlpFieldToU64SAsm.savedFrame (spC + signExtend12 (-32 : BitVec 12))
+            EvmAsm.Codegen.RlpFieldToU64StrictSAsm.savedFrame (spC + signExtend12 (-32 : BitVec 12))
               ⟨LinkRA, BitVec.ofNat 64 lengths.length, lenBase⟩ **
             (IterPtr ↦ₘ hdrBaseAt hdrBase lengths i) ** (IterI ↦ₘ BitVec.ofNat 64 i) **
             ((lenBase + BitVec.ofNat 64 (8 * i)) ↦ₘ BitVec.ofNat 64 lengths[i]!) **
@@ -1085,7 +1085,7 @@ theorem cvbgmIterDispatch
               regOwn .x30 ** regOwn .x31 ** (Field ↦ₘ value) ** memOwn RfuOff ** memOwn RfuLen **
               stackFree (spC + signExtend12 (-32 : BitVec 12)) 8 **
               bytesRegion (hdrBaseAt hdrBase lengths i) (bigBytes.drop (hdrOff lengths i)) **
-              EvmAsm.Codegen.RlpFieldToU64SAsm.savedFrame (spC + signExtend12 (-32 : BitVec 12))
+              EvmAsm.Codegen.RlpFieldToU64StrictSAsm.savedFrame (spC + signExtend12 (-32 : BitVec 12))
                 ⟨LinkRA, BitVec.ofNat 64 lengths.length, lenBase⟩ **
               (IterPtr ↦ₘ hdrBaseAt hdrBase lengths i) ** (IterI ↦ₘ BitVec.ofNat 64 i) **
               ((lenBase + BitVec.ofNat 64 (8 * i)) ↦ₘ BitVec.ofNat 64 lengths[i]!) **
@@ -1107,7 +1107,7 @@ theorem cvbgmIterDispatch
                   regOwn .x30 ** regOwn .x31 ** (Field ↦ₘ value) ** memOwn RfuOff **
                   memOwn RfuLen ** stackFree (spC + signExtend12 (-32 : BitVec 12)) 8 **
                   bytesRegion (hdrBaseAt hdrBase lengths i) (bigBytes.drop (hdrOff lengths i)) **
-                  EvmAsm.Codegen.RlpFieldToU64SAsm.savedFrame (spC + signExtend12 (-32 : BitVec 12))
+                  EvmAsm.Codegen.RlpFieldToU64StrictSAsm.savedFrame (spC + signExtend12 (-32 : BitVec 12))
                     ⟨LinkRA, BitVec.ofNat 64 lengths.length, lenBase⟩ **
                   (IterPtr ↦ₘ hdrBaseAt hdrBase lengths i) ** (IterI ↦ₘ BitVec.ofNat 64 i) **
                   ((lenBase + BitVec.ofNat 64 (8 * i)) ↦ₘ BitVec.ofNat 64 lengths[i]!) **
@@ -1126,7 +1126,7 @@ theorem cvbgmIterDispatch
           EvmAsm.Evm64.bytesRegion_split hdrBase bigBytes (hdrOff lengths i) halign hlen, ← hHB]
         have hp1 : ((Field ↦ₘ value) ** (IterPtr ↦ₘ hdrBaseAt hdrBase lengths i) **
             (IterI ↦ₘ BitVec.ofNat 64 i) **
-            EvmAsm.Codegen.RlpFieldToU64SAsm.savedFrame (spC + signExtend12 (-32 : BitVec 12))
+            EvmAsm.Codegen.RlpFieldToU64StrictSAsm.savedFrame (spC + signExtend12 (-32 : BitVec 12))
               ⟨LinkRA, BitVec.ofNat 64 lengths.length, lenBase⟩ **
             ((.x10 ↦ᵣ status) ** (validPtr ↦ₘ (1 : Word)) **
               (firstBadPtr ↦ₘ BitVec.ofNat 64 i) ** (.x1 ↦ᵣ raIn) ** (.x2 ↦ᵣ sp0) **
@@ -1200,7 +1200,7 @@ theorem cvbgmIter (sp0 spC hdrBase lenBase validPtr firstBadPtr raIn : Word)
       memOwn IterPtr ** memOwn IterI ** regOwn .x1 ** regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
       regOwn .x10 ** regOwn .x11 ** regOwn .x12 ** regOwn .x13 ** regOwn .x14 ** regOwn .x28 **
       regOwn .x29 ** regOwn .x30 ** regOwn .x31 ** (.x0 ↦ᵣ (0 : Word)) **
-      frameSlotsOwn EvmAsm.Codegen.RlpFieldToU64SAsm.frame (spC + signExtend12 (-32 : BitVec 12)) **
+      frameSlotsOwn EvmAsm.Codegen.RlpFieldToU64StrictSAsm.frame (spC + signExtend12 (-32 : BitVec 12)) **
       stackFree (spC + signExtend12 (-32 : BitVec 12)) 8) with hEBody
   refine cpsTripleWithin_weaken (fun h hp => by
     unfold LoopInv payload scratchRegs at hp

--- a/EvmAsm/Codegen/Programs/ChainValidateBlobGasMultipleLoopClose.lean
+++ b/EvmAsm/Codegen/Programs/ChainValidateBlobGasMultipleLoopClose.lean
@@ -29,7 +29,7 @@ local macro "pcfx" : tactic =>
       | exact bytesRegion_pcFree _ _ | exact pcFree_frameSlotsOwn _ _
       | exact pcFree_stackFree _ _
       | exact pcFree_wordArray _ _ | exact pcFree_wordArrayFrom _ _ _ | unfold savedFrame
-      | unfold EvmAsm.Codegen.RlpFieldToU64SAsm.savedFrame)
+      | unfold EvmAsm.Codegen.RlpFieldToU64StrictSAsm.savedFrame)
 
 /-- Step budget for the loop with `r = N − i` iterations remaining: each full
     iteration is `cvbgmIter`'s cost, the exhausted guard + all-valid exit is
@@ -92,7 +92,7 @@ theorem cvbgmLoop (sp0 spC hdrBase lenBase validPtr firstBadPtr raIn : Word)
             payload hdrBase lenBase bigBytes lengths ** regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
             regOwn .x11 ** regOwn .x12 ** regOwn .x13 ** regOwn .x14 ** regOwn .x28 **
             regOwn .x29 ** regOwn .x30 ** regOwn .x31 ** (.x0 ↦ᵣ (0 : Word)) **
-            frameSlotsOwn EvmAsm.Codegen.RlpFieldToU64SAsm.frame
+            frameSlotsOwn EvmAsm.Codegen.RlpFieldToU64StrictSAsm.frame
               (spC + signExtend12 (-32 : BitVec 12)) **
             stackFree (spC + signExtend12 (-32 : BitVec 12)) 8) ** regOwn .x1) **
           regOwn .x10)
@@ -108,7 +108,7 @@ theorem cvbgmLoop (sp0 spC hdrBase lenBase validPtr firstBadPtr raIn : Word)
             payload hdrBase lenBase bigBytes lengths ** regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
             regOwn .x11 ** regOwn .x12 ** regOwn .x13 ** regOwn .x14 ** regOwn .x28 **
             regOwn .x29 ** regOwn .x30 ** regOwn .x31 ** (.x0 ↦ᵣ (0 : Word)) **
-            frameSlotsOwn EvmAsm.Codegen.RlpFieldToU64SAsm.frame
+            frameSlotsOwn EvmAsm.Codegen.RlpFieldToU64StrictSAsm.frame
               (spC + signExtend12 (-32 : BitVec 12)) **
             stackFree (spC + signExtend12 (-32 : BitVec 12)) 8 **
             (.x10 ↦ᵣ o10)) ** regOwn .x1)
@@ -134,7 +134,7 @@ theorem cvbgmLoop (sp0 spC hdrBase lenBase validPtr firstBadPtr raIn : Word)
         (firstBadPtr ↦ₘ (0 : Word)) ** payload hdrBase lenBase bigBytes lengths **
         regOwn .x5 ** regOwn .x6 ** regOwn .x7 ** regOwn .x11 ** regOwn .x12 ** regOwn .x13 **
         regOwn .x14 ** regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
-        (.x0 ↦ᵣ (0 : Word)) ** frameSlotsOwn EvmAsm.Codegen.RlpFieldToU64SAsm.frame
+        (.x0 ↦ᵣ (0 : Word)) ** frameSlotsOwn EvmAsm.Codegen.RlpFieldToU64StrictSAsm.frame
           (spC + signExtend12 (-32 : BitVec 12)) **
         stackFree (spC + signExtend12 (-32 : BitVec 12)) 8 **
         savedFrame spC csaved) (by unfold payload; pcfx) htaken
@@ -143,7 +143,7 @@ theorem cvbgmLoop (sp0 spC hdrBase lenBase validPtr firstBadPtr raIn : Word)
         (payload hdrBase lenBase bigBytes lengths ** regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
           regOwn .x11 ** regOwn .x12 ** regOwn .x13 ** regOwn .x14 ** regOwn .x28 ** regOwn .x29 **
           regOwn .x30 ** regOwn .x31 ** (.x0 ↦ᵣ (0 : Word)) **
-          frameSlotsOwn EvmAsm.Codegen.RlpFieldToU64SAsm.frame
+          frameSlotsOwn EvmAsm.Codegen.RlpFieldToU64StrictSAsm.frame
             (spC + signExtend12 (-32 : BitVec 12)) **
           stackFree (spC + signExtend12 (-32 : BitVec 12)) 8 **
           (validPtr ↦ₘ (1 : Word)) ** (firstBadPtr ↦ₘ (0 : Word)))
@@ -224,7 +224,7 @@ theorem chain_validate_blob_gas_used_multiple_spec_within
         wordArray lenBase lengths ** bytesRegion hdrBase bigBytes **
         memOwn Field ** memOwn RfuOff ** memOwn RfuLen ** memOwn IterPtr ** memOwn IterI **
         regOwn .x6 ** regOwn .x7 ** regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
-        frameSlotsOwn EvmAsm.Codegen.RlpFieldToU64SAsm.frame (spC + signExtend12 (-32 : BitVec 12)) **
+        frameSlotsOwn EvmAsm.Codegen.RlpFieldToU64StrictSAsm.frame (spC + signExtend12 (-32 : BitVec 12)) **
         stackFree (spC + signExtend12 (-32 : BitVec 12)) 8)
       (cvbgmPost sp0 spC (spC + signExtend12 (-32 : BitVec 12)) hdrBase lenBase validPtr
         firstBadPtr ⟨raIn, cs0, cs1, cs2, cs3, cs4, cs5⟩ bigBytes lengths) := by
@@ -238,7 +238,7 @@ theorem chain_validate_blob_gas_used_multiple_spec_within
     (wordArray lenBase lengths ** bytesRegion hdrBase bigBytes **
       memOwn Field ** memOwn RfuOff ** memOwn RfuLen ** memOwn IterPtr ** memOwn IterI **
       regOwn .x6 ** regOwn .x7 ** regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
-      frameSlotsOwn EvmAsm.Codegen.RlpFieldToU64SAsm.frame (spC + signExtend12 (-32 : BitVec 12)) **
+      frameSlotsOwn EvmAsm.Codegen.RlpFieldToU64StrictSAsm.frame (spC + signExtend12 (-32 : BitVec 12)) **
       stackFree (spC + signExtend12 (-32 : BitVec 12)) 8)
     (by pcfx)
     (cpsTripleWithin_extend_code cvbgm_mono
@@ -265,7 +265,7 @@ theorem chain_validate_blob_gas_used_multiple_spec_within
           memOwn Field ** memOwn RfuOff ** memOwn RfuLen ** memOwn IterPtr ** memOwn IterI **
           regOwn .x6 ** regOwn .x7 ** regOwn .x28 ** regOwn .x29 ** regOwn .x30 **
           regOwn .x31 ** (.x0 ↦ᵣ (0 : Word)) **
-          frameSlotsOwn EvmAsm.Codegen.RlpFieldToU64SAsm.frame
+          frameSlotsOwn EvmAsm.Codegen.RlpFieldToU64StrictSAsm.frame
             (spC + signExtend12 (-32 : BitVec 12)) **
           stackFree (spC + signExtend12 (-32 : BitVec 12)) 8)) h := by
       rw [hnWord] at hp; xperm_hyp hp

--- a/EvmAsm/Codegen/Programs/ChainValidateBlobGasMultipleSpec.lean
+++ b/EvmAsm/Codegen/Programs/ChainValidateBlobGasMultipleSpec.lean
@@ -12,7 +12,7 @@
   It is the SECOND `field_to_u64` sibling (a near-copy of
   `chain_validate_blob_gas_used_under_max`), reusing the generic array-loop
   infrastructure (`wordArray`, `hdrOff`/`hdrBaseAt`, the `ret*` exit shapes) and
-  the strict `rlp_field_to_u64` (K34) call.  It differs only in the per-header
+  the strict `rlp_field_to_u64_strict` (K34) call.  It differs only in the per-header
   check: `and x30, x6, x7 ; bne x30, x0` where `x7 = Mask = GAS_PER_BLOB - 1 =
   131071` (built by `lui x7, 32` = `2^17` then `addiw x7, x7, -1`), i.e. a
   power-of-two modulus test `(value &&& Mask) = 0`, in place of the under-max
@@ -36,7 +36,7 @@
 
   Per iteration `i` (`i < N`) the program:
     * loads `len_i := header_lengths[i]` (aligned array load at `x9 + i*8`);
-    * calls the verified strict `rlp_field_to_u64` on the current header
+    * calls the verified strict `rlp_field_to_u64_strict` on the current header
       (base `x18`, list length `len_i`, field index 17, output cell `Field`);
     * on status ≠ 0 → `a0 = status`, `*first_bad = i`, return (parse-fail);
     * else reloads the decoded value, computes `x30 := value &&& Mask` and
@@ -51,7 +51,7 @@
 
 import EvmAsm.Codegen.Programs.ChainValidateBlob
 import EvmAsm.Codegen.Programs.ChainValidateExtraDataLengthLoop
-import EvmAsm.Codegen.Programs.RlpFieldToU64FlatSAsm
+import EvmAsm.Codegen.Programs.RlpFieldToU64StrictFlatSAsm
 import EvmAsm.Rv64.LaResolve
 import EvmAsm.Rv64.Tactics.RunBlock
 
@@ -80,32 +80,32 @@ theorem cvbgm_length : cvbgmProg.length = 68 := by decide
 def cvbgmCode : CodeReq := CodeReq.ofProg D cvbgmProg
 
 /-- The full linked closure: the chain accessor plus the strict K34
-    `rlp_field_to_u64` wrapper and its transitive callees. -/
-def fullCode : CodeReq := cvbgmCode.union EvmAsm.Codegen.RlpFieldToU64SAsm.code
+    `rlp_field_to_u64_strict` wrapper and its transitive callees. -/
+def fullCode : CodeReq := cvbgmCode.union EvmAsm.Codegen.RlpFieldToU64StrictSAsm.code
 
 theorem cvbgm_disjoint :
-    cvbgmCode.Disjoint EvmAsm.Codegen.RlpFieldToU64SAsm.code := by
-  unfold cvbgmCode EvmAsm.Codegen.RlpFieldToU64SAsm.code
-    EvmAsm.Codegen.RlpFieldToU64SAsm.wrapperCode EvmAsm.Codegen.RlpFieldToU64SAsm.contentCode
+    cvbgmCode.Disjoint EvmAsm.Codegen.RlpFieldToU64StrictSAsm.code := by
+  unfold cvbgmCode EvmAsm.Codegen.RlpFieldToU64StrictSAsm.code
+    EvmAsm.Codegen.RlpFieldToU64StrictSAsm.wrapperCode EvmAsm.Codegen.RlpFieldToU64StrictSAsm.contentCode
   refine CodeReq.Disjoint.union_right ?_ (CodeReq.Disjoint.union_right ?_ ?_)
   · apply CodeReq.Disjoint.ofProg_ranges
     · rw [cvbgm_length]; decide
-    · rw [EvmAsm.Codegen.RlpFieldToU64SAsm.program_length]; decide
-    · right; rw [EvmAsm.Codegen.RlpFieldToU64SAsm.program_length]; decide
+    · rw [EvmAsm.Codegen.RlpFieldToU64StrictSAsm.program_length]; decide
+    · left; rw [cvbgm_length]; decide
   · apply CodeReq.Disjoint.ofProg_ranges
     · rw [cvbgm_length]; decide
     · rw [EvmAsm.Codegen.RlpListNthItemSAsm.total_length]; decide
     · right; rw [EvmAsm.Codegen.RlpListNthItemSAsm.total_length]; decide
-  · unfold EvmAsm.Rv64.RLP.rlp_content_to_u64_code
+  · unfold EvmAsm.Rv64.RLP.rlp_content_to_u64_strict_code
     apply CodeReq.Disjoint.ofProg_ranges
     · rw [cvbgm_length]; decide
-    · rw [EvmAsm.Rv64.RLP.rlp_content_to_u64_prog_length]; decide
+    · rw [EvmAsm.Rv64.RLP.rlp_content_to_u64_strict_prog_length]; decide
     · left; rw [cvbgm_length]; decide
 
 
 /-- K34's linked code is subsumed by the chain accessor's full closure. -/
 theorem k34_mono :
-    ∀ a i, EvmAsm.Codegen.RlpFieldToU64SAsm.code a = some i → fullCode a = some i := by
+    ∀ a i, EvmAsm.Codegen.RlpFieldToU64StrictSAsm.code a = some i → fullCode a = some i := by
   intro a i hi
   unfold fullCode
   exact CodeReq.mono_union_right cvbgm_disjoint (fun _ _ h => h) a i hi
@@ -141,7 +141,7 @@ abbrev Mask : Word := (131071 : Word)
 def hdrMultiple (hdrBase : Word) (bigBytes : List (BitVec 8)) (lengths : List Nat)
     (i : Nat) : Prop :=
   ∃ value,
-    EvmAsm.Codegen.RlpFieldToU64SAsm.Result (bigBytes.drop (hdrOff lengths i))
+    EvmAsm.Codegen.RlpFieldToU64StrictSAsm.Result (bigBytes.drop (hdrOff lengths i))
       (hdrBaseAt hdrBase lengths i) (lengths[i]!) 17 0 value ∧
     (value &&& Mask) = 0
 
@@ -150,7 +150,7 @@ def hdrMultiple (hdrBase : Word) (bigBytes : List (BitVec 8)) (lengths : List Na
 def hdrNotMultiple (hdrBase : Word) (bigBytes : List (BitVec 8)) (lengths : List Nat)
     (i : Nat) : Prop :=
   ∃ value,
-    EvmAsm.Codegen.RlpFieldToU64SAsm.Result (bigBytes.drop (hdrOff lengths i))
+    EvmAsm.Codegen.RlpFieldToU64StrictSAsm.Result (bigBytes.drop (hdrOff lengths i))
       (hdrBaseAt hdrBase lengths i) (lengths[i]!) 17 0 value ∧
     (value &&& Mask) ≠ 0
 
@@ -158,7 +158,7 @@ def hdrNotMultiple (hdrBase : Word) (bigBytes : List (BitVec 8)) (lengths : List
 def hdrBadParse (hdrBase : Word) (bigBytes : List (BitVec 8)) (lengths : List Nat)
     (i : Nat) (status : Word) : Prop :=
   ∃ value,
-    EvmAsm.Codegen.RlpFieldToU64SAsm.Result (bigBytes.drop (hdrOff lengths i))
+    EvmAsm.Codegen.RlpFieldToU64StrictSAsm.Result (bigBytes.drop (hdrOff lengths i))
       (hdrBaseAt hdrBase lengths i) (lengths[i]!) 17 status value ∧ status ≠ 0
 
 /-! ## Frames -/
@@ -177,7 +177,7 @@ def scratchRegs (calleeNewSp : Word) : Assertion :=
   regOwn .x1 ** regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
   regOwn .x10 ** regOwn .x11 ** regOwn .x12 ** regOwn .x13 ** regOwn .x14 **
   regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
-  (.x0 ↦ᵣ (0 : Word)) ** frameSlotsOwn EvmAsm.Codegen.RlpFieldToU64SAsm.frame calleeNewSp **
+  (.x0 ↦ᵣ (0 : Word)) ** frameSlotsOwn EvmAsm.Codegen.RlpFieldToU64StrictSAsm.frame calleeNewSp **
   stackFree calleeNewSp 8
 
 /-- Loop invariant at the guard (`D + 68`) entering iteration `i` (`i ≤ N`). -/
@@ -199,7 +199,7 @@ def commonRet (sp0 spC calleeNewSp hdrBase lenBase : Word) (csaved : Saved)
   regOwn .x5 ** regOwn .x6 ** regOwn .x7 ** regOwn .x11 **
   regOwn .x12 ** regOwn .x13 ** regOwn .x14 ** regOwn .x28 ** regOwn .x29 **
   regOwn .x30 ** regOwn .x31 ** (.x0 ↦ᵣ (0 : Word)) **
-  frameSlotsOwn EvmAsm.Codegen.RlpFieldToU64SAsm.frame calleeNewSp **
+  frameSlotsOwn EvmAsm.Codegen.RlpFieldToU64StrictSAsm.frame calleeNewSp **
   stackFree calleeNewSp 8 ** payload hdrBase lenBase bigBytes lengths
 
 /-- All headers under max: `a0 = 0`, `*validPtr = 1`, `*firstBadPtr = 0`, and

--- a/EvmAsm/Codegen/Programs/ChainValidateBlobGasUnderMaxLoop.lean
+++ b/EvmAsm/Codegen/Programs/ChainValidateBlobGasUnderMaxLoop.lean
@@ -4,7 +4,7 @@
   Builds on `ChainValidateBlobGasUnderMaxSpec` (model, prologue, epilogue, exit
   blocks) and reuses the generic array pieces from
   `ChainValidateExtraDataLengthSpec`.  The per-header body differs from the
-  pattern-setter only in the callee (the strict `rlp_field_to_u64` K34 wrapper),
+  pattern-setter only in the callee (the strict `rlp_field_to_u64_strict` K34 wrapper),
   the field index (17), and the check (a `bltu` against 2752512 on the decoded
   u64 rather than a length compare).
 -/
@@ -176,7 +176,7 @@ theorem cvbgumAdvance (hbi lenBase iW : Word) (Li : Nat) (o28 o29 : Word) :
 theorem lengths_getElem_bang {lengths : List Nat} {i : Nat} (hi : i < lengths.length) :
     lengths[i]! = lengths[i] := getElem!_pos lengths i hi
 
-/-! ## Call block (instructions 18--31 + K34): setup ;; jal ;; rlp_field_to_u64
+/-! ## Call block (instructions 18--31 + K34): setup ;; jal ;; rlp_field_to_u64_strict
 
     From the loop-guard fall-through (`D+72`) to the return site (`D+128`),
     producing K34's `flatPost` for header `hbi` (field 17), with the spill
@@ -184,9 +184,9 @@ theorem lengths_getElem_bang {lengths : List Nat} {i : Nat} (hi : i < lengths.le
 
 /-- K34's whole-routine step count for field index 17 (matching the flat
     spec's `((7 + 4 + callSteps) + ((1 + tailSteps) + 5))` with `index = 17`). -/
-def nCall (bytesLen : Nat) : Nat :=
+def nCall (_bytesLen : Nat) : Nat :=
   (7 + 4 + (1 + ((12 + ((85 + 93 * (17 + 2)) + 6)) + 9)))
-    + ((1 + ((7 + (1 + (7 * bytesLen + 11))) + 5)) + 5)
+    + ((1 + ((7 + (1 + (7 * (2 ^ 64 - 1) + 11))) + 5)) + 5)
 
 set_option maxRecDepth 8000 in
 theorem cvbgumCall (hbi lenBase spC iW : Word) (Li : Nat)
@@ -206,14 +206,14 @@ theorem cvbgumCall (hbi lenBase spC iW : Word) (Li : Nat)
         (.x1 ↦ᵣ oldX1) ** (.x8 ↦ᵣ nN) ** (.x19 ↦ᵣ s3) ** (.x20 ↦ᵣ s4) **
         (.x14 ↦ᵣ old14) ** regOwn .x6 ** regOwn .x7 ** regOwn .x29 ** regOwn .x30 **
         regOwn .x31 ** (.x0 ↦ᵣ (0 : Word)) **
-        frameSlotsOwn EvmAsm.Codegen.RlpFieldToU64SAsm.frame (spC + signExtend12 (-32 : BitVec 12)) **
+        frameSlotsOwn EvmAsm.Codegen.RlpFieldToU64StrictSAsm.frame (spC + signExtend12 (-32 : BitVec 12)) **
         stackFree (spC + signExtend12 (-32 : BitVec 12)) 8 **
         (Field ↦ₘ oldOut) ** (RfuOff ↦ₘ oldOff) ** (RfuLen ↦ₘ oldLen) **
         bytesRegion hbi bytes ** savedFrame spC csaved)
       ((.x1 ↦ᵣ LinkRA) **
-        EvmAsm.Codegen.RlpFieldToU64SAsm.flatPost spC (spC + signExtend12 (-32 : BitVec 12)) hbi
-          oldOff oldLen (⟨LinkRA, nN, lenBase⟩ : EvmAsm.Codegen.RlpFieldToU64SAsm.Saved)
-          (⟨EvmAsm.Codegen.RlpFieldToU64SAsm.B + 48, hbi, Field, hbi, s3, s4, iW⟩ : Saved)
+        EvmAsm.Codegen.RlpFieldToU64StrictSAsm.flatPost spC (spC + signExtend12 (-32 : BitVec 12)) hbi
+          oldOff oldLen (⟨LinkRA, nN, lenBase⟩ : EvmAsm.Codegen.RlpFieldToU64StrictSAsm.Saved)
+          (⟨EvmAsm.Codegen.RlpFieldToU64StrictSAsm.B + 48, hbi, Field, hbi, s3, s4, iW⟩ : Saved)
           bytes Li 17 **
         (IterPtr ↦ₘ hbi) ** (IterI ↦ₘ iW) **
         ((lenBase + (iW <<< 3)) ↦ₘ BitVec.ofNat 64 Li) ** savedFrame spC csaved) := by
@@ -225,7 +225,7 @@ theorem cvbgumCall (hbi lenBase spC iW : Word) (Li : Nat)
     ((.x1 ↦ᵣ oldX1) ** (.x8 ↦ᵣ nN) ** (.x19 ↦ᵣ s3) ** (.x20 ↦ᵣ s4) **
       (.x14 ↦ᵣ old14) ** regOwn .x6 ** regOwn .x7 ** regOwn .x29 ** regOwn .x30 **
       regOwn .x31 ** (.x0 ↦ᵣ (0 : Word)) **
-      frameSlotsOwn EvmAsm.Codegen.RlpFieldToU64SAsm.frame calleeNewSp **
+      frameSlotsOwn EvmAsm.Codegen.RlpFieldToU64StrictSAsm.frame calleeNewSp **
       stackFree calleeNewSp 8 **
       (Field ↦ₘ oldOut) ** (RfuOff ↦ₘ oldOff) ** (RfuLen ↦ₘ oldLen) **
       bytesRegion hbi bytes ** savedFrame spC csaved)
@@ -233,19 +233,19 @@ theorem cvbgumCall (hbi lenBase spC iW : Word) (Li : Nat)
                       | exact pcFree_memIs | exact pcFree_memOwn
                       | exact pcFree_frameSlotsOwn _ _ | exact pcFree_stackFree _ _
                       | exact bytesRegion_pcFree _ _) hsetup
-  -- [31] jal x1, rlp_field_to_u64
+  -- [31] jal x1, rlp_field_to_u64_strict
   have hjal := jal_link_spec_within
-    (EvmAsm.Codegen.jalOff GuestAddrs.rlp_field_to_u64
+    (EvmAsm.Codegen.jalOff GuestAddrs.rlp_field_to_u64_strict
       (GuestAddrs.chain_validate_blob_gas_used_under_max + 124)) (D + 124) oldX1
-  rw [show (D + 124) + signExtend21 (EvmAsm.Codegen.jalOff GuestAddrs.rlp_field_to_u64
+  rw [show (D + 124) + signExtend21 (EvmAsm.Codegen.jalOff GuestAddrs.rlp_field_to_u64_strict
       (GuestAddrs.chain_validate_blob_gas_used_under_max + 124))
-      = EvmAsm.Codegen.RlpFieldToU64SAsm.B from by decide,
+      = EvmAsm.Codegen.RlpFieldToU64StrictSAsm.B from by decide,
     show (D + 124 + 4 : Word) = LinkRA from by
       change (D + 124 + 4 : Word) = D + 128; bv_omega] at hjal
   have hjalC := cpsTripleWithin_extend_code cvbgum_mono
     (cpsTripleWithin_extend_code (cr' := cvbgumCode)
       (CodeReq.ofProg_mem_at D (D + 124) cvbgumProg 31
-        (.JAL .x1 (EvmAsm.Codegen.jalOff GuestAddrs.rlp_field_to_u64
+        (.JAL .x1 (EvmAsm.Codegen.jalOff GuestAddrs.rlp_field_to_u64_strict
           (GuestAddrs.chain_validate_blob_gas_used_under_max + 124))) (by bv_omega)
         (by rw [cvbgum_length]; decide) rfl (by rw [cvbgum_length]; decide)) hjal)
   have hjalF := cpsTripleWithin_frameR
@@ -257,7 +257,7 @@ theorem cvbgumCall (hbi lenBase spC iW : Word) (Li : Nat)
       (.x8 ↦ᵣ nN) ** (.x19 ↦ᵣ s3) ** (.x20 ↦ᵣ s4) ** (.x14 ↦ᵣ old14) **
       regOwn .x6 ** regOwn .x7 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
       (.x0 ↦ᵣ (0 : Word)) **
-      frameSlotsOwn EvmAsm.Codegen.RlpFieldToU64SAsm.frame calleeNewSp **
+      frameSlotsOwn EvmAsm.Codegen.RlpFieldToU64StrictSAsm.frame calleeNewSp **
       stackFree calleeNewSp 8 **
       (Field ↦ₘ oldOut) ** (RfuOff ↦ₘ oldOff) ** (RfuLen ↦ₘ oldLen) **
       bytesRegion hbi bytes ** savedFrame spC csaved)
@@ -266,30 +266,30 @@ theorem cvbgumCall (hbi lenBase spC iW : Word) (Li : Nat)
                       | exact pcFree_frameSlotsOwn _ _ | exact pcFree_stackFree _ _
                       | exact bytesRegion_pcFree _ _) hjalC
   -- K34 flat callee, lifted to fullCode, framed with the spill/array/chain payload.
-  have hcallee0 := EvmAsm.Codegen.RlpFieldToU64SAsm.rlpFieldToU64_flat_spec_within
+  have hcallee0 := EvmAsm.Codegen.RlpFieldToU64StrictSAsm.rlpFieldToU64_flat_spec_within
     spC calleeNewSp hbi (BitVec.ofNat 64 Li) (17 : Word) Field oldOut oldOff oldLen old14
-    (⟨LinkRA, nN, lenBase⟩ : EvmAsm.Codegen.RlpFieldToU64SAsm.Saved) hbi s3 s4 iW bytes Li 17
+    (⟨LinkRA, nN, lenBase⟩ : EvmAsm.Codegen.RlpFieldToU64StrictSAsm.Saved) hbi s3 s4 iW bytes Li 17
     hcalleeNewSp rfl (by decide) (by decide)
     hsalign hslack hover hvalid (by show LinkRA &&& ~~~(1 : Word) = LinkRA; decide)
   have hcalleeC := cpsTripleWithin_extend_code k34_mono hcallee0
   -- Present K34's entry footprint as explicit atoms, with `x5`/`x28` shown owned.
-  have hcallee : cpsTripleWithin (nCall bytes.length) EvmAsm.Codegen.RlpFieldToU64SAsm.B LinkRA fullCode
+  have hcallee : cpsTripleWithin (nCall bytes.length) EvmAsm.Codegen.RlpFieldToU64StrictSAsm.B LinkRA fullCode
       (regOwn .x5 ** regOwn .x28 **
         ((.x1 ↦ᵣ LinkRA) ** (.x2 ↦ᵣ spC) ** (.x8 ↦ᵣ nN) ** (.x9 ↦ᵣ lenBase) **
           (.x18 ↦ᵣ hbi) ** (.x19 ↦ᵣ s3) ** (.x20 ↦ᵣ s4) ** (.x21 ↦ᵣ iW) **
           (.x10 ↦ᵣ hbi) ** (.x11 ↦ᵣ BitVec.ofNat 64 Li) ** (.x12 ↦ᵣ (17 : Word)) **
           (.x13 ↦ᵣ Field) ** (.x14 ↦ᵣ old14) ** regOwn .x6 ** regOwn .x7 **
           regOwn .x29 ** regOwn .x30 ** regOwn .x31 ** (.x0 ↦ᵣ (0 : Word)) **
-          frameSlotsOwn EvmAsm.Codegen.RlpFieldToU64SAsm.frame calleeNewSp **
+          frameSlotsOwn EvmAsm.Codegen.RlpFieldToU64StrictSAsm.frame calleeNewSp **
           stackFree calleeNewSp 8 ** bytesRegion hbi bytes **
           (Field ↦ₘ oldOut) ** (RfuOff ↦ₘ oldOff) ** (RfuLen ↦ₘ oldLen)))
       ((.x1 ↦ᵣ LinkRA) **
-        EvmAsm.Codegen.RlpFieldToU64SAsm.flatPost spC calleeNewSp hbi oldOff oldLen
-          (⟨LinkRA, nN, lenBase⟩ : EvmAsm.Codegen.RlpFieldToU64SAsm.Saved)
-          (⟨EvmAsm.Codegen.RlpFieldToU64SAsm.B + 48, hbi, Field, hbi, s3, s4, iW⟩ : Saved)
+        EvmAsm.Codegen.RlpFieldToU64StrictSAsm.flatPost spC calleeNewSp hbi oldOff oldLen
+          (⟨LinkRA, nN, lenBase⟩ : EvmAsm.Codegen.RlpFieldToU64StrictSAsm.Saved)
+          (⟨EvmAsm.Codegen.RlpFieldToU64StrictSAsm.B + 48, hbi, Field, hbi, s3, s4, iW⟩ : Saved)
           bytes Li 17) :=
     cpsTripleWithin_weaken (fun h hp => by
-      unfold EvmAsm.Codegen.RlpFieldToU64SAsm.flatPre EvmAsm.Codegen.RlpFieldToU64SAsm.wholeRest
+      unfold EvmAsm.Codegen.RlpFieldToU64StrictSAsm.flatPre EvmAsm.Codegen.RlpFieldToU64StrictSAsm.wholeRest
       xperm_hyp hp) (fun _ hq => hq) hcalleeC
   have hcalleeF := cpsTripleWithin_frameR
     ((IterPtr ↦ₘ hbi) ** (IterI ↦ₘ iW) **
@@ -305,7 +305,7 @@ theorem cvbgumCall (hbi lenBase spC iW : Word) (Li : Nat)
         (.x10 ↦ᵣ hbi) ** (.x11 ↦ᵣ BitVec.ofNat 64 Li) ** (.x12 ↦ᵣ (17 : Word)) **
         (.x13 ↦ᵣ Field) ** (.x14 ↦ᵣ old14) ** regOwn .x6 ** regOwn .x7 **
         regOwn .x29 ** regOwn .x30 ** regOwn .x31 ** (.x0 ↦ᵣ (0 : Word)) **
-        frameSlotsOwn EvmAsm.Codegen.RlpFieldToU64SAsm.frame calleeNewSp **
+        frameSlotsOwn EvmAsm.Codegen.RlpFieldToU64StrictSAsm.frame calleeNewSp **
         stackFree calleeNewSp 8 ** bytesRegion hbi bytes **
         (Field ↦ₘ oldOut) ** (RfuOff ↦ₘ oldOff) ** (RfuLen ↦ₘ oldLen) **
         (IterPtr ↦ₘ hbi) ** (IterI ↦ₘ iW) **
@@ -336,16 +336,16 @@ theorem cvbgumCallOwned (hbi lenBase spC iW : Word) (Li : Nat)
           (.x8 ↦ᵣ nN) ** (.x19 ↦ᵣ s3) ** (.x20 ↦ᵣ s4) **
           regOwn .x6 ** regOwn .x7 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
           (.x0 ↦ᵣ (0 : Word)) **
-          frameSlotsOwn EvmAsm.Codegen.RlpFieldToU64SAsm.frame (spC + signExtend12 (-32 : BitVec 12)) **
+          frameSlotsOwn EvmAsm.Codegen.RlpFieldToU64StrictSAsm.frame (spC + signExtend12 (-32 : BitVec 12)) **
           stackFree (spC + signExtend12 (-32 : BitVec 12)) 8 **
           (Field ↦ₘ oldOut) ** (RfuOff ↦ₘ oldOff) ** (RfuLen ↦ₘ oldLen) **
           bytesRegion hbi bytes ** savedFrame spC csaved) **
         regOwn .x5 ** regOwn .x10 ** regOwn .x11 ** regOwn .x12 ** regOwn .x13 **
         regOwn .x14 ** regOwn .x28) ** regOwn .x1)
       ((.x1 ↦ᵣ LinkRA) **
-        EvmAsm.Codegen.RlpFieldToU64SAsm.flatPost spC (spC + signExtend12 (-32 : BitVec 12)) hbi
-          oldOff oldLen (⟨LinkRA, nN, lenBase⟩ : EvmAsm.Codegen.RlpFieldToU64SAsm.Saved)
-          (⟨EvmAsm.Codegen.RlpFieldToU64SAsm.B + 48, hbi, Field, hbi, s3, s4, iW⟩ : Saved)
+        EvmAsm.Codegen.RlpFieldToU64StrictSAsm.flatPost spC (spC + signExtend12 (-32 : BitVec 12)) hbi
+          oldOff oldLen (⟨LinkRA, nN, lenBase⟩ : EvmAsm.Codegen.RlpFieldToU64StrictSAsm.Saved)
+          (⟨EvmAsm.Codegen.RlpFieldToU64StrictSAsm.B + 48, hbi, Field, hbi, s3, s4, iW⟩ : Saved)
           bytes Li 17 **
         (IterPtr ↦ₘ hbi) ** (IterI ↦ₘ iW) **
         ((lenBase + (iW <<< 3)) ↦ₘ BitVec.ofNat 64 Li) ** savedFrame spC csaved) := by
@@ -358,16 +358,16 @@ theorem cvbgumCallOwned (hbi lenBase spC iW : Word) (Li : Nat)
           (.x8 ↦ᵣ nN) ** (.x19 ↦ᵣ s3) ** (.x20 ↦ᵣ s4) **
           regOwn .x6 ** regOwn .x7 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
           (.x0 ↦ᵣ (0 : Word)) **
-          frameSlotsOwn EvmAsm.Codegen.RlpFieldToU64SAsm.frame (spC + signExtend12 (-32 : BitVec 12)) **
+          frameSlotsOwn EvmAsm.Codegen.RlpFieldToU64StrictSAsm.frame (spC + signExtend12 (-32 : BitVec 12)) **
           stackFree (spC + signExtend12 (-32 : BitVec 12)) 8 **
           (Field ↦ₘ oldOut) ** (RfuOff ↦ₘ oldOff) ** (RfuLen ↦ₘ oldLen) **
           bytesRegion hbi bytes ** savedFrame spC csaved) ** (.x1 ↦ᵣ v1)) **
         regOwn .x5 ** regOwn .x10 ** regOwn .x11 ** regOwn .x12 ** regOwn .x13 **
         regOwn .x14 ** regOwn .x28)
       ((.x1 ↦ᵣ LinkRA) **
-        EvmAsm.Codegen.RlpFieldToU64SAsm.flatPost spC (spC + signExtend12 (-32 : BitVec 12)) hbi
-          oldOff oldLen (⟨LinkRA, nN, lenBase⟩ : EvmAsm.Codegen.RlpFieldToU64SAsm.Saved)
-          (⟨EvmAsm.Codegen.RlpFieldToU64SAsm.B + 48, hbi, Field, hbi, s3, s4, iW⟩ : Saved)
+        EvmAsm.Codegen.RlpFieldToU64StrictSAsm.flatPost spC (spC + signExtend12 (-32 : BitVec 12)) hbi
+          oldOff oldLen (⟨LinkRA, nN, lenBase⟩ : EvmAsm.Codegen.RlpFieldToU64StrictSAsm.Saved)
+          (⟨EvmAsm.Codegen.RlpFieldToU64StrictSAsm.B + 48, hbi, Field, hbi, s3, s4, iW⟩ : Saved)
           bytes Li 17 **
         (IterPtr ↦ₘ hbi) ** (IterI ↦ₘ iW) **
         ((lenBase + (iW <<< 3)) ↦ₘ BitVec.ofNat 64 Li) ** savedFrame spC csaved) from ?_)
@@ -411,14 +411,14 @@ theorem cvbgumIterEntry (spC hdrBase lenBase validPtr firstBadPtr : Word)
         regOwn .x1 ** regOwn .x5 ** regOwn .x6 ** regOwn .x7 ** regOwn .x10 **
         regOwn .x11 ** regOwn .x12 ** regOwn .x13 ** regOwn .x14 ** regOwn .x28 **
         regOwn .x29 ** regOwn .x30 ** regOwn .x31 ** (.x0 ↦ᵣ (0 : Word)) **
-        frameSlotsOwn EvmAsm.Codegen.RlpFieldToU64SAsm.frame (spC + signExtend12 (-32 : BitVec 12)) **
+        frameSlotsOwn EvmAsm.Codegen.RlpFieldToU64StrictSAsm.frame (spC + signExtend12 (-32 : BitVec 12)) **
         stackFree (spC + signExtend12 (-32 : BitVec 12)) 8)
       ((.x1 ↦ᵣ LinkRA) **
-        EvmAsm.Codegen.RlpFieldToU64SAsm.flatPost spC (spC + signExtend12 (-32 : BitVec 12))
+        EvmAsm.Codegen.RlpFieldToU64StrictSAsm.flatPost spC (spC + signExtend12 (-32 : BitVec 12))
           (hdrBaseAt hdrBase lengths i) oldOff oldLen
           (⟨LinkRA, BitVec.ofNat 64 lengths.length, lenBase⟩ :
-            EvmAsm.Codegen.RlpFieldToU64SAsm.Saved)
-          (⟨EvmAsm.Codegen.RlpFieldToU64SAsm.B + 48, hdrBaseAt hdrBase lengths i, Field,
+            EvmAsm.Codegen.RlpFieldToU64StrictSAsm.Saved)
+          (⟨EvmAsm.Codegen.RlpFieldToU64StrictSAsm.B + 48, hdrBaseAt hdrBase lengths i, Field,
             hdrBaseAt hdrBase lengths i, validPtr, firstBadPtr, BitVec.ofNat 64 i⟩ : Saved)
           (bigBytes.drop (hdrOff lengths i)) lengths[i]! 17 **
         (IterPtr ↦ₘ hdrBaseAt hdrBase lengths i) ** (IterI ↦ₘ BitVec.ofNat 64 i) **
@@ -454,7 +454,7 @@ theorem cvbgumIterEntry (spC hdrBase lenBase validPtr firstBadPtr : Word)
       regOwn .x1 ** regOwn .x5 ** regOwn .x6 ** regOwn .x7 ** regOwn .x10 **
       regOwn .x11 ** regOwn .x12 ** regOwn .x13 ** regOwn .x14 ** regOwn .x28 **
       regOwn .x29 ** regOwn .x30 ** regOwn .x31 ** (.x0 ↦ᵣ (0 : Word)) **
-      frameSlotsOwn EvmAsm.Codegen.RlpFieldToU64SAsm.frame (spC + signExtend12 (-32 : BitVec 12)) **
+      frameSlotsOwn EvmAsm.Codegen.RlpFieldToU64StrictSAsm.frame (spC + signExtend12 (-32 : BitVec 12)) **
       stackFree (spC + signExtend12 (-32 : BitVec 12)) 8)
     (by repeat' first | apply pcFree_sepConj | exact pcFree_regIs | exact pcFree_regOwn
                       | exact pcFree_memIs | exact pcFree_memOwn
@@ -496,26 +496,26 @@ def dispNorm (spC calleeNewSp hbi validPtr firstBadPtr nN lenBase iW value statu
   regOwn .x14 ** regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
   memOwn RfuOff ** memOwn RfuLen ** stackFree calleeNewSp 8 **
   bytesRegion hbi bytes **
-  EvmAsm.Codegen.RlpFieldToU64SAsm.savedFrame calleeNewSp ⟨LinkRA, nN, lenBase⟩
+  EvmAsm.Codegen.RlpFieldToU64StrictSAsm.savedFrame calleeNewSp ⟨LinkRA, nN, lenBase⟩
 
 set_option maxRecDepth 8000 in
 theorem flatPost_normalize (spC hbi validPtr firstBadPtr nN lenBase iW oldOff oldLen : Word)
     (bytes : List (BitVec 8)) (Li : Nat) : ∀ h,
-    (EvmAsm.Codegen.RlpFieldToU64SAsm.flatPost spC (spC + signExtend12 (-32 : BitVec 12)) hbi
-      oldOff oldLen (⟨LinkRA, nN, lenBase⟩ : EvmAsm.Codegen.RlpFieldToU64SAsm.Saved)
-      (⟨EvmAsm.Codegen.RlpFieldToU64SAsm.B + 48, hbi, Field, hbi, validPtr, firstBadPtr, iW⟩ : Saved)
+    (EvmAsm.Codegen.RlpFieldToU64StrictSAsm.flatPost spC (spC + signExtend12 (-32 : BitVec 12)) hbi
+      oldOff oldLen (⟨LinkRA, nN, lenBase⟩ : EvmAsm.Codegen.RlpFieldToU64StrictSAsm.Saved)
+      (⟨EvmAsm.Codegen.RlpFieldToU64StrictSAsm.B + 48, hbi, Field, hbi, validPtr, firstBadPtr, iW⟩ : Saved)
       bytes Li 17) h →
     (∃ status value,
       (dispNorm spC (spC + signExtend12 (-32 : BitVec 12)) hbi validPtr firstBadPtr nN lenBase iW
           value status bytes **
-        ⌜EvmAsm.Codegen.RlpFieldToU64SAsm.Result bytes hbi Li 17 status value⌝) h) := by
+        ⌜EvmAsm.Codegen.RlpFieldToU64StrictSAsm.Result bytes hbi Li 17 status value⌝) h) := by
   intro h hp
-  unfold EvmAsm.Codegen.RlpFieldToU64SAsm.flatPost at hp
+  unfold EvmAsm.Codegen.RlpFieldToU64StrictSAsm.flatPost at hp
   rcases hp with hs | hf
   · -- success arm: status = wrapperStatus, value = outputValue.
-    unfold EvmAsm.Codegen.RlpFieldToU64SAsm.flatSuccessReturned at hs
+    unfold EvmAsm.Codegen.RlpFieldToU64StrictSAsm.flatSuccessReturned at hs
     obtain ⟨offset, len, v12, x5v, scalarStatus, wrapperStatus, outputValue, hs⟩ := hs
-    unfold EvmAsm.Codegen.RlpFieldToU64SAsm.successPayload at hs
+    unfold EvmAsm.Codegen.RlpFieldToU64StrictSAsm.successPayload at hs
     refine ⟨wrapperStatus, outputValue, ?_⟩
     obtain ⟨h1, h2, hd, hu, hO, hP⟩ := hs
     obtain ⟨hBig, hRes⟩ := (sepConj_pure_right _).1 hP
@@ -530,16 +530,16 @@ theorem flatPost_normalize (spC hbi validPtr firstBadPtr nN lenBase iW oldOff ol
           regOwn .x6 ** regOwn .x7 ** regOwn .x13 ** regOwn .x14 ** regOwn .x28 **
           regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
           stackFree (spC + signExtend12 (-32 : BitVec 12)) 8 ** bytesRegion hbi bytes **
-          EvmAsm.Codegen.RlpFieldToU64SAsm.savedFrame (spC + signExtend12 (-32 : BitVec 12))
+          EvmAsm.Codegen.RlpFieldToU64StrictSAsm.savedFrame (spC + signExtend12 (-32 : BitVec 12))
             ⟨LinkRA, nN, lenBase⟩)) h := by xperm_hyp hOB
     have hp2 := sepConj_mono memIs_implies_memOwn (sepConj_mono memIs_implies_memOwn
       (sepConj_mono (regIs_implies_regOwn .x5) (sepConj_mono (regIs_implies_regOwn .x11)
         (sepConj_mono (regIs_implies_regOwn .x12) (fun _ x => x))))) h hp1
     xperm_hyp hp2
   · -- failure arm: status = 1, value = 0.
-    unfold EvmAsm.Codegen.RlpFieldToU64SAsm.flatFailureReturned at hf
+    unfold EvmAsm.Codegen.RlpFieldToU64StrictSAsm.flatFailureReturned at hf
     obtain ⟨v11, v12, hf⟩ := hf
-    unfold EvmAsm.Codegen.RlpFieldToU64SAsm.failurePayload at hf
+    unfold EvmAsm.Codegen.RlpFieldToU64StrictSAsm.failurePayload at hf
     refine ⟨(1 : Word), (0 : Word), ?_⟩
     obtain ⟨h1, h2, hd, hu, hO, hP⟩ := hf
     obtain ⟨hBig, hRes⟩ := (sepConj_pure_right _).1 hP
@@ -554,7 +554,7 @@ theorem flatPost_normalize (spC hbi validPtr firstBadPtr nN lenBase iW oldOff ol
           regOwn .x5 ** regOwn .x6 ** regOwn .x7 ** regOwn .x13 ** regOwn .x14 **
           regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
           stackFree (spC + signExtend12 (-32 : BitVec 12)) 8 ** bytesRegion hbi bytes **
-          EvmAsm.Codegen.RlpFieldToU64SAsm.savedFrame (spC + signExtend12 (-32 : BitVec 12))
+          EvmAsm.Codegen.RlpFieldToU64StrictSAsm.savedFrame (spC + signExtend12 (-32 : BitVec 12))
             ⟨LinkRA, nN, lenBase⟩)) h := by xperm_hyp hOB
     have hp2 := sepConj_mono memIs_implies_memOwn (sepConj_mono memIs_implies_memOwn
       (sepConj_mono (regIs_implies_regOwn .x11) (sepConj_mono (regIs_implies_regOwn .x12)
@@ -565,14 +565,14 @@ theorem flatPost_normalize (spC hbi validPtr firstBadPtr nN lenBase iW oldOff ol
 /-- K34's 3-slot saved frame, once restored, weakens to the merely-owned frame
     slots the loop invariant carries. -/
 theorem k34SavedFrame_implies_frameSlotsOwn (newSp : Word)
-    (saved : EvmAsm.Codegen.RlpFieldToU64SAsm.Saved) : ∀ h,
-    EvmAsm.Codegen.RlpFieldToU64SAsm.savedFrame newSp saved h →
-    frameSlotsOwn EvmAsm.Codegen.RlpFieldToU64SAsm.frame newSp h := by
+    (saved : EvmAsm.Codegen.RlpFieldToU64StrictSAsm.Saved) : ∀ h,
+    EvmAsm.Codegen.RlpFieldToU64StrictSAsm.savedFrame newSp saved h →
+    frameSlotsOwn EvmAsm.Codegen.RlpFieldToU64StrictSAsm.frame newSp h := by
   intro h hp
-  rw [← EvmAsm.Codegen.RlpFieldToU64SAsm.frameSlotsSaved_frame] at hp
+  rw [← EvmAsm.Codegen.RlpFieldToU64StrictSAsm.frameSlotsSaved_frame] at hp
   exact EvmAsm.Codegen.ChainValidateExtraDataLengthSpec.frameSlotsSaved_implies_frameSlotsOwn
-    EvmAsm.Codegen.RlpFieldToU64SAsm.frame newSp
-    (EvmAsm.Codegen.RlpFieldToU64SAsm.savedVals saved) h hp
+    EvmAsm.Codegen.RlpFieldToU64StrictSAsm.frame newSp
+    (EvmAsm.Codegen.RlpFieldToU64StrictSAsm.savedVals saved) h hp
 
 /-- pcFree discharger covering the assertion atoms used in the dispatch. -/
 local macro "pcfx" : tactic =>
@@ -582,7 +582,7 @@ local macro "pcfx" : tactic =>
       | exact bytesRegion_pcFree _ _ | exact pcFree_frameSlotsOwn _ _
       | exact pcFree_stackFree _ _
       | exact pcFree_wordArrayFrom _ _ _ | unfold savedFrame
-      | unfold EvmAsm.Codegen.RlpFieldToU64SAsm.savedFrame)
+      | unfold EvmAsm.Codegen.RlpFieldToU64StrictSAsm.savedFrame)
 
 /-! ## Status dispatch (instruction 32 onward): tie K34's `Result` to the post
 
@@ -614,11 +614,11 @@ theorem cvbgumIterDispatch
           bigBytes lengths)) :
     cpsTripleWithin (25 + nTail) (D + 128) raIn fullCode
       ((.x1 ↦ᵣ LinkRA) **
-        EvmAsm.Codegen.RlpFieldToU64SAsm.flatPost spC (spC + signExtend12 (-32 : BitVec 12))
+        EvmAsm.Codegen.RlpFieldToU64StrictSAsm.flatPost spC (spC + signExtend12 (-32 : BitVec 12))
           (hdrBaseAt hdrBase lengths i) oldOff oldLen
           (⟨LinkRA, BitVec.ofNat 64 lengths.length, lenBase⟩ :
-            EvmAsm.Codegen.RlpFieldToU64SAsm.Saved)
-          (⟨EvmAsm.Codegen.RlpFieldToU64SAsm.B + 48, hdrBaseAt hdrBase lengths i, Field,
+            EvmAsm.Codegen.RlpFieldToU64StrictSAsm.Saved)
+          (⟨EvmAsm.Codegen.RlpFieldToU64StrictSAsm.B + 48, hdrBaseAt hdrBase lengths i, Field,
             hdrBaseAt hdrBase lengths i, validPtr, firstBadPtr, BitVec.ofNat 64 i⟩ : Saved)
           (bigBytes.drop (hdrOff lengths i)) lengths[i]! 17 **
         (IterPtr ↦ₘ hdrBaseAt hdrBase lengths i) ** (IterI ↦ₘ BitVec.ofNat 64 i) **
@@ -647,7 +647,7 @@ theorem cvbgumIterDispatch
             (dispNorm spC (spC + signExtend12 (-32 : BitVec 12)) (hdrBaseAt hdrBase lengths i)
                 validPtr firstBadPtr (BitVec.ofNat 64 lengths.length) lenBase (BitVec.ofNat 64 i)
                 value status (bigBytes.drop (hdrOff lengths i)) **
-              ⌜EvmAsm.Codegen.RlpFieldToU64SAsm.Result (bigBytes.drop (hdrOff lengths i))
+              ⌜EvmAsm.Codegen.RlpFieldToU64StrictSAsm.Result (bigBytes.drop (hdrOff lengths i))
                 (hdrBaseAt hdrBase lengths i) lengths[i]! 17 status value⌝) **
             ((IterPtr ↦ₘ hdrBaseAt hdrBase lengths i) ** (IterI ↦ₘ BitVec.ofNat 64 i) **
               ((lenBase + BitVec.ofNat 64 (8 * i)) ↦ₘ BitVec.ofNat 64 lengths[i]!) **
@@ -668,7 +668,7 @@ theorem cvbgumIterDispatch
     -- Pull the semantic `Result` out of the precondition.
     refine cpsTripleWithin_weaken (fun h hp => ?hpull) (fun _ hq => hq)
       (cpsTripleWithin_pure_pre
-        (P := EvmAsm.Codegen.RlpFieldToU64SAsm.Result (bigBytes.drop (hdrOff lengths i))
+        (P := EvmAsm.Codegen.RlpFieldToU64StrictSAsm.Result (bigBytes.drop (hdrOff lengths i))
           (hdrBaseAt hdrBase lengths i) lengths[i]! 17 status value)
         (H := (.x1 ↦ᵣ LinkRA) ** (.x2 ↦ᵣ spC) ** (.x8 ↦ᵣ BitVec.ofNat 64 lengths.length) **
           (.x9 ↦ᵣ lenBase) ** (.x18 ↦ᵣ hdrBaseAt hdrBase lengths i) ** (.x19 ↦ᵣ validPtr) **
@@ -679,7 +679,7 @@ theorem cvbgumIterDispatch
           regOwn .x31 ** memOwn RfuOff ** memOwn RfuLen **
           stackFree (spC + signExtend12 (-32 : BitVec 12)) 8 **
           bytesRegion (hdrBaseAt hdrBase lengths i) (bigBytes.drop (hdrOff lengths i)) **
-          EvmAsm.Codegen.RlpFieldToU64SAsm.savedFrame (spC + signExtend12 (-32 : BitVec 12))
+          EvmAsm.Codegen.RlpFieldToU64StrictSAsm.savedFrame (spC + signExtend12 (-32 : BitVec 12))
             ⟨LinkRA, BitVec.ofNat 64 lengths.length, lenBase⟩ **
           (IterPtr ↦ₘ hdrBaseAt hdrBase lengths i) ** (IterI ↦ₘ BitVec.ofNat 64 i) **
           ((lenBase + BitVec.ofNat 64 (8 * i)) ↦ₘ BitVec.ofNat 64 lengths[i]!) **
@@ -706,7 +706,7 @@ theorem cvbgumIterDispatch
             regOwn .x31 ** memOwn RfuOff ** memOwn RfuLen **
             stackFree (spC + signExtend12 (-32 : BitVec 12)) 8 **
             bytesRegion (hdrBaseAt hdrBase lengths i) (bigBytes.drop (hdrOff lengths i)) **
-            EvmAsm.Codegen.RlpFieldToU64SAsm.savedFrame (spC + signExtend12 (-32 : BitVec 12))
+            EvmAsm.Codegen.RlpFieldToU64StrictSAsm.savedFrame (spC + signExtend12 (-32 : BitVec 12))
               ⟨LinkRA, BitVec.ofNat 64 lengths.length, lenBase⟩ **
             (IterPtr ↦ₘ hdrBaseAt hdrBase lengths i) ** (IterI ↦ₘ BitVec.ofNat 64 i) **
             ((lenBase + BitVec.ofNat 64 (8 * i)) ↦ₘ BitVec.ofNat 64 lengths[i]!) **
@@ -743,7 +743,7 @@ theorem cvbgumIterDispatch
                 memOwn RfuOff ** memOwn RfuLen **
                 stackFree (spC + signExtend12 (-32 : BitVec 12)) 8 **
                 bytesRegion (hdrBaseAt hdrBase lengths i) (bigBytes.drop (hdrOff lengths i)) **
-                EvmAsm.Codegen.RlpFieldToU64SAsm.savedFrame (spC + signExtend12 (-32 : BitVec 12))
+                EvmAsm.Codegen.RlpFieldToU64StrictSAsm.savedFrame (spC + signExtend12 (-32 : BitVec 12))
                   ⟨LinkRA, BitVec.ofNat 64 lengths.length, lenBase⟩ **
                 (IterPtr ↦ₘ hdrBaseAt hdrBase lengths i) ** (IterI ↦ₘ BitVec.ofNat 64 i) **
                 ((lenBase + BitVec.ofNat 64 (8 * i)) ↦ₘ BitVec.ofNat 64 lengths[i]!) **
@@ -767,7 +767,7 @@ theorem cvbgumIterDispatch
               regOwn .x14 ** memOwn RfuOff ** memOwn RfuLen **
               stackFree (spC + signExtend12 (-32 : BitVec 12)) 8 **
               bytesRegion (hdrBaseAt hdrBase lengths i) (bigBytes.drop (hdrOff lengths i)) **
-              EvmAsm.Codegen.RlpFieldToU64SAsm.savedFrame (spC + signExtend12 (-32 : BitVec 12))
+              EvmAsm.Codegen.RlpFieldToU64StrictSAsm.savedFrame (spC + signExtend12 (-32 : BitVec 12))
                 ⟨LinkRA, BitVec.ofNat 64 lengths.length, lenBase⟩ **
               ((lenBase + BitVec.ofNat 64 (8 * i)) ↦ₘ BitVec.ofNat 64 lengths[i]!) **
               wordArrayFrom lenBase 0 (lengths.take i) **
@@ -814,7 +814,7 @@ theorem cvbgumIterDispatch
                   memOwn RfuOff ** memOwn RfuLen **
                   stackFree (spC + signExtend12 (-32 : BitVec 12)) 8 **
                   bytesRegion (hdrBaseAt hdrBase lengths i) (bigBytes.drop (hdrOff lengths i)) **
-                  EvmAsm.Codegen.RlpFieldToU64SAsm.savedFrame (spC + signExtend12 (-32 : BitVec 12))
+                  EvmAsm.Codegen.RlpFieldToU64StrictSAsm.savedFrame (spC + signExtend12 (-32 : BitVec 12))
                     ⟨LinkRA, BitVec.ofNat 64 lengths.length, lenBase⟩ **
                   ((lenBase + BitVec.ofNat 64 (8 * i)) ↦ₘ BitVec.ofNat 64 lengths[i]!) **
                   wordArrayFrom lenBase 0 (lengths.take i) **
@@ -834,7 +834,7 @@ theorem cvbgumIterDispatch
                   memOwn RfuOff ** memOwn RfuLen **
                   stackFree (spC + signExtend12 (-32 : BitVec 12)) 8 **
                   bytesRegion (hdrBaseAt hdrBase lengths i) (bigBytes.drop (hdrOff lengths i)) **
-                  EvmAsm.Codegen.RlpFieldToU64SAsm.savedFrame (spC + signExtend12 (-32 : BitVec 12))
+                  EvmAsm.Codegen.RlpFieldToU64StrictSAsm.savedFrame (spC + signExtend12 (-32 : BitVec 12))
                     ⟨LinkRA, BitVec.ofNat 64 lengths.length, lenBase⟩ **
                   ((lenBase + BitVec.ofNat 64 (8 * i)) ↦ₘ BitVec.ofNat 64 lengths[i]!) **
                   wordArrayFrom lenBase 0 (lengths.take i) **
@@ -858,7 +858,7 @@ theorem cvbgumIterDispatch
                       regOwn .x14 ** memOwn RfuOff ** memOwn RfuLen **
                       stackFree (spC + signExtend12 (-32 : BitVec 12)) 8 **
                       bytesRegion (hdrBaseAt hdrBase lengths i) (bigBytes.drop (hdrOff lengths i)) **
-                      EvmAsm.Codegen.RlpFieldToU64SAsm.savedFrame
+                      EvmAsm.Codegen.RlpFieldToU64StrictSAsm.savedFrame
                         (spC + signExtend12 (-32 : BitVec 12))
                         ⟨LinkRA, BitVec.ofNat 64 lengths.length, lenBase⟩ **
                       ((lenBase + BitVec.ofNat 64 (8 * i)) ↦ₘ BitVec.ofNat 64 lengths[i]!) **
@@ -880,7 +880,7 @@ theorem cvbgumIterDispatch
                 (.x28 ↦ᵣ v28) ** (.x29 ↦ᵣ v29) ** (.x30 ↦ᵣ v30) ** (.x31 ↦ᵣ v31) **
                 (Field ↦ₘ value) ** (IterPtr ↦ₘ hdrBaseAt hdrBase lengths i) **
                 (IterI ↦ₘ BitVec.ofNat 64 i) **
-                EvmAsm.Codegen.RlpFieldToU64SAsm.savedFrame (spC + signExtend12 (-32 : BitVec 12))
+                EvmAsm.Codegen.RlpFieldToU64StrictSAsm.savedFrame (spC + signExtend12 (-32 : BitVec 12))
                   ⟨LinkRA, BitVec.ofNat 64 lengths.length, lenBase⟩ **
                 ((.x10 ↦ᵣ (0 : Word)) ** (validPtr ↦ₘ (0 : Word)) **
                   (firstBadPtr ↦ₘ BitVec.ofNat 64 i) ** (.x1 ↦ᵣ raIn) ** (.x2 ↦ᵣ sp0) **
@@ -924,7 +924,7 @@ theorem cvbgumIterDispatch
                   memOwn RfuOff ** memOwn RfuLen **
                   stackFree (spC + signExtend12 (-32 : BitVec 12)) 8 **
                   bytesRegion (hdrBaseAt hdrBase lengths i) (bigBytes.drop (hdrOff lengths i)) **
-                  EvmAsm.Codegen.RlpFieldToU64SAsm.savedFrame (spC + signExtend12 (-32 : BitVec 12))
+                  EvmAsm.Codegen.RlpFieldToU64StrictSAsm.savedFrame (spC + signExtend12 (-32 : BitVec 12))
                     ⟨LinkRA, BitVec.ofNat 64 lengths.length, lenBase⟩ **
                   ((lenBase + BitVec.ofNat 64 (8 * i)) ↦ₘ BitVec.ofNat 64 lengths[i]!) **
                   wordArrayFrom lenBase 0 (lengths.take i) **
@@ -954,7 +954,7 @@ theorem cvbgumIterDispatch
                 regOwn .x13 ** regOwn .x14 ** memOwn RfuOff ** memOwn RfuLen **
                 stackFree (spC + signExtend12 (-32 : BitVec 12)) 8 **
                 bytesRegion (hdrBaseAt hdrBase lengths i) (bigBytes.drop (hdrOff lengths i)) **
-                EvmAsm.Codegen.RlpFieldToU64SAsm.savedFrame (spC + signExtend12 (-32 : BitVec 12))
+                EvmAsm.Codegen.RlpFieldToU64StrictSAsm.savedFrame (spC + signExtend12 (-32 : BitVec 12))
                   ⟨LinkRA, BitVec.ofNat 64 lengths.length, lenBase⟩ **
                 wordArrayFrom lenBase 0 (lengths.take i) **
                 wordArrayFrom lenBase (i + 1) (lengths.drop (i + 1)) **
@@ -977,7 +977,7 @@ theorem cvbgumIterDispatch
                       (.x29 ↦ᵣ BitVec.ofNat 64 lengths[i]!) ** (.x30 ↦ᵣ v30) ** (.x31 ↦ᵣ v31) **
                       (Field ↦ₘ value) ** (IterPtr ↦ₘ hdrBaseAt hdrBase lengths i) **
                       (IterI ↦ₘ BitVec.ofNat 64 i) **
-                      EvmAsm.Codegen.RlpFieldToU64SAsm.savedFrame
+                      EvmAsm.Codegen.RlpFieldToU64StrictSAsm.savedFrame
                         (spC + signExtend12 (-32 : BitVec 12))
                         ⟨LinkRA, BitVec.ofNat 64 lengths.length, lenBase⟩ **
                       ((.x2 ↦ᵣ spC) ** (.x8 ↦ᵣ BitVec.ofNat 64 lengths.length) **
@@ -1039,7 +1039,7 @@ theorem cvbgumIterDispatch
             regOwn .x31 ** memOwn RfuOff ** memOwn RfuLen **
             stackFree (spC + signExtend12 (-32 : BitVec 12)) 8 **
             bytesRegion (hdrBaseAt hdrBase lengths i) (bigBytes.drop (hdrOff lengths i)) **
-            EvmAsm.Codegen.RlpFieldToU64SAsm.savedFrame (spC + signExtend12 (-32 : BitVec 12))
+            EvmAsm.Codegen.RlpFieldToU64StrictSAsm.savedFrame (spC + signExtend12 (-32 : BitVec 12))
               ⟨LinkRA, BitVec.ofNat 64 lengths.length, lenBase⟩ **
             (IterPtr ↦ₘ hdrBaseAt hdrBase lengths i) ** (IterI ↦ₘ BitVec.ofNat 64 i) **
             ((lenBase + BitVec.ofNat 64 (8 * i)) ↦ₘ BitVec.ofNat 64 lengths[i]!) **
@@ -1057,7 +1057,7 @@ theorem cvbgumIterDispatch
               regOwn .x30 ** regOwn .x31 ** (Field ↦ₘ value) ** memOwn RfuOff ** memOwn RfuLen **
               stackFree (spC + signExtend12 (-32 : BitVec 12)) 8 **
               bytesRegion (hdrBaseAt hdrBase lengths i) (bigBytes.drop (hdrOff lengths i)) **
-              EvmAsm.Codegen.RlpFieldToU64SAsm.savedFrame (spC + signExtend12 (-32 : BitVec 12))
+              EvmAsm.Codegen.RlpFieldToU64StrictSAsm.savedFrame (spC + signExtend12 (-32 : BitVec 12))
                 ⟨LinkRA, BitVec.ofNat 64 lengths.length, lenBase⟩ **
               (IterPtr ↦ₘ hdrBaseAt hdrBase lengths i) ** (IterI ↦ₘ BitVec.ofNat 64 i) **
               ((lenBase + BitVec.ofNat 64 (8 * i)) ↦ₘ BitVec.ofNat 64 lengths[i]!) **
@@ -1079,7 +1079,7 @@ theorem cvbgumIterDispatch
                   regOwn .x30 ** regOwn .x31 ** (Field ↦ₘ value) ** memOwn RfuOff **
                   memOwn RfuLen ** stackFree (spC + signExtend12 (-32 : BitVec 12)) 8 **
                   bytesRegion (hdrBaseAt hdrBase lengths i) (bigBytes.drop (hdrOff lengths i)) **
-                  EvmAsm.Codegen.RlpFieldToU64SAsm.savedFrame (spC + signExtend12 (-32 : BitVec 12))
+                  EvmAsm.Codegen.RlpFieldToU64StrictSAsm.savedFrame (spC + signExtend12 (-32 : BitVec 12))
                     ⟨LinkRA, BitVec.ofNat 64 lengths.length, lenBase⟩ **
                   (IterPtr ↦ₘ hdrBaseAt hdrBase lengths i) ** (IterI ↦ₘ BitVec.ofNat 64 i) **
                   ((lenBase + BitVec.ofNat 64 (8 * i)) ↦ₘ BitVec.ofNat 64 lengths[i]!) **
@@ -1098,7 +1098,7 @@ theorem cvbgumIterDispatch
           EvmAsm.Evm64.bytesRegion_split hdrBase bigBytes (hdrOff lengths i) halign hlen, ← hHB]
         have hp1 : ((Field ↦ₘ value) ** (IterPtr ↦ₘ hdrBaseAt hdrBase lengths i) **
             (IterI ↦ₘ BitVec.ofNat 64 i) **
-            EvmAsm.Codegen.RlpFieldToU64SAsm.savedFrame (spC + signExtend12 (-32 : BitVec 12))
+            EvmAsm.Codegen.RlpFieldToU64StrictSAsm.savedFrame (spC + signExtend12 (-32 : BitVec 12))
               ⟨LinkRA, BitVec.ofNat 64 lengths.length, lenBase⟩ **
             ((.x10 ↦ᵣ status) ** (validPtr ↦ₘ (1 : Word)) **
               (firstBadPtr ↦ₘ BitVec.ofNat 64 i) ** (.x1 ↦ᵣ raIn) ** (.x2 ↦ᵣ sp0) **
@@ -1172,7 +1172,7 @@ theorem cvbgumIter (sp0 spC hdrBase lenBase validPtr firstBadPtr raIn : Word)
       memOwn IterPtr ** memOwn IterI ** regOwn .x1 ** regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
       regOwn .x10 ** regOwn .x11 ** regOwn .x12 ** regOwn .x13 ** regOwn .x14 ** regOwn .x28 **
       regOwn .x29 ** regOwn .x30 ** regOwn .x31 ** (.x0 ↦ᵣ (0 : Word)) **
-      frameSlotsOwn EvmAsm.Codegen.RlpFieldToU64SAsm.frame (spC + signExtend12 (-32 : BitVec 12)) **
+      frameSlotsOwn EvmAsm.Codegen.RlpFieldToU64StrictSAsm.frame (spC + signExtend12 (-32 : BitVec 12)) **
       stackFree (spC + signExtend12 (-32 : BitVec 12)) 8) with hEBody
   refine cpsTripleWithin_weaken (fun h hp => by
     unfold LoopInv payload scratchRegs at hp

--- a/EvmAsm/Codegen/Programs/ChainValidateBlobGasUnderMaxLoopClose.lean
+++ b/EvmAsm/Codegen/Programs/ChainValidateBlobGasUnderMaxLoopClose.lean
@@ -29,7 +29,7 @@ local macro "pcfx" : tactic =>
       | exact bytesRegion_pcFree _ _ | exact pcFree_frameSlotsOwn _ _
       | exact pcFree_stackFree _ _
       | exact pcFree_wordArray _ _ | exact pcFree_wordArrayFrom _ _ _ | unfold savedFrame
-      | unfold EvmAsm.Codegen.RlpFieldToU64SAsm.savedFrame)
+      | unfold EvmAsm.Codegen.RlpFieldToU64StrictSAsm.savedFrame)
 
 /-- Step budget for the loop with `r = N − i` iterations remaining: each full
     iteration is `cvbgumIter`'s cost, the exhausted guard + all-valid exit is
@@ -92,7 +92,7 @@ theorem cvbgumLoop (sp0 spC hdrBase lenBase validPtr firstBadPtr raIn : Word)
             payload hdrBase lenBase bigBytes lengths ** regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
             regOwn .x11 ** regOwn .x12 ** regOwn .x13 ** regOwn .x14 ** regOwn .x28 **
             regOwn .x29 ** regOwn .x30 ** regOwn .x31 ** (.x0 ↦ᵣ (0 : Word)) **
-            frameSlotsOwn EvmAsm.Codegen.RlpFieldToU64SAsm.frame
+            frameSlotsOwn EvmAsm.Codegen.RlpFieldToU64StrictSAsm.frame
               (spC + signExtend12 (-32 : BitVec 12)) **
             stackFree (spC + signExtend12 (-32 : BitVec 12)) 8) ** regOwn .x1) **
           regOwn .x10)
@@ -108,7 +108,7 @@ theorem cvbgumLoop (sp0 spC hdrBase lenBase validPtr firstBadPtr raIn : Word)
             payload hdrBase lenBase bigBytes lengths ** regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
             regOwn .x11 ** regOwn .x12 ** regOwn .x13 ** regOwn .x14 ** regOwn .x28 **
             regOwn .x29 ** regOwn .x30 ** regOwn .x31 ** (.x0 ↦ᵣ (0 : Word)) **
-            frameSlotsOwn EvmAsm.Codegen.RlpFieldToU64SAsm.frame
+            frameSlotsOwn EvmAsm.Codegen.RlpFieldToU64StrictSAsm.frame
               (spC + signExtend12 (-32 : BitVec 12)) **
             stackFree (spC + signExtend12 (-32 : BitVec 12)) 8 **
             (.x10 ↦ᵣ o10)) ** regOwn .x1)
@@ -134,7 +134,7 @@ theorem cvbgumLoop (sp0 spC hdrBase lenBase validPtr firstBadPtr raIn : Word)
         (firstBadPtr ↦ₘ (0 : Word)) ** payload hdrBase lenBase bigBytes lengths **
         regOwn .x5 ** regOwn .x6 ** regOwn .x7 ** regOwn .x11 ** regOwn .x12 ** regOwn .x13 **
         regOwn .x14 ** regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
-        (.x0 ↦ᵣ (0 : Word)) ** frameSlotsOwn EvmAsm.Codegen.RlpFieldToU64SAsm.frame
+        (.x0 ↦ᵣ (0 : Word)) ** frameSlotsOwn EvmAsm.Codegen.RlpFieldToU64StrictSAsm.frame
           (spC + signExtend12 (-32 : BitVec 12)) **
         stackFree (spC + signExtend12 (-32 : BitVec 12)) 8 **
         savedFrame spC csaved) (by unfold payload; pcfx) htaken
@@ -143,7 +143,7 @@ theorem cvbgumLoop (sp0 spC hdrBase lenBase validPtr firstBadPtr raIn : Word)
         (payload hdrBase lenBase bigBytes lengths ** regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
           regOwn .x11 ** regOwn .x12 ** regOwn .x13 ** regOwn .x14 ** regOwn .x28 ** regOwn .x29 **
           regOwn .x30 ** regOwn .x31 ** (.x0 ↦ᵣ (0 : Word)) **
-          frameSlotsOwn EvmAsm.Codegen.RlpFieldToU64SAsm.frame
+          frameSlotsOwn EvmAsm.Codegen.RlpFieldToU64StrictSAsm.frame
             (spC + signExtend12 (-32 : BitVec 12)) **
           stackFree (spC + signExtend12 (-32 : BitVec 12)) 8 **
           (validPtr ↦ₘ (1 : Word)) ** (firstBadPtr ↦ₘ (0 : Word)))
@@ -222,7 +222,7 @@ theorem chain_validate_blob_gas_used_under_max_spec_within
         wordArray lenBase lengths ** bytesRegion hdrBase bigBytes **
         memOwn Field ** memOwn RfuOff ** memOwn RfuLen ** memOwn IterPtr ** memOwn IterI **
         regOwn .x6 ** regOwn .x7 ** regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
-        frameSlotsOwn EvmAsm.Codegen.RlpFieldToU64SAsm.frame (spC + signExtend12 (-32 : BitVec 12)) **
+        frameSlotsOwn EvmAsm.Codegen.RlpFieldToU64StrictSAsm.frame (spC + signExtend12 (-32 : BitVec 12)) **
         stackFree (spC + signExtend12 (-32 : BitVec 12)) 8)
       (cvbgumPost sp0 spC (spC + signExtend12 (-32 : BitVec 12)) hdrBase lenBase validPtr
         firstBadPtr ⟨raIn, cs0, cs1, cs2, cs3, cs4, cs5⟩ bigBytes lengths) := by
@@ -236,7 +236,7 @@ theorem chain_validate_blob_gas_used_under_max_spec_within
     (wordArray lenBase lengths ** bytesRegion hdrBase bigBytes **
       memOwn Field ** memOwn RfuOff ** memOwn RfuLen ** memOwn IterPtr ** memOwn IterI **
       regOwn .x6 ** regOwn .x7 ** regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
-      frameSlotsOwn EvmAsm.Codegen.RlpFieldToU64SAsm.frame (spC + signExtend12 (-32 : BitVec 12)) **
+      frameSlotsOwn EvmAsm.Codegen.RlpFieldToU64StrictSAsm.frame (spC + signExtend12 (-32 : BitVec 12)) **
       stackFree (spC + signExtend12 (-32 : BitVec 12)) 8)
     (by pcfx)
     (cpsTripleWithin_extend_code cvbgum_mono
@@ -263,7 +263,7 @@ theorem chain_validate_blob_gas_used_under_max_spec_within
           memOwn Field ** memOwn RfuOff ** memOwn RfuLen ** memOwn IterPtr ** memOwn IterI **
           regOwn .x6 ** regOwn .x7 ** regOwn .x28 ** regOwn .x29 ** regOwn .x30 **
           regOwn .x31 ** (.x0 ↦ᵣ (0 : Word)) **
-          frameSlotsOwn EvmAsm.Codegen.RlpFieldToU64SAsm.frame
+          frameSlotsOwn EvmAsm.Codegen.RlpFieldToU64StrictSAsm.frame
             (spC + signExtend12 (-32 : BitVec 12)) **
           stackFree (spC + signExtend12 (-32 : BitVec 12)) 8)) h := by
       rw [hnWord] at hp; xperm_hyp hp

--- a/EvmAsm/Codegen/Programs/ChainValidateBlobGasUnderMaxSpec.lean
+++ b/EvmAsm/Codegen/Programs/ChainValidateBlobGasUnderMaxSpec.lean
@@ -11,7 +11,7 @@
   pattern-setter, reusing the generic array-loop infrastructure
   (`wordArray`, `hdrOff`/`hdrBaseAt`, the `ret*` exit shapes) from
   `ChainValidateExtraDataLengthSpec`.  The per-header body differs: the callee
-  is the strict `rlp_field_to_u64` (K34) wrapper (field decoded to a u64 tied
+  is the strict `rlp_field_to_u64_strict` (K34) wrapper (field decoded to a u64 tied
   to the field bytes via K34's `Result`), and the check is an
   `MAX_BLOB_GAS_PER_BLOCK` `bltu` compare rather than a length compare.
 
@@ -32,7 +32,7 @@
 
   Per iteration `i` (`i < N`) the program:
     * loads `len_i := header_lengths[i]` (aligned array load at `x9 + i*8`);
-    * calls the verified strict `rlp_field_to_u64` on the current header
+    * calls the verified strict `rlp_field_to_u64_strict` on the current header
       (base `x18`, list length `len_i`, field index 17, output cell `Field`);
     * on status ≠ 0 → `a0 = status`, `*first_bad = i`, return (parse-fail);
     * else reloads the decoded value and compares with 2752512
@@ -47,7 +47,7 @@
 
 import EvmAsm.Codegen.Programs.ChainValidateBlob
 import EvmAsm.Codegen.Programs.ChainValidateExtraDataLengthLoop
-import EvmAsm.Codegen.Programs.RlpFieldToU64FlatSAsm
+import EvmAsm.Codegen.Programs.RlpFieldToU64StrictFlatSAsm
 import EvmAsm.Rv64.LaResolve
 import EvmAsm.Rv64.Tactics.RunBlock
 
@@ -76,32 +76,32 @@ theorem cvbgum_length : cvbgumProg.length = 66 := by decide
 def cvbgumCode : CodeReq := CodeReq.ofProg D cvbgumProg
 
 /-- The full linked closure: the chain accessor plus the strict K34
-    `rlp_field_to_u64` wrapper and its transitive callees. -/
-def fullCode : CodeReq := cvbgumCode.union EvmAsm.Codegen.RlpFieldToU64SAsm.code
+    `rlp_field_to_u64_strict` wrapper and its transitive callees. -/
+def fullCode : CodeReq := cvbgumCode.union EvmAsm.Codegen.RlpFieldToU64StrictSAsm.code
 
 theorem cvbgum_disjoint :
-    cvbgumCode.Disjoint EvmAsm.Codegen.RlpFieldToU64SAsm.code := by
-  unfold cvbgumCode EvmAsm.Codegen.RlpFieldToU64SAsm.code
-    EvmAsm.Codegen.RlpFieldToU64SAsm.wrapperCode EvmAsm.Codegen.RlpFieldToU64SAsm.contentCode
+    cvbgumCode.Disjoint EvmAsm.Codegen.RlpFieldToU64StrictSAsm.code := by
+  unfold cvbgumCode EvmAsm.Codegen.RlpFieldToU64StrictSAsm.code
+    EvmAsm.Codegen.RlpFieldToU64StrictSAsm.wrapperCode EvmAsm.Codegen.RlpFieldToU64StrictSAsm.contentCode
   refine CodeReq.Disjoint.union_right ?_ (CodeReq.Disjoint.union_right ?_ ?_)
   · apply CodeReq.Disjoint.ofProg_ranges
     · rw [cvbgum_length]; decide
-    · rw [EvmAsm.Codegen.RlpFieldToU64SAsm.program_length]; decide
-    · right; rw [EvmAsm.Codegen.RlpFieldToU64SAsm.program_length]; decide
+    · rw [EvmAsm.Codegen.RlpFieldToU64StrictSAsm.program_length]; decide
+    · left; rw [cvbgum_length]; decide
   · apply CodeReq.Disjoint.ofProg_ranges
     · rw [cvbgum_length]; decide
     · rw [EvmAsm.Codegen.RlpListNthItemSAsm.total_length]; decide
     · right; rw [EvmAsm.Codegen.RlpListNthItemSAsm.total_length]; decide
-  · unfold EvmAsm.Rv64.RLP.rlp_content_to_u64_code
+  · unfold EvmAsm.Rv64.RLP.rlp_content_to_u64_strict_code
     apply CodeReq.Disjoint.ofProg_ranges
     · rw [cvbgum_length]; decide
-    · rw [EvmAsm.Rv64.RLP.rlp_content_to_u64_prog_length]; decide
+    · rw [EvmAsm.Rv64.RLP.rlp_content_to_u64_strict_prog_length]; decide
     · left; rw [cvbgum_length]; decide
 
 
 /-- K34's linked code is subsumed by the chain accessor's full closure. -/
 theorem k34_mono :
-    ∀ a i, EvmAsm.Codegen.RlpFieldToU64SAsm.code a = some i → fullCode a = some i := by
+    ∀ a i, EvmAsm.Codegen.RlpFieldToU64StrictSAsm.code a = some i → fullCode a = some i := by
   intro a i hi
   unfold fullCode
   exact CodeReq.mono_union_right cvbgum_disjoint (fun _ _ h => h) a i hi
@@ -134,7 +134,7 @@ abbrev MaxBlobGas : Word := (2752512 : Word)
 def hdrUnderMax (hdrBase : Word) (bigBytes : List (BitVec 8)) (lengths : List Nat)
     (i : Nat) : Prop :=
   ∃ value,
-    EvmAsm.Codegen.RlpFieldToU64SAsm.Result (bigBytes.drop (hdrOff lengths i))
+    EvmAsm.Codegen.RlpFieldToU64StrictSAsm.Result (bigBytes.drop (hdrOff lengths i))
       (hdrBaseAt hdrBase lengths i) (lengths[i]!) 17 0 value ∧
     ¬ BitVec.ult MaxBlobGas value
 
@@ -142,7 +142,7 @@ def hdrUnderMax (hdrBase : Word) (bigBytes : List (BitVec 8)) (lengths : List Na
 def hdrOverMax (hdrBase : Word) (bigBytes : List (BitVec 8)) (lengths : List Nat)
     (i : Nat) : Prop :=
   ∃ value,
-    EvmAsm.Codegen.RlpFieldToU64SAsm.Result (bigBytes.drop (hdrOff lengths i))
+    EvmAsm.Codegen.RlpFieldToU64StrictSAsm.Result (bigBytes.drop (hdrOff lengths i))
       (hdrBaseAt hdrBase lengths i) (lengths[i]!) 17 0 value ∧
     BitVec.ult MaxBlobGas value
 
@@ -150,7 +150,7 @@ def hdrOverMax (hdrBase : Word) (bigBytes : List (BitVec 8)) (lengths : List Nat
 def hdrBadParse (hdrBase : Word) (bigBytes : List (BitVec 8)) (lengths : List Nat)
     (i : Nat) (status : Word) : Prop :=
   ∃ value,
-    EvmAsm.Codegen.RlpFieldToU64SAsm.Result (bigBytes.drop (hdrOff lengths i))
+    EvmAsm.Codegen.RlpFieldToU64StrictSAsm.Result (bigBytes.drop (hdrOff lengths i))
       (hdrBaseAt hdrBase lengths i) (lengths[i]!) 17 status value ∧ status ≠ 0
 
 /-! ## Frames -/
@@ -169,7 +169,7 @@ def scratchRegs (calleeNewSp : Word) : Assertion :=
   regOwn .x1 ** regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
   regOwn .x10 ** regOwn .x11 ** regOwn .x12 ** regOwn .x13 ** regOwn .x14 **
   regOwn .x28 ** regOwn .x29 ** regOwn .x30 ** regOwn .x31 **
-  (.x0 ↦ᵣ (0 : Word)) ** frameSlotsOwn EvmAsm.Codegen.RlpFieldToU64SAsm.frame calleeNewSp **
+  (.x0 ↦ᵣ (0 : Word)) ** frameSlotsOwn EvmAsm.Codegen.RlpFieldToU64StrictSAsm.frame calleeNewSp **
   stackFree calleeNewSp 8
 
 /-- Loop invariant at the guard (`D + 68`) entering iteration `i` (`i ≤ N`). -/
@@ -191,7 +191,7 @@ def commonRet (sp0 spC calleeNewSp hdrBase lenBase : Word) (csaved : Saved)
   regOwn .x5 ** regOwn .x6 ** regOwn .x7 ** regOwn .x11 **
   regOwn .x12 ** regOwn .x13 ** regOwn .x14 ** regOwn .x28 ** regOwn .x29 **
   regOwn .x30 ** regOwn .x31 ** (.x0 ↦ᵣ (0 : Word)) **
-  frameSlotsOwn EvmAsm.Codegen.RlpFieldToU64SAsm.frame calleeNewSp **
+  frameSlotsOwn EvmAsm.Codegen.RlpFieldToU64StrictSAsm.frame calleeNewSp **
   stackFree calleeNewSp 8 ** payload hdrBase lenBase bigBytes lengths
 
 /-- All headers under max: `a0 = 0`, `*validPtr = 1`, `*firstBadPtr = 0`, and

--- a/EvmAsm/Codegen/Programs/ExcessBlobGasAtBlockHash.lean
+++ b/EvmAsm/Codegen/Programs/ExcessBlobGasAtBlockHash.lean
@@ -116,7 +116,8 @@ def ziskExcessBlobGasAtBlockHashPrologue : String :=
   zkvmKeccak256Function ++ "\n" ++
   witnessLookupByHashFunction ++ "\n" ++
   rlpListNthItemFunction ++ "\n" ++
-  rlpFieldToU64Function ++ "\n" ++
+  rlpContentToU64StrictFunction ++ "\n" ++
+  rlpFieldToU64StrictFunction ++ "\n" ++
   headerExtractExcessBlobGasFunction ++ "\n" ++
   excessBlobGasAtBlockHashFunction ++ "\n" ++
   ".Lebgbh_pdone:"

--- a/EvmAsm/Codegen/Programs/ExcessBlobGasAtBlockNumber.lean
+++ b/EvmAsm/Codegen/Programs/ExcessBlobGasAtBlockNumber.lean
@@ -159,7 +159,8 @@ def ziskExcessBlobGasAtBlockNumberPrologue : String :=
   "  sd a0, 0(t0)\n" ++
   "  j .Lebgn_pdone\n" ++
   rlpListNthItemFunction ++ "\n" ++
-  rlpFieldToU64Function ++ "\n" ++
+  rlpContentToU64StrictFunction ++ "\n" ++
+  rlpFieldToU64StrictFunction ++ "\n" ++
   headerExtractNumberFunction ++ "\n" ++
   headerExtractExcessBlobGasFunction ++ "\n" ++
   excessBlobGasAtBlockNumberFunction ++ "\n" ++

--- a/EvmAsm/Codegen/Programs/Header.lean
+++ b/EvmAsm/Codegen/Programs/Header.lean
@@ -32,7 +32,16 @@
     K75  validate_header_full
 
   No proofs yet -- these are codegen `String` defs only.
--/
+
+  Header scalar routing (Amsterdam `blocks.py` / `SpecRef.Types`):
+    `number : Uint`       -> lenient K34
+    `gas_limit : Uint`    -> lenient K34
+    `gas_used : Uint`     -> lenient K34
+    `timestamp : U256`    -> lenient path (the guest's u64 projection)
+    `blob_gas_used : U64` -> strict K34
+    `excess_blob_gas : U64` -> strict K34
+  The per-field reference type, rather than the shared header location, is
+  what selects the decoder family. -/
 
 import EvmAsm.Rv64.Program
 import EvmAsm.Codegen.Layout
@@ -96,7 +105,7 @@ def headerExtractBlobGasPairFunction : String :=
   "  # Field 17: blob_gas_used → out[0..8]\n" ++
   "  mv a0, s0; mv a1, s1; li a2, 17\n" ++
   "  mv a3, s2\n" ++
-  "  jal ra, rlp_field_to_u64\n" ++
+  "  jal ra, rlp_field_to_u64_strict\n" ++
   "  beqz a0, .Lhebgp_f18\n" ++
   "  sd zero, 0(s2); sd zero, 8(s2)\n" ++
   "  li a0, 1\n" ++
@@ -105,7 +114,7 @@ def headerExtractBlobGasPairFunction : String :=
   "  # Field 18: excess_blob_gas → out[8..16]\n" ++
   "  mv a0, s0; mv a1, s1; li a2, 18\n" ++
   "  addi a3, s2, 8\n" ++
-  "  jal ra, rlp_field_to_u64\n" ++
+  "  jal ra, rlp_field_to_u64_strict\n" ++
   "  beqz a0, .Lhebgp_ok\n" ++
   "  sd zero, 0(s2); sd zero, 8(s2)\n" ++
   "  li a0, 2\n" ++
@@ -133,7 +142,8 @@ def ziskHeaderExtractBlobGasPairPrologue : String :=
   "  sd a0, 0(t0)                # status\n" ++
   "  j .Lhebgp_pdone\n" ++
   rlpListNthItemFunction ++ "\n" ++
-  rlpFieldToU64Function ++ "\n" ++
+  rlpContentToU64StrictFunction ++ "\n" ++
+  rlpFieldToU64StrictFunction ++ "\n" ++
   headerExtractBlobGasPairFunction ++ "\n" ++
   ".Lhebgp_pdone:"
 
@@ -206,7 +216,7 @@ def blockValidateBlobGasMaxCapFunction : String :=
   "  # a0,a1 still hold (header_ptr, header_len).\n" ++
   "  li a2, 17\n" ++
   "  la a3, bvbmc_bgu\n" ++
-  "  jal ra, rlp_field_to_u64\n" ++
+  "  jal ra, rlp_field_to_u64_strict\n" ++
   "  beqz a0, .Lbvbmc_step2\n" ++
   "  li a0, 1\n" ++
   "  j .Lbvbmc_ret\n" ++
@@ -247,7 +257,8 @@ def ziskBlockValidateBlobGasMaxCapPrologue : String :=
   "  sd a0, 0(t0)                # status\n" ++
   "  j .Lbvbmc_pdone\n" ++
   rlpListNthItemFunction ++ "\n" ++
-  rlpFieldToU64Function ++ "\n" ++
+  rlpContentToU64StrictFunction ++ "\n" ++
+  rlpFieldToU64StrictFunction ++ "\n" ++
   blockValidateBlobGasMaxCapFunction ++ "\n" ++
   ".Lbvbmc_pdone:"
 

--- a/EvmAsm/Codegen/Programs/HeaderDecode.lean
+++ b/EvmAsm/Codegen/Programs/HeaderDecode.lean
@@ -50,7 +50,9 @@ open EvmAsm.Rv64.Program
                      or timestamp > 8 bytes BE).
 
      Composes the cursor walker (`rlp_walk_init` +
-     `rlp_walk_next` + `rlp_content_to_u64`). The four wanted
+     `rlp_walk_next` + `rlp_content_to_u64`). The scalar fields remain on the
+     lenient path where their reference types are `Uint`/`U256`; the two U64
+     blob fields use `rlp_content_to_u64_strict`. The four wanted
      fields live at indices {0,3,8,11}; the walker visits the
      first 12 items once (single O(N) pass), capturing the four
      wanted fields and skipping the eight in between. The hash
@@ -338,7 +340,7 @@ def headerExtendedDecode_prog : Program :=
     .BNE .x11 .x0 (72 : BitVec 13),
     .SUB .x10 .x10 .x12,
     .MV .x11 .x12,
-    .JAL .x1 (jalOff GuestAddrs.rlp_content_to_u64 (GuestAddrs.header_extended_decode + 604)),
+    .JAL .x1 (jalOff GuestAddrs.rlp_content_to_u64_strict (GuestAddrs.header_extended_decode + 604)),
     .BNE .x11 .x0 (56 : BitVec 13),
     .SD .x18 .x10 (128 : BitVec 12),
     .MV .x10 .x19,
@@ -348,7 +350,7 @@ def headerExtendedDecode_prog : Program :=
     .BNE .x11 .x0 (32 : BitVec 13),
     .SUB .x10 .x10 .x12,
     .MV .x11 .x12,
-    .JAL .x1 (jalOff GuestAddrs.rlp_content_to_u64 (GuestAddrs.header_extended_decode + 644)),
+    .JAL .x1 (jalOff GuestAddrs.rlp_content_to_u64_strict (GuestAddrs.header_extended_decode + 644)),
     .BNE .x11 .x0 (16 : BitVec 13),
     .SD .x18 .x10 (136 : BitVec 12),
     .LI .x10 (0 : Word),
@@ -390,9 +392,9 @@ def headerExtendedDecode_relocs : RelocTable :=
     (137, .jal .x1 "rlp_content_to_u256_be"),
     (141, .jal .x1 "rlp_walk_next"),
     (146, .jal .x1 "rlp_walk_next"),
-    (151, .jal .x1 "rlp_content_to_u64"),
+    (151, .jal .x1 "rlp_content_to_u64_strict"),
     (156, .jal .x1 "rlp_walk_next"),
-    (161, .jal .x1 "rlp_content_to_u64") ]
+    (161, .jal .x1 "rlp_content_to_u64_strict") ]
 
 def headerExtendedDecodeFunction : String :=
   "header_extended_decode:\n" ++ emitProgramR headerExtendedDecode_prog headerExtendedDecode_relocs
@@ -428,6 +430,7 @@ def ziskHeaderExtendedDecodePrologue : String :=
   "  sd a0, 0(t0)\n" ++
   "  j .Lhed_pdone\n" ++
   rlpWalkHelpersClosure ++ "\n" ++
+  rlpContentToU64StrictFunction ++ "\n" ++
   headerExtendedDecodeFunction ++ "\n" ++
   ".Lhed_pdone:"
 

--- a/EvmAsm/Codegen/Programs/HeaderExtractNumberBridge.lean
+++ b/EvmAsm/Codegen/Programs/HeaderExtractNumberBridge.lean
@@ -1,7 +1,7 @@
 /-
   EvmAsm.Codegen.Programs.HeaderExtractNumberBridge
 
-  Model tie for #11351: from `rlp_field_to_u64`'s `Result` at field index 8,
+  Model tie for #11351: from the lenient `rlp_field_to_u64` `Result` at field index 8,
   read off the value the model's `_decode_header` assigns to `number`.
 
   The machine side is `HeaderExtractNumberSpec.header_extract_number_spec_within`;
@@ -35,7 +35,7 @@ open EvmAsm.Rv64 EvmAsm.Rv64.RLP EvmAsm.EL.RLP
 open EvmAsm.Codegen.RlpFieldToU64SAsm
 open EvmAsm.Codegen.RlpListNthItemSAsm
 
-/-- **The value tie.**  Under the two strictness restrictions, the guest
+/-- **The value tie.**  Under the explicit width assumption, the lenient guest
     reports success and its output is the big-endian decode of the field
     content — which is exactly what `bytesBEtoNat` computes on the port side. -/
 theorem result_value_of_success

--- a/EvmAsm/Codegen/Programs/HeaderExtractNumberSpec.lean
+++ b/EvmAsm/Codegen/Programs/HeaderExtractNumberSpec.lean
@@ -3,12 +3,12 @@
 
   `headerExtractNumber_prog` allocates a 16-byte frame, saves `ra`, shuffles
   its arguments (`a3 := a2` output pointer, `a2 := 8` field index), tail-calls
-  the verified strict `rlp_field_to_u64` selector, then restores `ra`,
+  the verified lenient `rlp_field_to_u64` selector, then restores `ra`,
   deallocates, and returns.  Its whole-program contract is therefore
 
       prologue  ;;  rlpFieldToU64_flat_spec_within  ;;  epilogue
 
-  and its success post pins the caller's output cell to the canonical
+  and its success post pins the caller's output cell to the
   big-endian decode of the real field-8 content (via K34's `Result`).
 -/
 
@@ -20,7 +20,11 @@ namespace EvmAsm.Codegen.HeaderExtractNumberSpec
 open EvmAsm.Rv64 EvmAsm.Rv64.RLP EvmAsm.Rv64.SAsm
 open EvmAsm.Codegen.RlpFieldToU64SAsm
 
-/-! ## Base addresses and linked code -/
+/-! ## Base addresses and linked code
+
+    Header field 8 (`number`) is `Uint` in the reference model, so this
+    wrapper intentionally uses the lenient K34 path.  The machine-side width
+    assumption remains explicit in the bridge below. -/
 
 abbrev H : Word := (GuestAddrs.header_extract_number : Word)
 
@@ -29,7 +33,7 @@ theorem hdr_length : headerExtractNumber_prog.length = 8 := by decide
 /-- The wrapper's own re-emitted instructions at `header_extract_number`. -/
 def hdrCode : CodeReq := CodeReq.ofProg H headerExtractNumber_prog
 
-/-- The full linked closure: this wrapper plus the strict K34 selector and its
+/-- The full linked closure: this wrapper plus the lenient K34 selector and its
     transitive callees. -/
 def fullCode : CodeReq := hdrCode.union EvmAsm.Codegen.RlpFieldToU64SAsm.code
 
@@ -92,9 +96,9 @@ def hdrPre
   (outputPtr ↦ₘ oldOut) ** (offsetCell ↦ₘ oldOffset) **
   (lengthCell ↦ₘ oldLen)
 
-/-- Success return: `a0 = 0` (or the empty/canonical join encoded in K34's
-    `Result`), and the output cell `saved.s1 = outputPtr` holds the canonical
-    big-endian decode of the field-8 content (pinned inside `successPayload`'s
+/-- Success return: `a0 = 0` (or the empty join encoded in K34's `Result`),
+    and the output cell `saved.s1 = outputPtr` holds the big-endian decode of
+    the field-8 content (pinned inside `successPayload`'s
     `Result`). -/
 def hdrSuccess
     (sp0 spH newSp raIn listBase : Word) (outer : Saved)
@@ -367,7 +371,7 @@ theorem hdrEpilogue
 set_option maxRecDepth 8000 in
 /-- **`header_extract_number` caller contract.**  The 8-instruction wrapper =
     prologue ;; `rlpFieldToU64_flat_spec_within` (field index 8) ;; epilogue.
-    On `a0 = 0` the caller's output cell holds the canonical big-endian decode
+    On `a0 = 0` the caller's output cell holds the big-endian decode
     of the real field-8 content (pinned inside `successPayload`'s `Result`);
     `a0 = 1` is an RLP parse failure and `a0 = 2` a field wider than 8 bytes,
     both with a zeroed output cell. -/
@@ -403,7 +407,7 @@ theorem header_extract_number_spec_within
   have hpro := hdrPrologue sp0 raIn oldRaSlot spH newSp listBase listLenW
     outputPtr old13 old14 oldOut oldOffset oldLen s0In s1In s2 s3 s4 s5 outer
     bytes rfl hspH
-  -- Call: instruction 4 (jal) + strict K34.
+  -- Call: instruction 4 (jal) + lenient K34.
   have hflat := rlpFieldToU64_flat_spec_within spH newSp listBase listLenW
     (8 : Word) outputPtr oldOut oldOffset oldLen old14 outer s2 s3 s4 s5 bytes
     listLen 8 hnewSp hlistLenW (by decide) (by decide) hsalign hslack hover

--- a/EvmAsm/Codegen/Programs/HeaderGasLimits.lean
+++ b/EvmAsm/Codegen/Programs/HeaderGasLimits.lean
@@ -438,7 +438,7 @@ def chainExtractExcessBlobGasFirstLastFunction : String :=
   "  mv a0, s2\n" ++
   "  li a2, 18\n" ++
   "  mv a3, s3\n" ++
-  "  jal ra, rlp_field_to_u64\n" ++
+  "  jal ra, rlp_field_to_u64_strict\n" ++
   "  bnez a0, .Lceebgfl_propagate\n" ++
   "  # Advance to last header\n" ++
   "  mv t1, s2\n" ++
@@ -456,7 +456,7 @@ def chainExtractExcessBlobGasFirstLastFunction : String :=
   "  mv a0, t1\n" ++
   "  li a2, 18\n" ++
   "  mv a3, s4\n" ++
-  "  jal ra, rlp_field_to_u64\n" ++
+  "  jal ra, rlp_field_to_u64_strict\n" ++
   "  bnez a0, .Lceebgfl_propagate\n" ++
   "  li a0, 0\n" ++
   "  j .Lceebgfl_ret\n" ++
@@ -485,7 +485,8 @@ def ziskChainExtractExcessBlobGasFirstLastPrologue : String :=
   "  sd a0, 0(t0)\n" ++
   "  j .Lceebgfl_pdone\n" ++
   rlpListNthItemFunction ++ "\n" ++
-  rlpFieldToU64Function ++ "\n" ++
+  rlpContentToU64StrictFunction ++ "\n" ++
+  rlpFieldToU64StrictFunction ++ "\n" ++
   chainExtractExcessBlobGasFirstLastFunction ++ "\n" ++
   ".Lceebgfl_pdone:"
 

--- a/EvmAsm/Codegen/Programs/HeaderU64.lean
+++ b/EvmAsm/Codegen/Programs/HeaderU64.lean
@@ -10,7 +10,7 @@
     K217  header_extract_nonce            (field 14, 8 B BE u64)
     K218  header_validate_nonce_zero      (field 14 all-zero)
     K219  header_validate_difficulty_zero (field 7 length 0)
-    K233  header_extract_number           (field 8,  u64)
+    K233  header_extract_number           (field 8,  Uint projected to u64)
 
   All six functions are thin wrappers around `rlp_list_nth_item`
   + `rlp_field_to_u64` (or a small byte-level body), depending
@@ -444,7 +444,9 @@ def ziskHeaderValidateDifficultyZeroProbeUnit : BuildUnit := {
 
 /-! ## header_extract_number -- PR-K233
 
-    Extract `block.number` (field 8, u64 BE) from a header RLP.
+    Extract `block.number` (field 8, reference `Uint`, projected to u64 BE)
+    from a header RLP.  `Uint` is intentionally routed through lenient K34;
+    the caller's width assumption is recorded by HeaderExtractNumberBridge.
     Cross-fork — every header has a number.
 
     Calling convention:
@@ -641,7 +643,7 @@ def headerExtractBlobGasUsedFunction : String :=
   "  sd ra, 0(sp)\n" ++
   "  mv a3, a2\n" ++
   "  li a2, 17\n" ++
-  "  jal ra, rlp_field_to_u64\n" ++
+  "  jal ra, rlp_field_to_u64_strict\n" ++
   "  ld ra, 0(sp)\n" ++
   "  addi sp, sp, 16\n" ++
   "  ret"
@@ -657,7 +659,8 @@ def ziskHeaderExtractBlobGasUsedPrologue : String :=
   "  sd a0, 0(t0)\n" ++
   "  j .Lhebgu_pdone\n" ++
   rlpListNthItemFunction ++ "\n" ++
-  rlpFieldToU64Function ++ "\n" ++
+  rlpContentToU64StrictFunction ++ "\n" ++
+  rlpFieldToU64StrictFunction ++ "\n" ++
   headerExtractBlobGasUsedFunction ++ "\n" ++
   ".Lhebgu_pdone:"
 
@@ -705,7 +708,7 @@ def headerExtractExcessBlobGasFunction : String :=
   "  sd ra, 0(sp)\n" ++
   "  mv a3, a2\n" ++
   "  li a2, 18\n" ++
-  "  jal ra, rlp_field_to_u64\n" ++
+  "  jal ra, rlp_field_to_u64_strict\n" ++
   "  ld ra, 0(sp)\n" ++
   "  addi sp, sp, 16\n" ++
   "  ret"
@@ -721,7 +724,8 @@ def ziskHeaderExtractExcessBlobGasPrologue : String :=
   "  sd a0, 0(t0)\n" ++
   "  j .Lhebg_pdone\n" ++
   rlpListNthItemFunction ++ "\n" ++
-  rlpFieldToU64Function ++ "\n" ++
+  rlpContentToU64StrictFunction ++ "\n" ++
+  rlpFieldToU64StrictFunction ++ "\n" ++
   headerExtractExcessBlobGasFunction ++ "\n" ++
   ".Lhebg_pdone:"
 

--- a/scripts/asm-fixtures/chainValidateBlobGasUsedMultipleFunction.s
+++ b/scripts/asm-fixtures/chainValidateBlobGasUsedMultipleFunction.s
@@ -16,7 +16,7 @@ chain_validate_blob_gas_used_multiple:
   ld a1, 0(t3)
   mv a0, s2; li a2, 17
   la a3, cvbgm_field
-  jal ra, rlp_field_to_u64
+  jal ra, rlp_field_to_u64_strict
   bnez a0, .Lcvbgm_propagate
   la t0, cvbgm_iter_ptr; ld s2, 0(t0)
   la t0, cvbgm_iter_i;   ld s5, 0(t0)

--- a/scripts/asm-fixtures/chainValidateBlobGasUsedUnderMaxFunction.s
+++ b/scripts/asm-fixtures/chainValidateBlobGasUsedUnderMaxFunction.s
@@ -16,7 +16,7 @@ chain_validate_blob_gas_used_under_max:
   ld a1, 0(t3)
   mv a0, s2; li a2, 17
   la a3, cvbgum_field
-  jal ra, rlp_field_to_u64
+  jal ra, rlp_field_to_u64_strict
   bnez a0, .Lcvbgum_propagate
   la t0, cvbgum_iter_ptr; ld s2, 0(t0)
   la t0, cvbgum_iter_i;   ld s5, 0(t0)

--- a/scripts/asm-fixtures/headerExtendedDecodeFunction.s
+++ b/scripts/asm-fixtures/headerExtendedDecodeFunction.s
@@ -89,13 +89,13 @@ header_extended_decode:
   # field 17: blob_gas_used (u64 @ struct+128)
   mv a0, s3; mv a1, s1; jal ra, rlp_walk_next
   mv s3, a0; bnez a1, .Lhed_fail
-  sub a0, a0, a2; mv a1, a2; jal ra, rlp_content_to_u64
+  sub a0, a0, a2; mv a1, a2; jal ra, rlp_content_to_u64_strict
   bnez a1, .Lhed_fail
   sd a0, 128(s2)
   # field 18: excess_blob_gas (u64 @ struct+136)
   mv a0, s3; mv a1, s1; jal ra, rlp_walk_next
   mv s3, a0; bnez a1, .Lhed_fail
-  sub a0, a0, a2; mv a1, a2; jal ra, rlp_content_to_u64
+  sub a0, a0, a2; mv a1, a2; jal ra, rlp_content_to_u64_strict
   bnez a1, .Lhed_fail
   sd a0, 136(s2)
   li a0, 0


### PR DESCRIPTION
## Scope and reason

The header and chain callers now select the RLP decoder by the Amsterdam reference type, not by the shared header location. Fields 17 (`blob_gas_used`) and 18 (`excess_blob_gas`) are `U64`, so their direct header extractors and derived chain/accessor paths use the already-verified strict K34 route. Field 8 (`number`), `gas_limit`, and `gas_used` are `Uint`, while `timestamp` is `U256`; those paths intentionally remain lenient. This is spec-typed alignment, not a project-wide strictness change.

There is no known false accept on this header path: the checked non-canonical header mutant rejects on both the current-main control and this candidate. The change records the execution-specs typing decision without manufacturing a false reject on the lenient `Uint`/`U256` paths.

## Prediction before measurement

- Only calls that decode U64 header fields 17/18 would retarget from `rlp_field_to_u64` to the existing `rlp_field_to_u64_strict` helper.
- No new helper or instruction-count change was expected; any image-size or symbol movement beyond call-site relocation immediates would have been a finding.
- The `HeaderExtractNumber` spec/bridge prose was corrected to describe the lenient field-8 `Uint` projection and its explicit width assumption.

## Emitted image

Rebased from current main `6019b35b839150bf524c79f55eca93a09c0cc4b1`. The four generated layout artifacts were regenerated in dependency order; the second complete pass was a no-op.

- candidate commit: `5d6aa29f97110af9de43ec51c84ee1577f8b491b`
- candidate guest ELF SHA256: `63094aab55012b8da1de8cc44b49e990a9dca859c94135a0873ab8f6bbb038a0`
- fresh current-main control ELF SHA256: `fffbf41fab177cb98a9bbb295452d4a9ba49a0093a74e03e1a8ddfff45ab1f0d`
- `.text=0x53454`, `.data=0x5310`, `.bss=0x1aedaf00`, `.state_gas_diag=0x61a78` on both images
- four distinct production call instructions retargeted: `header_extended_decode+0x250` (field 17), `header_extended_decode+0x278` (field 18), and the field-17 calls at `chain_validate_blob_gas_used_multiple+0x6c` and `chain_validate_blob_gas_used_under_max+0x6c`; the control is lenient at all four and the candidate is strict at all four
- each changed JAL encoding differs in two `.text` byte positions, explaining the eight `.text` byte differences; the remaining raw ELF difference is symbol/string-table ordering metadata, with no section-size or symbol-layout drift

## Regression evidence

Fixture tag `tests-zkevm@v0.6.2`, Spike backend, random seed `4242`, 200 rows:

- base: 200/200 full, root, succ, and tail matches; fail=0; budget=0
- candidate: 200/200 full, root, succ, and tail matches; fail=0; budget=0
- A/B joined 198 rows (the two shared-input groups cover four duplicate rows); FA=0 and FR=0 on both sides, status differences=0, output-byte differences=0
- explicit base-PASS → candidate-FR flip set: `∅`

## Verification

- `lake build` — PASS, 4771 jobs
- `scripts/check-build-parallel.sh` — all lanes PASS (codegen 6/6, reports 5/5, GuestAddrs, asm-to-program, axioms, arithmetic fuzz)
- source guards — PASS: forbidden tactics, retired predicates, Sail pin, hardcoded PCs, GuestAddrs starts, file size, unimported modules, correspondence deps, round-trip coverage, ELF override, heartbeat approvals, routine liveness, registry cross-check, layering, code-preimage, opcode structure, SpecRef citations, and no-warnings
- `git diff --check` — PASS
