### PR TITLE
docs(progress): the correspondence row for rlp_encode_list_prefix names the wrong cut

### DIFF
--- a/EvmAsm/Progress/Correspondence.lean
+++ b/EvmAsm/Progress/Correspondence.lean
@@ -359,7 +359,17 @@ reubOut_eq_encode_toBytesBE." },
     spec := some "rlp_encode_list_prefix_short_pinned_spec_within",
     verdict := .domainRestricted, basis := .bridged,
     reference := "header of encode_sequence",
-    note := "no unified dispatch theorem; lenlen ≥ 2 (payload ≥ 256 B) uncovered" },
+    note := "no unified dispatch theorem — three per-form pinned triples, cited here by \
+the short one because this file carries one row per routine. Coverage is `len < 65536`: \
+short (`len < 56`), long1 (`56 ≤ len < 256`, `rlp_encode_list_prefix_long1_pinned_spec_within`) \
+and long2 (`256 ≤ len < 65536`, `…_long2_pinned_spec_within`, where the length-byte loop \
+first runs more than once and `long2_first_length_byte_ne_zero` makes canonical form a real \
+obligation rather than a vacuous one). ⚠️ THE CUT IS `lenlen ≥ 3` (payload ≥ 65536 B), NOT \
+`lenlen ≥ 2` as this note said until #10780's long2 arm landed — `Progress/Routines.lean` \
+carried all three rows while this row still described the pre-long2 state, so the two \
+registries disagreed about the same routine. The general arm wants the loop invariant \
+sketched at `RlpEncodeListPrefixLong2Spec.lean:47-52` (`x30` holds the top `k` bytes of \
+`len`, `x29 = lenlen - 1 - k`); unrolling stops paying around `lenlen = 4`" },
   { family := "rlp", routine := "rlp_encode_bytes",
     spec := some "reb_spec_within",
     verdict := .agrees, basis := .bridged, reference := "encode_bytes",


### PR DESCRIPTION
`Correspondence.lean`'s `rlp_encode_list_prefix` row said:

> no unified dispatch theorem; lenlen ≥ 2 (payload ≥ 256 B) uncovered

That stopped being true when #10780's **long2** arm landed. long2 covers `256 ≤ len < 65536`, which *is* `lenlen = 2`.

⭐ **The two registries disagreed about the same routine.** `Progress/Routines.lean:472-484` already carried all three rows — short, long1, long2 — with the cut correctly stated as `lenlen ≥ 3`. `Correspondence.lean` still described the pre-long2 state. A reader reaching for coverage hits the stale one, and it undercounts the routine by a whole arm.

Same class of defect as #11944, and found the same way: reading the registry against the tree rather than against itself.

## What the row says now

- names all three per-form pinned triples, and why only one is cited (this file carries one row per routine)
- states the real coverage: **`len < 65536`**
- states the real cut: **`lenlen ≥ 3`** (payload ≥ 65536 B)
- records that long2 is where the length-byte loop first runs more than once, and where `long2_first_length_byte_ne_zero` makes canonical form a real obligation rather than a vacuous one
- points at the loop invariant the general arm wants (`RlpEncodeListPrefixLong2Spec.lean:47-52` — `x30` holds the top `k` bytes of `len`, `x29 = lenlen - 1 - k`), so the next reader does not re-derive it

Note-only. No `verdict`, `basis`, or `spec` reference changes; no proof changes.

## Gates actually run

```
LAKE_ARTIFACT_CACHE=false lake build      Build completed successfully (4805 jobs)
scripts/check-no-warnings.sh build.log    0 warnings under EvmAsm/
scripts/check-axioms.sh                   OK — 187 witnesses; classical axioms only
scripts/check-progress.sh                 OK
scripts/check-correspondence-deps.sh      OK — 46 modules in closure (budget 80), 0 violations
```

Confirmed no generated markdown (`PROGRESS.md`, `docs/`) embeds the old string, so this is a single-file change.

Addresses #10780.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
