### PR TITLE
docs(progress): refresh accelerator obligation 6 (#11924)

### DIFF
--- a/EvmAsm/Progress/Obligations.lean
+++ b/EvmAsm/Progress/Obligations.lean
@@ -178,8 +178,15 @@ opcodes plus the 14 `.execSpec` rows. `no_proven_opcode_blockers` below now \
 fails the build if a `.proven` opcode is ever listed here again" },
   { id := 6, name := "Accelerator ECALL bridges per `zkvm_accelerators.h`",
     status := .blocked,
-    blockedBy := [.infra "per-precompile EL bridges not yet codegen-wired"],
-    note := "vendored header + EL bridges; not codegen-wired" },
+    blockedBy :=
+      [.infra "55 accelerator-site bridges remain after the landed `zkvm_keccak256` \
+pilot: secp256k1 recovery (0x01), BN254, P256VERIFY, BLS G1, and the curve/complex \
+accelerator families 0x802–0x80A; the 56-site census is recorded in #10552 and the \
+family inventory is `docs/4ch8f-crypto-kernel-inventory.md`"],
+    auditedAt := some "2026-08-11 @84e000579",
+    note := "Pilot landed: `EvmAsm.Codegen.Proofs.zkvm_keccak256_spec_within` in \
+`HashBridgeKeccakTop.lean:283`, a genuine accelerator-site triple. One site is \
+covered; the other 55 sites and the remaining accelerator families are still open." },
   -- Audited as part of #11803. Not one of the rows that issue named, but the
   -- same defect class pointing the other way: a row understating its own
   -- progress hides that the work is startable, which is just as misleading to

--- a/EvmAsm/Progress/Obligations.lean
+++ b/EvmAsm/Progress/Obligations.lean
@@ -182,7 +182,9 @@ fails the build if a `.proven` opcode is ever listed here again" },
       [.infra "55 accelerator-site bridges remain after the landed `zkvm_keccak256` \
 pilot: secp256k1 recovery (0x01), BN254, P256VERIFY, BLS G1, and the curve/complex \
 accelerator families 0x802–0x80A; the 56-site census is recorded in #10552 and the \
-family inventory is `docs/4ch8f-crypto-kernel-inventory.md`"],
+family inventory is `docs/4ch8f-crypto-kernel-inventory.md`; the 56 figure counts \
+decoded CSRRS encodings, while that inventory's 64 counts raw pre-encoded `.4byte` \
+sites, so the two populations are not yet reconciled"],
     auditedAt := some "2026-08-11 @84e000579",
     note := "Pilot landed: `EvmAsm.Codegen.Proofs.zkvm_keccak256_spec_within` in \
 `HashBridgeKeccakTop.lean:283`, a genuine accelerator-site triple. One site is \


### PR DESCRIPTION
## Summary

- Refresh obligation 6 against origin/main `84e000579`.
- Keep the obligation blocked, but record the landed pilot theorem
  `EvmAsm.Codegen.Proofs.zkvm_keccak256_spec_within` at
  `EvmAsm/Codegen/Proofs/HashBridgeKeccakTop.lean:283`.
- Record the remaining scope as 55 accelerator-site/family bridges after the
  56-site census from #10552: secp256k1 recovery (0x01), BN254, P256VERIFY,
  BLS G1, and curve/complex accelerator families 0x802–0x80A.

The row now carries `auditedAt := 2026-08-11 @84e000579`; it does not make a
blanket claim that the accelerator family is retired. One site is covered by
the landed pilot and the remaining sites/families are still open.

## Inventory note

The crypto-kernel inventory currently says “64 sites”, while the #10552 census
and this obligation use 56 sites. This PR intentionally does not propagate the
stale 64-site count; the discrepancy is reported for reconciliation.

## Validation

- `env LAKE_ARTIFACT_CACHE=false lake build EvmAsm.Progress.Obligations`
  completed successfully (2203 jobs).
- `scripts/check-layering.sh` reports that layering invariants hold.
- `git diff --check` is clean.
- `scripts/check-obligation-blockers.sh` still reports unrelated pre-existing
  stale references to closed issues #11345, #11573, #11578, #11795 and #11799;
  row 6 is not one of those stale references.

No guest or generated artifact changes are included.
