### PR TITLE
proof: tie empty trie root via split Keccak KAT (#12045)

### DIFF
--- a/EvmAsm/Codegen/Programs/AccountDecodeCorrespondence.lean
+++ b/EvmAsm/Codegen/Programs/AccountDecodeCorrespondence.lean
@@ -7,9 +7,8 @@
   #11517 asks for one of three outcomes per pairing — a correspondence theorem, a
   documented pairing with a stated gap, or a divergence — and names this pair as the one
   to start with, *"because the answer is already known and it establishes the template"*.
-  This module delivers a **kernel correspondence for the code-hash sentinel** and a
-  **numeral drift pin for the trie-root sentinel**, plus a **documented gap with a named
-  blocker** for the field contents (outcome 2). No divergence was found; the one that
+  This module delivers **kernel correspondences for both empty sentinels**, plus a
+  **documented gap with a named blocker** for the field contents (outcome 2). No divergence was found; the one that
   motivated #11517 (#11516) is already repaired.
 
   ## ⭐ What was actually unpinned: the constants, in triplicate
@@ -30,14 +29,12 @@
   `adEmptyCodeHashBytes = EMPTY_CODE_HASH` is now a genuine kernel-checked theorem.
   Its proof isolates the concrete one-block absorption and consumes the pre-existing
   `Accel.keccakF_kat_empty`; the new lemmas add no recursion-depth or heartbeat option.
-  The KAT's existing `maxRecDepth 8000` is documented in `ZiskAccel.lean` as the
-  intrinsic evaluation depth of its 24 rounds.
+  The KAT now evaluates two concrete 12-round chunks under the default recursion
+  limit; no raised limit is part of this correspondence.
 
-  `adEmptyTrieRootBytes = EMPTY_TRIE_ROOT` remains a numeral pin.  Its input is
-  `keccak256 [0x80]`, which needs a different 24-round KAT; a direct concrete proof
-  exhausts the default recursion depth, and this change deliberately adds no new limit
-  raise. Thus the trie-root half stays an honest drift gate until an independently
-  justified intrinsic-depth KAT exists, while the code-hash half is proved to be keccak.
+  The trie-root sentinel now uses the same split-round route with a dedicated
+  keccakF_kat_rlp_empty for the 0x80 RLP input. Neither sentinel correspondence adds
+  a recursion-depth or heartbeat override.
 
   ## The fold, and where the pairing bottoms out
 
@@ -67,10 +64,9 @@ open EvmAsm.Stateless.SpecRef (bytesBEtoNat)
 
 /-! ## The sentinel pins
 
-    The literal-value pins are `decide`-checked 32-byte big-endian folds, which the
-    kernel's GMP-backed `Nat` handles directly. The numerals are the ones
-    `WitnessState.lean:41-46` checks `EMPTY_CODE_HASH` and `EMPTY_TRIE_ROOT` against;
-    the code-hash copy additionally has the direct Keccak theorem above. -/
+    The literal-value pins are decide-checked 32-byte big-endian folds, which the
+    kernel's GMP-backed Nat handles directly. Both copies additionally have direct
+    Keccak correspondences through the split KATs in ZiskAccel.lean. -/
 
 /-- `adEmptyTrieRootBytes` is `keccak256(rlp(""))`, pinned through the numeral SpecRef's
     `#guard` uses for `EMPTY_TRIE_ROOT`. -/
@@ -90,6 +86,11 @@ theorem adEmptyCodeHashBytes_value :
 theorem adEmptyCodeHashBytes_eq_spec :
     adEmptyCodeHashBytes = EvmAsm.Stateless.SpecRef.EMPTY_CODE_HASH := by
   exact EvmAsm.Codegen.AccountDecodeSpec.adEmptyCodeHashBytes_eq_spec
+
+/-- The account-decoder trie-root sentinel is the SpecRef EMPTY_TRIE_ROOT value. -/
+theorem adEmptyTrieRootBytes_eq_spec :
+    adEmptyTrieRootBytes = EvmAsm.Stateless.SpecRef.EMPTY_TRIE_ROOT := by
+  exact EvmAsm.Codegen.AccountDecodeSpec.adEmptyTrieRootBytes_eq_spec
 
 /-- The `account_is_eip161_empty` copy is pinned to the same numeral. -/
 theorem aieEmptyCodeHashBytes_value :

--- a/EvmAsm/Codegen/Programs/AccountDecodeSpec.lean
+++ b/EvmAsm/Codegen/Programs/AccountDecodeSpec.lean
@@ -469,6 +469,41 @@ theorem adEmptyCodeHashBytes_eq_spec :
     adEmptyCodeHash_keccak_empty, Accel.keccakF_kat_empty]
   decide
 
