### PR TITLE
proof(rlp): the 3-length-byte long form — the first arm that cites the loop instead of unrolling it

### DIFF
--- a/EvmAsm/Codegen/Programs/RlpEncodeListPrefixLong3Spec.lean
+++ b/EvmAsm/Codegen/Programs/RlpEncodeListPrefixLong3Spec.lean
@@ -1,0 +1,580 @@
+/-
+  EvmAsm.Codegen.Programs.RlpEncodeListPrefixLong3Spec
+
+  **`rlp_encode_list_prefix`, 3-length-byte long form** (GH #10780 item 3, next width).
+
+  `RlpSpliceHelperSpec.lean` proves the short form (`len < 56`) and the 1-length-byte
+  long form (`56 ≤ len < 256`); `RlpEncodeListPrefixLong2Spec.lean` proves
+  `256 ≤ len < 65536`. This module adds `65536 ≤ len < 16777216`: header byte `0xFA`
+  followed by the three big-endian length bytes, header length 4.
+
+  ## ⭐ What is different from the long2 arm
+
+  1. **The lenlen ladder falls one branch further.** `BLTU x10, 65536` (idx13) is *not*
+     taken, so control falls into idx14–16, where `x28 := 3` and `x29 := 65536 <<< 8`
+     before `BLTU x10, 16777216` (idx16) jumps to the shared header writer at idx30.
+     That is three extra dispatch steps over long2, and it is the only part of this arm
+     that is genuinely per-width: the routine computes `x28` by falling through `k`
+     branches, so the ladder is inherently eight cases.
+  2. ⭐ **The length-byte loop is cited, not unrolled.** Long2's closing note warned that
+     unrolling stops paying around `lenlen = 4` and that the general arm wants the loop
+     stated once with an invariant. That lemma now exists —
+     `RlpEncodeListPrefixLoopSpec.lpLolLoop` covers idx35–idx41 whole, at a symbolic
+     trip count `m`, in `7 * m + 1` steps with postcondition
+     `writeShift dst di len.toNat m`. This arm instantiates it at `m := 3`, `di := 1`,
+     so the loop contributes **22 steps and about fifteen lines**, where long2 spent
+     ~110 lines unrolling two iterations. Nothing about the loop is re-proved here.
+  3. **Step count 42**, versus long2's 32: 11 to reach idx30 (idx 0, 1, 8, 9, 10, 11,
+     12, 13, 14, 15, 16) + 5 for idx30–34 + 22 for the loop + 3 for idx42–44 + 1 for
+     the `JALR`. Long2's 32 is the same accounting with 8 ladder steps and a 14-step
+     unrolled loop (2 × 7) plus its own exit test.
+
+  ## Byte order, read off the loop rather than assumed
+
+  `x29` starts at `lenlen - 1 = 2` and counts **down**, while `x30` starts at
+  `outPtr + 1` and counts **up**. So the iterations store `len >>> 16`, `len >>> 8`,
+  `len` at `out[1]`, `out[2]`, `out[3]` — big-endian, most significant first, matching
+  RLP. As in long2 the postcondition pins **each index to its own shift**, because a
+  symmetric statement would not detect the two cursors being swapped.
+
+  ## Canonical form
+
+  The first length byte is nonzero, which is what makes the emitted header canonical
+  RLP (#10780 item 1: a length-of-length carrying a leading zero still *parses* and
+  hashes differently). It is not re-derived here:
+  `RlpEncodeListPrefixCanonical.first_length_byte_ne_zero` proves it at every width
+  from `u64ByteLen`'s own bounds, and `long3_first_length_byte_ne_zero` below is its
+  `lenlen = 3` instance — the same relationship `first_length_byte_ne_zero_long2` has
+  to long2's arm.
+
+  ## Scope
+
+  Proof only; no emitted bytes change. `lenlen ∈ 4..8` remain open, and with `lpLolLoop`
+  in hand each is now just its ladder path plus this same fixed header/epilogue — the
+  per-width cost is the dispatch, not the loop.
+-/
+
+import EvmAsm.Rv64.InstructionSpecs
+import EvmAsm.Rv64.SyscallSpecs
+import EvmAsm.Rv64.ControlFlow
+import EvmAsm.Rv64.MemRegion
+import EvmAsm.Rv64.MemRegionStore
+import EvmAsm.Rv64.SAsm.FramePort
+import EvmAsm.Rv64.Tactics.XSimp
+import EvmAsm.Evm64.CallingConvention
+import EvmAsm.EL.RLP.Properties
+import EvmAsm.Codegen.Programs.RlpRead
+import EvmAsm.Codegen.Programs.RlpEncodeListPrefixLoopSpec
+import EvmAsm.Codegen.Programs.RlpEncodeListPrefixCanonical
+import EvmAsm.Codegen.GuestAddrs
+
+namespace EvmAsm.Codegen
+
+namespace RlpEncodeListPrefixLong3Spec
+
+open EvmAsm.Rv64 EvmAsm.Rv64.SAsm
+open EvmAsm.EL.RLP
+open EvmAsm.Codegen.RlpEncodeBytesSAsm (writeShift truncate_shift_eq)
+open EvmAsm.Codegen.RlpEncodeListPrefixLoopSpec (lpLolLoop)
+open EvmAsm.Codegen.RlpListEncodedSizeSAsm (u64ByteLen)
+
+/-- Code-membership for a `∀ base` `ofProg` slice: instruction `k` of the program,
+    addressed as a concrete `base + OFF` term. Mirrors the file-local macro of the same
+    name in the long1/long2/loop modules (each is `local`, so not importable). -/
+local macro "cmem" k:term:max : tactic =>
+  `(tactic| exact CodeReq.singleton_mono
+      (CodeReq.ofProg_lookup_addr _ _ $k _ (by decide) (by decide) (by bv_omega)))
+
+/-! ## Arithmetic helpers
+
+    Re-declared from `RlpSpliceHelperSpec.lean`/`RlpEncodeListPrefixLong2Spec.lean`,
+    where they are `private`. -/
+
+private theorem ult_of_toNat_lt {a c : Word} (h : a.toNat < c.toNat) :
+    BitVec.ult a c := by
+  simpa [BitVec.ult, decide_eq_true_eq] using h
+
+private theorem not_ult_of_toNat_ge {a c : Word} (h : c.toNat ≤ a.toNat) :
+    ¬ BitVec.ult a c := by
+  simp only [BitVec.ult, decide_eq_true_eq]
+  omega
+
+private theorem trunc8_eq_ofNat_toNat (len : Word) :
+    len.truncate 8 = BitVec.ofNat 8 len.toNat := by
+  apply BitVec.eq_of_toNat_eq
+  rw [BitVec.toNat_setWidth, BitVec.toNat_ofNat]
+
+/-! ## ⭐ The loop's output, in the long2 postcondition's shape
+
+    `lpLolLoop` hands back `writeShift outBytes 1 len.toNat 3`. The theorem below states
+    the region as three nested `List.set`s instead, exactly as long2 does, so the two
+    arms' postconditions read the same way and each byte is pinned to its own shift.
+    This is the whole bridge between the two forms. -/
+
+/-- The `i`-th stored byte, moving from `writeShift`'s division form to the shift form
+    the postcondition names. `truncate_shift_eq` already has the hard direction. -/
+private theorem byte_div_eq_shift (v : Word) (i : Nat) :
+    BitVec.ofNat 8 (v.toNat / 256 ^ i % 256) = BitVec.ofNat 8 (v >>> (8 * i)).toNat :=
+  (truncate_shift_eq v i).symm.trans (trunc8_eq_ofNat_toNat (v >>> (8 * i)))
+
+private theorem shift_zero_id (v : Word) : v >>> (0 : Nat) = v := by
+  apply BitVec.eq_of_toNat_eq
+  rw [BitVec.toNat_ushiftRight]
+  simp
+
+/-- ⭐ **Three length bytes at index 1, spelled as `List.set`s.** Each index is tied to
+    its own shift: `out[1]` to `len >>> 16`, `out[2]` to `len >>> 8`, `out[3]` to `len`.
+    Unfolding `writeShift` at the literal width is definitional; the only content is
+    rewriting `len.toNat / 256 ^ i % 256` into `(len >>> 8i).toNat`. -/
+private theorem writeShift_three (dst : List Byte) (len : Word) :
+    writeShift dst 1 len.toNat 3
+      = ((dst.set 1 (BitVec.ofNat 8 (len >>> (16 : Nat)).toNat)).set 2
+          (BitVec.ofNat 8 (len >>> (8 : Nat)).toNat)).set 3
+          (BitVec.ofNat 8 len.toNat) := by
+  have hstep : writeShift dst 1 len.toNat 3
+      = ((dst.set 1 (BitVec.ofNat 8 (len.toNat / 256 ^ 2 % 256))).set 2
+          (BitVec.ofNat 8 (len.toNat / 256 ^ 1 % 256))).set 3
+          (BitVec.ofNat 8 (len.toNat / 256 ^ 0 % 256)) := rfl
+  have h2 := byte_div_eq_shift len 2
+  have h1 := byte_div_eq_shift len 1
+  have h0 := byte_div_eq_shift len 0
+  rw [show 8 * 2 = 16 from by norm_num] at h2
+  rw [show 8 * 1 = 8 from by norm_num] at h1
+  rw [show 8 * 0 = 0 from by norm_num, shift_zero_id len] at h0
+  rw [hstep, h2, h1, h0]
+
+/-! ## ⭐ Canonical form: the length-of-length carries no leading zero -/
+
+/-- **The first length byte is nonzero**, at this arm's width.
+
+    Not re-proved: `RlpEncodeListPrefixCanonical.first_length_byte_ne_zero` establishes
+    it for every `lenlen ∈ 1..8` from the two bounds `u64ByteLen`'s own definition
+    contains, and this is its `lenlen = 3` instance — the same relationship
+    `first_length_byte_ne_zero_long2` has to the long2 arm. Combined with the triple
+    below, `out[1] ≠ 0`, which is what makes the emitted header canonical RLP rather
+    than a header that merely parses (#10780 item 1). -/
+theorem long3_first_length_byte_ne_zero {len : Word}
+    (h_lo : 65536 ≤ len.toNat) (h_hi : len.toNat < 16777216) :
+    BitVec.ofNat 8 (len >>> (16 : Nat)).toNat ≠ 0 := by
+  have hwidth : u64ByteLen len = 3 := by
+    unfold u64ByteLen
+    split_ifs <;> omega
+  have h := RlpEncodeListPrefixCanonical.first_length_byte_ne_zero (len := len) (by omega)
+  rwa [hwidth, show 8 * (3 - 1) = 16 from by norm_num] at h
+
+/-! ## The triple -/
+
+/-- **`rlp_encode_list_prefix`, 3-length-byte long form** (`65536 ≤ len < 16777216`):
+    writes the header bytes `[0xFA, len >>> 16, len >>> 8, len]` and header length 4,
+    returns `a0 = 0`; scratch registers pinned.
+
+    Clobbers `t0`/`t3`–`t6` (`x5`, `x28`–`x31`) as the long1/long2 arms do; `x6`/`x7`
+    are untouched on this path and so do not appear.
+
+    The three length bytes are pinned to their own shifts because the loop counts `x29`
+    down while counting `x30` up, and a symmetric statement would not detect the cursors
+    being swapped. Together with `long3_first_length_byte_ne_zero`, `out[1]` is
+    additionally known to be nonzero, so the emitted header is canonical RLP.
+
+    ⭐ The loop (idx35–idx41) is discharged by one application of `lpLolLoop` at `m := 3`,
+    `di := 1` — 22 of the 42 steps — rather than unrolled per iteration. -/
+theorem rlp_encode_list_prefix_long3_pinned_spec_within
+    (base len outPtr cellPtr raVal v5 v28 v29 v30 v31 : Word)
+    (outBytes : List (BitVec 8)) (cellOld : Word)
+    (h_len_lo : 65536 ≤ len.toNat)
+    (h_len_hi : len.toNat < 16777216)
+    (h_out_align : outPtr.toNat % 8 = 0)
+    (h_out_len : 3 < outBytes.length)
+    (h_out_valid : ∀ k, k < outBytes.length →
+      isValidByteAccess (outPtr + BitVec.ofNat 64 k) = true) :
+    cpsTripleWithin 42 base (raVal &&& ~~~1)
+      (CodeReq.ofProg base rlpEncodeListPrefix_prog)
+      (((.x1 : Reg) ↦ᵣ raVal) ** ((.x10 : Reg) ↦ᵣ len) **
+       ((.x11 : Reg) ↦ᵣ outPtr) ** ((.x12 : Reg) ↦ᵣ cellPtr) **
+       ((.x5 : Reg) ↦ᵣ v5) ** ((.x28 : Reg) ↦ᵣ v28) ** ((.x29 : Reg) ↦ᵣ v29) **
+       ((.x30 : Reg) ↦ᵣ v30) ** ((.x31 : Reg) ↦ᵣ v31) **
+       ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+       bytesRegion outPtr outBytes ** (cellPtr ↦ₘ cellOld))
+      (((.x1 : Reg) ↦ᵣ raVal) ** ((.x10 : Reg) ↦ᵣ (0 : Word)) **
+       ((.x11 : Reg) ↦ᵣ outPtr) ** ((.x12 : Reg) ↦ᵣ cellPtr) **
+       regOwn .x5 ** regOwn .x28 ** regOwn .x29 **
+       regOwn .x30 ** regOwn .x31 **
+       ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+       bytesRegion outPtr
+         ((((outBytes.set 0 (0xFA : BitVec 8)).set 1
+              (BitVec.ofNat 8 (len >>> (16 : Nat)).toNat)).set 2
+             (BitVec.ofNat 8 (len >>> (8 : Nat)).toNat)).set 3
+           (BitVec.ofNat 8 len.toNat)) **
+       (cellPtr ↦ₘ (4 : Word))) := by
+  set CR := CodeReq.ofProg base rlpEncodeListPrefix_prog with hCR
+  have h_out_len0 : 0 < outBytes.length := by omega
+  -- idx0 (base+0): LI x5, 56
+  have hli5 := liftCode (cr' := CR)
+    (li_spec_gen_within .x5 v5 (56 : Word) base (by decide))
+    (by rw [hCR]; cmem 0)
+  -- idx1 (base+4): BGEU x10, x5, +28 — TAKEN (len ≥ 56) → base+32
+  have hbr1 := cpsBranchWithin_extend_code (cr' := CR)
+    (hmono := by rw [hCR]; cmem 1)
+    (h := bgeu_spec_gen_within .x10 .x5 (28 : BitVec 13) len (56 : Word) (base + 4))
+  rw [show (base + 4 : Word) + signExtend13 (28 : BitVec 13) = base + 32 from by
+        rw [show signExtend13 (28 : BitVec 13) = (28 : Word) from by decide]; bv_omega,
+      show (base + 4 : Word) + 4 = base + 8 from by bv_omega] at hbr1
+  have hnult56 : ¬ BitVec.ult len (56 : Word) :=
+    not_ult_of_toNat_ge (by rw [show ((56 : Word)).toNat = 56 from by decide]; omega)
+  have ht1 := cpsBranchWithin_takenStripPure2 hbr1 (fun hp hQf => by
+    obtain ⟨_, _, _, _, _, hQ⟩ := hQf
+    exact hnult56 ((sepConj_pure_right _).1 hQ).2)
+  -- idx8 (base+32): LI x28, 1
+  have hli28 := liftCode (cr' := CR)
+    (li_spec_gen_within .x28 v28 (1 : Word) (base + 32) (by decide))
+    (by rw [hCR]; cmem 8)
+  rw [show (base + 32 : Word) + 4 = base + 36 from by bv_omega] at hli28
+  -- idx9 (base+36): LI x29, 256
+  have hli29 := liftCode (cr' := CR)
+    (li_spec_gen_within .x29 v29 (256 : Word) (base + 36) (by decide))
+    (by rw [hCR]; cmem 9)
+  rw [show (base + 36 : Word) + 4 = base + 40 from by bv_omega] at hli29
+  -- idx10 (base+40): BLTU x10, x29, +80 — NOT taken (len ≥ 256) → base+44
+  have hbr10 := cpsBranchWithin_extend_code (cr' := CR)
+    (hmono := by rw [hCR]; cmem 10)
+    (h := bltu_spec_gen_within .x10 .x29 (80 : BitVec 13) len (256 : Word) (base + 40))
+  rw [show (base + 40 : Word) + signExtend13 (80 : BitVec 13) = base + 120 from by
+        rw [show signExtend13 (80 : BitVec 13) = (80 : Word) from by decide]; bv_omega,
+      show (base + 40 : Word) + 4 = base + 44 from by bv_omega] at hbr10
+  have hnult256 : ¬ BitVec.ult len (256 : Word) :=
+    not_ult_of_toNat_ge (by rw [show ((256 : Word)).toNat = 256 from by decide]; omega)
+  have hnt10 := cpsBranchWithin_ntakenStripPure2 hbr10 (fun hp hQt => by
+    obtain ⟨_, _, _, _, _, hQ⟩ := hQt
+    exact hnult256 ((sepConj_pure_right _).1 hQ).2)
+  -- idx11 (base+44): LI x28, 2
+  have hli28b := liftCode (cr' := CR)
+    (li_spec_gen_within .x28 (1 : Word) (2 : Word) (base + 44) (by decide))
+    (by rw [hCR]; cmem 11)
+  rw [show (base + 44 : Word) + 4 = base + 48 from by bv_omega] at hli28b
+  -- idx12 (base+48): SLLI x29, x29, 8 — x29 := 65536
+  have hsll12 := liftCode (cr' := CR)
+    (slli_spec_gen_same_within .x29 (256 : Word) (8 : BitVec 6) (base + 48) (by decide))
+    (by rw [hCR]; cmem 12)
+  rw [show (base + 48 : Word) + 4 = base + 52 from by bv_omega,
+      show ((256 : Word) <<< ((8 : BitVec 6)).toNat) = (65536 : Word) from by decide] at hsll12
+  -- idx13 (base+52): BLTU x10, x29, +68 — NOT taken (len ≥ 65536) → base+56
+  have hbr13 := cpsBranchWithin_extend_code (cr' := CR)
+    (hmono := by rw [hCR]; cmem 13)
+    (h := bltu_spec_gen_within .x10 .x29 (68 : BitVec 13) len (65536 : Word) (base + 52))
+  rw [show (base + 52 : Word) + signExtend13 (68 : BitVec 13) = base + 120 from by
+        rw [show signExtend13 (68 : BitVec 13) = (68 : Word) from by decide]; bv_omega,
+      show (base + 52 : Word) + 4 = base + 56 from by bv_omega] at hbr13
+  have hnult65536 : ¬ BitVec.ult len (65536 : Word) :=
+    not_ult_of_toNat_ge (by rw [show ((65536 : Word)).toNat = 65536 from by decide]; omega)
+  have hnt13 := cpsBranchWithin_ntakenStripPure2 hbr13 (fun hp hQt => by
+    obtain ⟨_, _, _, _, _, hQ⟩ := hQt
+    exact hnult65536 ((sepConj_pure_right _).1 hQ).2)
+  -- idx14 (base+56): LI x28, 3
+  have hli28c := liftCode (cr' := CR)
+    (li_spec_gen_within .x28 (2 : Word) (3 : Word) (base + 56) (by decide))
+    (by rw [hCR]; cmem 14)
+  rw [show (base + 56 : Word) + 4 = base + 60 from by bv_omega] at hli28c
+  -- idx15 (base+60): SLLI x29, x29, 8 — x29 := 16777216
+  have hsll15 := liftCode (cr' := CR)
+    (slli_spec_gen_same_within .x29 (65536 : Word) (8 : BitVec 6) (base + 60) (by decide))
+    (by rw [hCR]; cmem 15)
+  rw [show (base + 60 : Word) + 4 = base + 64 from by bv_omega,
+      show ((65536 : Word) <<< ((8 : BitVec 6)).toNat) = (16777216 : Word) from by
+        decide] at hsll15
+  -- idx16 (base+64): BLTU x10, x29, +56 — TAKEN (len < 2^24) → base+120
+  have hbr16 := cpsBranchWithin_extend_code (cr' := CR)
+    (hmono := by rw [hCR]; cmem 16)
+    (h := bltu_spec_gen_within .x10 .x29 (56 : BitVec 13) len (16777216 : Word) (base + 64))
+  rw [show (base + 64 : Word) + signExtend13 (56 : BitVec 13) = base + 120 from by
+        rw [show signExtend13 (56 : BitVec 13) = (56 : Word) from by decide]; bv_omega,
+      show (base + 64 : Word) + 4 = base + 68 from by bv_omega] at hbr16
+  have hult16m : BitVec.ult len (16777216 : Word) :=
+    ult_of_toNat_lt (by rw [show ((16777216 : Word)).toNat = 16777216 from by decide]; omega)
+  have ht16 := cpsBranchWithin_takenStripPure2 hbr16 (fun hp hQf => by
+    obtain ⟨_, _, _, _, _, hQ⟩ := hQf
+    exact ((sepConj_pure_right _).1 hQ).2 hult16m)
+  -- idx30 (base+120): ADDI x29, x28, 247 — x29 := 0xFA
+  have ha30 := liftCode (cr' := CR)
+    (addi_spec_gen_within .x29 .x28 (16777216 : Word) (3 : Word)
+      (247 : BitVec 12) (base + 120) (by decide))
+    (by rw [hCR]; cmem 30)
+  rw [show (base + 120 : Word) + 4 = base + 124 from by bv_omega,
+      show (3 : Word) + signExtend12 (247 : BitVec 12) = (250 : Word) from by decide] at ha30
+  -- idx31 (base+124): SB x11, x29 — out[0] := 0xFA
+  have hsb31 := liftCode (cr' := CR)
+    (bytesRegion_sb_within .x11 .x29 outPtr (250 : Word) (base + 124) outBytes 0
+      h_out_align h_out_len0 (by have := outPtr.isLt; omega) (h_out_valid 0 h_out_len0))
+    (by rw [hCR]; cmem 31)
+  rw [show outPtr + BitVec.ofNat 64 0 = outPtr from by bv_omega,
+      show ((250 : Word)).truncate 8 = (0xFA : BitVec 8) from by decide,
+      show (base + 124 : Word) + 4 = base + 128 from by bv_omega] at hsb31
+  -- idx32 (base+128): MV x30, x11
+  have hmv := liftCode (cr' := CR)
+    (mv_spec_gen_within .x30 .x11 outPtr v30 (base + 128) (by decide))
+    (by rw [hCR]; cmem 32)
+  rw [show (base + 128 : Word) + 4 = base + 132 from by bv_omega] at hmv
+  -- idx33 (base+132): ADDI x30, x30, 1 — x30 := outPtr + 1
+  have ha33 := liftCode (cr' := CR)
+    (addi_spec_gen_same_within .x30 outPtr (1 : BitVec 12) (base + 132) (by decide))
+    (by rw [hCR]; cmem 33)
+  rw [show (base + 132 : Word) + 4 = base + 136 from by bv_omega,
+      show outPtr + signExtend12 (1 : BitVec 12) = outPtr + BitVec.ofNat 64 1 from by
+        rw [show signExtend12 (1 : BitVec 12) = BitVec.ofNat 64 1 from by decide]] at ha33
+  -- idx34 (base+136): ADDI x29, x28, -1 — x29 := 2 = lenlen - 1
+  have ha34 := liftCode (cr' := CR)
+    (addi_spec_gen_within .x29 .x28 (250 : Word) (3 : Word)
+      (-1 : BitVec 12) (base + 136) (by decide))
+    (by rw [hCR]; cmem 34)
+  rw [show (base + 136 : Word) + 4 = base + 140 from by bv_omega,
+      show (3 : Word) + signExtend12 (-1 : BitVec 12) = (2 : Word) from by decide] at ha34
+  -- ══ ⭐ idx35–41 (base+140 → base+168): the length-byte loop, cited whole ══
+  have hloop := lpLolLoop base outPtr v31 (56 : Word) len
+    (outBytes.set 0 (0xFA : BitVec 8)) 1 3 (by omega) h_out_align
+    (by rw [List.length_set]; omega)
+    (by have := outPtr.isLt; omega)
+    (fun k hk => h_out_valid (1 + k) (by omega))
+  rw [show 7 * 3 + 1 = 22 from by norm_num,
+      show BitVec.ofNat 64 3 - 1 = (2 : Word) from by decide,
+      show (1 : Nat) + 3 = 4 from by norm_num,
+      writeShift_three (outBytes.set 0 (0xFA : BitVec 8)) len] at hloop
+  -- idx42 (base+168): ADDI x30, x28, 1 — x30 := 4 (header length)
+  have ha42 := liftCode (cr' := CR)
+    (addi_spec_gen_within .x30 .x28 (outPtr + BitVec.ofNat 64 4) (3 : Word)
+      (1 : BitVec 12) (base + 168) (by decide))
+    (by rw [hCR]; cmem 42)
+  rw [show (base + 168 : Word) + 4 = base + 172 from by bv_omega,
+      show (3 : Word) + signExtend12 (1 : BitVec 12) = (4 : Word) from by decide] at ha42
+  -- idx43 (base+172): SD x12, x30 — *cell := 4
+  have hsd := liftCode (cr' := CR)
+    (sd_spec_within .x12 .x30 cellPtr (4 : Word) cellOld (0 : BitVec 12) (base + 172))
+    (by rw [hCR]; cmem 43)
+  simp only [signExtend12_0] at hsd
+  rw [show cellPtr + (0 : Word) = cellPtr from by bv_omega,
+      show (base + 172 : Word) + 4 = base + 176 from by bv_omega] at hsd
+  -- idx44 (base+176): LI x10, 0
+  have hli10 := liftCode (cr' := CR)
+    (li_spec_gen_within .x10 len (0 : Word) (base + 176) (by decide))
+    (by rw [hCR]; cmem 44)
+  rw [show (base + 176 : Word) + 4 = base + 180 from by bv_omega] at hli10
+  -- idx45 (base+180): ret
+  have hret := liftCode (cr' := CR)
+    (EvmAsm.Evm64.ret_spec_within' (base + 180) raVal)
+    (by rw [hCR]; cmem 45)
+  -- ══ frames ══
+  have hli5F := cpsTripleWithin_frameR
+    (((.x1 : Reg) ↦ᵣ raVal) ** ((.x10 : Reg) ↦ᵣ len) **
+     ((.x11 : Reg) ↦ᵣ outPtr) ** ((.x12 : Reg) ↦ᵣ cellPtr) **
+     ((.x28 : Reg) ↦ᵣ v28) ** ((.x29 : Reg) ↦ᵣ v29) **
+     ((.x30 : Reg) ↦ᵣ v30) ** ((.x31 : Reg) ↦ᵣ v31) **
+     ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+     bytesRegion outPtr outBytes ** (cellPtr ↦ₘ cellOld))
+    (by pcf) hli5
+  have ht1F := cpsTripleWithin_frameR
+    (((.x1 : Reg) ↦ᵣ raVal) ** ((.x11 : Reg) ↦ᵣ outPtr) ** ((.x12 : Reg) ↦ᵣ cellPtr) **
+     ((.x28 : Reg) ↦ᵣ v28) ** ((.x29 : Reg) ↦ᵣ v29) **
+     ((.x30 : Reg) ↦ᵣ v30) ** ((.x31 : Reg) ↦ᵣ v31) **
+     ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+     bytesRegion outPtr outBytes ** (cellPtr ↦ₘ cellOld))
+    (by pcf) ht1
+  have hli28F := cpsTripleWithin_frameR
+    (((.x1 : Reg) ↦ᵣ raVal) ** ((.x10 : Reg) ↦ᵣ len) **
+     ((.x11 : Reg) ↦ᵣ outPtr) ** ((.x12 : Reg) ↦ᵣ cellPtr) **
+     ((.x5 : Reg) ↦ᵣ (56 : Word)) ** ((.x29 : Reg) ↦ᵣ v29) **
+     ((.x30 : Reg) ↦ᵣ v30) ** ((.x31 : Reg) ↦ᵣ v31) **
+     ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+     bytesRegion outPtr outBytes ** (cellPtr ↦ₘ cellOld))
+    (by pcf) hli28
+  have hli29F := cpsTripleWithin_frameR
+    (((.x1 : Reg) ↦ᵣ raVal) ** ((.x10 : Reg) ↦ᵣ len) **
+     ((.x11 : Reg) ↦ᵣ outPtr) ** ((.x12 : Reg) ↦ᵣ cellPtr) **
+     ((.x5 : Reg) ↦ᵣ (56 : Word)) ** ((.x28 : Reg) ↦ᵣ (1 : Word)) **
+     ((.x30 : Reg) ↦ᵣ v30) ** ((.x31 : Reg) ↦ᵣ v31) **
+     ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+     bytesRegion outPtr outBytes ** (cellPtr ↦ₘ cellOld))
+    (by pcf) hli29
+  have hnt10F := cpsTripleWithin_frameR
+    (((.x1 : Reg) ↦ᵣ raVal) ** ((.x11 : Reg) ↦ᵣ outPtr) ** ((.x12 : Reg) ↦ᵣ cellPtr) **
+     ((.x5 : Reg) ↦ᵣ (56 : Word)) ** ((.x28 : Reg) ↦ᵣ (1 : Word)) **
+     ((.x30 : Reg) ↦ᵣ v30) ** ((.x31 : Reg) ↦ᵣ v31) **
+     ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+     bytesRegion outPtr outBytes ** (cellPtr ↦ₘ cellOld))
+    (by pcf) hnt10
+  have hli28bF := cpsTripleWithin_frameR
+    (((.x1 : Reg) ↦ᵣ raVal) ** ((.x10 : Reg) ↦ᵣ len) **
+     ((.x11 : Reg) ↦ᵣ outPtr) ** ((.x12 : Reg) ↦ᵣ cellPtr) **
+     ((.x5 : Reg) ↦ᵣ (56 : Word)) ** ((.x29 : Reg) ↦ᵣ (256 : Word)) **
+     ((.x30 : Reg) ↦ᵣ v30) ** ((.x31 : Reg) ↦ᵣ v31) **
+     ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+     bytesRegion outPtr outBytes ** (cellPtr ↦ₘ cellOld))
+    (by pcf) hli28b
+  have hsll12F := cpsTripleWithin_frameR
+    (((.x1 : Reg) ↦ᵣ raVal) ** ((.x10 : Reg) ↦ᵣ len) **
+     ((.x11 : Reg) ↦ᵣ outPtr) ** ((.x12 : Reg) ↦ᵣ cellPtr) **
+     ((.x5 : Reg) ↦ᵣ (56 : Word)) ** ((.x28 : Reg) ↦ᵣ (2 : Word)) **
+     ((.x30 : Reg) ↦ᵣ v30) ** ((.x31 : Reg) ↦ᵣ v31) **
+     ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+     bytesRegion outPtr outBytes ** (cellPtr ↦ₘ cellOld))
+    (by pcf) hsll12
+  have hnt13F := cpsTripleWithin_frameR
+    (((.x1 : Reg) ↦ᵣ raVal) ** ((.x11 : Reg) ↦ᵣ outPtr) ** ((.x12 : Reg) ↦ᵣ cellPtr) **
+     ((.x5 : Reg) ↦ᵣ (56 : Word)) ** ((.x28 : Reg) ↦ᵣ (2 : Word)) **
+     ((.x30 : Reg) ↦ᵣ v30) ** ((.x31 : Reg) ↦ᵣ v31) **
+     ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+     bytesRegion outPtr outBytes ** (cellPtr ↦ₘ cellOld))
+    (by pcf) hnt13
+  have hli28cF := cpsTripleWithin_frameR
+    (((.x1 : Reg) ↦ᵣ raVal) ** ((.x10 : Reg) ↦ᵣ len) **
+     ((.x11 : Reg) ↦ᵣ outPtr) ** ((.x12 : Reg) ↦ᵣ cellPtr) **
+     ((.x5 : Reg) ↦ᵣ (56 : Word)) ** ((.x29 : Reg) ↦ᵣ (65536 : Word)) **
+     ((.x30 : Reg) ↦ᵣ v30) ** ((.x31 : Reg) ↦ᵣ v31) **
+     ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+     bytesRegion outPtr outBytes ** (cellPtr ↦ₘ cellOld))
+    (by pcf) hli28c
+  have hsll15F := cpsTripleWithin_frameR
+    (((.x1 : Reg) ↦ᵣ raVal) ** ((.x10 : Reg) ↦ᵣ len) **
+     ((.x11 : Reg) ↦ᵣ outPtr) ** ((.x12 : Reg) ↦ᵣ cellPtr) **
+     ((.x5 : Reg) ↦ᵣ (56 : Word)) ** ((.x28 : Reg) ↦ᵣ (3 : Word)) **
+     ((.x30 : Reg) ↦ᵣ v30) ** ((.x31 : Reg) ↦ᵣ v31) **
+     ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+     bytesRegion outPtr outBytes ** (cellPtr ↦ₘ cellOld))
+    (by pcf) hsll15
+  have ht16F := cpsTripleWithin_frameR
+    (((.x1 : Reg) ↦ᵣ raVal) ** ((.x11 : Reg) ↦ᵣ outPtr) ** ((.x12 : Reg) ↦ᵣ cellPtr) **
+     ((.x5 : Reg) ↦ᵣ (56 : Word)) ** ((.x28 : Reg) ↦ᵣ (3 : Word)) **
+     ((.x30 : Reg) ↦ᵣ v30) ** ((.x31 : Reg) ↦ᵣ v31) **
+     ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+     bytesRegion outPtr outBytes ** (cellPtr ↦ₘ cellOld))
+    (by pcf) ht16
+  have ha30F := cpsTripleWithin_frameR
+    (((.x1 : Reg) ↦ᵣ raVal) ** ((.x10 : Reg) ↦ᵣ len) **
+     ((.x11 : Reg) ↦ᵣ outPtr) ** ((.x12 : Reg) ↦ᵣ cellPtr) **
+     ((.x5 : Reg) ↦ᵣ (56 : Word)) **
+     ((.x30 : Reg) ↦ᵣ v30) ** ((.x31 : Reg) ↦ᵣ v31) **
+     ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+     bytesRegion outPtr outBytes ** (cellPtr ↦ₘ cellOld))
+    (by pcf) ha30
+  have hsb31F := cpsTripleWithin_frameR
+    (((.x1 : Reg) ↦ᵣ raVal) ** ((.x10 : Reg) ↦ᵣ len) ** ((.x12 : Reg) ↦ᵣ cellPtr) **
+     ((.x5 : Reg) ↦ᵣ (56 : Word)) ** ((.x28 : Reg) ↦ᵣ (3 : Word)) **
+     ((.x30 : Reg) ↦ᵣ v30) ** ((.x31 : Reg) ↦ᵣ v31) **
+     ((.x0 : Reg) ↦ᵣ (0 : Word)) ** (cellPtr ↦ₘ cellOld))
+    (by pcf) hsb31
+  have hmvF := cpsTripleWithin_frameR
+    (((.x1 : Reg) ↦ᵣ raVal) ** ((.x10 : Reg) ↦ᵣ len) ** ((.x12 : Reg) ↦ᵣ cellPtr) **
+     ((.x5 : Reg) ↦ᵣ (56 : Word)) ** ((.x28 : Reg) ↦ᵣ (3 : Word)) **
+     ((.x29 : Reg) ↦ᵣ (250 : Word)) ** ((.x31 : Reg) ↦ᵣ v31) **
+     ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+     bytesRegion outPtr (outBytes.set 0 (0xFA : BitVec 8)) ** (cellPtr ↦ₘ cellOld))
+    (by pcf) hmv
+  have ha33F := cpsTripleWithin_frameR
+    (((.x1 : Reg) ↦ᵣ raVal) ** ((.x10 : Reg) ↦ᵣ len) **
+     ((.x11 : Reg) ↦ᵣ outPtr) ** ((.x12 : Reg) ↦ᵣ cellPtr) **
+     ((.x5 : Reg) ↦ᵣ (56 : Word)) ** ((.x28 : Reg) ↦ᵣ (3 : Word)) **
+     ((.x29 : Reg) ↦ᵣ (250 : Word)) ** ((.x31 : Reg) ↦ᵣ v31) **
+     ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+     bytesRegion outPtr (outBytes.set 0 (0xFA : BitVec 8)) ** (cellPtr ↦ₘ cellOld))
+    (by pcf) ha33
+  have ha34F := cpsTripleWithin_frameR
+    (((.x1 : Reg) ↦ᵣ raVal) ** ((.x10 : Reg) ↦ᵣ len) **
+     ((.x11 : Reg) ↦ᵣ outPtr) ** ((.x12 : Reg) ↦ᵣ cellPtr) **
+     ((.x5 : Reg) ↦ᵣ (56 : Word)) **
+     ((.x30 : Reg) ↦ᵣ (outPtr + BitVec.ofNat 64 1)) ** ((.x31 : Reg) ↦ᵣ v31) **
+     ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+     bytesRegion outPtr (outBytes.set 0 (0xFA : BitVec 8)) ** (cellPtr ↦ₘ cellOld))
+    (by pcf) ha34
+  have hloopF := cpsTripleWithin_frameR
+    (((.x1 : Reg) ↦ᵣ raVal) ** ((.x11 : Reg) ↦ᵣ outPtr) ** ((.x12 : Reg) ↦ᵣ cellPtr) **
+     ((.x28 : Reg) ↦ᵣ (3 : Word)) ** (cellPtr ↦ₘ cellOld))
+    (by pcf) hloop
+  have ha42F := cpsTripleWithin_frameR
+    (((.x1 : Reg) ↦ᵣ raVal) ** ((.x10 : Reg) ↦ᵣ len) **
+     ((.x11 : Reg) ↦ᵣ outPtr) ** ((.x12 : Reg) ↦ᵣ cellPtr) **
+     regOwn .x5 ** ((.x29 : Reg) ↦ᵣ (-1 : Word)) ** regOwn .x31 **
+     ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+     bytesRegion outPtr
+       ((((outBytes.set 0 (0xFA : BitVec 8)).set 1
+            (BitVec.ofNat 8 (len >>> (16 : Nat)).toNat)).set 2
+           (BitVec.ofNat 8 (len >>> (8 : Nat)).toNat)).set 3
+         (BitVec.ofNat 8 len.toNat)) ** (cellPtr ↦ₘ cellOld))
+    (by pcf) ha42
+  have hsdF := cpsTripleWithin_frameR
+    (((.x1 : Reg) ↦ᵣ raVal) ** ((.x10 : Reg) ↦ᵣ len) **
+     ((.x11 : Reg) ↦ᵣ outPtr) **
+     regOwn .x5 ** ((.x28 : Reg) ↦ᵣ (3 : Word)) **
+     ((.x29 : Reg) ↦ᵣ (-1 : Word)) ** regOwn .x31 **
+     ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+     bytesRegion outPtr
+       ((((outBytes.set 0 (0xFA : BitVec 8)).set 1
+            (BitVec.ofNat 8 (len >>> (16 : Nat)).toNat)).set 2
+           (BitVec.ofNat 8 (len >>> (8 : Nat)).toNat)).set 3
+         (BitVec.ofNat 8 len.toNat)))
+    (by pcf) hsd
+  have hli10F := cpsTripleWithin_frameR
+    (((.x1 : Reg) ↦ᵣ raVal) ** ((.x11 : Reg) ↦ᵣ outPtr) ** ((.x12 : Reg) ↦ᵣ cellPtr) **
+     regOwn .x5 ** ((.x28 : Reg) ↦ᵣ (3 : Word)) **
+     ((.x29 : Reg) ↦ᵣ (-1 : Word)) ** ((.x30 : Reg) ↦ᵣ (4 : Word)) ** regOwn .x31 **
+     ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+     bytesRegion outPtr
+       ((((outBytes.set 0 (0xFA : BitVec 8)).set 1
+            (BitVec.ofNat 8 (len >>> (16 : Nat)).toNat)).set 2
+           (BitVec.ofNat 8 (len >>> (8 : Nat)).toNat)).set 3
+         (BitVec.ofNat 8 len.toNat)) **
+     (cellPtr ↦ₘ (4 : Word)))
+    (by pcf) hli10
+  have hretF := cpsTripleWithin_frameR
+    (((.x10 : Reg) ↦ᵣ (0 : Word)) ** ((.x11 : Reg) ↦ᵣ outPtr) **
+     ((.x12 : Reg) ↦ᵣ cellPtr) **
+     regOwn .x5 ** ((.x28 : Reg) ↦ᵣ (3 : Word)) **
+     ((.x29 : Reg) ↦ᵣ (-1 : Word)) ** ((.x30 : Reg) ↦ᵣ (4 : Word)) ** regOwn .x31 **
+     ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+     bytesRegion outPtr
+       ((((outBytes.set 0 (0xFA : BitVec 8)).set 1
+            (BitVec.ofNat 8 (len >>> (16 : Nat)).toNat)).set 2
+           (BitVec.ofNat 8 (len >>> (8 : Nat)).toNat)).set 3
+         (BitVec.ofNat 8 len.toNat)) **
+     (cellPtr ↦ₘ (4 : Word)))
+    (by pcf) hret
+  -- ══ compose: 11 ladder + 5 header + 22 loop + 3 epilogue + 1 ret = 42 ══
+  have hc1 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) hli5F ht1F
+  have hc2 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) hc1 hli28F
+  have hc3 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) hc2 hli29F
+  have hc4 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) hc3 hnt10F
+  have hc5 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) hc4 hli28bF
+  have hc6 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) hc5 hsll12F
+  have hc7 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) hc6 hnt13F
+  have hc8 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) hc7 hli28cF
+  have hc9 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) hc8 hsll15F
+  have hc10 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) hc9 ht16F
+  have hc11 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) hc10 ha30F
+  have hc12 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) hc11 hsb31F
+  have hc13 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) hc12 hmvF
+  have hc14 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) hc13 ha33F
+  have hc15 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) hc14 ha34F
+  have hc16 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) hc15 hloopF
+  have hc17 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) hc16 ha42F
+  have hc18 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) hc17 hsdF
+  have hc19 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) hc18 hli10F
+  have hc20 := cpsTripleWithin_seq_perm_same_cr (fun _ hp => by xperm_hyp hp) hc19 hretF
+  refine cpsTripleWithin_weaken (fun _ hp => by xperm_hyp hp) (fun h hq => ?_) hc20
+  have hq1 : (((.x28 : Reg) ↦ᵣ (3 : Word)) **
+      (((.x29 : Reg) ↦ᵣ (-1 : Word)) **
+       (((.x30 : Reg) ↦ᵣ (4 : Word)) **
+        (((.x1 : Reg) ↦ᵣ raVal) ** ((.x10 : Reg) ↦ᵣ (0 : Word)) **
+         ((.x11 : Reg) ↦ᵣ outPtr) ** ((.x12 : Reg) ↦ᵣ cellPtr) **
+         regOwn .x5 ** regOwn .x31 **
+         ((.x0 : Reg) ↦ᵣ (0 : Word)) **
+         bytesRegion outPtr
+           ((((outBytes.set 0 (0xFA : BitVec 8)).set 1
+                (BitVec.ofNat 8 (len >>> (16 : Nat)).toNat)).set 2
+               (BitVec.ofNat 8 (len >>> (8 : Nat)).toNat)).set 3
+             (BitVec.ofNat 8 len.toNat)) **
+         (cellPtr ↦ₘ (4 : Word)))))) h := by
+    xperm_hyp hq
+  have hq2 := sepConj_mono (regIs_to_regOwn .x28 _)
+    (sepConj_mono (regIs_to_regOwn .x29 _)
+      (sepConj_mono (regIs_to_regOwn .x30 _) (fun _ hh => hh))) h hq1
+  xperm_hyp hq2
+
+end RlpEncodeListPrefixLong3Spec
+
+end EvmAsm.Codegen

--- a/EvmAsm/Progress/AxiomWitnesses.lean
+++ b/EvmAsm/Progress/AxiomWitnesses.lean
@@ -124,6 +124,10 @@ import EvmAsm.Progress.Correspondence
 
 #print axioms EvmAsm.Codegen.RlpEncodeListPrefixLong2Spec.rlp_encode_list_prefix_long2_pinned_spec_within
 
+#print axioms EvmAsm.Codegen.RlpEncodeListPrefixLong3Spec.long3_first_length_byte_ne_zero
+
+#print axioms EvmAsm.Codegen.RlpEncodeListPrefixLong3Spec.rlp_encode_list_prefix_long3_pinned_spec_within
+
 #print axioms EvmAsm.Codegen.RlpEncodeListPrefixLoopSpec.lpLolBody
 
 #print axioms EvmAsm.Codegen.RlpEncodeListPrefixLoopSpec.lpLolLoop

--- a/EvmAsm/Progress/Correspondence.lean
+++ b/EvmAsm/Progress/Correspondence.lean
@@ -359,17 +359,23 @@ reubOut_eq_encode_toBytesBE." },
     spec := some "rlp_encode_list_prefix_short_pinned_spec_within",
     verdict := .domainRestricted, basis := .bridged,
     reference := "header of encode_sequence",
-    note := "no unified dispatch theorem — three per-form pinned triples, cited here by \
-the short one because this file carries one row per routine. Coverage is `len < 65536`: \
-short (`len < 56`), long1 (`56 ≤ len < 256`, `rlp_encode_list_prefix_long1_pinned_spec_within`) \
-and long2 (`256 ≤ len < 65536`, `…_long2_pinned_spec_within`, where the length-byte loop \
-first runs more than once and `long2_first_length_byte_ne_zero` makes canonical form a real \
-obligation rather than a vacuous one). ⚠️ THE CUT IS `lenlen ≥ 3` (payload ≥ 65536 B), NOT \
-`lenlen ≥ 2` as this note said until #10780's long2 arm landed — `Progress/Routines.lean` \
-carried all three rows while this row still described the pre-long2 state, so the two \
-registries disagreed about the same routine. The general arm wants the loop invariant \
-sketched at `RlpEncodeListPrefixLong2Spec.lean:47-52` (`x30` holds the top `k` bytes of \
-`len`, `x29 = lenlen - 1 - k`); unrolling stops paying around `lenlen = 4`" },
+    note := "no unified dispatch theorem — FOUR per-form pinned triples, cited here by \
+the short one because this file carries one row per routine. Coverage is \
+`len < 16777216`: short (`len < 56`), long1 (`56 ≤ len < 256`), long2 \
+(`256 ≤ len < 65536`, where the length-byte loop first runs more than once and canonical \
+form stops being vacuous) and long3 (`65536 ≤ len < 16777216`, \
+`…_long3_pinned_spec_within`). ⚠️ THE CUT IS `lenlen ≥ 4` (payload ≥ 16777216 B). It was \
+`lenlen ≥ 2` in this note until long2 landed and `lenlen ≥ 3` until long3 did; \
+`Progress/Routines.lean` carried the rows both times while this row described the previous \
+state, so keep them in step. ⭐ The remaining widths are no longer priced at the \
+~200-lines-per-byte the long2 header warned about: `lpLolLoop` \
+(`RlpEncodeListPrefixLoopSpec`) proves the length-byte loop idx35-idx41 at ANY trip count \
+`≤ 8`, and `first_length_byte_ne_zero` (`RlpEncodeListPrefixCanonical`) discharges \
+canonicality at every width, so each further arm is its ladder path plus the fixed \
+header/epilogue — long3 is the worked instance. ⚠️ At `lenlen = 8` the loop's overflow \
+side condition needs `outPtr.toNat + 9 ≤ 2^64`, which is MORE slack than the 8 that \
+`outPtr.toNat % 8 = 0` alone supplies; that arm needs an explicit bound rather than \
+reusing long3's `omega` step" },
   { family := "rlp", routine := "rlp_encode_bytes",
     spec := some "reb_spec_within",
     verdict := .agrees, basis := .bridged, reference := "encode_bytes",

--- a/EvmAsm/Progress/Routines.lean
+++ b/EvmAsm/Progress/Routines.lean
@@ -88,6 +88,9 @@ import EvmAsm.Codegen.Programs.RlpListNthItemSAsm
 import EvmAsm.Codegen.Programs.RlpListCountItemsSAsm
 import EvmAsm.Codegen.Programs.RlpEncodeListPrefixCanonical
 import EvmAsm.Codegen.Programs.RlpEncodeListPrefixLoopSpec
+-- #10780 item 3, next width: the 3-length-byte long form, first arm to cite
+-- `lpLolLoop` instead of unrolling the length-byte loop.
+import EvmAsm.Codegen.Programs.RlpEncodeListPrefixLong3Spec
 import EvmAsm.Codegen.Programs.AccountDecodeCorrespondence
 import EvmAsm.Codegen.Programs.RlpListCountItemsBridge
 import EvmAsm.Codegen.Programs.BgvU32leSpec
@@ -490,6 +493,24 @@ def routineRegistry : List RoutineEntry := [
         ++ "discharged separately by `long2_first_length_byte_ne_zero`: the high "
         ++ "byte is nonzero, so the length-of-length carries no leading zero — "
         ++ "vacuous at long1, real from here on"),
+  -- #10780 item 3: the first arm that CITES the length-byte loop instead of
+  -- unrolling it. `lpLolLoop` (RlpEncodeListPrefixLoopSpec) proves idx35-idx41 at
+  -- a symbolic trip count, so this arm is its ladder path plus the fixed
+  -- header/epilogue -- which is why it costs 580 lines rather than the ~200/byte
+  -- the long2 header priced unrolling at.
+  routine "rlp_encode_list_prefix" .conditional
+      (some "rlp_encode_list_prefix_long3_pinned_spec_within")
+      (gate := "`65536 ≤ len.toNat < 16777216` — the 3-length-byte long form. With "
+        ++ "the short, long1 and long2 rows this covers `len < 16777216`; the cut "
+        ++ "moves to `lenlen ≥ 4`")
+      (notes := "per-form (\"long3\") pinned triple; writes "
+        ++ "`[0xFA, len >>> 16, len >>> 8, len]` and sets the cell flag to 4. Step "
+        ++ "bound 42 = 11 ladder + 5 header + 22 loop (`7*3+1`) + 3 epilogue + 1 "
+        ++ "`JALR`. ⭐ The loop is CITED, not unrolled: `lpLolLoop` covers "
+        ++ "idx35-idx41 at any trip count `≤ 8`, so each further width is its "
+        ++ "ladder path plus this same epilogue. Canonical form comes from the "
+        ++ "all-widths `first_length_byte_ne_zero`, specialised here as "
+        ++ "`long3_first_length_byte_ne_zero`"),
 
   -- #11291: the whole-routine triple already existed (landed 2026-07-17,
   -- closed #10782) but was never registered. It is `wdPrologue ;; wdBBField0`
@@ -657,10 +678,10 @@ def routineCount : Nat := routineRegistry.length
 def routineCountTier (t : ProofTier) : Nat :=
   (routineRegistry.filter (fun e => e.tier == t)).length
 
-theorem routineCount_eq : routineCount = 52 := by decide
+theorem routineCount_eq : routineCount = 53 := by decide
 
 theorem routineProvenCount_eq      : routineCountTier .proven      = 37 := by decide
-theorem routineConditionalCount_eq : routineCountTier .conditional = 15 := by decide
+theorem routineConditionalCount_eq : routineCountTier .conditional = 16 := by decide
 theorem routinePartlyCount_eq      : routineCountTier .partly      = 0 := by decide
 
 /-- Every row names a witness theorem. The `none` case is what
@@ -921,6 +942,10 @@ private noncomputable abbrev _rlp_encode_list_prefix_long2_routine_witness :=
   @EvmAsm.Codegen.RlpEncodeListPrefixLong2Spec.rlp_encode_list_prefix_long2_pinned_spec_within
 private noncomputable abbrev _rlp_encode_list_prefix_long2_canonical_witness :=
   @EvmAsm.Codegen.RlpEncodeListPrefixLong2Spec.long2_first_length_byte_ne_zero
+private noncomputable abbrev _rlp_encode_list_prefix_long3_routine_witness :=
+  @EvmAsm.Codegen.RlpEncodeListPrefixLong3Spec.rlp_encode_list_prefix_long3_pinned_spec_within
+private noncomputable abbrev _rlp_encode_list_prefix_long3_canonical_witness :=
+  @EvmAsm.Codegen.RlpEncodeListPrefixLong3Spec.long3_first_length_byte_ne_zero
 -- #11291: the whole-routine withdrawal decoder (existed since #10782).
 private noncomputable abbrev _bgv_u32le_routine_witness :=
   @EvmAsm.Codegen.ExecutionRequestsHashBgvOffset.bgv_u32le_offset_spec_within


### PR DESCRIPTION
#12028 landed `lpLolLoop` — the length-byte loop at a **symbolic** trip count. This is the first arm to consume it, and it is the evidence that doing so composes.

`rlp_encode_list_prefix_long3_pinned_spec_within` covers `65536 ≤ len < 16777216`: writes `[0xFA, len >>> 16, len >>> 8, len]`, sets the cell flag to 4, returns `a0 = 0`.

**The registry cut moves from `lenlen ≥ 3` to `lenlen ≥ 4`.** `routineCount` 52 → 53, `conditional` 15 → 16 — both `decide`-checked, and they caught the new row on the first build, which is the registry doing its job.

## ⭐ The loop is cited, not unrolled

`RlpEncodeListPrefixLong2Spec.lean:47-52` priced the general arm at **~200 lines per byte** and warned that unrolling stops paying around `lenlen = 4`. This arm is **580 lines** and required no new loop reasoning at all: idx35–idx41 is a single `lpLolLoop` instantiation at `m = 3`.

So what remains per width is the ladder path plus a fixed header/epilogue. Long3 is the worked instance of that, not a one-off.

Canonicality comes from the all-widths `first_length_byte_ne_zero` (#12019), specialised here as `long3_first_length_byte_ne_zero` — exactly the way `first_length_byte_ne_zero_long2` recovers long2's. Both non-mechanical obligations of the general arm were discharged before this PR; this one only assembles them.

## Step bound 42, and it is self-checking

11 ladder (idx 0,1,8,9,10,11,12,13,14,15,16) + 5 header (idx30–34) + 22 loop (`7*3+1`, which subsumes the exit test) + 3 epilogue + 1 `JALR` = **42**.

That number is unified against the sum the 20 `seq` compositions produce, so the file would not elaborate at any other value. long2's 32 reproduces under the same accounting (8 ladder + 5 + 7 + 7 + 1 + 3 + 1) — I checked that first rather than trusting the derivation for 42.

## Output region: nested `List.set`

Rather than leave the post in `writeShift` form, each index is pinned to its own shift — `out[1] ↦ len >>> 16`, `out[2] ↦ len >>> 8`, `out[3] ↦ len`. That is the anti-swap property long2's header argues for (the loop counts `x29` **down** while `x30` counts **up**, so a symmetric statement would not detect the two being exchanged), and it keeps the two arms diffable. `writeShift_three` bridges the loop's internal `len.toNat / 256^i % 256` form to it.

## ⚠️ One thing recorded for the widest arm

`lpLolLoop`'s overflow side condition wants `outPtr.toNat + (di + m) ≤ 2^64`. At `lenlen = 3` that is `outPtr.toNat + 4`, which `omega` gets from `h_out_align : outPtr.toNat % 8 = 0` — a latent dependency, not from `outPtr.isLt` alone.

**At `lenlen = 8` the requirement is `outPtr.toNat + 9`, which is more slack than alignment supplies.** That arm needs an explicit bound rather than reusing this one's `omega` step. Noted in the correspondence row so it is found before the proof stalls rather than after.

## Discipline

No `set_option maxRecDepth`, no raised elaboration budget anywhere, no `sorry`, no `native_decide`/`bv_decide`.

## Gates actually run

```
LAKE_ARTIFACT_CACHE=false lake build      Build completed successfully (4782 jobs)
scripts/check-no-warnings.sh build.log    0 warnings under EvmAsm/
scripts/check-axioms.sh                   OK — 210 witnesses; classical axioms only
scripts/check-progress.sh                 OK
all 14 CI source-check scripts            PASS
```

Registry: one new `routine` row plus two witness abbrevs; `Correspondence.lean`'s row updated to the new cut, with the `lenlen = 8` overflow note.

Addresses #10780.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
