### PR TITLE
proof(rlp): #11795's residual is false, not open — refuted by the tree's own counterexample

### DIFF
--- a/EvmAsm/Codegen/Programs/RlpListCountItemsBridge.lean
+++ b/EvmAsm/Codegen/Programs/RlpListCountItemsBridge.lean
@@ -506,18 +506,30 @@ theorem rlpListInteriorsDecode_of_strict {bytes : List (BitVec 8)} {base endPtr 
   obtain ⟨_, hpay⟩ := hstrict off next len hitem
   exact hpay b hget hlist
 
-/-- **The residual, as one statement about the ROUTINE.** `rlp_walk_next` accepts an item
-    only when the strict relation holds — i.e. the relation stops understating the guest.
+/-- ⛔ **NOT a routine obligation — see `not_rlpWalkNextStrict_nestedNonCanonical`.**
 
-    After #11776 this should be true: `rlp_walk_next_core` recursively validates list
-    payloads, requiring exact cursor-to-end exhaustion and rejecting malformed, truncated,
-    non-canonical, nested-malformed and trailing interiors with status 7. The relation
-    simply never recorded it.
+    ⚠️ The docstring this declaration originally carried was WRONG, and the correction
+    matters because #11795 schedules work against it. It claimed this was a statement
+    about `rlp_walk_next` that *"after #11776 should be true"*, dischargeable by
+    *"the walker's triple"*. Both halves are false:
 
-    Stated as a `Prop` over the walker's accept predicate rather than proved: discharging
-    it is the walker's triple, which is out of scope here. Naming it means #11795's
-    residual is a routine obligation with a known discharge route, not a model-side
-    impossibility. -/
+    * **It contains no machine execution.** Its hypothesis is `rlpItemDecode`, a pure
+      five-disjunct relation over `bytes` (`WalkNext.lean:3649`). So this is a property
+      of the BYTE STRING, not of the routine, and no Hoare triple can discharge a goal
+      the machine does not appear in.
+    * **It is FALSE**, refuted below on the counterexample the tree already records at
+      `ItemDecodeForward.lean:10-14`. `rlpItemDecode` accepts a list whose span fits and
+      whose interior is malformed; `decodeAux` rejects it. That is precisely the gap
+      `RlpListInteriorsDecode` (`:405`) names — and that declaration states the
+      situation correctly (*"NOT dischargeable from `rlpItemDecode` alone"*), so the two
+      disagreed with each other in the same file.
+
+    ⇒ Restricting `bytes` so that this holds is exactly **route 1** (import a caller-side
+    well-formedness fact), the option #11795 and #11898 both rejected — it was reached by
+    accident, wearing route 2's label. Kept (not deleted) because
+    `rlpItemDecodeBridgesFrom_of_walkNextStrict` consumes it and the implication is still
+    true; what changes is that its hypothesis is now known to be a domain restriction
+    rather than a scheduled proof. -/
 def RlpWalkNextStrict (bytes : List (BitVec 8)) (base endPtr : Word) (floor : Nat) : Prop :=
   ∀ (off : Nat) (next len : Word),
     rlpItemDecode bytes off (base + BitVec.ofNat 64 off) endPtr next len →
@@ -538,5 +550,143 @@ theorem rlpItemDecodeBridgesFrom_of_walkNextStrict {bytes : List (BitVec 8)}
     (hstrict : RlpWalkNextStrict bytes base endPtr floor) :
     RlpItemDecodeBridgesFrom bytes base endPtr floor :=
   rlpItemDecodeBridgesFrom_of_parts hbytes (rlpListInteriorsDecode_of_strict hstrict)
+
+/-! ## ⛔ Negative control: `RlpWalkNextStrict` is FALSE, not merely unproven
+
+    A predicate that is quietly false is worse than an open goal: it reads as scheduled
+    work, it makes every theorem consuming it vacuous on the domain that matters, and the
+    next reader spends their time trying to prove it. So the refutation is checked by the
+    kernel here rather than asserted in prose.
+
+    The witness is the one `ItemDecodeForward.lean:10-14` already records as the reason
+    the guest→model direction is false for the list disjuncts, reused rather than
+    reinvented. -/
+
+/-- `[0xc3, 0xc2, 0x81, 0x00]` — an outer 3-byte list containing a 2-byte list whose sole
+    element is the **non-canonical** `81 00` (a one-byte string with content `< 0x80`,
+    which RLP requires to use the single-byte form).
+
+    The outer span is 4 bytes and fits the window, so the machine relation's short-list
+    arm accepts it. The model rejects it two levels down. -/
+private def nestedNonCanonical : List (BitVec 8) := [0xc3, 0xc2, 0x81, 0x00]
+
+/-- The model rejects it, at the budget `decode` would supply (`2 * bs.length = 8`). -/
+private theorem decodeAux_nestedNonCanonical :
+    decodeAux 8 nestedNonCanonical = none := by
+  decide
+
+/-- The machine relation accepts it: the short-list arm asks only for header range and a
+    span fit, and `4 = endPtr - cursor` fits exactly. -/
+private theorem rlpItemDecode_nestedNonCanonical :
+    rlpItemDecode nestedNonCanonical 0
+      ((0x1000 : Word) + BitVec.ofNat 64 0) (0x1004 : Word) (0x1004 : Word) (4 : Word) := by
+  refine ⟨0xc3, by decide, ?_⟩
+  exact Or.inr (Or.inr (Or.inr (Or.inl ⟨by decide, by decide, by decide, by decide, by decide⟩)))
+
+/-- ⭐ **`RlpWalkNextStrict` is false.** Its hypothesis is the machine relation, which the
+    counterexample satisfies; its conclusion needs the model decode, which fails. No
+    strengthening of `rlp_walk_next` can change this, because the routine never appears in
+    the statement — which is the point of recording it.
+
+    Consequence for #11795: `rlpItemDecodeBridgesFrom_of_walkNextStrict` is a true
+    implication whose hypothesis is **unsatisfiable on any byte string containing a
+    span-fitting list with a malformed interior** — i.e. on exactly the MPT inline-node
+    domain that made `rlp_list_count_items` need the bridge in the first place. -/
+theorem not_rlpWalkNextStrict_nestedNonCanonical :
+    ¬ RlpWalkNextStrict nestedNonCanonical (0x1000 : Word) (0x1004 : Word) 8 := by
+  intro h
+  obtain ⟨-, hpay⟩ := h 0 (0x1004 : Word) (4 : Word) rlpItemDecode_nestedNonCanonical
+  obtain ⟨inner, hdec⟩ := hpay 0xc3 (by decide) (by decide)
+  rw [show (nestedNonCanonical.drop 0) = nestedNonCanonical from rfl,
+    decodeAux_nestedNonCanonical] at hdec
+  exact absurd hdec.symm (Option.some_ne_none _)
+
+/-! ## The residual, stated so that the routine actually appears in it
+
+    What #11795 needs is not a fact about `bytes` but a fact about **acceptance**: when
+    `rlp_walk_next` returns status 0, the model decode succeeds. `rlpItemDecode` is only a
+    NECESSARY condition of acceptance (it is what the existing per-form postconditions
+    pin), never a sufficient one — that asymmetry is the whole defect above.
+
+    So the obligation is parameterised by the routine's accept predicate, left abstract
+    here for a reason recorded below. -/
+
+/-- The corrected residual: `accept off next len` — read as *"`rlp_walk_next` run at
+    `base + off` returned status 0 with outputs `next`/`len`"* — implies the strict
+    relation. Unlike `RlpWalkNextStrict` this is genuinely a routine obligation, because
+    the antecedent is about a machine run rather than about `bytes`. -/
+def RlpWalkNextAccepts (accept : Nat → Word → Word → Prop)
+    (bytes : List (BitVec 8)) (base endPtr : Word) (floor : Nat) : Prop :=
+  ∀ (off : Nat) (next len : Word),
+    accept off next len →
+    rlpItemDecodeStrict bytes off (base + BitVec.ofNat 64 off) endPtr next len
+      (next - base).toNat floor
+
+/-- The per-item bridge, restricted to offsets the routine actually accepted. This is the
+    honest replacement for `rlpItemDecodeBridgesFrom_of_walkNextStrict`: same conclusion
+    shape, but the quantifier ranges over accepted items instead of over everything the
+    weak relation admits. -/
+def RlpItemDecodeBridgesOn (accept : Nat → Word → Word → Prop)
+    (bytes : List (BitVec 8)) (base : Word) (floor : Nat) : Prop :=
+  ∀ (off : Nat) (next len : Word),
+    accept off next len →
+    ∃ item : RLPItem,
+      decodeAux floor (bytes.drop off) = some (item, bytes.drop (next - base).toNat)
+
+/-- ⭐ Given the corrected residual, the accept-indexed bridge follows for **both** prefix
+    classes — lists from the strict conjunct, byte strings from the already-proven half —
+    with no domain restriction on `bytes` anywhere.
+
+    That it goes through cleanly is the evidence that the defect was in *where the
+    quantifier sat*, not in the surrounding development: nothing else in this file had to
+    change. -/
+theorem rlpItemDecodeBridgesOn_of_accepts {accept : Nat → Word → Word → Prop}
+    {bytes : List (BitVec 8)} {base endPtr : Word} {floor : Nat}
+    (hbytes : ∀ (off : Nat) (next len : Word) (b : BitVec 8),
+      bytes[off]? = some b →
+      BitVec.ult (b.zeroExtend 64) (0xc0 : Word) = true →
+      rlpItemDecode bytes off (base + BitVec.ofNat 64 off) endPtr next len →
+      ∃ item : RLPItem,
+        decodeAux floor (bytes.drop off) = some (item, bytes.drop (next - base).toNat))
+    (haccept : RlpWalkNextAccepts accept bytes base endPtr floor) :
+    RlpItemDecodeBridgesOn accept bytes base floor := by
+  intro off next len hacc
+  obtain ⟨hweak, hlist⟩ := haccept off next len hacc
+  have hcopy := hweak
+  obtain ⟨b, hget, -⟩ := hcopy
+  by_cases hlt : BitVec.ult (b.zeroExtend 64) (0xc0 : Word) = true
+  · exact hbytes off next len b hget hlt hweak
+  · obtain ⟨inner, hdec⟩ := hlist b hget hlt
+    exact ⟨.list inner, hdec⟩
+
+/-! ## ⛔ Why `accept` is abstract, and what unblocks #11795
+
+    `accept` is left as a parameter because **there is nothing to instantiate it with.**
+    The interior validation that #11776 added lives in `rlpWalkNextFunction`
+    (`RlpWalk.lean:155`), hand-written RISC-V emitted as a raw `String`. Measured against
+    the guest image, the split is exact:
+
+    | symbol | size | Lean representation |
+    |---|---|---|
+    | `rlp_walk_next` (entry) | 52 B | none |
+    | `rlp_walk_next_nested` | 4 B | none |
+    | `rlp_walk_next_shared` (the recursive validator) | 208 B | none |
+    | `rlp_walk_next_core` (one item) | 412 B | `rlp_walk_next_prog`, 103 instrs |
+
+    (sizes from `docs/4ch8f-guest-image-coverage.md:114-118`; the core's 103 × 4 = 412 B
+    is what `rlpWalkNextCoreFunction_eq_verified_prog` (`RlpWalk.lean:264`) pins, and that
+    theorem's own docstring calls the wrapper *"intentionally codegen-specific"*).
+
+    So the 264 bytes that do the recursing have no model, and the 412 that do have one
+    validate a single item — the half that was never in question.
+
+    ⇒ The exact behaviour #11795 needs — recursive payload validation, exact cursor-to-end
+    exhaustion, status 7 on nested-malformed interiors — is the behaviour that is NOT in
+    the model. So the blocker is a **representation gap, not a proof effort**: the wrapper
+    must become a `Program` before any triple about interior validation is statable, let
+    alone provable. Sizing the bridge as "the walker's triple" understated it by the cost
+    of an SAsm transcription.
+
+    Until then `rlp_list_count_items` stays `.machineOnly`, and correctly so. -/
 
 end EvmAsm.Codegen.RlpListCountItemsBridge

--- a/EvmAsm/Progress/AxiomWitnesses.lean
+++ b/EvmAsm/Progress/AxiomWitnesses.lean
@@ -112,6 +112,10 @@ import EvmAsm.Progress.Correspondence
 
 #print axioms EvmAsm.Codegen.RlpItemSpanSpec.rlp_item_span_spec_within
 
+#print axioms EvmAsm.Codegen.RlpListCountItemsBridge.not_rlpWalkNextStrict_nestedNonCanonical
+
+#print axioms EvmAsm.Codegen.RlpListCountItemsBridge.rlpItemDecodeBridgesOn_of_accepts
+
 #print axioms EvmAsm.Codegen.RlpListCountItemsSAsm.rlp_list_count_items_spec_within
 
 #print axioms EvmAsm.Codegen.RlpListEncodedSizeSAsm.rlpListEncodedSize_encode_spec

--- a/EvmAsm/Progress/Routines.lean
+++ b/EvmAsm/Progress/Routines.lean
@@ -86,6 +86,7 @@ import EvmAsm.Codegen.Programs.RlpListEncodedSizeSAsm
 import EvmAsm.Codegen.Programs.RlpListEncodedSizeBridge
 import EvmAsm.Codegen.Programs.RlpListNthItemSAsm
 import EvmAsm.Codegen.Programs.RlpListCountItemsSAsm
+import EvmAsm.Codegen.Programs.RlpListCountItemsBridge
 import EvmAsm.Codegen.Programs.BgvU32leSpec
 import EvmAsm.Codegen.Programs.CheckGasLimitBridge
 import EvmAsm.Codegen.Programs.BytesToNibblesBridge
@@ -712,6 +713,16 @@ private noncomputable abbrev _rlp_item_size_routine_witness :=
   @EvmAsm.Codegen.RlpSpliceHelperSpec.rlp_item_size_spec_within
 private noncomputable abbrev _rlp_item_span_routine_witness :=
   @EvmAsm.Codegen.RlpItemSpanSpec.rlp_item_span_spec_within
+-- #11795: the REFUTATION of `RlpWalkNextStrict`, plus the accept-indexed bridge that
+-- replaces it. Neither changes a registry row -- witnessed because a negative control is
+-- only worth what its axioms are, and this one is load-bearing for the issue's
+-- sequencing: it is what says the residual is FALSE rather than open, so nobody schedules
+-- a proof against it. The replacement is witnessed alongside so the correction and its
+-- repair cannot drift apart.
+private noncomputable abbrev _not_rlpWalkNextStrict_witness :=
+  @EvmAsm.Codegen.RlpListCountItemsBridge.not_rlpWalkNextStrict_nestedNonCanonical
+private noncomputable abbrev _rlpItemDecodeBridgesOn_of_accepts_witness :=
+  @EvmAsm.Codegen.RlpListCountItemsBridge.rlpItemDecodeBridgesOn_of_accepts
 private noncomputable abbrev _account_rlp_walk_init_routine_witness :=
   @EvmAsm.Evm64.account_rlp_walk_init_spec_within
 private noncomputable abbrev _rlp_walk_init_long1_routine_witness :=


### PR DESCRIPTION
## ⚠️ Correction: #11795's residual is **false**, not open — and the docstring that said otherwise is mine

`RlpWalkNextStrict` (`RlpListCountItemsBridge.lean:521`, landed in #11922) was documented as *"the residual, as one statement about the ROUTINE"*, something that *"after #11776 should be true"* and whose discharge is *"the walker's triple"*. Both halves are wrong.

**1. It contains no machine execution.** Its hypothesis is `rlpItemDecode` — the pure five-disjunct relation over `bytes` (`WalkNext.lean:3649`). So it is a property of the **byte string**, not of the routine, and no Hoare triple can discharge a goal the machine never appears in. Strengthening `rlp_walk_next` cannot move it.

**2. It is false.** Refuted here on `[0xc3, 0xc2, 0x81, 0x00]` — the counterexample the tree *already* records at `ItemDecodeForward.lean:10-14` as the reason the guest→model direction fails for the list disjuncts. An outer 3-byte list whose span fits exactly, containing a 2-byte list whose sole element is the non-canonical `81 00` (a one-byte string with content `< 0x80`, which RLP requires to use the single-byte form). The machine relation's short-list arm accepts it — it asks only for header range and a span fit. `decodeAux` rejects it two levels down.

⇒ Restricting `bytes` so the predicate holds is exactly **route 1** — import a caller-side well-formedness fact — the option this issue and #11898 both rejected. It was reached by accident, wearing route 2's label.

⭐ The same file already said this correctly about `RlpListInteriorsDecode` (`:398`: *"NOT dischargeable from `rlpItemDecode` alone — it is strictly more information"*). Two declarations 116 lines apart disagreed with each other, and the optimistic one is the one this issue was sequencing against.

## Why a negative control, and not a comment

A predicate that is quietly false reads as scheduled work. It makes every theorem consuming it vacuous on precisely the domain that matters — here, the MPT inline-node domain with nested lists, which is *why* `rlp_list_count_items` needed the bridge at all. So `not_rlpWalkNextStrict_nestedNonCanonical` is kernel-checked rather than asserted in prose, and witnessed in the axiom gate: a negative control is only worth what its axioms are.

Both halves close by `decide` (no `native_decide`/`bv_decide`).

## The repair

| declaration | role |
|---|---|
| `RlpWalkNextAccepts accept …` | the residual with the **routine in the antecedent** — `accept off next len` reads as *"`rlp_walk_next` ran at `base + off` and returned status 0"*. Genuinely a routine obligation. |
| `RlpItemDecodeBridgesOn accept …` | the per-item bridge quantified over **accepted** offsets, not over everything the weak relation admits |
| `rlpItemDecodeBridgesOn_of_accepts` | the two prefix classes compose — lists from the strict conjunct, byte strings from the already-proven half — with **no domain restriction on `bytes` anywhere** |

That this went through with **zero** other changes to the file is the evidence that the defect was in *where the quantifier sat*, not in the surrounding development. `rlpItemDecodeBridgesFrom_of_walkNextStrict` is kept, not deleted: the implication is still true, and what changes is that its hypothesis is now known to be a domain restriction rather than a scheduled proof.

## ⛔ What actually blocks #11795, measured

`accept` is left abstract because **there is nothing to instantiate it with**. Against the guest image:

| symbol | size | Lean representation |
|---|---|---|
| `rlp_walk_next` (entry) | 52 B | none |
| `rlp_walk_next_nested` | 4 B | none |
| `rlp_walk_next_shared` (the recursive validator) | 208 B | none |
| `rlp_walk_next_core` (one item) | 412 B | `rlp_walk_next_prog`, 103 instrs |

Sizes from `docs/4ch8f-guest-image-coverage.md:114-118`; the core's 103 × 4 = 412 B is exactly what `rlpWalkNextCoreFunction_eq_verified_prog` (`RlpWalk.lean:264`) pins, and that theorem's own docstring calls the wrapper *"intentionally codegen-specific"*.

So the 264 bytes that do the recursing — the interior validation #11776 added, which is the entire behaviour #11795 needs — have **no model**, and the 412 that do have one validate a single item, the half that was never in question.

⇒ **The blocker is a representation gap, not a proof effort.** The wrapper must become a `Program` before any triple about interior validation is *statable*, let alone provable. Sizing it as "the walker's triple" understated it by the cost of an SAsm transcription.

## Gates actually run

```
lake build                          clean, no errors, no warnings
scripts/check-forbidden-tactics.sh  OK — no native_decide/bv_decide in EvmAsm/
scripts/check-axioms.sh             OK — 189 witnesses; classical axioms only
python3 scripts/gen-axiom-witnesses.py --write   (regenerated; 2 new #print axioms rows)
```

No registry row changes. `rlp_list_count_items` stays `.machineOnly`, and now for a reason that is written down and checked.

Addresses #11795.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