+/-! The RLP encoding of an empty byte string is one byte, 0x80.  Keccak's
+    domain suffix is the following 0x01, so the first absorbed lane is
+    0x0180, not merely 0x80; the final padding bit remains lane 16. -/
+private theorem adEmptyTrieRoot_absorb_block :
+    keccakAbsorbBlock (List.replicate 25 (0 : BitVec 64)) (keccakPad [0x80]) =
+      [0x0180#64, 0#64, 0#64, 0#64, 0#64, 0#64, 0#64, 0#64,
+       0#64, 0#64, 0#64, 0#64, 0#64, 0#64, 0#64, 0#64,
+       0x8000000000000000#64, 0#64, 0#64, 0#64, 0#64, 0#64,
+       0#64, 0#64, 0#64] := by
+  decide
+
+private theorem adEmptyTrieRoot_keccak_rlp :
+    keccak256 [0x80] =
+      ((Accel.keccakF (List.ofFn (n := 25) (fun j =>
+        if j.val = 0 then 0x0000000000000180
+        else if j.val = 16 then 0x8000000000000000
+        else 0))).take 4).flatMap (fun lane => natToBytesLE 8 lane.toNat) := by
+  have hchunks : chunkBytes 136 (keccakPad [0x80]) = [keccakPad [0x80]] := by
+    simp [chunkBytes, chunkBytesAux, keccakPad, keccakRateBytes]
+  have hchunks' : chunkBytes keccakRateBytes (keccakPad [0x80]) =
+      [keccakPad [0x80]] := by
+    simpa [keccakRateBytes] using hchunks
+  unfold keccak256
+  rw [hchunks']
+  simp only [keccakAbsorb]
+  rw [adEmptyTrieRoot_absorb_block]
+  congr 2
+
+/-- The baked-in trie-root sentinel is the SpecRef EMPTY_TRIE_ROOT value. -/
+theorem adEmptyTrieRootBytes_eq_spec :
+    adEmptyTrieRootBytes = EMPTY_TRIE_ROOT := by
+  rw [show EMPTY_TRIE_ROOT = keccak256 [0x80] from rfl,
+    adEmptyTrieRoot_keccak_rlp, Accel.keccakF_kat_rlp_empty]
+  decide
+
 /-- A hash output cell: the 32 copied content bytes, or the fold constant when
     the field was zero-length.  `fixed32Copied` cannot express the folded case
     for any offset — it is an unconditional copy from the input buffer — which

--- a/EvmAsm/Progress/AxiomWitnesses.lean
+++ b/EvmAsm/Progress/AxiomWitnesses.lean
@@ -42,6 +42,8 @@ import EvmAsm.Progress.Correspondence
 
 #print axioms EvmAsm.Codegen.AccountDecodeCorrespondence.adEmptyCodeHashBytes_value
 
+#print axioms EvmAsm.Codegen.AccountDecodeCorrespondence.adEmptyTrieRootBytes_eq_spec
+
 #print axioms EvmAsm.Codegen.AccountDecodeCorrespondence.adEmptyTrieRootBytes_value
 
 #print axioms EvmAsm.Codegen.AccountDecodeCorrespondence.aieEmptyCodeHashBytes_value

--- a/EvmAsm/Progress/Routines.lean
+++ b/EvmAsm/Progress/Routines.lean
@@ -747,17 +747,17 @@ private noncomputable abbrev _rlp_item_span_routine_witness :=
 -- `lenlen >= 3` arm will consume it as a specification, and a specification outside the
 -- axiom gate is the #11637 failure mode -- the same reason the `LongSpan` lemmas are
 -- gated. No registry row changes: this is a side condition, not a routine triple.
--- #11517 (template pair): the account-leaf sentinels. `EMPTY_CODE_HASH` now has a
--- kernel-checked SpecRef tie through the split Keccak proof; the trie-root copy remains a
--- numeral drift pin because its distinct `keccak256 [0x80]` KAT would need a separately
--- justified intrinsic-depth theorem. The pins stay gated so CI rechecks the remaining
--- literal correspondence.
+-- #11517 (template pair): the account-leaf sentinels. Both `EMPTY_CODE_HASH` and
+-- `EMPTY_TRIE_ROOT` now have kernel-checked SpecRef ties through split Keccak proofs.
+-- The literal pins remain gated so CI also rechecks their byte values.
 private noncomputable abbrev _ad_empty_trie_root_value_witness :=
   @EvmAsm.Codegen.AccountDecodeCorrespondence.adEmptyTrieRootBytes_value
 private noncomputable abbrev _ad_empty_code_hash_value_witness :=
   @EvmAsm.Codegen.AccountDecodeCorrespondence.adEmptyCodeHashBytes_value
 private noncomputable abbrev _ad_empty_code_hash_spec_witness :=
   @EvmAsm.Codegen.AccountDecodeCorrespondence.adEmptyCodeHashBytes_eq_spec
+private noncomputable abbrev _ad_empty_trie_root_spec_witness :=
+  @EvmAsm.Codegen.AccountDecodeCorrespondence.adEmptyTrieRootBytes_eq_spec
 private noncomputable abbrev _aie_empty_code_hash_value_witness :=
   @EvmAsm.Codegen.AccountDecodeCorrespondence.aieEmptyCodeHashBytes_value
 private noncomputable abbrev _ad_empty_code_hash_eq_aie_witness :=

--- a/EvmAsm/Rv64/ZiskAccel.lean
+++ b/EvmAsm/Rv64/ZiskAccel.lean
@@ -109,6 +109,23 @@ def keccakRound (rc : BitVec 64) (st : List (BitVec 64)) : List (BitVec 64) :=
 def keccakF (st : List (BitVec 64)) : List (BitVec 64) :=
   keccakRC.foldl (fun s rc => keccakRound rc s) st
 
+/-! A named round-list runner lets concrete KATs be checked in bounded chunks.
+    The permutation itself remains the 24-round `keccakF`; this is only a
+    proof-evaluation seam, avoiding one monolithic kernel reduction. -/
+def keccakRounds (rcs : List (BitVec 64)) (st : List (BitVec 64)) : List (BitVec 64) :=
+  rcs.foldl (fun s rc => keccakRound rc s) st
+
+theorem keccakF_eq_keccakRounds_split (st : List (BitVec 64)) :
+    keccakF st =
+      keccakRounds (List.drop 12 keccakRC) (keccakRounds (List.take 12 keccakRC) st) := by
+  calc
+    keccakF st = keccakRounds (List.take 12 keccakRC ++ List.drop 12 keccakRC) st := by
+      unfold keccakF keccakRounds
+      rw [List.take_append_drop]
+    _ = keccakRounds (List.drop 12 keccakRC) (keccakRounds (List.take 12 keccakRC) st) := by
+      unfold keccakRounds
+      rw [List.foldl_append]
+
 /-- Each round materializes exactly the 25 lanes (`List.ofFn`), whatever
     the input length. -/
 theorem keccakRound_length (rc : BitVec 64) (st : List (BitVec 64)) :
@@ -132,25 +149,79 @@ theorem keccakF_length (st : List (BitVec 64)) : (keccakF st).length = 25 := by
   rw [hrc, List.foldl_cons]
   exact aux rest _ (keccakRound_length rc st)
 
-set_option maxRecDepth 8000 in
 /-- Known-answer test, kernel-checked: absorbing the padded empty message
     into a zero state (rate 1088: `st[0] ^= 0x01`, `st[16] ^= 0x80 << 56`)
     and permuting yields `keccak256("") =
     c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470`
     in the first four LE lanes.
 
-    The `maxRecDepth` bump is NOT proof-search scaling: `decide` here is
-    concrete evaluation, and the recursion depth is the intrinsic
-    evaluation depth of 24 chained rounds (each round's lanes read the
-    previous round's materialized list), not a symptom of a mis-stated
-    goal. -/
+    The proof evaluates two concrete 12-round chunks separately, so no
+    recursion-depth override is needed: each round reads the previous
+    materialized list, but the default limit handles each half. -/
 theorem keccakF_kat_empty :
     (keccakF (List.ofFn (n := 25) (fun j =>
       if j.val = 0 then 0x0000000000000001
       else if j.val = 16 then 0x8000000000000000
       else 0))).take 4
     = [0x3C23F7860146D2C5, 0xC003C7DCB27D7E92,
-       0x3B2782CA53B600E5, 0x70A4855D04D8FA7B] := by decide
+       0x3B2782CA53B600E5, 0x70A4855D04D8FA7B] := by
+  let input : List (BitVec 64) := List.ofFn (n := 25) (fun j =>
+    if j.val = 0 then 0x0000000000000001
+    else if j.val = 16 then 0x8000000000000000
+    else 0)
+  let mid : List (BitVec 64) :=
+    [0xe215d0d659163823, 0x8683974493a469b1, 0xf64f37f10bf45b28,
+     0xfdee927ea471df68, 0x500c7269f3ee0799, 0x45d78ea405a3a964,
+     0x03557220b429a4d3, 0x3195deb85a7107ab, 0x3d502ddda7398a8d,
+     0xc2febbf32d430d7b, 0x917923e1a60bf1be, 0xc22dd9cf3e60efbe,
+     0x21ce54a25b74d00d, 0x9868de16a584c50e, 0xa62d01cd00859e89,
+     0xd1c3d4f6f08da26f, 0xb0be6294f4d17ace, 0x69da1afce162547d,
+     0x03c8a7b614f3cab7, 0xc5b26f28bfdb70e2, 0x795ad43d7a4beaea,
+     0x9d9bba34ab9d1948, 0x7be76f07d92b7c83, 0x1528c0dc1cce7e4e,
+     0x2831a3bf7aeeb33e]
+  have hmid : keccakRounds (List.take 12 keccakRC) input = mid := by decide
+  have htail :
+      (keccakRounds (List.drop 12 keccakRC) mid).take 4 =
+        [0x3c23f7860146d2c5, 0xc003c7dcb27d7e92, 0x3b2782ca53b600e5,
+         0x70a4855d04d8fa7b] := by decide
+  rw [keccakF_eq_keccakRounds_split]
+  change (keccakRounds (List.drop 12 keccakRC)
+      (keccakRounds (List.take 12 keccakRC) input)).take 4 = _
+  rw [hmid, htail]
+
+/-! The same split evaluation for the RLP encoding of an empty byte string.
+    `keccakPad [0x80]` absorbs lane 0 as `0x0180`: `0x80` is the RLP byte and
+    `0x01` is Keccak's domain suffix. -/
+theorem keccakF_kat_rlp_empty :
+    (keccakF (List.ofFn (n := 25) (fun j =>
+      if j.val = 0 then 0x0000000000000180
+      else if j.val = 16 then 0x8000000000000000
+      else 0))).take 4
+    = [0xa655cc1b171fe856, 0x6ef8c092e64583ff,
+       0xc0ad6c991be0485b, 0x21b463e3b52f6201] := by
+  let input : List (BitVec 64) := List.ofFn (n := 25) (fun j =>
+    if j.val = 0 then 0x0000000000000180
+    else if j.val = 16 then 0x8000000000000000
+    else 0)
+  let mid : List (BitVec 64) :=
+    [0x9274d3ed9e5067fb, 0xc5e372db6f26d7f6, 0x1cf2f4de22080ca5,
+     0x760f767a4525ee2f, 0x6b760d7168e341fd, 0xb59864c9d3bd788b,
+     0xa13c7bb52744135c, 0x289652e9c670511b, 0x0011c5a834fa332b,
+     0x25ce52eb3e8ee470, 0x7776b79a07f8a6bc, 0xc4a7399afd8d0c44,
+     0x9dddb4859b104d9e, 0xe478dfe2e639525b, 0x4797911ec008c55c,
+     0x51dd25b22fd158f5, 0x201a1d0e365113ea, 0x4e0a875bc60fee60,
+     0xb440a0f245401d65, 0xfd532878cb53a182, 0xe3c607cf61f32c54,
+     0xbe496f726be93b7e, 0xbfb57adc43cc2270, 0x2dc5913f0719f645,
+     0x2bd8f57b9f103185]
+  have hmid : keccakRounds (List.take 12 keccakRC) input = mid := by decide
+  have htail :
+      (keccakRounds (List.drop 12 keccakRC) mid).take 4 =
+        [0xa655cc1b171fe856, 0x6ef8c092e64583ff,
+         0xc0ad6c991be0485b, 0x21b463e3b52f6201] := by decide
+  rw [keccakF_eq_keccakRounds_split]
+  change (keccakRounds (List.drop 12 keccakRC)
+      (keccakRounds (List.take 12 keccakRC) input)).take 4 = _
+  rw [hmid, htail]
 
 -- ============================================================================
 -- SHA-256 compression


### PR DESCRIPTION
## Summary

This is the final step for #12045, stacked on the landed #12040 branch.

- Remove the maxRecDepth 8000 wrapper from Accel.keccakF_kat_empty.
- Add a reusable keccakRounds runner and a foldl split theorem.
- Prove both 24-round KATs through two concrete 12-round decide lemmas:
  the padded empty message and the RLP empty-string byte 0x80.
- Tie AccountDecodeSpec.adEmptyTrieRootBytes directly to
  SpecRef.EMPTY_TRIE_ROOT, and register the public correspondence.

The RLP input is checked against the reference padding, not assumed from a
description: keccakPad [0x80] is 0x80, 0x01, zeroes, final 0x80, so lane 0 is
0x0000000000000180 and lane 16 is 0x8000000000000000. The resulting first
little-endian lane is 0xa655cc1b171fe856, whose bytes are the leading
56e81f171bcc55a6 of EMPTY_TRIE_ROOT. The tempting lane-0 = 0x80 state hashes
to a different value and is not used.

The existing SHA-256 compression KAT still has its maxRecDepth wrapper. The
same downward-composition technique appears applicable, but SHA-256 is
explicitly out of scope for this PR.

## Evidence

The isolated no-override decide timings (including Lean startup/import) were:

- empty-message first 12-round half: 3.31 s
- empty-message second 12-round half: 3.01 s
- RLP-empty first 12-round half: 3.12 s
- RLP-empty second 12-round half: 2.89 s

The unsplit 24-round decide probe reaches the default recursion-depth limit.
The source target build for ZiskAccel completed in 12.68 s after removing the
raise. The public witness count increased from 203 to 204.

## Validation

- Full non-cache tree build completed successfully (4824 jobs, 6m21s).
- check-axioms: 204 witnesses; only propext, Classical.choice and Quot.sound.
- check-forbidden-tactics: clean.
- check-heartbeats-approved: all 117 mentions sanctioned.
- git diff --check: clean.

No generated guest artifacts or runtime behavior are changed.
