### PR TITLE
docs(codegen): document mpt kindTag bridge boundary

### DIFF
--- a/EvmAsm/Codegen/Programs/MptNodeKindSpec.lean
+++ b/EvmAsm/Codegen/Programs/MptNodeKindSpec.lean
@@ -42,7 +42,15 @@ def mptNodeKindGuest (node : List (BitVec 8)) : Nat :=
       | _ => 3
   | _ => 3
 
-/-- Under `MptNode.WF`, guest kind equals the structural tag. -/
+/-- Under `MptNode.WF`, guest kind equals the structural tag.
+
+    This is a pure well-formed-node bridge only.  The machine theorem
+    `mpt_node_kind_spec_within` posts the operational `MptNodeKindResult`, and
+    its current consumers carry that result through the walk dispatch; no
+    machine consumer currently invokes this theorem or derives `kindTag` from
+    the operational result.  Thus this declaration does not by itself wire
+    the machine classifier to the `MptNode`/SpecRef tag; a future wiring proof
+    must provide that Result-to-WF/decode bridge explicitly. -/
 theorem mptNodeKindGuest_eq_kindTag (n : MptNode) (hwf : n.WF) :
     mptNodeKindGuest n.rlp = n.kindTag := by
   have hdec := decodeFully_encode n.rlpItem (n.rlp_length_lt hwf)

--- a/EvmAsm/Progress/Correspondence.lean
+++ b/EvmAsm/Progress/Correspondence.lean
@@ -465,8 +465,9 @@ regOwn export discarded information the machine preserves and blocked every cons
 that needed the path. PRE unchanged (kindCallerPre already carried concrete v18..v21 \
 via countAmbient). WHY `.machineOnly` AND NOT `.ported`/`.bridged`: the MPT family has \
 no executable differential, and the top triple is stated over the operational result \
-rather than over SpecRef `kindTag` — callers that want `kindTag` under WF use the pure \
-bridge `mptNodeKindGuest_eq_kindTag` (MptNodeKindSpec). The pure \
+rather than over SpecRef `kindTag` — no current caller uses the pure bridge \
+`mptNodeKindGuest_eq_kindTag`; a caller wanting `kindTag` under WF first needs the \
+missing Result-to-WF/decode bridge. The pure \
 `MptAssertions.mptNodeKindSpec` is LOOSER (2 < len → branch) and STALE vs the arity-17 \
 guest; it is NOT the machine post. FULL DOMAIN: no input-domain gate (ABI hyps only — \
 region wf, alignment, stack free for nth frame). coverRef \

--- a/EvmAsm/Progress/Routines.lean
+++ b/EvmAsm/Progress/Routines.lean
@@ -533,8 +533,9 @@ def routineRegistry : List RoutineEntry := [
   -- `mpt_node_kind`. Full guest domain (arity-17 branch / arity-2 HP path /
   -- fail joins) with operational `MptNodeKindResult` post — no input-domain
   -- gate, so `.proven`. Pure `mptNodeKindSpec` (MptAssertions) is looser/stale
-  -- vs the arity-exact guest; do not rest the post on it. Callers that want
-  -- `kindTag` under WF use `mptNodeKindGuest_eq_kindTag`.
+  -- vs the arity-exact guest; do not rest the post on it. No current caller
+  -- uses `mptNodeKindGuest_eq_kindTag`; a caller wanting `kindTag` under WF
+  -- first needs the missing Result-to-WF/decode bridge.
   routine "mpt_node_kind" .proven (some "mpt_node_kind_spec_within")
       (notes := "whole-routine triple at `GuestAddrs.mpt_node_kind` / `kindB`: "
         ++ "count via `rlp_list_count_items`, nth via `rlp_list_nth_item` index 0, "


### PR DESCRIPTION
## Finding

The transitive machine consumer graph reaches `mpt_node_kind_spec_within` through `mpt_walk_kind_callWithin` and the `MptWalkKindDispatch` branch/nth paths. Those consumers carry the operational `MptNodeKindResult`; none invokes `mptNodeKindGuest_eq_kindTag`, `mptNodeKindSpec_eq_guest_of_WF`, or derives `kindTag` from the operational result. The existing bridge is therefore declared but unreachable from the machine consumer graph, not a usable bridge at a reachable callsite.

## Change

The declaration docstring for `mptNodeKindGuest_eq_kindTag` now states this boundary explicitly and names the missing future obligation: a Result-to-WF/decode bridge must be proved before wiring the machine classifier to the `MptNode`/SpecRef tag. No machine behavior or theorem statement changes.

## Verification

`LAKE_ARTIFACT_CACHE=false lake build EvmAsm.Codegen.Programs.MptNodeKindSpec` passed (1047 jobs); `git diff --check` clean.

No changes to frozen #12025 or other proof branches.