### PR TITLE
proof(account): split Keccak empty-hash reduction (#12034)

### DIFF
--- a/EvmAsm/Codegen/Programs/AccountDecodeCorrespondence.lean
+++ b/EvmAsm/Codegen/Programs/AccountDecodeCorrespondence.lean
@@ -7,9 +7,10 @@
   #11517 asks for one of three outcomes per pairing — a correspondence theorem, a
   documented pairing with a stated gap, or a divergence — and names this pair as the one
   to start with, *"because the answer is already known and it establishes the template"*.
-  This module delivers a **correspondence for the sentinel constants** (outcome 1) and a
-  **documented gap with a named blocker** for the field contents (outcome 2). No
-  divergence was found; the one that motivated #11517 (#11516) is already repaired.
+  This module delivers a **kernel correspondence for the code-hash sentinel** and a
+  **numeral drift pin for the trie-root sentinel**, plus a **documented gap with a named
+  blocker** for the field contents (outcome 2). No divergence was found; the one that
+  motivated #11517 (#11516) is already repaired.
 
   ## ⭐ What was actually unpinned: the constants, in triplicate
 
@@ -26,18 +27,17 @@
   failure shape (*"the asm-side predicate contradicted the reference model of the same
   spec function, and no gate noticed"*) applied to a constant instead of a length bound.
 
-  ⚠️ **A direct kernel tie is not available**, and the reason is worth recording rather
-  than working around: `adEmptyCodeHashBytes = EMPTY_CODE_HASH` requires the kernel to
-  evaluate Keccak-f[1600], and `decide` exhausts the recursion limit on it. Raising the
-  limit is forbidden (CLAUDE.md; #10780 calls a proof that only closes with a raised limit
-  a failure result), and `native_decide` is out of the trusted base entirely.
+  `adEmptyCodeHashBytes = EMPTY_CODE_HASH` is now a genuine kernel-checked theorem.
+  Its proof isolates the concrete one-block absorption and consumes the pre-existing
+  `Accel.keccakF_kat_empty`; the new lemmas add no recursion-depth or heartbeat option.
+  The KAT's existing `maxRecDepth 8000` is documented in `ZiskAccel.lean` as the
+  intrinsic evaluation depth of its 24 rounds.
 
-  So the pin is built the honest way, through a **written numeral**: each literal is
-  kernel-checked equal to the same hex value that SpecRef's own `#guard`s
-  (`WitnessState.lean:41-46`) check its computed constants against. Editing any one copy
-  breaks a build. The seam is that SpecRef's half is `#guard` — compiler-evaluated, not
-  kernel — so this is a drift gate, not a proof that the literals *are* keccak. That
-  distinction is the point of stating it rather than asserting agreement.
+  `adEmptyTrieRootBytes = EMPTY_TRIE_ROOT` remains a numeral pin.  Its input is
+  `keccak256 [0x80]`, which needs a different 24-round KAT; a direct concrete proof
+  exhausts the default recursion depth, and this change deliberately adds no new limit
+  raise. Thus the trie-root half stays an honest drift gate until an independently
+  justified intrinsic-depth KAT exists, while the code-hash half is proved to be keccak.
 
   ## The fold, and where the pairing bottoms out
 
@@ -67,9 +67,10 @@ open EvmAsm.Stateless.SpecRef (bytesBEtoNat)
 
 /-! ## The sentinel pins
 
-    Each is `decide`-checked: a 32-byte big-endian fold, which the kernel's GMP-backed
-    `Nat` handles directly. The numerals are the ones `WitnessState.lean:41-46` checks
-    `EMPTY_CODE_HASH` and `EMPTY_TRIE_ROOT` against. -/
+    The literal-value pins are `decide`-checked 32-byte big-endian folds, which the
+    kernel's GMP-backed `Nat` handles directly. The numerals are the ones
+    `WitnessState.lean:41-46` checks `EMPTY_CODE_HASH` and `EMPTY_TRIE_ROOT` against;
+    the code-hash copy additionally has the direct Keccak theorem above. -/
 
 /-- `adEmptyTrieRootBytes` is `keccak256(rlp(""))`, pinned through the numeral SpecRef's
     `#guard` uses for `EMPTY_TRIE_ROOT`. -/
@@ -84,6 +85,11 @@ theorem adEmptyCodeHashBytes_value :
     bytesBEtoNat adEmptyCodeHashBytes
       = 0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470 := by
   decide
+
+/-- The account-decoder code-hash sentinel is the SpecRef `EMPTY_CODE_HASH` value. -/
+theorem adEmptyCodeHashBytes_eq_spec :
+    adEmptyCodeHashBytes = EvmAsm.Stateless.SpecRef.EMPTY_CODE_HASH := by
+  exact EvmAsm.Codegen.AccountDecodeSpec.adEmptyCodeHashBytes_eq_spec
 
 /-- The `account_is_eip161_empty` copy is pinned to the same numeral. -/
 theorem aieEmptyCodeHashBytes_value :

--- a/EvmAsm/Codegen/Programs/AccountDecodeSpec.lean
+++ b/EvmAsm/Codegen/Programs/AccountDecodeSpec.lean
@@ -47,10 +47,12 @@
 import EvmAsm.Codegen.Programs.RlpListNthItemSAsm
 import EvmAsm.Codegen.Programs.State
 import EvmAsm.Evm64.Terminating.ReturnWindowLoopSpec
+import EvmAsm.Stateless.SpecRef.WitnessState
 
 namespace EvmAsm.Codegen.AccountDecodeSpec
 
 open EvmAsm.Rv64 EvmAsm.Rv64.RLP EvmAsm.Rv64.SAsm
+open EvmAsm.Stateless.SpecRef
 
 /-! ## Code layout -/
 
@@ -431,6 +433,41 @@ def adEmptyCodeHashBytes : List (BitVec 8) :=
     0x7b, 0xfa, 0xd8, 0x04, 0x5d, 0x85, 0xa4, 0x70 ]
 
 theorem adEmptyCodeHashBytes_length : adEmptyCodeHashBytes.length = 32 := by decide
+
+/-! The concrete `keccak256 []` reduction is deliberately split from the
+    sentinel theorem below.  Unfolding the 24-round Keccak permutation directly
+    at each use exhausts the default recursion depth; the one-block absorption
+    and the existing accelerator KAT keep that cost contained in one lemma. -/
+
+private theorem adEmptyCodeHash_absorb_block :
+    keccakAbsorbBlock (List.replicate 25 (0 : BitVec 64)) (keccakPad []) =
+      [1#64, 0#64, 0#64, 0#64, 0#64, 0#64, 0#64, 0#64, 0#64, 0#64,
+       0#64, 0#64, 0#64, 0#64, 0#64, 0#64, 0x8000000000000000#64,
+       0#64, 0#64, 0#64, 0#64, 0#64, 0#64, 0#64, 0#64] := by
+  decide
+
+private theorem adEmptyCodeHash_keccak_empty :
+    keccak256 [] =
+      ((Accel.keccakF (List.ofFn (n := 25) (fun j =>
+        if j.val = 0 then 0x0000000000000001
+        else if j.val = 16 then 0x8000000000000000
+        else 0))).take 4).flatMap (fun lane => natToBytesLE 8 lane.toNat) := by
+  have hchunks : chunkBytes 136 (keccakPad []) = [keccakPad []] := by
+    simp [chunkBytes, chunkBytesAux, keccakPad, keccakRateBytes]
+  have hchunks' : chunkBytes keccakRateBytes (keccakPad []) = [keccakPad []] := by
+    simpa [keccakRateBytes] using hchunks
+  unfold keccak256
+  rw [hchunks']
+  simp only [keccakAbsorb]
+  rw [adEmptyCodeHash_absorb_block]
+  congr 2
+
+/-- The baked-in code-hash sentinel is the SpecRef `EMPTY_CODE_HASH` value. -/
+theorem adEmptyCodeHashBytes_eq_spec :
+    adEmptyCodeHashBytes = EMPTY_CODE_HASH := by
+  rw [show EMPTY_CODE_HASH = keccak256 [] from rfl,
+    adEmptyCodeHash_keccak_empty, Accel.keccakF_kat_empty]
+  decide
 
 /-- A hash output cell: the 32 copied content bytes, or the fold constant when
     the field was zero-length.  `fixed32Copied` cannot express the folded case

--- a/EvmAsm/Progress/AxiomWitnesses.lean
+++ b/EvmAsm/Progress/AxiomWitnesses.lean
@@ -38,6 +38,8 @@ import EvmAsm.Progress.Correspondence
 
 #print axioms EvmAsm.Codegen.AccountDecodeCorrespondence.adEmptyCodeHashBytes_eq_aie
 
+#print axioms EvmAsm.Codegen.AccountDecodeCorrespondence.adEmptyCodeHashBytes_eq_spec
+
 #print axioms EvmAsm.Codegen.AccountDecodeCorrespondence.adEmptyCodeHashBytes_value
 
 #print axioms EvmAsm.Codegen.AccountDecodeCorrespondence.adEmptyTrieRootBytes_value

--- a/EvmAsm/Progress/Routines.lean
+++ b/EvmAsm/Progress/Routines.lean
@@ -747,15 +747,17 @@ private noncomputable abbrev _rlp_item_span_routine_witness :=
 -- `lenlen >= 3` arm will consume it as a specification, and a specification outside the
 -- axiom gate is the #11637 failure mode -- the same reason the `LongSpan` lemmas are
 -- gated. No registry row changes: this is a side condition, not a routine triple.
--- #11517 (template pair): the account-leaf sentinels, pinned. `EMPTY_TRIE_ROOT` /
--- `EMPTY_CODE_HASH` existed in three unconnected copies -- SpecRef's computed pair and two
--- baked asm literals -- so a typo in one typechecked everywhere and produced a wrong state
--- root. These are the ties. Gated deliberately: the value of a drift pin is that CI
--- rechecks it, and a pin outside the gate is a comment.
+-- #11517 (template pair): the account-leaf sentinels. `EMPTY_CODE_HASH` now has a
+-- kernel-checked SpecRef tie through the split Keccak proof; the trie-root copy remains a
+-- numeral drift pin because its distinct `keccak256 [0x80]` KAT would need a separately
+-- justified intrinsic-depth theorem. The pins stay gated so CI rechecks the remaining
+-- literal correspondence.
 private noncomputable abbrev _ad_empty_trie_root_value_witness :=
   @EvmAsm.Codegen.AccountDecodeCorrespondence.adEmptyTrieRootBytes_value
 private noncomputable abbrev _ad_empty_code_hash_value_witness :=
   @EvmAsm.Codegen.AccountDecodeCorrespondence.adEmptyCodeHashBytes_value
+private noncomputable abbrev _ad_empty_code_hash_spec_witness :=
+  @EvmAsm.Codegen.AccountDecodeCorrespondence.adEmptyCodeHashBytes_eq_spec
 private noncomputable abbrev _aie_empty_code_hash_value_witness :=
   @EvmAsm.Codegen.AccountDecodeCorrespondence.aieEmptyCodeHashBytes_value
 private noncomputable abbrev _ad_empty_code_hash_eq_aie_witness :=


### PR DESCRIPTION
## Summary

Split the concrete EMPTY_CODE_HASH reduction so the kernel does not unfold the full Keccak permutation at each sentinel use.

- `adEmptyCodeHash_absorb_block` proves the one-block padded state by `decide`.
- `adEmptyCodeHash_keccak_empty` unfolds `keccak256 []`, reduces the single chunk/absorb step, and consumes the existing `Accel.keccakF_kat_empty`.
- `adEmptyCodeHashBytes_eq_spec` now proves the baked decoder literal equals SpecRef `EMPTY_CODE_HASH`.

The direct monolithic `decide`/`rfl` hit the default recursion depth in about 2.2s. The split proof is kernel-checkable in about 1.97s in the isolated probe. The new lemmas add no `maxRecDepth` or heartbeat setting. The terminal `Accel.keccakF_kat_empty` carries its pre-existing `maxRecDepth 8000`, documented in `ZiskAccel.lean` as intrinsic depth for the 24-round KAT.

## Scope and limitation

The code-hash sentinel is now a genuine SpecRef theorem. The trie-root literal remains a numeral drift pin: `EMPTY_TRIE_ROOT = keccak256 [0x80]` needs a different 24-round KAT, and a direct proof hits the default recursion depth (about 3.5s). This PR deliberately adds no new limit raise, so it records that remaining limitation rather than claiming the trie-root equation.

The #12032 correspondence text and routine registry now say exactly this: code hash is proved; trie root remains a numeral pin pending an independently justified intrinsic-depth KAT.

## Gates

- `LAKE_ARTIFACT_CACHE=false lake build EvmAsm`: Build completed successfully (4824 jobs).
- `LAKE_ARTIFACT_CACHE=false scripts/check-axioms.sh`: OK — 203 witnesses, classical axioms only.
- `scripts/check-layering.sh`: clean.
- `git diff --check`: clean.

This branch is stacked on `work/11517-account-decode-corr` (the #12032 head); no changes were made to that branch.
